### PR TITLE
Addition of eh.image.load_image()

### DIFF
--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -1986,7 +1986,8 @@ def load_image(image, display=False, aipscc=False):
       print("Image format is not recognized. Was expecting .fits, .txt, or Image. Got {0}. Returning False.".format(type(image)))
       return False
 
-    if display: im.display()
+    if display: 
+      im.display()
 
     return im
 

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -1979,7 +1979,8 @@ def load_image(image, display=False, aipscc=False):
         return False
 
 
-    elif isinstance(image, ehtim.image.Image): im = image
+    elif isinstance(image, ehtim.image.Image): 
+      im = image
 
     else: 
       print("Image format is not recognized. Was expecting .fits, .txt, or Image. Got {0}. Returning False.".format(type(image)))

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -1968,18 +1968,21 @@ def load_image(image, display=False, aipscc=False):
             (Image):    loaded image object
             (boolean):  False if the image cannot be read
     """
-    
+
     if type(image) == type("str"):
       if image.endswith('.fits'):  
         im = ehtim.io.load.load_im_fits(image, aipscc=aipscc)
       elif image.endswith('.txt'):   
         im = ehtim.io.load.load_im_txt(image)
+      else:
+        print("Image format is not recognized. Was expecting .fits, .txt, or Image. Got <.{0}>. Returning False.".format(image.split('.')[-1]))
+        return False
 
 
     elif isinstance(image, ehtim.image.Image): im = image
 
     else: 
-      print("Image format is not recognized. Returning False.")
+      print("Image format is not recognized. Was expecting .fits, .txt, or Image. Got {0}. Returning False.".format(type(image)))
       return False
 
     if display: im.display()

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -1954,6 +1954,39 @@ def make_square(obs, npix, fov, pulse=PULSE_DEFAULT):
     im = np.zeros((npix,npix))
     return Image(im, pdim, obs.ra, obs.dec, rf=obs.rf, source=obs.source, mjd=obs.mjd, pulse=pulse)
 
+
+def load_image(image, display=False, aipscc=False):
+
+    """Read in an image from a text, .fits, or ehtim.image.Image object
+
+       Args:
+            image (str/Image): path to input file
+            display (boolean): determine whether to display the image default
+            aipscc (boolean): if True, then AIPS CC table will be loaded instead
+                              of the original brightness distribution.
+       Returns:
+            (Image):    loaded image object
+            (boolean):  False if the image cannot be read
+    """
+    
+    if type(image) == type("str"):
+      if image.endswith('.fits'):  
+        im = ehtim.io.load.load_im_fits(image, aipscc=aipscc)
+      elif image.endswith('.txt'):   
+        im = ehtim.io.load.load_im_txt(image)
+
+
+    elif isinstance(image, ehtim.image.Image): im = image
+
+    else: 
+      print("Image format is not recognized. Returning False.")
+      return False
+
+    if display: im.display()
+
+    return im
+
+
 def load_txt(fname):
 
     """Read in an image from a text file.


### PR DESCRIPTION
I've added a function called `load_image()`. It can be accessed just by calling `eh.image.load_image()`. It robustly takes different kinds of image inputs and figures out which function to use to read it. `load_image` can read `.fits`, `.txt`, and `eh.image.Image` types and return an `eh.image.Image` object. You can also set the argument `display=True` to have it automatically display the image. 

This function can be useful in a lot of circumstances. Instead of having to check the filetype of what you're loading, this will do it for you. If you have a long list of images, in various formats, this will save you a couple of if statements and let you load them all in with the same line. Finally, it's very easy to add filetypes to the function, so its flexibility can increase in the future. 

Example usage:

```python
import ehtim as eh

images = [
	"avery_sgra_eofn.fits",
	"avery_sgra_eofn.txt",
	eh.image.load_fits("avery_sgra_eofn.fits")
]

for im in images:
	img = eh.image.load_image(im) # load image robustly, without worrying about type
	print img.psize
```

(p.s. -- this commit (unintentionally) gives image.py 2018 lines. Huzzah!)