### PR TITLE
some averaging-related changes

### DIFF
--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -857,7 +857,48 @@ class Obsdata(object):
                        ampcal=self.ampcal, phasecal=self.phasecal, opacitycal=self.opacitycal, dcal=self.dcal, frcal=self.frcal,
                        timetype=self.timetype, scantable=self.scans)
   
-    def add_amp(self, return_type='rec', 
+    
+    
+    def add_amp(self, avg_time=0, tcoh=0,err_type='predicted',return_type='rec',debias=True,num_samples=int(1e3),scan_avg=False):
+        """Creates array of visibility amplitudes as an imaging data product
+            
+            Args:
+                avg_time: total averaging time in seconds
+                tcoh: coherent averaging time prior to incoherent averaging
+                debias: whether debiasing is applied during incoherent averaging
+                return_type: 'rec' for numpy record array (as used by ehtim), 'df' for data frame
+                err_type: 'predicted' for modeled error, 'measured' for bootstrap empirical variability estimator
+        """
+        #if avg_time>0:
+        if tcoh > avg_time:
+            print('Coherent averaging must be no longer than total averaging time! Assuming tcoh=avg_time.')
+            tcoh=avg_time
+        #START WITH COHERENT AVERAGING for Tcoh
+        foo = self.copy()
+        if tcoh > 0:
+            foo.avg_coherent(tcoh)
+
+        ###TODO MACIEK
+        #I forced return_vis='vis' to avoid errors in chisqdata_amp_nfft
+        #and unpacking 'vis'
+        #in future we should use enable using DTAMP dataproduct that has no 'vis' column
+        #amp = make_amp_incoh(foo,avg_time,return_type=return_type,err_type=err_type,debias=debias,num_samples=num_samples)
+        amp = make_amp_incoh(foo,avg_time,return_type='vis',err_type=err_type,debias=debias,scan_avg=scan_avg,num_samples=num_samples)
+        self.amp=amp
+        #else:
+        #    data = copy.deepcopy(self.data)
+        #    data['vis'] = np.abs(data['vis'])
+        #    data['qvis'] = np.abs(data['vis'])
+        #    data['uvis'] = np.abs(data['vis'])
+        #    data['vvis'] = np.abs(data['vis'])
+        #    self.amp = data
+        if scan_avg==False:
+            print("updated self.amp: avg_time %f s\n" % avg_time)
+        else:
+            print("updated self.amp: scan-long averaging")
+    
+    
+    def add_amp_old(self, return_type='rec', 
                       avg_time=0, debias=True, err_type='predicted'):
 
         #TODO store averaging timescale/other parameters?

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -634,7 +634,20 @@ class Obsdata(object):
                          ampcal=self.ampcal, phasecal=self.phasecal, opacitycal=self.opacitycal, dcal=self.dcal, frcal=self.frcal,
                          timetype=self.timetype, scantable=self.scans)
 
-    def avg_coherent(self, inttime, msgtype='bar'):
+    def avg_coherent(self, inttime=0, scan_avg=False):
+        """Coherently average data along u,v tracks in chunks of length inttime (sec)
+        using pandas library
+           Args:
+                inttime (float): coherent integration time in seconds
+           Returns:
+                (Obsdata): Obsdata object containing averaged data
+        """
+        vis_avg = coh_avg_vis(self,dt=inttime,return_type='rec',err_type='predicted',scan_avg=scan_avg)
+        return Obsdata(self.ra, self.dec, self.rf, self.bw, vis_avg, self.tarr, source=self.source, mjd=self.mjd,
+                       ampcal=self.ampcal, phasecal=self.phasecal, opacitycal=self.opacitycal, dcal=self.dcal, frcal=self.frcal,
+                       timetype=self.timetype, scantable=self.scans)
+
+    def avg_coherent_old(self, inttime, msgtype='bar'):
 
         """Coherently average data along u,v tracks in chunks of length inttime (sec).
 

--- a/ehtim/statistics/dataframes.py
+++ b/ehtim/statistics/dataframes.py
@@ -293,7 +293,7 @@ def make_bsp_df(obs,mode='all',count='min',round_s=0.1,band='unknown',polarizati
     df = pd.DataFrame(data=data).copy()
     df['fmjd'] = df['time']/24.
     df['mjd'] = mjd0 + df['fmjd']
-    df['triangle'] = list(map(lambda x: x[0].decode('unicode_escape')+'-'+x[1].decode('unicode_escape')+'-'+x[2].decode('unicode_escape'),zip(df['t1'],df['t2'],df['t3'])))
+    df['triangle'] = list(map(lambda x: x[0]+'-'+x[1]+'-'+x[2],zip(df['t1'],df['t2'],df['t3'])))
     df['datetime'] = Time(df['mjd'], format='mjd').datetime
     df['datetime'] =list(map(lambda x: round_time(x,round_s=round_s),df['datetime']))
     df['jd'] = Time(df['mjd'], format='mjd').jd

--- a/ehtim/statistics/dataframes.py
+++ b/ehtim/statistics/dataframes.py
@@ -28,19 +28,16 @@ try:
 except ImportError:
     print("Warning: pandas not installed!")
     print("Please install pandas to use statistics package!")
-
+import ehtim.obsdata
 import datetime as datetime
 from astropy.time import Time
 from ehtim.statistics.stats import *
 
-def make_df(obs,polarization='unknown',band='unknown',round_s=0.1):
-
+def make_df(obs,round_s=0.1,polarization='unknown',band='unknown'):
     """converts visibilities from obs.data to DataFrame format
-
     Args:
         obs: ObsData object
-        round_s: accuracy of datetime object in seconds
-
+        round_s (float): accuracy of datetime object in seconds
     Returns:
         df: observation visibility data in DataFrame format
     """
@@ -49,7 +46,7 @@ def make_df(obs,polarization='unknown',band='unknown',round_s=0.1):
     df['fmjd'] = df['time']/24.
     df['mjd'] = obs.mjd + df['fmjd']
     telescopes = list(zip(df['t1'],df['t2']))
-    telescopes = [(x[0].decode('unicode_escape'),x[1].decode('unicode_escape')) for x in telescopes]
+    telescopes = [(x[0],x[1]) for x in telescopes]
     df['baseline'] = [x[0]+'-'+x[1] for x in telescopes]
     df['amp'] = list(map(np.abs,df['vis']))
     df['phase'] = list(map(lambda x: (180./np.pi)*np.angle(x),df['vis']))
@@ -62,6 +59,70 @@ def make_df(obs,polarization='unknown',band='unknown',round_s=0.1):
     df['source'] = sour
     df['baselength'] = np.sqrt(np.asarray(df.u)**2+np.asarray(df.v)**2)
     return df
+
+def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',num_samples=int(1e3)):
+    """coherently averages visibilities
+    Args:
+        obs: ObsData object
+        dt (float): integration time in seconds
+        return_type (str): 'rec' for numpy record array (as used by ehtim), 'df' for data frame
+        err_type (str): 'predicted' for modeled error, 'measured' for bootstrap empirical variability estimator
+        num_samples: 'bootstrap' resample set size for measured error
+        scan_avg (bool): should scan-long averaging be performed. If True, overrides dt
+    Returns:
+        vis_avg: coherently averaged visibilities
+    """
+    if (dt<=0)&(scan_avg==False):
+        return obs.data
+    else:
+        vis = make_df(obs)
+        if scan_avg==False:
+            t0 = datetime.datetime(1960,1,1)
+            vis['round_time'] = list(map(lambda x: np.round((x- t0).total_seconds()/float(dt)),vis.datetime))  
+            grouping=['tau1','tau2','polarization','band','baseline','t1','t2','round_time']
+        else:
+            bins, labs = get_bins_labels(obs.scans)
+            vis['scan'] = list(pd.cut(vis.time/24., bins,labels=labs))
+            grouping=['tau1','tau2','polarization','band','baseline','t1','t2','scan']
+        #column just for counting the elements
+        vis['number'] = 1
+        aggregated = {'datetime': np.min, 'time': np.min,
+        'number': lambda x: len(x), 'u':np.mean, 'v':np.mean,'tint': np.sum,
+        'qvis': lambda x: 0*1j, 'uvis': lambda x: 0*1j, 'vvis': lambda x: 0*1j,'qsigma':lambda x: 0,'usigma': lambda x: 0, 'vsigma': lambda x: 0}
+
+        #AVERAGING-------------------------------    
+        if err_type=='measured':
+            vis['dummy'] = vis['vis']
+            aggregated['vis'] = np.mean
+            aggregated['dummy'] = lambda x: bootstrap(np.abs(x), np.mean, num_samples=num_samples,wrapping_variable=False)
+        elif err_type=='predicted':
+            aggregated['vis'] = np.mean
+            aggregated['sigma'] = lambda x: np.sqrt(np.sum(x**2)/len(x)**2)
+        else:
+            print("Error type can only be 'predicted' or 'measured'! Assuming 'predicted'.")
+            aggregated['vis'] = np.mean
+            aggregated['sigma'] = lambda x: np.sqrt(np.sum(x**2)/len(x)**2)
+
+        #ACTUAL AVERAGING
+        vis_avg = vis.groupby(grouping).agg(aggregated).reset_index()
+        
+        if err_type=='measured':
+            vis_avg['sigma'] = [0.5*(x[1][1]-x[1][0]) for x in list(vis_avg['dummy'])]
+
+        vis_avg['amp'] = list(map(np.abs,vis_avg['vis']))
+        vis_avg['phase'] = list(map(lambda x: (180./np.pi)*np.angle(x),vis_avg['vis']))
+        vis_avg['snr'] = vis_avg['amp']/vis_avg['sigma']
+        if scan_avg==False:
+            #round datetime and time to the begining of the bucket
+            vis_avg['datetime'] =  list(map(lambda x: t0 + datetime.timedelta(seconds= int(dt*x)), vis_avg['round_time']))
+            vis_avg['time']  = list(map(lambda x: (Time(x).mjd-np.floor(Time(x).mjd))*24., vis_avg['datetime']))
+        else:
+            vis_avg.drop(list(vis_avg[vis_avg.scan<0].index.values),inplace=True)
+        if return_type=='rec':
+            return df_to_rec(vis_avg,'vis')
+        elif return_type=='df':
+            return vis_avg
+
 
 def make_cphase_df(obs,band='unknown',polarization='unknown',mode='all',count='max',round_s=0.1):
 
@@ -80,7 +141,7 @@ def make_cphase_df(obs,band='unknown',polarization='unknown',mode='all',count='m
     df = pd.DataFrame(data=data).copy()
     df['fmjd'] = df['time']/24.
     df['mjd'] = obs.mjd + df['fmjd']
-    df['triangle'] = list(map(lambda x: x[0].decode('unicode_escape')+'-'+x[1].decode('unicode_escape')+'-'+x[2].decode('unicode_escape'),zip(df['t1'],df['t2'],df['t3'])))
+    df['triangle'] = list(map(lambda x: x[0]+'-'+x[1]+'-'+x[2],zip(df['t1'],df['t2'],df['t3'])))
     df['datetime'] = Time(df['mjd'], format='mjd').datetime
     df['datetime'] =list(map(lambda x: round_time(x,round_s=round_s),df['datetime']))
     df['jd'] = Time(df['mjd'], format='mjd').jd
@@ -106,7 +167,7 @@ def make_camp_df(obs,ctype='logcamp',debias=False,band='unknown',polarization='u
     df = pd.DataFrame(data=data).copy()
     df['fmjd'] = df['time']/24.
     df['mjd'] = obs.mjd + df['fmjd']
-    df['quadrangle'] = list(map(lambda x: x[0].decode('unicode_escape')+'-'+x[1].decode('unicode_escape')+'-'+x[2].decode('unicode_escape')+'-'+x[3].decode('unicode_escape'),zip(df['t1'],df['t2'],df['t3'],df['t4'])))
+    df['quadrangle'] = list(map(lambda x: x[0]+'-'+x[1]+'-'+x[2]+'-'+x[3],zip(df['t1'],df['t2'],df['t3'],df['t4'])))
     df['datetime'] = Time(df['mjd'], format='mjd').datetime
     df['datetime'] =list(map(lambda x: round_time(x,round_s=round_s),df['datetime']))
     df['jd'] = Time(df['mjd'], format='mjd').jd
@@ -133,7 +194,7 @@ def make_bsp_df(obs,band='unknown',polarization='unknown',mode='all',count='min'
     df = pd.DataFrame(data=data).copy()
     df['fmjd'] = df['time']/24.
     df['mjd'] = obs.mjd + df['fmjd']
-    df['triangle'] = list(map(lambda x: x[0].decode('unicode_escape')+'-'+x[1].decode('unicode_escape')+'-'+x[2].decode('unicode_escape'),zip(df['t1'],df['t2'],df['t3'])))
+    df['triangle'] = list(map(lambda x: x[0]+'-'+x[1]+'-'+x[2],zip(df['t1'],df['t2'],df['t3'])))
     df['datetime'] = Time(df['mjd'], format='mjd').datetime
     df['datetime'] =list(map(lambda x: round_time(x,round_s=round_s),df['datetime']))
     df['jd'] = Time(df['mjd'], format='mjd').jd
@@ -331,3 +392,37 @@ def round_time(t,round_s=0.1):
     microseconds = int(1e6*(foo_s - days*3600*24 - seconds))
     round_t = t0+datetime.timedelta(days,seconds,microseconds)
     return round_t
+
+def get_bins_labels(intervals,dt=0.00001):
+    '''gets bins and labels necessary to perform averaging by scan
+    Args:
+        dt: time margin to add to the scan limits
+    ''' 
+    def is_overlapping(interval0,interval1):
+        if ((interval1[0]<=interval0[0])&(interval1[1]>=interval0[0]))|((interval1[0]<=interval0[1])&(interval1[1]>=interval0[1])):
+            return True
+        else: return False
+    
+    def merge_overlapping_intervals(intervals):
+        return (np.min([x[0] for x in intervals]),np.max([x[1] for x in intervals]))
+
+    def replace_overlapping_intervals(intervals,element_ind):
+        indic_not_overlap=[not is_overlapping(x,intervals[element_ind]) for x in intervals]
+        indic_overlap=[is_overlapping(x,intervals[element_ind]) for x in intervals]
+        fooarr=np.asarray(intervals)
+        return sorted([tuple(x) for x in fooarr[indic_not_overlap]]+[merge_overlapping_intervals(list(fooarr[indic_overlap]))])
+    
+    intervals = sorted(list(set(zip(intervals[:,0],intervals[:,1]))))
+    cou=0
+    while cou < len(intervals): 
+        intervals = replace_overlapping_intervals(intervals,cou)
+        cou+=1
+        
+    binsT=[None]*(2*np.shape(intervals)[0])
+    binsT[::2] = [x[0]-dt for x in intervals]
+    binsT[1::2] = [x[1]+dt for x in intervals]
+    labels=[None]*(2*np.shape(intervals)[0]-1)
+    labels[::2] = [cou for cou in range(1,len(intervals)+1)]
+    labels[1::2] = [-cou for cou in range(1,len(intervals))]
+    
+    return binsT, labels

--- a/ehtim/statistics/dataframes.py
+++ b/ehtim/statistics/dataframes.py
@@ -188,7 +188,7 @@ def make_amp_incoh(obs,dt=0,return_type='rec',err_type='predicted',debias=True,s
             amp_avg['time']  = list(map(lambda x: (Time(x).mjd-np.floor(Time(x).mjd))*24., amp_avg['datetime']))
         else:
             amp_avg.drop(list(amp_avg[amp_avg.scan<0].index.values),inplace=True)    
-        amp_avg['source'] = sour
+    amp_avg.drop(list(amp_avg[amp_avg.amp==0].index.values),inplace=True)    
     if return_type=='rec':
         return df_to_rec(amp_avg,'amp')
     elif return_type=='df':

--- a/ehtim/statistics/stats.py
+++ b/ehtim/statistics/stats.py
@@ -214,3 +214,32 @@ def bootstrap(data, statistic, num_samples=int(1e3), alpha='1sig',wrapping_varia
     bootstrap_value = np.median(stat)+m
     bootstrap_CI = [stat[int((alpha/2.0)*num_samples)]+m, stat[int((1-alpha/2.0)*num_samples)]+m]
     return bootstrap_value, bootstrap_CI
+
+
+def debiasing(x,y, debias_type='amp_sample'):
+    '''performes debiasing element by element
+        Args:
+               x (float, array): vector to debias
+               y(float, array): sigma/snr to use for debiasing
+               debias_type (str): don't debias ('none'), debias amplitudes ('amp_sample'), debias logamps ('logamp')
+    '''
+    if debias_type=='none':
+        #for 'none' act as identity
+        return x
+    elif debias_type=='amp_sample':
+        #interprets x as amplitudes/visibilities and y as errors and debias each sample separately
+        return debias_sample(x,y)
+    elif debias_type=='logamp':
+        #interprets x as log amplitudes and y as snrs and debias each sample separately
+        return log_debias(x,y)
+    
+def log_debias(logamp,snr):
+    if (hasattr(snr, "__len__")):
+        snr= np.asarray(snr)
+    return logamp + ss.expi(-snr**2/2.)/2.
+  
+def debias_sample(x,y):
+    x=np.abs(x)
+    y=np.abs(y)
+    deb_amp = np.sqrt(np.maximum(x**2-1*y**2,0))
+    return deb_amp

--- a/ehtim/statistics/stats.py
+++ b/ehtim/statistics/stats.py
@@ -104,6 +104,7 @@ def mean_incoh_amp(amp,sigma,debias=True,err_type='predicted',num_samples=int(1e
     Returns:
         amp0: estimator of unbiased amplitude
     """
+    amp=np.abs(amp)
     if (not hasattr(amp, "__len__")):
         amp = [amp]
     amp = np.asarray(amp, dtype=np.float32) 


### PR DESCRIPTION
Hi Andrew,
I added some changes to ehtim and noticed some problems.

Main addition is that you can do scan averaging of quantities based on obs.scans, for coherent averaging as well as for closures averaging, with option avg_scan.

Then I added some options to the averaging, initial coherent averaging of the closure quantity (so that we can average different products coherently for different time), averaging bispectra all closure phases.

I also deleted string unicode escape that made the averaging fail in python 3.

I noticed some problems with closure amplitudes and I wasn't able to track them down, I'd prefer to do it with you next week. So basically averaging closure amplitudes doesn't work right at the moment.

If you want to check something, could you run some example imaging with

obs.camp = obs.c_amplitudes(mode='all', count='min', ctype='camp', debias=True)

in python 2 and in python 3. I'm getting a very different behavior when measuring chi2 on the actual synthetic image (it's ok in python 3 and bad in python 2). Also, I figure this should be the same as running imager on obs without camp attribute, but in python 2 it's not.

