### PR TITLE
time-variable gain errors

### DIFF
--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -2095,21 +2095,24 @@ def apply_systematic_noise_snrcut(data_arr, systematic_noise, snrcut):
     snrmask = np.abs(amp/sigma) >= snrcut
 
     if type(systematic_noise) is dict:
-        sys_level = np.zeros(len(t1))
-        for i in range(len(t1)):
-            if t1[i] in systematic_noise.keys():
-                t1sys = systematic_noise[t1[i]]
-            else:
-                t1sys = 0.
-            if t2[i] in systematic_noise.keys():
-                t2sys = systematic_noise[t2[i]]
-            else:
-                t2sys = 0.
+        if 'sys_level' in systematic_noise.keys():
+            sys_level = systematic_noise['sys_level']
+        else:
+            sys_level = np.zeros(len(t1))
+            for i in range(len(t1)):
+                if t1[i] in systematic_noise.keys():
+                    t1sys = systematic_noise[t1[i]]
+                else:
+                    t1sys = 0.
+                if t2[i] in systematic_noise.keys():
+                    t2sys = systematic_noise[t2[i]]
+                else:
+                    t2sys = 0.
 
-            if t1sys<0 or t2sys<0:
-                sys_level[i] = -1
-            else:
-                sys_level[i] = np.sqrt(t1sys**2 + t2sys**2)
+                if t1sys<0 or t2sys<0:
+                    sys_level[i] = -1
+                else:
+                    sys_level[i] = np.sqrt(t1sys**2 + t2sys**2)
     else:
         sys_level = np.sqrt(2)*systematic_noise*np.ones(len(t1))
 

--- a/ehtim/statistics/dataframes.py
+++ b/ehtim/statistics/dataframes.py
@@ -175,7 +175,7 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
             #round datetime and time to the begining of the bucket and add half of a bucket time
             half_bucket = dt/2.
             vis_avg['datetime'] =  list(map(lambda x: t0 + datetime.timedelta(seconds= int(dt*x) + half_bucket), vis_avg['round_time']))
-            vis_avg['time']  = list(map(lambda x: (Time(x).mjd-np.floor(Time(x).mjd))*24., vis_avg['datetime']))
+            vis_avg['time']  = list(map(lambda x: (Time(x).mjd-obs.mjd)*24., vis_avg['datetime']))
         else:
             #drop values that couldn't be matched to any scan
             vis_avg.drop(list(vis_avg[vis_avg.scan<0].index.values),inplace=True)
@@ -272,7 +272,7 @@ def incoh_avg_vis(obs,dt=0,debias=True,scan_avg=False,return_type='rec',rec_type
             #round datetime and time to the begining of the bucket and add half of a bucket time
             half_bucket = dt/2.
             vis_avg['datetime'] =  list(map(lambda x: t0 + datetime.timedelta(seconds= int(dt*x) + half_bucket), vis_avg['round_time']))
-            vis_avg['time']  = list(map(lambda x: (Time(x).mjd-np.floor(Time(x).mjd))*24., vis_avg['datetime']))
+            vis_avg['time']  = list(map(lambda x: (Time(x).mjd-obs.mjd)*24., vis_avg['datetime']))
         else:
             #drop values that couldn't be matched to any scan
             vis_avg.drop(list(vis_avg[vis_avg.scan<0].index.values),inplace=True)


### PR DESCRIPTION
these changes will allow to have time-dependent systematic errors for visibility amplitude gains, for instance when LMT isn't performing so well. The way it will work is it will be possible to pass precomputed list of systematic errors in systematic_error dictionary. This is a function to generate this precomputed list from dictionary of {(station, time_start, time_stop) : systematic_error} and to apply it to the errors data.