### PR TITLE
Logically rotate image and cache its FFT for fast resampling visibilities

### DIFF
--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -1568,7 +1568,7 @@ class Image(object):
 
         return outim
 
-    def sample_uv(self, uv, sgrscat=False, polrep_obs='stokes', ttype='nfft', fft_pad_factor=2):
+    def sample_uv(self, uv, sgrscat=False, polrep_obs='stokes', ttype='nfft', cache=False, fft_pad_factor=2):
 
         """Sample the image on the selected uv points without adding noise.
 
@@ -1588,10 +1588,10 @@ class Image(object):
             raise Exception("polrep_obs must be either 'stokes' or 'circ'")
 
         data = simobs.sample_vis(self, uv, sgrscat=sgrscat, polrep_obs=polrep_obs,
-                                       ttype=ttype, fft_pad_factor=fft_pad_factor)
+                                       ttype=ttype, cache=cache, fft_pad_factor=fft_pad_factor)
         return data
 
-    def observe_same_nonoise(self, obs, sgrscat=False,  ttype="nfft", fft_pad_factor=2):
+    def observe_same_nonoise(self, obs, sgrscat=False,  ttype="nfft", cache=False, fft_pad_factor=2):
 
         """Observe the image on the same baselines as an existing observation object without adding noise.
 
@@ -1625,7 +1625,7 @@ class Image(object):
         # Extract uv datasample
         uv = recarr_to_ndarr(obsdata[['u','v']],'f8')
         data = simobs.sample_vis(self, uv, sgrscat=sgrscat, polrep_obs=obs.polrep,
-                                       ttype=ttype, fft_pad_factor=fft_pad_factor)
+                                       ttype=ttype, cache=cache, fft_pad_factor=fft_pad_factor)
 
         # put visibilities into the obsdata
         if obs.polrep=='stokes':

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -309,7 +309,7 @@ class Image(object):
         """
 
         # Make new  image with primary polarization
-        newim = Image(self.imvec.reshape(self.ydim,self.xdim), self.psize, self.ra, self.dec,
+        newim = Image(self.imvec.reshape(self.ydim,self.xdim), self.psize, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -468,7 +468,7 @@ class Image(object):
             raise Exception("for switch_polrep to %s with pol_prim_out=%s, \n"%(polrep_out,pol_prim_out) +
                             "output image is not defined")
 
-        newim = Image(imvec.reshape(self.ydim,self.xdim), self.psize, self.ra, self.dec,
+        newim = Image(imvec.reshape(self.ydim,self.xdim), self.psize, self.ra, self.dec, self.pa,
                       polrep=polrep_out, pol_prim=pol_prim_out, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -686,7 +686,7 @@ class Image(object):
         imarr=np.pad(imarr,((pady,pady),(padx,padx)),'constant')
 
         # Make new image
-        outim = Image(imarr, self.psize, self.ra, self.dec,
+        outim = Image(imarr, self.psize, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -752,7 +752,7 @@ class Image(object):
         imarr_new *= scaling
 
         # Make new image
-        outim = Image(imarr_new, psize_new, self.ra, self.dec,
+        outim = Image(imarr_new, psize_new, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -805,7 +805,7 @@ class Image(object):
         # Make new image
         imarr_new = interp_imvec(self.imvec)
 
-        outim = Image(imarr_new, psize_new, self.ra, self.dec,
+        outim = Image(imarr_new, psize_new, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -847,7 +847,7 @@ class Image(object):
 
         # Make new image
         imarr_rot = rot_imvec(self.imvec)
-        outim = Image(imarr_rot, self.psize, self.ra, self.dec,
+        outim = Image(imarr_rot, self.psize, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -880,7 +880,7 @@ class Image(object):
 
         # Make new image
         imarr_shift = shift_imvec(self.imvec)
-        outim = Image(imarr_shift, self.psize, self.ra, self.dec,
+        outim = Image(imarr_shift, self.psize, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -942,7 +942,7 @@ class Image(object):
         imarr = (self.imvec).reshape(self.ydim, self.xdim)
 
 
-        outim = Image(blur(imarr,gauss), self.psize, self.ra, self.dec,
+        outim = Image(blur(imarr,gauss), self.psize, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -984,7 +984,7 @@ class Image(object):
         # Blur the primary image
         imarr = self.imvec.reshape(self.ydim, self.xdim)
         imarr = blur(imarr,sigmap)
-        outim = Image(imarr, self.psize, self.ra, self.dec,
+        outim = Image(imarr, self.psize, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1035,7 +1035,7 @@ class Image(object):
 
         # Find the gradient for the primary image
         gradarr = gradim(self.imvec)
-        outim = Image(gradarr, self.psize, self.ra, self.dec,
+        outim = Image(gradarr, self.psize, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1086,7 +1086,7 @@ class Image(object):
 
         # make the primary image
         maskarr = maskvec.reshape(mask.ydim, mask.xdim)
-        mask = Image(maskarr, self.psize, self.ra, self.dec,
+        mask = Image(maskarr, self.psize, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1121,7 +1121,7 @@ class Image(object):
         # Mask the primary image
         imvec = self.imvec
         imvec[~maskvec] = fill_val
-        outim = Image(imvec.reshape(self.ydim,self.xdim), self.psize, self.ra, self.dec,
+        outim = Image(imvec.reshape(self.ydim,self.xdim), self.psize, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim,  time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1190,7 +1190,7 @@ class Image(object):
         if pol==self.pol_prim:
             imarr += flatarr
 
-        outim = Image(imarr, self.psize, self.ra, self.dec,
+        outim = Image(imarr, self.psize, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1241,7 +1241,7 @@ class Image(object):
         if pol==self.pol_prim:
             imarr += hatarr
 
-        outim = Image(imarr, self.psize, self.ra, self.dec,
+        outim = Image(imarr, self.psize, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1305,7 +1305,7 @@ class Image(object):
         if pol==self.pol_prim:
             imarr += gaussarr
 
-        outim = Image(imarr, self.psize, self.ra, self.dec,
+        outim = Image(imarr, self.psize, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1365,7 +1365,7 @@ class Image(object):
         if pol==self.pol_prim:
             imarr += crescarr
 
-        outim = Image(imarr, self.psize, self.ra, self.dec,
+        outim = Image(imarr, self.psize, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim,  time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1423,7 +1423,7 @@ class Image(object):
                           for i in xlist]
                           for j in ylist])
         ringarr = ringarr[0:self.ydim, 0:self.xdim]
-        tmp = Image(ringarr, self.psize, self.ra, self.dec, rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
+        tmp = Image(ringarr, self.psize, self.ra, self.dec, self.pa, rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
         tmp = tmp.blur_circ(sigma)
         tmp.imvec *= flux/(tmp.total_flux())
         ringarr = tmp.imvec.reshape(self.ydim, self.xdim)
@@ -1433,7 +1433,7 @@ class Image(object):
         if pol==self.pol_prim:
             imarr += ringarr
 
-        outim = Image(imarr, self.psize, self.ra, self.dec,
+        outim = Image(imarr, self.psize, self.ra, self.dec, self.pa,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1482,7 +1482,7 @@ class Image(object):
 
         # create the new stokes image object
         iarr = ivec.reshape(im.ydim,im.xdim).copy()
-        outim = Image(iarr, self.psize, self.ra, self.dec,
+        outim = Image(iarr, self.psize, self.ra, self.dec, self.pa,
                       polrep='stokes', pol_prim='I', time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1529,7 +1529,7 @@ class Image(object):
 
         # create the new stokes image object
         iarr = ivec.reshape(im.ydim,im.xdim).copy()
-        outim = Image(iarr, self.psize, self.ra, self.dec,
+        outim = Image(iarr, self.psize, self.ra, self.dec, self.pa,
                       polrep='stokes', pol_prim='I', time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -70,7 +70,7 @@ class Image(object):
 
     """
 
-    def __init__(self, image, psize, ra, dec,
+    def __init__(self, image, psize, ra, dec, pa=0.0,
                        polrep='stokes', pol_prim=None,
                        rf=RF_DEFAULT, pulse=PULSE_DEFAULT, source=SOURCE_DEFAULT,
                        mjd=MJD_DEFAULT, time=0.):
@@ -85,6 +85,7 @@ class Image(object):
                psize (float): The pixel dimension in radians
                ra (float): The source Right Ascension in fractional hours
                dec (float): The source declination in fractional degrees
+               pa (float): logical positional angle of the image
                rf (float): The image frequency in Hz
                pulse (function): The function convolved with the pixel values for continuous image.
                source (str): The source name
@@ -138,11 +139,15 @@ class Image(object):
         self.ydim = image.shape[0]
 
         # Save the image metadata
-        self.ra = float(ra)
+        self.ra  = float(ra)
         self.dec = float(dec)
-        self.rf = float(rf)
+        self.pa  = float(pa)
+        self.rf  = float(rf)
         self.source = str(source)
         self.mjd = int(mjd)
+
+        # Cached FFT of the image
+        self.cached_fft = None
 
         if time > 24:
             self.mjd += int((time - time % 24)/24)
@@ -2953,4 +2958,3 @@ def load_fits(fname, aipscc=False, pulse=PULSE_DEFAULT,
 
     return ehtim.io.load.load_im_fits(fname, aipscc=aipscc,pulse=pulse,
                                       polrep=polrep, pol_prim=pol_prim,  zero_pol=zero_pol)
-

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -147,7 +147,7 @@ class Image(object):
         self.mjd = int(mjd)
 
         # Cached FFT of the image
-        self.cached_fft = None
+        self.cached_fft = {}
 
         if time > 24:
             self.mjd += int((time - time % 24)/24)

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -66,13 +66,13 @@ class Image(object):
 
            imvec (array): The vector of pixel I values in Jy/pixel (len xdim*ydim)
            polrep (str): polarization representation, either 'stokes' or 'circ'
-           pol_prim (str): The default image: I,Q,U or V for Stokes, or RR,LL,LR,RL for Circular              
+           pol_prim (str): The default image: I,Q,U or V for Stokes, or RR,LL,LR,RL for Circular
 
     """
 
-    def __init__(self, image, psize, ra, dec, 
+    def __init__(self, image, psize, ra, dec,
                        polrep='stokes', pol_prim=None,
-                       rf=RF_DEFAULT, pulse=PULSE_DEFAULT, source=SOURCE_DEFAULT, 
+                       rf=RF_DEFAULT, pulse=PULSE_DEFAULT, source=SOURCE_DEFAULT,
                        mjd=MJD_DEFAULT, time=0.):
 
         """A polarimetric image (in units of Jy/pixel).
@@ -80,7 +80,7 @@ class Image(object):
            Args:
                image (numpy.array): The 2D intensity values in a Jy/pixel array
                polrep (str): polarization representation, either 'stokes' or 'circ'
-               pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular              
+               pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular
 
                psize (float): The pixel dimension in radians
                ra (float): The source Right Ascension in fractional hours
@@ -117,7 +117,7 @@ class Image(object):
                 raise Exception("for polrep=='stokes', pol_prim must be 'I','Q','U', or 'V'!")
 
         elif polrep=='circ':
-            if pol_prim is None: 
+            if pol_prim is None:
                 print("polrep is 'circ' and no pol_prim specified! Setting pol_prim='RR'")
                 pol_prim = 'RR'
             if pol_prim=='RR':
@@ -160,7 +160,7 @@ class Image(object):
         if len(vec) != self.xdim*self.ydim:
             raise Exception("imvec size is not consistent with xdim*ydim!")
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._imdict[self.pol_prim] =  vec        
+        self._imdict[self.pol_prim] =  vec
 
     @property
     def ivec(self):
@@ -176,7 +176,7 @@ class Image(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._imdict['I'] =  vec        
+        self._imdict['I'] =  vec
 
     @property
     def qvec(self):
@@ -192,7 +192,7 @@ class Image(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._imdict['Q'] =  vec        
+        self._imdict['Q'] =  vec
 
     @property
     def uvec(self):
@@ -208,8 +208,8 @@ class Image(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._imdict['U'] =  vec   
-   
+        self._imdict['U'] =  vec
+
     @property
     def vvec(self):
         if self.polrep!='stokes':
@@ -224,7 +224,7 @@ class Image(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._imdict['V'] =  vec      
+        self._imdict['V'] =  vec
 
     @property
     def rrvec(self):
@@ -240,7 +240,7 @@ class Image(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._imdict['RR'] =  vec      
+        self._imdict['RR'] =  vec
 
     @property
     def llvec(self):
@@ -256,7 +256,7 @@ class Image(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._imdict['LL'] =  vec      
+        self._imdict['LL'] =  vec
 
     @property
     def rlvec(self):
@@ -272,7 +272,7 @@ class Image(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._imdict['RL'] =  vec   
+        self._imdict['RL'] =  vec
 
     @property
     def lrvec(self):
@@ -291,8 +291,8 @@ class Image(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._imdict['LR'] =  vec      
-   
+        self._imdict['LR'] =  vec
+
     def copy(self):
 
         """Return a copy of the Image object.
@@ -304,7 +304,7 @@ class Image(object):
         """
 
         # Make new  image with primary polarization
-        newim = Image(self.imvec.reshape(self.ydim,self.xdim), self.psize, self.ra, self.dec, 
+        newim = Image(self.imvec.reshape(self.ydim,self.xdim), self.psize, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -324,7 +324,7 @@ class Image(object):
 
         for pol in list(self._imdict.keys()):
 
-            if (pol==self.pol_prim): 
+            if (pol==self.pol_prim):
                 continue
 
             polvec = old_image._imdict[pol]
@@ -333,7 +333,7 @@ class Image(object):
 
     def add_pol_image(self, image, pol):
 
-        """Add another image polarization. 
+        """Add another image polarization.
 
            Args:
                image (list): 2D image frame (possibly complex) in a Jy/pixel array
@@ -344,7 +344,7 @@ class Image(object):
             raise Exception("new pol in add_pol_image is the same as pol_prim!")
         if image.shape != (self.ydim, self.xdim):
             raise Exception("add_pol_image image shapes incompatible with primary image!")
-        if not (pol in list(self._imdict.keys())): 
+        if not (pol in list(self._imdict.keys())):
             raise Exception("for polrep==%s, pol in add_pol_image in "%self.polrep + ",".join(list(self._imdict.keys())))
 
         if self.polrep=='stokes':
@@ -400,7 +400,7 @@ class Image(object):
         """Return a new image with the polarization representation changed
            Args:
                polrep_out (str):  the polrep of the output data
-               pol_prim_out (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular              
+               pol_prim_out (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular
 
            Returns:
                (Image): new Image object with potentially different polrep
@@ -408,7 +408,7 @@ class Image(object):
 
         if polrep_out not in ['stokes','circ']:
             raise Exception("polrep_out must be either 'stokes' or 'circ'")
-        if pol_prim_out is None: 
+        if pol_prim_out is None:
             if polrep_out=='stokes': pol_prim_out = 'I'
             elif polrep_out=='circ': pol_prim_out = 'RR'
 
@@ -417,7 +417,7 @@ class Image(object):
             return self.copy()
 
         # Assemble a dictionary of new polarization vectors
-        if polrep_out=='stokes':                 
+        if polrep_out=='stokes':
             if self.polrep=='stokes':
                 imdict = {'I':self.ivec,'Q':self.qvec,'U':self.uvec,'V':self.vvec}
             else:
@@ -440,7 +440,7 @@ class Image(object):
         elif polrep_out=='circ':
             if self.polrep=='circ':
                 imdict = {'RR':self.rrvec,'LL':self.llvec,'RL':self.rlvec,'LR':self.lrvec}
-            else:   
+            else:
                 if len(self.ivec)==0 or len(self.vvec)==0:
                     rrvec = []
                     llvec = []
@@ -463,7 +463,7 @@ class Image(object):
             raise Exception("for switch_polrep to %s with pol_prim_out=%s, \n"%(polrep_out,pol_prim_out) +
                             "output image is not defined")
 
-        newim = Image(imvec.reshape(self.ydim,self.xdim), self.psize, self.ra, self.dec, 
+        newim = Image(imvec.reshape(self.ydim,self.xdim), self.psize, self.ra, self.dec,
                       polrep=polrep_out, pol_prim=pol_prim_out, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -520,7 +520,7 @@ class Image(object):
         """Return the 2D image array of a given pol parameter.
 
            Args:
-               pol (str): I,Q,U or V for Stokes, or RR,LL,LR,RL for Circular 
+               pol (str): I,Q,U or V for Stokes, or RR,LL,LR,RL for Circular
 
            Returns:
                (numpy.array): 2D image array of dimension (ydim, xdim)
@@ -642,9 +642,9 @@ class Image(object):
         """
 
         if pol is None: pol=self.pol_prim
-        if not (pol in list(self._imdict.keys())): 
+        if not (pol in list(self._imdict.keys())):
             raise Exception("for polrep==%s, pol must be in "%self.polrep + ",".join(list(self._imdict.keys())))
-            
+
         pdim = self.psize
         imvec = self._imdict[pol]
         if len(imvec):
@@ -653,7 +653,7 @@ class Image(object):
             x0 = np.sum(np.outer(0.0*ylist+1.0, xlist).ravel()*imvec)/np.sum(imvec)
             y0 = np.sum(np.outer(ylist, 0.0*xlist+1.0).ravel()*imvec)/np.sum(imvec)
             centroid = np.array([x0, y0])
-        else: 
+        else:
             raise Exception("No %s image found!"  % pol)
 
         return centroid
@@ -681,7 +681,7 @@ class Image(object):
         imarr=np.pad(imarr,((pady,pady),(padx,padx)),'constant')
 
         # Make new image
-        outim = Image(imarr, self.psize, self.ra, self.dec, 
+        outim = Image(imarr, self.psize, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -723,9 +723,9 @@ class Image(object):
         ij = np.array([[[i*self.psize + (self.psize*self.xdim)/2.0 - self.psize/2.0, j*self.psize + (self.psize*self.ydim)/2.0 - self.psize/2.0]
                         for i in np.arange(0, -self.xdim, -1)]
                         for j in np.arange(0, -self.ydim, -1)]).reshape((self.xdim*self.ydim, 2))
-      
+
         def im_new_val(imvec,x_idx,y_idx):
-            x = x_idx*psize_new + (psize_new*xdim_new)/2.0 - psize_new/2.0      
+            x = x_idx*psize_new + (psize_new*xdim_new)/2.0 - psize_new/2.0
             y = y_idx*psize_new + (psize_new*ydim_new)/2.0 - psize_new/2.0
             mask = (((x - ker_size*self.psize/2.0) < ij[:,0]) * (ij[:,0] < (x + ker_size*self.psize/2.0)) *
                     ((y - ker_size*self.psize/2.0) < ij[:,1]) * (ij[:,1] < (y + ker_size*self.psize/2.0))
@@ -747,7 +747,7 @@ class Image(object):
         imarr_new *= scaling
 
         # Make new image
-        outim = Image(imarr_new, psize_new, self.ra, self.dec, 
+        outim = Image(imarr_new, psize_new, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -800,7 +800,7 @@ class Image(object):
         # Make new image
         imarr_new = interp_imvec(self.imvec)
 
-        outim = Image(imarr_new, psize_new, self.ra, self.dec, 
+        outim = Image(imarr_new, psize_new, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -829,7 +829,7 @@ class Image(object):
         if interp=='linear': order=1
         elif interp=='cubic': order=3
         elif interp=='quintic': order=5
-        
+
         # Define an interpolation function
         def rot_imvec(imvec):
             if np.any(np.imag(imvec)!=0):
@@ -842,7 +842,7 @@ class Image(object):
 
         # Make new image
         imarr_rot = rot_imvec(self.imvec)
-        outim = Image(imarr_rot, self.psize, self.ra, self.dec, 
+        outim = Image(imarr_rot, self.psize, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -875,7 +875,7 @@ class Image(object):
 
         # Make new image
         imarr_shift = shift_imvec(self.imvec)
-        outim = Image(imarr_shift, self.psize, self.ra, self.dec, 
+        outim = Image(imarr_shift, self.psize, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -923,7 +923,7 @@ class Image(object):
             return gauss
 
         gauss = gaussim(frac)
-        if frac_pol: 
+        if frac_pol:
             gausspol = gaussim(frac_pol)
 
         # Define a convolution function
@@ -937,7 +937,7 @@ class Image(object):
         imarr = (self.imvec).reshape(self.ydim, self.xdim)
 
 
-        outim = Image(blur(imarr,gauss), self.psize, self.ra, self.dec, 
+        outim = Image(blur(imarr,gauss), self.psize, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -979,7 +979,7 @@ class Image(object):
         # Blur the primary image
         imarr = self.imvec.reshape(self.ydim, self.xdim)
         imarr = blur(imarr,sigmap)
-        outim = Image(imarr, self.psize, self.ra, self.dec, 
+        outim = Image(imarr, self.psize, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1030,7 +1030,7 @@ class Image(object):
 
         # Find the gradient for the primary image
         gradarr = gradim(self.imvec)
-        outim = Image(gradarr, self.psize, self.ra, self.dec, 
+        outim = Image(gradarr, self.psize, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1081,7 +1081,7 @@ class Image(object):
 
         # make the primary image
         maskarr = maskvec.reshape(mask.ydim, mask.xdim)
-        mask = Image(maskarr, self.psize, self.ra, self.dec, 
+        mask = Image(maskarr, self.psize, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1108,7 +1108,7 @@ class Image(object):
         if (self.psize != mask_im.psize) or (self.xdim != mask_im.xdim) or (self.ydim != mask_im.ydim):
             raise Exception("mask image does not match dimensions of the current image!")
 
-        # Get the mask vector        
+        # Get the mask vector
         maskvec = mask_im.imvec.astype(bool)
         maskvec[maskvec <= 0] = 0
         maskvec[maskvec > 0] = 1
@@ -1116,7 +1116,7 @@ class Image(object):
         # Mask the primary image
         imvec = self.imvec
         imvec[~maskvec] = fill_val
-        outim = Image(imvec.reshape(self.ydim,self.xdim), self.psize, self.ra, self.dec, 
+        outim = Image(imvec.reshape(self.ydim,self.xdim), self.psize, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim,  time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1149,7 +1149,7 @@ class Image(object):
             cutoff=frac_i
             print("Warning!: using frac_i=%f as cutoff in threshold(). Rename 'frac_i' to 'cutoff' in future scripts!")
 
-        if fill_val is None or fill_val==False:        
+        if fill_val is None or fill_val==False:
             maxval = np.max(self.imvec)
             minval = np.min(self.imvec)
             #minval = np.max((np.min(self.imvec),0.))
@@ -1172,7 +1172,7 @@ class Image(object):
         """
 
         if pol is None: pol=self.pol_prim
-        if not (pol in list(self._imdict.keys())): 
+        if not (pol in list(self._imdict.keys())):
             raise Exception("for polrep==%s, pol must be in "%self.polrep + ",".join(list(self._imdict.keys())))
         if not len(self._imdict[pol]):
             raise Exception("no image for pol %s"%pol)
@@ -1185,7 +1185,7 @@ class Image(object):
         if pol==self.pol_prim:
             imarr += flatarr
 
-        outim = Image(imarr, self.psize, self.ra, self.dec, 
+        outim = Image(imarr, self.psize, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1215,7 +1215,7 @@ class Image(object):
         """
 
         if pol is None: pol=self.pol_prim
-        if not (pol in list(self._imdict.keys())): 
+        if not (pol in list(self._imdict.keys())):
             raise Exception("for polrep==%s, pol must be in "%self.polrep + ",".join(list(self._imdict.keys())))
         if not len(self._imdict[pol]):
             raise Exception("no image for pol %s"%pol)
@@ -1230,13 +1230,13 @@ class Image(object):
 
         hatarr = hatarr[0:self.ydim, 0:self.xdim]
         hatarr *= flux / np.sum(hatarr)
-        
+
         # Add to the main image and create the new image object
         imarr = self.imvec.reshape(self.ydim, self.xdim).copy()
         if pol==self.pol_prim:
             imarr += hatarr
 
-        outim = Image(imarr, self.psize, self.ra, self.dec, 
+        outim = Image(imarr, self.psize, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1266,11 +1266,11 @@ class Image(object):
         """
 
         if pol is None: pol=self.pol_prim
-        if not (pol in list(self._imdict.keys())): 
+        if not (pol in list(self._imdict.keys())):
             raise Exception("for polrep==%s, pol must be in "%self.polrep + ",".join(list(self._imdict.keys())))
         if not len(self._imdict[pol]):
             raise Exception("no image for pol %s"%pol)
-        
+
         # Make a Gaussian image
         try:
             x=beamparams[3]
@@ -1300,7 +1300,7 @@ class Image(object):
         if pol==self.pol_prim:
             imarr += gaussarr
 
-        outim = Image(imarr, self.psize, self.ra, self.dec, 
+        outim = Image(imarr, self.psize, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1335,7 +1335,7 @@ class Image(object):
         """
 
         if pol is None: pol=self.pol_prim
-        if not (pol in list(self._imdict.keys())): 
+        if not (pol in list(self._imdict.keys())):
             raise Exception("for polrep==%s, pol must be in "%self.polrep + ",".join(list(self._imdict.keys())))
         if not len(self._imdict[pol]):
             raise Exception("no image for pol %s"%pol)
@@ -1360,7 +1360,7 @@ class Image(object):
         if pol==self.pol_prim:
             imarr += crescarr
 
-        outim = Image(imarr, self.psize, self.ra, self.dec, 
+        outim = Image(imarr, self.psize, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim,  time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1394,7 +1394,7 @@ class Image(object):
         """
 
         if pol is None: pol=self.pol_prim
-        if not (pol in list(self._imdict.keys())): 
+        if not (pol in list(self._imdict.keys())):
             raise Exception("for polrep==%s, pol must be in "%self.polrep + ",".join(list(self._imdict.keys())))
         if not len(self._imdict[pol]):
             raise Exception("no image for pol %s"%pol)
@@ -1428,7 +1428,7 @@ class Image(object):
         if pol==self.pol_prim:
             imarr += ringarr
 
-        outim = Image(imarr, self.psize, self.ra, self.dec, 
+        outim = Image(imarr, self.psize, self.ra, self.dec,
                       polrep=self.polrep, pol_prim=self.pol_prim, time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1477,7 +1477,7 @@ class Image(object):
 
         # create the new stokes image object
         iarr = ivec.reshape(im.ydim,im.xdim).copy()
-        outim = Image(iarr, self.psize, self.ra, self.dec, 
+        outim = Image(iarr, self.psize, self.ra, self.dec,
                       polrep='stokes', pol_prim='I', time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1524,7 +1524,7 @@ class Image(object):
 
         # create the new stokes image object
         iarr = ivec.reshape(im.ydim,im.xdim).copy()
-        outim = Image(iarr, self.psize, self.ra, self.dec, 
+        outim = Image(iarr, self.psize, self.ra, self.dec,
                       polrep='stokes', pol_prim='I', time=self.time,
                       rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -1533,7 +1533,7 @@ class Image(object):
         dist = 1.0 * 3.086e21
         rdiff = np.abs(corr) * dist / 1e3
         theta_mas = 0.37 * 1.0/rdiff * 1000. * 3600. * 180./np.pi
-        sm = so.ScatteringModel(scatt_alpha = 1.67, observer_screen_distance = dist, source_screen_distance = 1.e5 * dist, theta_maj_mas_ref = theta_mas, theta_min_mas_ref = theta_mas, r_in = rdiff*2, r_out = 1e30)        
+        sm = so.ScatteringModel(scatt_alpha = 1.67, observer_screen_distance = dist, source_screen_distance = 1.e5 * dist, theta_maj_mas_ref = theta_mas, theta_min_mas_ref = theta_mas, r_in = rdiff*2, r_out = 1e30)
         ep = so.MakeEpsilonScreen(im.xdim, im.ydim, rngseed = seed)
         ps = np.array(sm.MakePhaseScreen(ep, im, obs_frequency_Hz=29.979e9).imvec)/1000**(1.66/2)
         qvec = ivec * mag * np.sin(ps)
@@ -1545,7 +1545,7 @@ class Image(object):
             dist = 1.0 * 3.086e21
             rdiff = np.abs(ccorr) * dist / 1e3
             theta_mas = 0.37 * 1.0/rdiff * 1000. * 3600. * 180./np.pi
-            sm = so.ScatteringModel(scatt_alpha = 1.67, observer_screen_distance = dist, source_screen_distance = 1.e5 * dist, theta_maj_mas_ref = theta_mas, theta_min_mas_ref = theta_mas, r_in = rdiff*2, r_out = 1e30)        
+            sm = so.ScatteringModel(scatt_alpha = 1.67, observer_screen_distance = dist, source_screen_distance = 1.e5 * dist, theta_maj_mas_ref = theta_mas, theta_min_mas_ref = theta_mas, r_in = rdiff*2, r_out = 1e30)
             ep = so.MakeEpsilonScreen(im.xdim, im.ydim, rngseed = seed*2)
             ps = np.array(sm.MakePhaseScreen(ep, im, obs_frequency_Hz=29.979e9).imvec)/1000**(1.66/2)
             vvec = ivec * cmag * np.sin(ps)
@@ -1619,7 +1619,7 @@ class Image(object):
 
         # Extract uv datasample
         uv = recarr_to_ndarr(obsdata[['u','v']],'f8')
-        data = simobs.sample_vis(self, uv, sgrscat=sgrscat, polrep_obs=obs.polrep, 
+        data = simobs.sample_vis(self, uv, sgrscat=sgrscat, polrep_obs=obs.polrep,
                                        ttype=ttype, fft_pad_factor=fft_pad_factor)
 
         # put visibilities into the obsdata
@@ -1642,13 +1642,13 @@ class Image(object):
                                              source=self.source, mjd=self.mjd, polrep=obs.polrep,
                                              ampcal=True, phasecal=True, opacitycal=True, dcal=True, frcal=True,
                                              timetype=obs.timetype, scantable=obs.scans)
-        
+
         return obs_no_noise
 
     def observe_same(self, obs_in, ttype='nfft', fft_pad_factor=2,
                            sgrscat=False, add_th_noise=True,
                            opacitycal=True, ampcal=True, phasecal=True, dcal=True, frcal=True, rlgaincal=True,
-                           stabilize_scan_phase=False, stabilize_scan_amp=False, 
+                           stabilize_scan_phase=False, stabilize_scan_amp=False,
                            jones=False, inv_jones=False,
                            tau=TAUDEF, taup=GAINPDEF,
                            gain_offset=GAINPDEF, gainp=GAINPDEF,
@@ -1679,19 +1679,19 @@ class Image(object):
                gain_offset (float): the base gain offset at all sites, or a dict giving one gain offset per site
                taup (float): the fractional std. dev. of the random error on the opacities
                dterm_offset (float): the base dterm offset at all sites, or a dict giving one dterm offset per site
-               
+
                caltable_path (string): The path and prefix that a caltable is saved with if adding noise through a Jones matrix
                seed (int): seeds the random component of the noise terms. do not set to 0!
-               
+
            Returns:
                (Obsdata): an observation object
         """
 
         if seed!=False:
             np.random.seed(seed=seed)
-            
+
         obs = self.observe_same_nonoise(obs_in, sgrscat=sgrscat, ttype=ttype, fft_pad_factor=fft_pad_factor)
-        
+
         # Jones Matrix Corruption & Calibration
         if jones:
             obsdata = simobs.add_jones_and_noise(obs, add_th_noise=add_th_noise,
@@ -1700,10 +1700,10 @@ class Image(object):
                                                  stabilize_scan_phase=stabilize_scan_phase,
                                                  stabilize_scan_amp=stabilize_scan_amp,
                                                  gainp=gainp, taup=taup, gain_offset=gain_offset,
-                                                 dterm_offset=dterm_offset, 
+                                                 dterm_offset=dterm_offset,
                                                  caltable_path=caltable_path, seed=seed)
 
-            obs =  ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr, 
+            obs =  ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr,
                                          source=obs.source, mjd=obs.mjd, polrep=obs_in.polrep,
                                          ampcal=ampcal, phasecal=phasecal, opacitycal=opacitycal, dcal=dcal, frcal=frcal,
                                          timetype=obs.timetype, scantable=obs.scans)
@@ -1711,9 +1711,9 @@ class Image(object):
             if inv_jones:
                 obsdata = simobs.apply_jones_inverse(obs, opacitycal=opacitycal, dcal=dcal, frcal=frcal)
 
-                obs =  ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr, 
+                obs =  ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr,
                                              source=obs.source, mjd=obs.mjd, polrep=obs_in.polrep,
-                                             ampcal=ampcal, phasecal=phasecal, 
+                                             ampcal=ampcal, phasecal=phasecal,
                                              opacitycal=True, dcal=True, frcal=True,
                                              timetype=obs.timetype, scantable=obs.scans)
                                              #these are always set to True after inverse jones call
@@ -1722,15 +1722,15 @@ class Image(object):
         # No Jones Matrices, Add noise the old way
         # NOTE There is an asymmetry here - in the old way, we don't offer the ability to *not* unscale estimated noise.
         else:
-        
-            if caltable_path: 
+
+            if caltable_path:
                 print('WARNING: the caltable is currently only saved if you apply noise with a Jones Matrix')
-                
+
             obsdata = simobs.add_noise(obs, add_th_noise=add_th_noise,
                                        ampcal=ampcal, phasecal=phasecal, opacitycal=opacitycal,
                                        gainp=gainp, taup=taup, gain_offset=gain_offset, seed=seed)
 
-            obs =  ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr, 
+            obs =  ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr,
                                          source=obs.source, mjd=obs.mjd, polrep=obs_in.polrep,
                                          ampcal=ampcal, phasecal=phasecal, opacitycal=True, dcal=True, frcal=True,
                                          timetype=obs.timetype, scantable=obs.scans)
@@ -1744,7 +1744,7 @@ class Image(object):
                       ttype='nfft', fft_pad_factor=2,
                       fix_theta_GMST=False, sgrscat=False, add_th_noise=True,
                       opacitycal=True, ampcal=True, phasecal=True, dcal=True, frcal=True, rlgaincal=True,
-                      stabilize_scan_phase=False, stabilize_scan_amp=False, 
+                      stabilize_scan_phase=False, stabilize_scan_amp=False,
                       jones=False, inv_jones=False,
                       tau=TAUDEF, taup=GAINPDEF,
                       gainp=GAINPDEF, gain_offset=GAINPDEF,
@@ -1788,7 +1788,7 @@ class Image(object):
                taup (float): the fractional std. dev. of the random error on the opacities
                dterm_offset (float): the base dterm offset at all sites, or a dict giving one dterm offset per site
                seed (int): seeds the random component of noise added. do not set to 0!
-               
+
            Returns:
                (Obsdata): an observation object
         """
@@ -1805,7 +1805,7 @@ class Image(object):
                             tau=tau, timetype=timetype, elevmin=elevmin, elevmax=elevmax, fix_theta_GMST=fix_theta_GMST)
 
         # Observe on the same baselines as the empty observation and add noise
-        obs = self.observe_same(obs, ttype=ttype, fft_pad_factor=fft_pad_factor, 
+        obs = self.observe_same(obs, ttype=ttype, fft_pad_factor=fft_pad_factor,
                                      sgrscat=sgrscat, add_th_noise=add_th_noise,
                                      opacitycal=opacitycal,ampcal=ampcal,phasecal=phasecal,dcal=dcal,frcal=frcal, rlgaincal=rlgaincal,
                                      stabilize_scan_phase=stabilize_scan_phase,
@@ -1821,7 +1821,7 @@ class Image(object):
                           polrep_obs=None, ttype='nfft', fft_pad_factor=2,
                           sgrscat=False, add_th_noise=True,
                           opacitycal=True, ampcal=True, phasecal=True, frcal=True, dcal=True, rlgaincal=True,
-                          stabilize_scan_phase=False, stabilize_scan_amp=False, 
+                          stabilize_scan_phase=False, stabilize_scan_amp=False,
                           jones=False, inv_jones=False,
                           tau=TAUDEF, taup=GAINPDEF, gainp=GAINPDEF, gain_offset=GAINPDEF,
                           dterm_offset=DTERMPDEF):
@@ -2003,7 +2003,7 @@ class Image(object):
         for i in range(0, len(im_list)):
             (idx, _, im0_pad_orig, im_pad) = im0.find_shift(im_list[i], target_fov=2*max_fov, psize=psize,
                                                             scale=scale, gamma=gamma, dynamic_range=dynamic_range[i+1])
-            
+
             if i==0:
                 npix = int(im0_pad_orig.xdim/2)
                 im0_pad = im0_pad_orig.regrid_image(final_fov, npix)
@@ -2070,7 +2070,7 @@ class Image(object):
             im2_pad = im2_pad.blur_gauss(beamparams, blur_frac)
 
         # Rescale the image vectors into log or gamma scale
-        # TODO -- what about negative values? threshold?  
+        # TODO -- what about negative values? threshold?
         im1_pad_vec = im1_pad.imvec
         im2_pad_vec = im2_pad.imvec
         if scale=='log':
@@ -2145,7 +2145,7 @@ class Image(object):
                 #im_edges.imvec[mask] = 1
                 im_edges.imvec[~mask] = 0
                 edges = im_edges.imvec.reshape(self.ydim, self.xdim)
-        else: 
+        else:
             im_edges = im.copy()
             if not (thresh is None):
                 thresh_val = thresh*np.max(im_edges.imvec)
@@ -2312,24 +2312,24 @@ class Image(object):
         image = self.copy()
 
         #or some generalized version for image sizes
-        y = np.linspace(0, image.ydim, image.ydim) 
-        x = np.linspace(0, image.xdim, image.xdim) 
-        
+        y = np.linspace(0, image.ydim, image.ydim)
+        x = np.linspace(0, image.xdim, image.xdim)
+
 
         #make the image grid
         z = image.imvec.reshape((image.ydim ,image.xdim ))
         maxz = max(image.imvec)
         ax = plt.gca()
-        
+
         if show_im:
             image.display(cfun=cfun,scale=scale, interp=interp, gamma=gamma, dynamic_range=dynamic_range,
                       plotp=plotp, nvec=nvec, pcut=pcut, label_type=label_type, has_title=has_title,
                       has_cbar=has_cbar, cbar_lims=cbar_lims, cbar_unit=cbar_unit, beamparams=beamparams, cbar_orientation=cbar_orientation)
         else:
-            image.imvec = 0.0*image.imvec  
+            image.imvec = 0.0*image.imvec
             image.display(cfun='afmhot',scale=scale, interp=interp, gamma=gamma, dynamic_range=dynamic_range,
                       plotp=plotp, nvec=nvec, pcut=pcut, label_type=label_type, has_title=has_title,
-                      has_cbar=False, cbar_lims=(0,10000), cbar_unit=cbar_unit, beamparams=beamparams) 
+                      has_cbar=False, cbar_lims=(0,10000), cbar_unit=cbar_unit, beamparams=beamparams)
 
         ax = plt.gcf()
 
@@ -2337,7 +2337,7 @@ class Image(object):
         for level in contour_levels:
             rgbval = contour_cfun(count/len(contour_levels))
             rgbstring = '#%02x%02x%02x' % (rgbval[0]*256, rgbval[1]*256, rgbval[2]*256)
-            cs = plt.contour(x,y,z, levels=[level*maxz],colors=rgbstring, cmap=None ) 
+            cs = plt.contour(x,y,z, levels=[level*maxz],colors=rgbstring, cmap=None )
             count += 1
             cs.collections[0].set_label(str(int(level*100)) + '%')
         if legend:
@@ -2345,17 +2345,17 @@ class Image(object):
 
         if show:
             plt.ion()
-            plt.show(block=False)           
+            plt.show(block=False)
 
         if export_pdf != "":
             ax.savefig(export_pdf, bbox_inches='tight', pad_inches = 0)
-        
+
         return ax
 
 
-    def display(self, pol=None, cfun='afmhot', interp='gaussian', 
+    def display(self, pol=None, cfun='afmhot', interp='gaussian',
                       scale='lin',gamma=0.5, dynamic_range=1.e3,
-                      plotp=False, nvec=20, pcut=0.1, 
+                      plotp=False, nvec=20, pcut=0.1,
                       label_type='ticks', has_title=True,
                       has_cbar=True, only_cbar=False, cbar_lims=(), cbar_unit = ('Jy', 'pixel'),
                       export_pdf="", pdf_pad_inches=0.0, show=True, beamparams=None, cbar_orientation="vertical"):
@@ -2406,7 +2406,7 @@ class Image(object):
             has_cbar = True
             label_type = 'none'
             has_title = False
-        
+
         f = plt.figure()
         plt.clf()
 
@@ -2459,7 +2459,7 @@ class Image(object):
             try:
                 imvec = np.array(self._imdict[pol]).reshape(-1)
             except KeyError:
-                try: 
+                try:
                     if self.polrep=='stokes': im2 = self.switch_polrep('circ')
                     elif self.polrep=='circ': im2 = self.switch_polrep('stokes')
                     imvec = np.array(im2._imdict[pol]).reshape(-1)
@@ -2472,7 +2472,7 @@ class Image(object):
 
             imvec = imvec * factor
             imarr = imvec.reshape(self.ydim, self.xdim)
-            unit = fluxunit 
+            unit = fluxunit
             if areaunit != '':
                 unit += ' / ' + areaunit
 
@@ -2503,14 +2503,14 @@ class Image(object):
                 im = plt.imshow(imarr, cmap=plt.get_cmap(cfun), interpolation=interp)
 
             if not(beamparams is None or (beamparams==False).any()):
-                beamparams = [beamparams[0], beamparams[1], beamparams[2], 
+                beamparams = [beamparams[0], beamparams[1], beamparams[2],
                               -.35*self.fovx(), -.35*self.fovy()]
                 beamimage = self.copy()
                 beamimage.imvec *= 0
                 beamimage = beamimage.add_gauss(1, beamparams)
                 halflevel = 0.5*np.max(beamimage.imvec)
-                beamimarr = (beamimage.imvec).reshape(beamimage.ydim,beamimage.xdim)   
-                plt.contour(beamimarr, levels=[halflevel], colors='w', linewidths=1) 
+                beamimarr = (beamimage.imvec).reshape(beamimage.ydim,beamimage.xdim)
+                plt.contour(beamimarr, levels=[halflevel], colors='w', linewidths=1)
 
             if has_cbar:
                 if only_cbar: im.set_visible(False)
@@ -2643,20 +2643,20 @@ class Image(object):
                    width=.005*self.xdim, units='x', pivot='mid', color='w', angles='uv', scale=1.1/thin)
 
             if not(beamparams is None or beamparams==False):
-                beamparams = [beamparams[0], beamparams[1], beamparams[2], 
+                beamparams = [beamparams[0], beamparams[1], beamparams[2],
                               -.35*self.fovx(), -.35*self.fovy()]
                 beamimage = self.copy()
                 beamimage.imvec *= 0
                 beamimage = beamimage.add_gauss(1, beamparams)
                 halflevel = 0.5*np.max(beamimage.imvec)
-                beamimarr = (beamimage.imvec).reshape(beamimage.ydim,beamimage.xdim)   
+                beamimarr = (beamimage.imvec).reshape(beamimage.ydim,beamimage.xdim)
                 plt.contour(beamimarr, levels=[halflevel], colors='w', linewidths=1)
 
             if has_cbar:
                 plt.colorbar(im, fraction=0.046, pad=0.04, label=unit, orientation=cbar_orientation)
                 if cbar_lims:
                     plt.clim(cbar_lims[0],cbar_lims[1])
-            if has_title: 
+            if has_title:
                 plt.title("%s %.2f GHz %s" % (self.source, self.rf/1e9, 'I'), fontsize=12)
             f.subplots_adjust(hspace=-.5,wspace=0.1)
 
@@ -2704,7 +2704,7 @@ class Image(object):
                               shift=[0,0], final_fov=False,
                               scale='lin', gamma=0.5, dynamic_range=[1.e3]):
 
-        """Overlay primary polarization images of a list of images to compare structures.  
+        """Overlay primary polarization images of a list of images to compare structures.
 
            Args:
                im_list (list): list of images to align to the current image
@@ -2834,7 +2834,7 @@ def make_square(obs, npix, fov, pulse=PULSE_DEFAULT, polrep='stokes', pol_prim=N
            pulse (function): the function convolved with the pixel values for continuous image
 
            polrep (str): polarization representation, either 'stokes' or 'circ'
-           pol_prim (str): The default image: I,Q,U or V for Stokes, or RR,LL,LR,RL for Circular              
+           pol_prim (str): The default image: I,Q,U or V for Stokes, or RR,LL,LR,RL for Circular
        Returns:
            (Image): an image object
     """
@@ -2846,8 +2846,8 @@ def make_square(obs, npix, fov, pulse=PULSE_DEFAULT, polrep='stokes', pol_prim=N
     return outim
 
 
-def make_empty(npix, fov, ra, dec, rf=RF_DEFAULT,source=SOURCE_DEFAULT, 
-               polrep='stokes', pol_prim=None,pulse=PULSE_DEFAULT, 
+def make_empty(npix, fov, ra, dec, rf=RF_DEFAULT,source=SOURCE_DEFAULT,
+               polrep='stokes', pol_prim=None,pulse=PULSE_DEFAULT,
                mjd=MJD_DEFAULT, time=0.):
 
     """Make an empty square image.
@@ -2861,7 +2861,7 @@ def make_empty(npix, fov, ra, dec, rf=RF_DEFAULT,source=SOURCE_DEFAULT,
 
            source (str): The source name
            polrep (str): polarization representation, either 'stokes' or 'circ'
-           pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular              
+           pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular
            pulse (function): The function convolved with the pixel values for continuous image.
 
            mjd (int): The integer MJD of the image
@@ -2874,7 +2874,7 @@ def make_empty(npix, fov, ra, dec, rf=RF_DEFAULT,source=SOURCE_DEFAULT,
     pdim = fov/float(npix)
     npix = int(npix)
     imarr = np.zeros((npix,npix))
-    outim = Image(imarr, pdim, ra, dec, 
+    outim = Image(imarr, pdim, ra, dec,
                   polrep=polrep, pol_prim=pol_prim,
                   rf=rf, source=source, mjd=mjd, time=time, pulse=pulse)
     return outim
@@ -2895,23 +2895,23 @@ def load_image(image, display=False, aipscc=False):
     """
 
     if type(image) == type("str"):
-      if image.endswith('.fits'):  
+      if image.endswith('.fits'):
         im = ehtim.io.load.load_im_fits(image, aipscc=aipscc)
-      elif image.endswith('.txt'):   
+      elif image.endswith('.txt'):
         im = ehtim.io.load.load_im_txt(image)
       else:
         print("Image format is not recognized. Was expecting .fits, .txt, or Image. Got <.{0}>. Returning False.".format(image.split('.')[-1]))
         return False
 
 
-    elif isinstance(image, ehtim.image.Image): 
+    elif isinstance(image, ehtim.image.Image):
       im = image
 
-    else: 
+    else:
       print("Image format is not recognized. Was expecting .fits, .txt, or Image. Got {0}. Returning False.".format(type(image)))
       return False
 
-    if display: 
+    if display:
       im.display()
 
     return im
@@ -2925,7 +2925,7 @@ def load_txt(fname, polrep='stokes', pol_prim=None, pulse=PULSE_DEFAULT, zero_po
             fname (str): path to input text file
             pulse (function): The function convolved with the pixel values for continuous image.
             polrep (str): polarization representation, either 'stokes' or 'circ'
-            pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular              
+            pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular
             zero_pol (bool): If True, loads any missing polarizations as zeros
 
        Returns:
@@ -2934,17 +2934,17 @@ def load_txt(fname, polrep='stokes', pol_prim=None, pulse=PULSE_DEFAULT, zero_po
 
     return ehtim.io.load.load_im_txt(fname, pulse=pulse, polrep=polrep, pol_prim=pol_prim, zero_pol=True)
 
-def load_fits(fname, aipscc=False, pulse=PULSE_DEFAULT, 
+def load_fits(fname, aipscc=False, pulse=PULSE_DEFAULT,
               polrep='stokes', pol_prim=None,  zero_pol=False):
 
     """Read in an image from a FITS file.
 
        Args:
            fname (str): path to input fits file
-           aipscc (bool): if True, then AIPS CC table will be loaded 
+           aipscc (bool): if True, then AIPS CC table will be loaded
            pulse (function): The function convolved with the pixel values for continuous image.
-           polrep (str): polarization representation, either 'stokes' or 'circ'          
-           pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular              
+           polrep (str): polarization representation, either 'stokes' or 'circ'
+           pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular
            zero_pol (bool): If True, loads any missing polarizations as zeros
 
        Returns:

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -60,7 +60,7 @@ POL_SOLVE = (0,1,1) # this means that pol imaging solves for m & chi (not I), fo
 #TODO -- pol_next tracks polarization of next image to make
 #     -- checks on the polrep of the prior & init --> exception to switch if necessary
 #     -- warnings not to use log transform if imaging V, Q, U, warnings that  RL & LR  have to wait for pol
-#     -- get data terms corresponding to  right pols 
+#     -- get data terms corresponding to  right pols
 
 ###########################################################################################################################################
 #Imager object
@@ -169,9 +169,9 @@ class Imager(object):
         """Make an image using current imager settings.
         """
 
-        if pol is None: 
+        if pol is None:
             pol_prim = self.pol_next
-        else: 
+        else:
             self.pol_next = pol
             pol_prim = pol
 
@@ -220,7 +220,7 @@ class Imager(object):
             if self.transform_next == 'mcv':
                 out = mcv(out)
 
-        elif self.transform_next == 'log': 
+        elif self.transform_next == 'log':
             out = np.exp(out)
 
         # Print final stats
@@ -237,24 +237,24 @@ class Imager(object):
 
         # embed image
         if self.pol_next=='P':
-            if np.any(np.invert(self._embed_mask)): 
+            if np.any(np.invert(self._embed_mask)):
                 out = embed_pol(out, self._embed_mask)
             iimage_out = out[0]
             qimage_out = make_q_image(out, POL_PRIM)
             uimage_out = make_u_image(out, POL_PRIM)
 
         else:
-            if np.any(np.invert(self._embed_mask)): 
+            if np.any(np.invert(self._embed_mask)):
                 out = embed(out, self._embed_mask)
             iimage_out = out
 
 
         # return image
         outim = image.Image(iimage_out.reshape(self.prior_next.ydim, self.prior_next.xdim),
-                            self.prior_next.psize, 
+                            self.prior_next.psize,
                             self.prior_next.ra, self.prior_next.dec,
                             rf=self.prior_next.rf, source=self.prior_next.source,
-                            polrep=self.prior_next.polrep, pol_prim=pol_prim, 
+                            polrep=self.prior_next.polrep, pol_prim=pol_prim,
                             mjd=self.prior_next.mjd, time=self.prior_next.time,
                             pulse=self.prior_next.pulse)
 
@@ -262,7 +262,7 @@ class Imager(object):
         # copy over other polarizations
         for pol2 in list(outim._imdict.keys()):
 
-            # Is it the base image? 
+            # Is it the base image?
             if pol2==outim.pol_prim: continue
 
             # Did we solve for polarimeric image or are we copying over old pols?
@@ -334,7 +334,7 @@ class Imager(object):
         if self._ttype not in ['fast','direct','nfft']:
             raise Exception("Possible ttype values are 'fast', 'direct','nfft'!")
 
-        if(self.pol_next in ['Q','U','V'] and 
+        if(self.pol_next in ['Q','U','V'] and
           ('gs' in self.reg_term_next.keys() or 'simple' in self.reg_term_next.keys())):
             raise Exception("'simple' and 'gs' MEM methods do not work with potentially negative Stokes Q, U, or V images!")
 
@@ -653,9 +653,9 @@ class Imager(object):
             self._inittuple = np.array((self._iinit, init1, init2))
 
             # change of variables
-            if self.transform_next == 'mcv': 
+            if self.transform_next == 'mcv':
                 self._xtuple =  mcv_r(self._inittuple)
-            else: 
+            else:
                 raise Exception("Polarimetric imaging only works with transform_next='mcv'")
 
             # pack into single vector
@@ -670,7 +670,7 @@ class Imager(object):
                 self._ninit = self.init_next.imvec[self._embed_mask]
 
             # change of variables
-            if self.transform_next == 'log': 
+            if self.transform_next == 'log':
                 self._xinit = np.log(self._ninit)
             else: self._xinit = self._ninit
 
@@ -739,11 +739,11 @@ class Imager(object):
             A = self._data_tuples[dname][2]
 
             if self.pol_next=='P':
-                chi2 = polchisq(imcur, A, data, sigma, dname, 
-                                ttype=self._ttype, mask=self._embed_mask, 
+                chi2 = polchisq(imcur, A, data, sigma, dname,
+                                ttype=self._ttype, mask=self._embed_mask,
                                 pol_prim=POL_PRIM)
             else:
-                chi2 = chisq(imcur, A, data, sigma, dname, 
+                chi2 = chisq(imcur, A, data, sigma, dname,
                              ttype=self._ttype, mask=self._embed_mask)
             chi2_dict[dname] = chi2
 
@@ -759,7 +759,7 @@ class Imager(object):
             A = self._data_tuples[dname][2]
 
             if self.pol_next=='P':
-                chi2grad = polchisqgrad(imcur, A, data, sigma, dname, 
+                chi2grad = polchisqgrad(imcur, A, data, sigma, dname,
                                         ttype=self._ttype, mask=self._embed_mask,
                                         pol_prim=POL_PRIM, pol_solve=POL_SOLVE)
             else:
@@ -776,7 +776,7 @@ class Imager(object):
         reg_dict = {}
         for regname in sorted(self.reg_term_next.keys()):
             if self.pol_next=='P':
-                reg = polregularizer(imcur, self._embed_mask,  
+                reg = polregularizer(imcur, self._embed_mask,
                                      self.prior_next.xdim, self.prior_next.ydim,
                                      self.prior_next.psize, regname,
                                      pol_prim=POL_PRIM
@@ -799,7 +799,7 @@ class Imager(object):
         for regname in sorted(self.reg_term_next.keys()):
 
             if self.pol_next=='P':
-                reg = polregularizergrad(imcur, self._embed_mask,  
+                reg = polregularizergrad(imcur, self._embed_mask,
                                      self.prior_next.xdim, self.prior_next.ydim,
                                      self.prior_next.psize, regname,
                                      pol_prim=POL_PRIM, pol_solve=POL_SOLVE
@@ -828,7 +828,7 @@ class Imager(object):
         if self.transform_next == 'log':
             imcur = np.exp(imcur)
         elif self.transform_next== 'mcv':
-            imcur = mcv(imcur)            
+            imcur = mcv(imcur)
 
         # data terms
         datterm = 0.
@@ -862,7 +862,7 @@ class Imager(object):
             imcur = np.exp(imcur)
         elif self.transform_next== 'mcv':
             cvcur = imcur.copy()
-            imcur = mcv(imcur)            
+            imcur = mcv(imcur)
 
         datterm = 0.
         chi2_term_dict = self.make_chisqgrad_dict(imcur)
@@ -907,7 +907,7 @@ class Imager(object):
                 if self.transform_next == 'log':
                     imcur = np.exp(imcur)
                 elif self.transform_next == "mcv":
-                    imcur = mcv(imcur) 
+                    imcur = mcv(imcur)
 
                 # get chi^2 and regularizer
                 chi2_term_dict = self.make_chisq_dict(imcur)
@@ -935,11 +935,11 @@ class Imager(object):
                 # embed and plot
                 if self.pol_next=='P':
                     if np.any(np.invert(self._embed_mask)):
-                        imcur = embed_pol(imcur, self._embed_mask) 
+                        imcur = embed_pol(imcur, self._embed_mask)
                     plot_m(imcur, self.prior_next, self._nit, chi2_term_dict, **kwargs)
 
                 else:
-                    if np.any(np.invert(self._embed_mask)): 
+                    if np.any(np.invert(self._embed_mask)):
                         imcur = embed(imcur, self._embed_mask)
 
                     plot_i(imcur, self.prior_next, self._nit, chi2_term_dict, pol=self.pol_next, **kwargs)
@@ -1036,7 +1036,7 @@ class Imager(object):
         reg_term_dict_scatt = self.make_reggrad_dict(scatt_im)
 
         for regname in sorted(self.reg_term_next.keys()):
-            #we need an exception if the regularizer is 'rgauss' 
+            #we need an exception if the regularizer is 'rgauss'
             if regname == 'rgauss':
                 #get gradient of the scattered image vector
                 gaussterm = self.reg_term_next[regname] * reg_term_dict_scatt[regname]
@@ -1046,7 +1046,7 @@ class Imager(object):
                 gx = (rF**2.0 * so.Wrapped_Convolve(self._ea_ker_gradient_x[::-1,::-1], phi_Gradient_x * (dgauss_dIa))).flatten()
                 gy = (rF**2.0 * so.Wrapped_Convolve(self._ea_ker_gradient_y[::-1,::-1], phi_Gradient_y * (dgauss_dIa))).flatten()
 
-                # Now we add the gradient for the unscattered image 
+                # Now we add the gradient for the unscattered image
                 regterm += so.Wrapped_Convolve(self._ea_ker[::-1,::-1], (dgauss_dIa)).flatten() + gx + gy
 
             else:

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -250,9 +250,8 @@ class Imager(object):
 
 
         # return image
-        outim = image.Image(iimage_out.reshape(self.prior_next.ydim, self.prior_next.xdim),
-                            self.prior_next.psize,
-                            self.prior_next.ra, self.prior_next.dec,
+        outim = image.Image(iimage_out.reshape(self.prior_next.ydim, self.prior_next.xdim), self.prior_next.psize,
+                            self.prior_next.ra, self.prior_next.dec, self.prior_next.pa,
                             rf=self.prior_next.rf, source=self.prior_next.source,
                             polrep=self.prior_next.polrep, pol_prim=pol_prim,
                             mjd=self.prior_next.mjd, time=self.prior_next.time,
@@ -959,9 +958,9 @@ class Imager(object):
         if self.transform_next == 'log':
             imvec = np.exp(imvec)
 
-        IM = ehtim.image.Image(imvec.reshape(N,N), self.prior_next.psize, self.prior_next.ra,
-                               self.prior_next.dec, rf=self.obs_next.rf,
-                               source=self.prior_next.source, mjd=self.prior_next.mjd)
+        IM = ehtim.image.Image(imvec.reshape(N,N), self.prior_next.psize,
+                               self.prior_next.ra, self.prior_next.dec, self.prior_next.pa,
+                               rf=self.obs_next.rf, source=self.prior_next.source, mjd=self.prior_next.mjd)
 
         #the scattered image vector
         scatt_im = self.scattering_model.Scatter(IM, Epsilon_Screen=so.MakeEpsilonScreenFromList(EpsilonList, N),
@@ -1009,9 +1008,9 @@ class Imager(object):
         if self.transform_next == 'log':
             imvec = np.exp(imvec)
 
-        IM = ehtim.image.Image(imvec.reshape(N,N), self.prior_next.psize, self.prior_next.ra,
-                               self.prior_next.dec, rf=self.obs_next.rf, source=self.prior_next.source,
-                               mjd=self.prior_next.mjd)
+        IM = ehtim.image.Image(imvec.reshape(N,N), self.prior_next.psize,
+                               self.prior_next.ra, self.prior_next.dec, self.prior_next.pa,
+                               rf=self.obs_next.rf, source=self.prior_next.source, mjd=self.prior_next.mjd)
         #the scattered image vector
         scatt_im = self.scattering_model.Scatter(IM, Epsilon_Screen=so.MakeEpsilonScreenFromList(EpsilonList, N),
                                                  ea_ker = self._ea_ker, sqrtQ=self._sqrtQ,
@@ -1131,9 +1130,9 @@ class Imager(object):
                 if self.transform_next == 'log':
                     imvec = np.exp(imvec)
 
-                IM = ehtim.image.Image(imvec.reshape(N,N), self.prior_next.psize, self.prior_next.ra,
-                                       self.prior_next.dec, rf=self.obs_next.rf,
-                                       source=self.prior_next.source, mjd=self.prior_next.mjd)
+                IM = ehtim.image.Image(imvec.reshape(N,N), self.prior_next.psize,
+                                       self.prior_next.ra, self.prior_next.dec, self.prior_next.pa,
+                                       rf=self.obs_next.rf, source=self.prior_next.source, mjd=self.prior_next.mjd)
                 #the scattered image vector
                 scatt_im = self.scattering_model.Scatter(IM, Epsilon_Screen=so.MakeEpsilonScreenFromList(EpsilonList, N),
                                                          ea_ker = self._ea_ker, sqrtQ=self._sqrtQ, Linearized_Approximation=True).imvec
@@ -1210,10 +1209,9 @@ class Imager(object):
             raise Exception("Embedding is not currently implemented!")
             out = embed(out, self._embed_mask)
 
-        outim = image.Image(out.reshape(N, N),
-                            self.prior_next.psize, self.prior_next.ra, self.prior_next.dec,
-                            rf=self.prior_next.rf, source=self.prior_next.source,
-                            mjd=self.prior_next.mjd, pulse=self.prior_next.pulse)
+        outim = image.Image(out.reshape(N, N), self.prior_next.psize,
+                            self.prior_next.ra, self.prior_next.dec, self.prior_next.pa,
+                            rf=self.prior_next.rf, source=self.prior_next.source, mjd=self.prior_next.mjd, pulse=self.prior_next.pulse)
         outep = res.x[N**2:]
         outscatt = self.scattering_model.Scatter(outim, Epsilon_Screen=so.MakeEpsilonScreenFromList(outep, N),
                                                  ea_ker = self._ea_ker, sqrtQ=self._sqrtQ,

--- a/ehtim/movie.py
+++ b/ehtim/movie.py
@@ -670,7 +670,7 @@ class Movie(object):
         return outim
 
 
-    def observe_same_nonoise(self, obs, sgrscat=False, ttype="nfft", fft_pad_factor=2, repeat=False):
+    def observe_same_nonoise(self, obs, sgrscat=False, ttype="nfft", cache=False, fft_pad_factor=2, repeat=False):
         """Observe the movie on the same baselines as an existing observation object without adding noise.
 
            Args:
@@ -727,7 +727,7 @@ class Movie(object):
             uv = recarr_to_ndarr(obsdata[['u','v']],'f8')
             im = self.get_frame(n)
             data = simobs.sample_vis(im, uv, sgrscat=sgrscat, polrep_obs=obs.polrep,
-                                        ttype=ttype, fft_pad_factor=fft_pad_factor, zero_empty_pol=True)
+                                        ttype=ttype, cache=cache, fft_pad_factor=fft_pad_factor, zero_empty_pol=True)
 
             # Put visibilities into the obsdata
             if obs.polrep=='stokes':

--- a/ehtim/movie.py
+++ b/ehtim/movie.py
@@ -670,7 +670,7 @@ class Movie(object):
         return outim
 
 
-    def observe_same_nonoise(self, obs, sgrscat=False, ttype="nfft", cache=False, fft_pad_factor=2, repeat=False):
+    def observe_same_nonoise(self, obs, sgrscat=False, ttype="nfft", fft_pad_factor=2, repeat=False):
         """Observe the movie on the same baselines as an existing observation object without adding noise.
 
            Args:
@@ -727,7 +727,7 @@ class Movie(object):
             uv = recarr_to_ndarr(obsdata[['u','v']],'f8')
             im = self.get_frame(n)
             data = simobs.sample_vis(im, uv, sgrscat=sgrscat, polrep_obs=obs.polrep,
-                                        ttype=ttype, cache=cache, fft_pad_factor=fft_pad_factor, zero_empty_pol=True)
+                                         ttype=ttype, fft_pad_factor=fft_pad_factor, zero_empty_pol=True)
 
             # Put visibilities into the obsdata
             if obs.polrep=='stokes':

--- a/ehtim/movie.py
+++ b/ehtim/movie.py
@@ -61,7 +61,7 @@ class Movie(object):
 
     def __init__(self, movie, framedur, psize, ra, dec, rf=RF_DEFAULT,
                        polrep='stokes', pol_prim=None,
-                       pulse=PULSE_DEFAULT, source=SOURCE_DEFAULT, 
+                       pulse=PULSE_DEFAULT, source=SOURCE_DEFAULT,
                        mjd=MJD_DEFAULT, start_hr=0.0):
 
         """A polarimetric image (in units of Jy/pixel).
@@ -74,7 +74,7 @@ class Movie(object):
                dec (float): The source declination in fractional degrees
                rf (float): The image frequency in Hz
                polrep (str): polarization representation, either 'stokes' or 'circ'
-               pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular              
+               pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular
                pulse (function): The function convolved with the pixel values for continuous image.
                source (str): The source name
                mjd (int): The integer MJD of the image
@@ -104,7 +104,7 @@ class Movie(object):
                 raise Exception("for polrep=='stokes', pol_prim must be 'I','Q','U', or 'V'!")
 
         elif polrep=='circ':
-            if pol_prim is None: 
+            if pol_prim is None:
                 print("polrep is 'circ' and no pol_prim specified! Setting pol_prim='RR'")
                 pol_prim = 'RR'
             if pol_prim=='RR':
@@ -146,7 +146,7 @@ class Movie(object):
             raise Exception("imvec size is not consistent with xdim*ydim!")
         #TODO -- more checks on consistency with the existing pol data???
 
-        self._movdict[self.pol_prim] =  frames        
+        self._movdict[self.pol_prim] =  frames
 
     @property
     def iframes(self):
@@ -164,7 +164,7 @@ class Movie(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._movdict['I'] =  frames     
+        self._movdict['I'] =  frames
 
     @property
     def qframes(self):
@@ -182,7 +182,7 @@ class Movie(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._movdict['Q'] =  frames     
+        self._movdict['Q'] =  frames
 
     @property
     def uframes(self):
@@ -200,8 +200,8 @@ class Movie(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._movdict['U'] =  frames     
-   
+        self._movdict['U'] =  frames
+
     @property
     def vframes(self):
 
@@ -218,7 +218,7 @@ class Movie(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._movdict['V'] =  frames     
+        self._movdict['V'] =  frames
 
     @property
     def rrframes(self):
@@ -236,7 +236,7 @@ class Movie(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._movdict['RR'] =  frames     
+        self._movdict['RR'] =  frames
 
     @property
     def llframes(self):
@@ -254,7 +254,7 @@ class Movie(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._movdict['LL'] =  frames     
+        self._movdict['LL'] =  frames
 
     @property
     def rlvec(self):
@@ -272,7 +272,7 @@ class Movie(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._movdict['RL'] =  frames     
+        self._movdict['RL'] =  frames
 
     @property
     def lrvec(self):
@@ -290,7 +290,7 @@ class Movie(object):
             raise Exception("vec size is not consistent with xdim*ydim!")
 
         #TODO -- more checks on the consistency of the imvec with the existing pol data???
-        self._movdict['LR'] =  frames     
+        self._movdict['LR'] =  frames
 
     def copy(self):
 
@@ -303,8 +303,8 @@ class Movie(object):
         """
 
         # Make new  movie with primary polarization
-        newmov = Movie([imvec.reshape(self.ydim,self.xdim) for imvec in self.frames], 
-                       self.framedur, self.psize, self.ra, self.dec, 
+        newmov = Movie([imvec.reshape(self.ydim,self.xdim) for imvec in self.frames],
+                       self.framedur, self.psize, self.ra, self.dec,
                        polrep=self.polrep, pol_prim=self.pol_prim, start_hr=self.start_hr,
                        rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -333,7 +333,7 @@ class Movie(object):
             raise Exception("new pol in add_pol_movie is the same as pol_prim!")
         if np.any(np.array([image.shape != (self.ydim, self.xdim) for image in movie])):
             raise Exception("add_pol_movie image shapes incompatible with primary image!")
-        if not (pol in list(self._movdict.keys())): 
+        if not (pol in list(self._movdict.keys())):
             raise Exception("for polrep==%s, pol in add_pol_movie must be in "%self.polrep + ",".join(list(self._movdict.keys())))
 
         if self.polrep=='stokes':
@@ -391,7 +391,7 @@ class Movie(object):
         """Return a new movie with the polarization representation changed
            Args:
                polrep_out (str):  the polrep of the output data
-               pol_prim_out (str): The default movie: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular              
+               pol_prim_out (str): The default movie: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular
 
            Returns:
                (Movie): new movie object with potentially different polrep
@@ -399,7 +399,7 @@ class Movie(object):
 
         if polrep_out not in ['stokes','circ']:
             raise Exception("polrep_out must be either 'stokes' or 'circ'")
-        if pol_prim_out is None: 
+        if pol_prim_out is None:
             if polrep_out=='stokes': pol_prim_out = 'I'
             elif polrep_out=='circ': pol_prim_out = 'RR'
 
@@ -408,7 +408,7 @@ class Movie(object):
             return self.copy()
 
         # Assemble a dictionary of new polarization vectors
-        if polrep_out=='stokes':                 
+        if polrep_out=='stokes':
             if self.polrep=='stokes':
                 movdict = {'I':self.iframes,'Q':self.qframes,'U':self.uframes,'V':self.vframes}
             else:
@@ -431,7 +431,7 @@ class Movie(object):
         elif polrep_out=='circ':
             if self.polrep=='circ':
                 movdict = {'RR':self.rrframes,'LL':self.llframes,'RL':self.rlframes,'LR':self.lrframes}
-            else:   
+            else:
                 if len(self.iframes)==0 or len(self.vframes)==0:
                     rrframes = []
                     llframes = []
@@ -454,8 +454,8 @@ class Movie(object):
             raise Exception("for switch_polrep to %s with pol_prim_out=%s, \n"%(polrep_out,pol_prim_out) +
                             "output movie is not defined")
 
-        newmov = Movie(frames, 
-                       self.framedur, self.psize, self.ra, self.dec, 
+        newmov = Movie(frames,
+                       self.framedur, self.psize, self.ra, self.dec,
                        polrep=polrep_out, pol_prim=pol_prim_out, start_hr=self.start_hr,
                        rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -584,12 +584,12 @@ class Movie(object):
         """Return the (signed) total fractional circular polarized flux over time
 
            Args:
-                
+
            Returns:
                 (numpy.ndarray) : image fractional circular polarized flux per frame
         """
         if self.polrep=='stokes':
-            frac = [np.sum(self.vframes[i]) / np.abs(np.sum(self.iframes[i])) 
+            frac = [np.sum(self.vframes[i]) / np.abs(np.sum(self.iframes[i]))
                     for i in range(self.nframes)]
         elif self.polrep=='circ':
             frac = [np.sum(self.rrframes[i]-self.llframes[i]) / np.abs(np.sum(self.rrframes[i] + self.llframes[i]))
@@ -603,7 +603,7 @@ class Movie(object):
 
            Args:
                n (int): the frame number
-           
+
            Returns:
                (Image): the Image object of the nth frame
         """
@@ -615,7 +615,7 @@ class Movie(object):
 
         # Make the primary image
         imarr = self.frames[n].reshape(self.ydim, self.xdim)
-        outim = ehtim.image.Image(imarr, self.psize, self.ra, self.dec, 
+        outim = ehtim.image.Image(imarr, self.psize, self.ra, self.dec,
                                     polrep=self.polrep, pol_prim=self.pol_prim, time=time,
                                     rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -635,7 +635,7 @@ class Movie(object):
         """Return a list of the movie frames
 
            Args:
-           
+
            Returns:
                (list): list of Image objects
         """
@@ -654,7 +654,7 @@ class Movie(object):
         # Make the primary image
         avg_imvec = np.mean(np.array(self.frames),axis=0)
         avg_imarr = avg_imvec.reshape(self.ydim, self.xdim)
-        outim = ehtim.image.Image(avg_imarr, self.psize, self.ra, self.dec, 
+        outim = ehtim.image.Image(avg_imarr, self.psize, self.ra, self.dec,
                                   polrep=self.polrep, pol_prim=self.pol_prim, time=self.start_hr,
                                   rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -724,11 +724,11 @@ class Movie(object):
 
 
             # Get the frame visibilities
-            uv = recarr_to_ndarr(obsdata[['u','v']],'f8')        
-            im = self.get_frame(n) 
-            data = simobs.sample_vis(im, uv, sgrscat=sgrscat, polrep_obs=obs.polrep, 
+            uv = recarr_to_ndarr(obsdata[['u','v']],'f8')
+            im = self.get_frame(n)
+            data = simobs.sample_vis(im, uv, sgrscat=sgrscat, polrep_obs=obs.polrep,
                                         ttype=ttype, fft_pad_factor=fft_pad_factor, zero_empty_pol=True)
-            
+
             # Put visibilities into the obsdata
             if obs.polrep=='stokes':
                 obsdata['vis'] = data[0]
@@ -762,10 +762,10 @@ class Movie(object):
     def observe_same(self, obs_in, ttype='direct', fft_pad_factor=2,  repeat=False,
                            sgrscat=False, add_th_noise=True,
                            opacitycal=True, ampcal=True, phasecal=True, frcal=True,dcal=True,
-                           stabilize_scan_phase=False, stabilize_scan_amp=False, 
+                           stabilize_scan_phase=False, stabilize_scan_amp=False,
                            jones=False, inv_jones=False,
                            tau=TAUDEF, taup=GAINPDEF,
-                           gainp=GAINPDEF, gain_offset=GAINPDEF, 
+                           gainp=GAINPDEF, gain_offset=GAINPDEF,
                            dtermp=DTERMPDEF, dterm_offset=DTERMPDEF):
 
         """Observe the image on the same baselines as an existing observation object and add noise.
@@ -774,7 +774,7 @@ class Movie(object):
                obs_in (Obsdata): the existing observation with  baselines where the image FT will be sampled
                ttype (str): if "fast" or "nfft", use FFT to produce visibilities. Else "direct" for DTFT
                fft_pad_factor (float): zero pad the image to fft_pad_factor * image size in FFT
-               
+
                repeat (bool): if True, repeat the movie to fill up the observation interval
                sgrscat (bool): if True, the visibilites will be blurred by the Sgr A* scattering kernel
                add_th_noise (bool): if True, baseline-dependent thermal noise is added to each data point
@@ -785,7 +785,7 @@ class Movie(object):
                stabilize_scan_phase (bool): if True, random phase errors are constant over scans
                stabilize_scan_amp (bool): if True, random amplitude errors are constant over scans
                dcal (bool): if False, time-dependent gaussian errors added to Jones matrices D-terms. Must have jones=True
-               
+
                jones (bool): if True, uses Jones matrix to apply mis-calibration effects (gains, phases, Dterms), otherwise uses old formalism without D-terms
                inv_jones (bool): if True, applies estimated inverse Jones matrix (not including random terms) to calibrate data
 
@@ -795,7 +795,7 @@ class Movie(object):
                taup (float): the fractional std. dev. of the random error on the opacities
                dtermp (float): the fractional std. dev. of the random error on the D-terms
                dterm_offset (float): the base dterm offset at all sites, or a dict giving one dterm offset per site
-          
+
             Returns:
                (Obsdata): an observation object
 
@@ -815,7 +815,7 @@ class Movie(object):
                                                  gainp=gainp, taup=taup, gain_offset=gain_offset,
                                                  dtermp=dtermp,dterm_offset=dterm_offset)
 
-            obs =  ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr, 
+            obs =  ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr,
                                          source=obs.source, mjd=obs.mjd, polrep=obs_in.polrep,
                                          ampcal=ampcal, phasecal=phasecal, opacitycal=opacitycal, dcal=dcal, frcal=frcal,
                                          timetype=obs.timetype, scantable=obs.scans)
@@ -823,9 +823,9 @@ class Movie(object):
             if inv_jones:
                 obsdata = simobs.apply_jones_inverse(obs, opacitycal=opacitycal, dcal=dcal, frcal=frcal)
 
-                obs =  ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr, 
+                obs =  ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr,
                                              source=obs.source, mjd=obs.mjd, polrep=obs_in.polrep,
-                                             ampcal=ampcal, phasecal=phasecal, 
+                                             ampcal=ampcal, phasecal=phasecal,
                                              opacitycal=True, dcal=True, frcal=True,
                                              timetype=obs.timetype, scantable=obs.scans)
                                              #these are always set to True after inverse jones call
@@ -837,7 +837,7 @@ class Movie(object):
                                        ampcal=ampcal, phasecal=phasecal, opacitycal=opacitycal,
                                        gainp=gainp, taup=taup, gain_offset=gain_offset)
 
-            obs =  ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr, 
+            obs =  ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr,
                                          source=obs.source, mjd=obs.mjd, polrep=obs_in.polrep,
                                          ampcal=ampcal, phasecal=phasecal, opacitycal=True, dcal=True, frcal=True,
                                          timetype=obs.timetype, scantable=obs.scans)
@@ -848,10 +848,10 @@ class Movie(object):
     def observe(self, array, tint, tadv, tstart, tstop, bw, repeat=False,
                       mjd=None, timetype='UTC', polrep_obs=None,
                       elevmin=ELEV_LOW, elevmax=ELEV_HIGH,
-                      ttype='nfft', fft_pad_factor=2, 
+                      ttype='nfft', fft_pad_factor=2,
                       fix_theta_GMST=False, sgrscat=False, add_th_noise=True,
                       opacitycal=True, ampcal=True, phasecal=True, frcal=True, dcal=True,
-                      stabilize_scan_phase=False, stabilize_scan_amp=False, 
+                      stabilize_scan_phase=False, stabilize_scan_amp=False,
                       jones=False, inv_jones=False,
                       tau=TAUDEF, taup=GAINPDEF,
                       gainp=GAINPDEF, gain_offset=GAINPDEF,
@@ -914,10 +914,10 @@ class Movie(object):
 
 
         # Observe on the same baselines as the empty observation and add noise
-        obs = self.observe_same(obs, ttype=ttype, fft_pad_factor=fft_pad_factor, repeat=repeat, 
+        obs = self.observe_same(obs, ttype=ttype, fft_pad_factor=fft_pad_factor, repeat=repeat,
                                      sgrscat=sgrscat, add_th_noise=add_th_noise,
                                      opacitycal=opacitycal,ampcal=ampcal,phasecal=phasecal,dcal=dcal,frcal=frcal,
-                                     stabilize_scan_phase=stabilize_scan_phase, stabilize_scan_amp=stabilize_scan_amp, 
+                                     stabilize_scan_phase=stabilize_scan_phase, stabilize_scan_amp=stabilize_scan_amp,
                                      gainp=gainp,gain_offset=gain_offset,
                                      tau=tau, taup=taup,
                                      dtermp=dtermp, dterm_offset=dterm_offset,
@@ -930,9 +930,9 @@ class Movie(object):
                           polrep_obs=None, ttype='nfft', fft_pad_factor=2,
                           sgrscat=False, add_th_noise=True,
                           opacitycal=True, ampcal=True, phasecal=True, frcal=True, dcal=True,
-                          stabilize_scan_phase=False, stabilize_scan_amp=False, 
+                          stabilize_scan_phase=False, stabilize_scan_amp=False,
                           jones=False, inv_jones=False,
-                          tau=TAUDEF, taup=GAINPDEF, gainp=GAINPDEF, gain_offset=GAINPDEF, 
+                          tau=TAUDEF, taup=GAINPDEF, gainp=GAINPDEF, gain_offset=GAINPDEF,
                           dtermp=DTERMPDEF, dterm_offset=DTERMPDEF, fix_theta_GMST=False):
 
         """Generate baselines from a vex file and observe the movie.
@@ -1023,12 +1023,12 @@ class Movie(object):
         obs = ehtim.obsdata.merge_obs(obs_List)
 
         obsout = movie.observe_same(obs, ttype=ttype, fft_pad_factor=fft_pad_factor, repeat=False,
-                                    sgrscat=sgrscat, add_th_noise=add_th_noise, 
+                                    sgrscat=sgrscat, add_th_noise=add_th_noise,
                                     opacitycal=opacitycal, ampcal=ampcal, phasecal=phasecal, frcal=frcal, dcal=dcal,
-                                    stabilize_scan_phase=stabilize_scan_phase, stabilize_scan_amp=stabilize_scan_amp, 
-                                    jones=jones, inv_jones=inv_jones, 
+                                    stabilize_scan_phase=stabilize_scan_phase, stabilize_scan_amp=stabilize_scan_amp,
+                                    jones=jones, inv_jones=inv_jones,
                                     tau=tau, taup=taup,
-                                    gainp=gainp, gain_offset=gain_offset, 
+                                    gainp=gainp, gain_offset=gain_offset,
                                     dtermp=dtermp, dterm_offset=dterm_offset)
 
         return obsout
@@ -1052,15 +1052,15 @@ class Movie(object):
 
            Args:
               fname (str): basename of output files
- 
+
            Returns:
         """
 
         ehtim.io.save.save_mov_fits(self, fname)
         return
 
-    def export_mp4(self, out='movie.mp4', fps=10, dpi=120, 
-                         interp='gaussian', scale='lin', dynamic_range=1000.0, cfun='afmhot', 
+    def export_mp4(self, out='movie.mp4', fps=10, dpi=120,
+                         interp='gaussian', scale='lin', dynamic_range=1000.0, cfun='afmhot',
                          nvec=20, pcut=0.01, plotp=False, gamma=0.5, frame_pad_factor=1, verbose=False):
         """Save the Movie to an mp4 file
         """
@@ -1235,8 +1235,8 @@ def merge_im_list(imlist, framedur=-1):
         framedur = ((hour - hour0)/float(nframes))*3600.0
 
     # Make new  movie with primary polarization
-    newmov = Movie(framelist, 
-                   framedur, psize0, ra0, dec0, 
+    newmov = Movie(framelist,
+                   framedur, psize0, ra0, dec0,
                    polrep=polrep0, pol_prim=pol_prim0, start_hr=hour0,
                    rf=rf0, source=src0, mjd=mjd0, pulse=pulse)
 
@@ -1266,7 +1266,7 @@ def load_hdf5(file_name, framedur_sec=-1, psize=-1, ra=17.761122472222223, dec=-
            source (str) : The source name
            pulse (function): The function convolved with the pixel values for continuous image
            polrep (str): polarization representation, either 'stokes' or 'circ'
-           pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular              
+           pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular
            zero_pol (bool): If True, loads any missing polarizations as zeros
 
        Returns:
@@ -1286,7 +1286,7 @@ def load_txt(basename, nframes, framedur=-1, pulse=PULSE_DEFAULT, polrep='stokes
            framedur (float): The frame duration in seconds (default = -1, corresponding to framedur taken from file headers)
            pulse (function): The function convolved with the pixel values for continuous image
            polrep (str): polarization representation, either 'stokes' or 'circ'
-           pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular              
+           pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular
            zero_pol (bool): If True, loads any missing polarizations as zeros
 
        Returns:
@@ -1306,7 +1306,7 @@ def load_fits(basename, nframes, framedur=-1, pulse=PULSE_DEFAULT, polrep='stoke
            framedur (float): The frame duration in seconds (default = -1, corresponding to framedur taken from file headers)
            pulse (function): The function convolved with the pixel values for continuous image
            polrep (str): polarization representation, either 'stokes' or 'circ'
-           pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular              
+           pol_prim (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for Circular
            zero_pol (bool): If True, loads any missing polarizations as zeros
 
        Returns:

--- a/ehtim/movie.py
+++ b/ehtim/movie.py
@@ -615,7 +615,7 @@ class Movie(object):
 
         # Make the primary image
         imarr = self.frames[n].reshape(self.ydim, self.xdim)
-        outim = ehtim.image.Image(imarr, self.psize, self.ra, self.dec,
+        outim = ehtim.image.Image(imarr, self.psize, self.ra, self.dec, self.pa,
                                     polrep=self.polrep, pol_prim=self.pol_prim, time=time,
                                     rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 
@@ -654,7 +654,7 @@ class Movie(object):
         # Make the primary image
         avg_imvec = np.mean(np.array(self.frames),axis=0)
         avg_imarr = avg_imvec.reshape(self.ydim, self.xdim)
-        outim = ehtim.image.Image(avg_imarr, self.psize, self.ra, self.dec,
+        outim = ehtim.image.Image(avg_imarr, self.psize, self.ra, self.dec, self.pa,
                                   polrep=self.polrep, pol_prim=self.pol_prim, time=self.start_hr,
                                   rf=self.rf, source=self.source, mjd=self.mjd, pulse=self.pulse)
 

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -189,7 +189,7 @@ class Obsdata(object):
         """
 
         newobs = copy.deepcopy(self)
-        
+
         #newobs = Obsdata(self.ra, self.dec, self.rf, self.bw, self.data, self.tarr, source=self.source, mjd=self.mjd, polrep=self.polrep,
         #                 ampcal=self.ampcal, phasecal=self.phasecal, opacitycal=self.opacitycal, dcal=self.dcal, frcal=self.frcal,
         #                 timetype=self.timetype, scantable=self.scans)
@@ -222,7 +222,7 @@ class Obsdata(object):
         elif polrep_out=='stokes': #circ -> stokes
             data = np.empty(len(self.data), dtype=DTPOL_STOKES)
             rrmask = np.isnan(self.data['rrvis'])
-            llmask = np.isnan(self.data['llvis'])            
+            llmask = np.isnan(self.data['llvis'])
 
             for f in DTPOL_STOKES:
                 f = f[0]
@@ -280,7 +280,7 @@ class Obsdata(object):
 
         newobs = Obsdata(self.ra, self.dec, self.rf, self.bw, data, self.tarr,
                          source=self.source, mjd=self.mjd, polrep=polrep_out,
-                         ampcal=self.ampcal, phasecal=self.phasecal, opacitycal=self.opacitycal, 
+                         ampcal=self.ampcal, phasecal=self.phasecal, opacitycal=self.opacitycal,
                          dcal=self.dcal, frcal=self.frcal,
                          timetype=self.timetype, scantable=self.scans)
         return newobs
@@ -457,7 +457,7 @@ class Obsdata(object):
                 datalist.append(np.array([obs for obs in group]))
         else:
             # Group measurements by scan
-            if np.any(self.scans == None) or len(self.scans) == 0: 
+            if np.any(self.scans == None) or len(self.scans) == 0:
                 print("No scan table in observation. Adding scan table before gathering...")
                 self.add_scans()
 
@@ -1180,7 +1180,7 @@ class Obsdata(object):
             tint0 = np.min(np.diff(np.asarray(sorted(list(set([x[0] for x in list(self.unpack('time'))]))))))*3600.
         else:
             tint0 = 0.0
-        
+
         if avg_time <= tint0:
             adf = make_amp(self,debias=debias,round_s=round_s)
             if return_type=='rec':
@@ -1214,7 +1214,7 @@ class Obsdata(object):
             tint0 = np.min(np.diff(np.asarray(sorted(list(set([x[0] for x in list(self.unpack('time'))]))))))*3600.
         else:
             tint0 = 0
-        
+
         cdf = make_bsp_df(self, mode='all', round_s=round_s, count=count)
         if avg_time>tint0:
             cdf = average_bispectra(cdf,avg_time,return_type=return_type,num_samples=num_samples)
@@ -1222,7 +1222,7 @@ class Obsdata(object):
             print("Updated self.bispec: no averaging")
             if return_type=='rec':
                 cdf = df_to_rec(cdf,'bispec')
-        
+
         self.bispec = cdf
         print("Updated self.bispec: avg_time %f s\n"%avg_time)
 
@@ -1249,7 +1249,7 @@ class Obsdata(object):
             tint0 = np.min(np.diff(np.asarray(sorted(list(set([x[0] for x in list(self.unpack('time'))]))))))*3600.
         else:
             tint0 = 0
-        
+
         cdf = make_cphase_df(self, mode='all', round_s=round_s, count=count)
         if avg_time>tint0:
             cdf = average_cphases(cdf, avg_time, return_type=return_type, err_type=err_type, num_samples=num_samples)
@@ -1285,14 +1285,14 @@ class Obsdata(object):
             tint0 = np.min(np.diff(np.asarray(sorted(list(set([x[0] for x in list(self.unpack('time'))]))))))*3600.
         else:
             tint0 = 0
-        
+
         if avg_time>tint0:
             foo = self.avg_incoherent(avg_time,debias=debias,err_type=err_type)
         else:
             foo = self
         cdf = make_camp_df(foo,ctype=ctype,debias=False,count=count,
                            round_s=round_s)
-    
+
         if ctype=='logcamp':
             print("updated self.lcamp: no averaging")
         elif ctype=='camp':
@@ -1384,7 +1384,7 @@ class Obsdata(object):
                 if (times_uni[cou+1]-times_uni[cou] > dt):
                     scan_id+=1
             scans[-1]=scan_id
-            scanlist = np.asarray([ np.asarray([np.min(times_uni[scans==cou])-margin,np.max(times_uni[scans==cou])+margin]) for cou in range(int(scans[-1])+1)])    
+            scanlist = np.asarray([ np.asarray([np.min(times_uni[scans==cou])-margin,np.max(times_uni[scans==cou])+margin]) for cou in range(int(scans[-1])+1)])
 
         elif info=='txt':
              scanlist = np.loadtxt(filepath)
@@ -1573,8 +1573,8 @@ class Obsdata(object):
 
     def add_leakage_noise(self, Dterm_amp=0.1, min_noise=0.01, debias=False):
         """Add estimated systematic noise from leakage at quadrature to the corresponding thermal noise.
-           Added noise requires cross-hand visibilities. 
-           Note that this operation is not currently tracked in the data so should be applied with extreme caution. 
+           Added noise requires cross-hand visibilities.
+           Note that this operation is not currently tracked in the data so should be applied with extreme caution.
 
            Args:
                Dterm_amp (float): Estimated magnitude of leakage terms
@@ -1586,7 +1586,7 @@ class Obsdata(object):
 
         # Extract visibility amplitudes
         # Switch to Stokes for graceful handling of circular basis products missing RR or LL
-        amp = self.switch_polrep('stokes').unpack('amp',debias=debias)['amp']      
+        amp = self.switch_polrep('stokes').unpack('amp',debias=debias)['amp']
         rlamp = np.nan_to_num(self.switch_polrep('circ').unpack('rlamp',debias=debias)['rlamp'])
         lramp = np.nan_to_num(self.switch_polrep('circ').unpack('lramp',debias=debias)['lramp'])
 
@@ -1599,15 +1599,15 @@ class Obsdata(object):
                 field = self.poldict[sigma]
                 out.data[field] = (self.data[field]**2 + np.abs(frac_noise*amp)**2)**0.5
             except KeyError:
-                continue    
+                continue
 
         return out
 
 
     def add_fractional_noise(self, frac_noise, debias=False):
-        """Add a constant fraction of each visibility amplitude at quadrature to the corresponding thermal noise, 
-           effectively imposing a maximal signal-to-noise ratio. Note that this operation is not currently tracked 
-           in the data so should be applied with extreme caution. 
+        """Add a constant fraction of each visibility amplitude at quadrature to the corresponding thermal noise,
+           effectively imposing a maximal signal-to-noise ratio. Note that this operation is not currently tracked
+           in the data so should be applied with extreme caution.
 
            Args:
                frac_noise (float): The fraction of noise to add. For example, frac_noise=0.05 would
@@ -1620,7 +1620,7 @@ class Obsdata(object):
 
         # Extract visibility amplitudes
         # Switch to Stokes for graceful handling of circular basis products missing RR or LL
-        amp = self.switch_polrep('stokes').unpack('amp',debias=debias)['amp']      
+        amp = self.switch_polrep('stokes').unpack('amp',debias=debias)['amp']
 
         out = self.copy()
         for sigma in ['sigma1','sigma2','sigma3','sigma4']:
@@ -1628,7 +1628,7 @@ class Obsdata(object):
                 field = self.poldict[sigma]
                 out.data[field] = (self.data[field]**2 + np.abs(frac_noise*amp)**2)**0.5
             except KeyError:
-                continue    
+                continue
 
         return out
 
@@ -2090,7 +2090,7 @@ class Obsdata(object):
                     vals[field] = np.nan_to_num(vals[field]) # nans will all be dropped, which can be problematic for polarimetric values
                 for j in range(len(vals)):
                     near_vals_mask = np.abs(vals['time'] - vals['time'][j])<max_diff_seconds/3600.0
-                    fields  = vals[field][np.abs(vals['time'] - vals['time'][j])<max_diff_seconds/3600.0]                    
+                    fields  = vals[field][np.abs(vals['time'] - vals['time'][j])<max_diff_seconds/3600.0]
 
                     # Here, we use median absolute deviation from the median as a robust proxy for standard deviation
                     dfields = np.median(np.abs(fields-np.median(fields)))
@@ -2260,29 +2260,29 @@ class Obsdata(object):
 
         obs_new = self.copy()
         npts = len(obs_new.data)
-        
+
         import scipy.spatial as spatial
         uvpoints = np.vstack((obs_new.data['u'], obs_new.data['v'])).transpose()
         uvpoints_tree1 = spatial.cKDTree(uvpoints)
         uvpoints_tree2 = spatial.cKDTree(-uvpoints)
-        
+
         for i in range(npts):
-            matches1 = uvpoints_tree1.query_ball_point(uvpoints[i,:], uv_radius) 
-            matches2 = uvpoints_tree2.query_ball_point(uvpoints[i,:], uv_radius) 
+            matches1 = uvpoints_tree1.query_ball_point(uvpoints[i,:], uv_radius)
+            matches2 = uvpoints_tree2.query_ball_point(uvpoints[i,:], uv_radius)
             nmatches = len(matches1) + len(matches2)
-        
+
             for sigma in ['sigma', 'qsigma', 'usigma', 'vsigma']:
                 obs_new.data[sigma][i] = np.sqrt(nmatches)
-        
+
         scale = np.mean( self.data['sigma'] ) / np.mean( obs_new.data['sigma'] )
         for sigma in ['sigma', 'qsigma', 'usigma', 'vsigma']:
             obs_new.data[sigma] *= scale*weightdist
-        
+
         if weightdist < 1.0:
             for i in range(npts):
                 for sigma in ['sigma', 'qsigma', 'usigma', 'vsigma']:
                     obs_new.data[sigma][i] = (1-weightdist)*obs_new.data[sigma][i]
-                
+
         return obs_new
 
 
@@ -2474,7 +2474,7 @@ class Obsdata(object):
 
         if mode == 'all':
             out = np.array(cps)
-            
+
         print("\n")
         return out
 
@@ -3168,7 +3168,7 @@ class Obsdata(object):
 
             # Plot the data
             tolerance = len(data[field2])
-            
+
             if label is None:
                 labelstr="%s-%s"%((str(bl[0]),str(bl[1])))
 

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -1434,7 +1434,7 @@ class Obsdata(object):
         im = im/np.sum(im)
 
         src = self.source + "_DB"
-        outim = ehtim.image.Image(im, pdim, self.ra, self.dec, rf=self.rf, source=src, mjd=self.mjd, pulse=pulse)
+        outim = ehtim.image.Image(im, pdim, self.ra, self.dec, self.pa, rf=self.rf, source=src, mjd=self.mjd, pulse=pulse)
 
         return outim
 
@@ -1565,7 +1565,7 @@ class Obsdata(object):
         uim = uim[0:npix, 0:npix]
         vim = vim[0:npix, 0:npix]
 
-        out = ehtim.image.Image(im, pdim, self.ra, self.dec, rf=self.rf, source=self.source, mjd=self.mjd, pulse=pulse)
+        out = ehtim.image.Image(im, pdim, self.ra, self.dec, self.pa, rf=self.rf, source=self.source, mjd=self.mjd, pulse=pulse)
         out.add_qu(qim, uim)
         out.add_v(vim)
 

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -215,10 +215,10 @@ def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
     if im.pa != 0.0:
         c = np.cos(im.pa)
         s = np.sin(im.pa)
-        u = np.copy(uv[:,0])
-        v = np.copy(uv[:,1])
-        uv[:,0] = c * u - s * v
-        uv[:,1] = s * u + c * v
+        u = uv[:,0]
+        v = uv[:,1]
+        uv = np.column_stack([c * u - s * v,
+                              s * u + c * v])
 
 #    umin = np.min(np.sqrt(uv[:,0]**2 + uv[:,1]**2))
 #    umax = np.max(np.sqrt(uv[:,0]**2 + uv[:,1]**2))

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -179,7 +179,7 @@ def make_uvpoints(array, ra, dec, rf, bw, tint, tadv, tstart, tstop, polrep='sto
 ##################################################################################################
 
 def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
-               ttype="nfft", fft_pad_factor=2, zero_empty_pol=True):
+               ttype="nfft", cache=False, fft_pad_factor=2, zero_empty_pol=True):
 
     """Observe a image on given baselines with no noise.
 
@@ -270,7 +270,8 @@ def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
                     imarr = imvec.reshape(im.ydim, im.xdim)
                     imarr = np.pad(imarr, ((padvalx1,padvalx2),(padvaly1,padvaly2)), 'constant', constant_values=0.0)
                     vis_im = np.fft.fftshift(np.fft.fft2(np.fft.ifftshift(imarr)))
-                    im.cached_fft[pol] = vis_im
+                    if cache == 'auto':
+                        im.cached_fft[pol] = vis_im
 
                 # Sample the visibilities
                 # default is cubic spline interpolation

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -145,7 +145,7 @@ def make_uvpoints(array, ra, dec, rf, bw, tint, tadv, tstart, tstop, polrep='sto
                                                               ra, dec, rf, timetype=timetype,
                                                               elevmin=elevmin, elevmax=elevmax,
                                                               fix_theta_GMST=fix_theta_GMST)
-  
+
                 for k in range(len(timesout)):
                     outlist.append(np.array((
                               timesout[k],
@@ -178,7 +178,7 @@ def make_uvpoints(array, ra, dec, rf, bw, tint, tadv, tstart, tstop, polrep='sto
 # Observe w/o noise
 ##################################################################################################
 
-def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes', 
+def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
                ttype="nfft", fft_pad_factor=2, zero_empty_pol=True):
 
     """Observe a image on given baselines with no noise.
@@ -190,7 +190,7 @@ def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
            polrep_obs (str): 'stokes' or 'circ' sets the data polarimetric representtion
            ttype (str): if "fast" or 'nfft', use FFT to produce visibilities. Else "direct" for DTFT
            fft_pad_factor (float): zero pad the image to fft_pad_factor * image size in FFT
-           zero_empty_pol (bool): if True, returns zero vec if the polarization doesn't exist. Otherwise return None 
+           zero_empty_pol (bool): if True, returns zero vec if the polarization doesn't exist. Otherwise return None
 
        Returns:
            (Obsdata): an observation object
@@ -261,7 +261,7 @@ def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
                 if zero_empty_pol:
                     obsdata.append(np.zeros(len(uv)))
                 else:
-                    obsdata.append(None)                
+                    obsdata.append(None)
             else:
                 # FFT for visibilities
                 imarr = imvec.reshape(im.ydim, im.xdim)
@@ -281,7 +281,7 @@ def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
                 obsdata.append(vis)
 
 
-    # Get visibilities from the NFFT 
+    # Get visibilities from the NFFT
     elif ttype=="nfft":
 
         uvdim = len(uv)
@@ -319,7 +319,7 @@ def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
                 if zero_empty_pol:
                     obsdata.append(np.zeros(len(uv)))
                 else:
-                    obsdata.append(None)                
+                    obsdata.append(None)
             else:
                 plan.f_hat = imvec.copy().reshape((im.ydim,im.xdim)).T
                 plan.trafo()
@@ -340,7 +340,7 @@ def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
                 if zero_empty_pol:
                     obsdata.append(np.zeros(len(uv)))
                 else:
-                    obsdata.append(None)                
+                    obsdata.append(None)
             else:
                 vis = np.dot(mat, imvec)
                 obsdata.append(vis)
@@ -361,7 +361,7 @@ def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
 ##################################################################################################
 
 def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True, frcal=True, rlgaincal=True,
-               stabilize_scan_phase=False, stabilize_scan_amp=False, 
+               stabilize_scan_phase=False, stabilize_scan_amp=False,
                taup=GAINPDEF, gainp=GAINPDEF, gain_offset=GAINPDEF, dterm_offset=DTERMPDEF,
                caltable_path=None, seed=False):
 
@@ -420,14 +420,14 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True, frca
                 if site not in sites_in:
                     taudict[site] = np.append(taudict[site], 0.0)
 
-    # Now define a list that accounts for periods where the phase or amplitude errors 
+    # Now define a list that accounts for periods where the phase or amplitude errors
     # are stable (e.g., over scans if stabilize_scan_phase==True)
     times_stable_phase = times.copy()
     times_stable_amp = times.copy()
     times_stable = times.copy()
     if stabilize_scan_phase==True or stabilize_scan_amp==True:
         scans = obs_tmp.scans
-        if np.all(scans) == None or len(scans) == 0: 
+        if np.all(scans) == None or len(scans) == 0:
             obs_scans = obs.copy()
             obs_scans.add_scans()
             scans = obs_scans.scans
@@ -484,14 +484,14 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True, frca
 
             # Note: R/L gain ratio is independent of time for each site
             # TODO: enforce gainR and gainL < 1
-            
+
             if rlgaincal:
                 gainr_string = 'gain'
                 gainl_string = 'gain'
             else:
                 gainr_string = 'gainR'
                 gainl_string = 'gainL'
-            
+
             gainR = np.sqrt(np.abs(np.fromiter((
                                                 (1.0 + goff * hashrandn(site,gainr_string,str(goff),seed)) *
                                                 (1.0 + gain_mult * hashrandn(site,'gain',str(time),str(gain_mult),seed))
@@ -507,7 +507,7 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True, frca
         # Opacity attenuation of amplitude gain
         if not opacitycal:
             taus = np.abs(np.fromiter((
-                                       taudict[site][j] * (1.0 + taup * hashrandn(site, 'tau', times_stable_amp[j], seed)) 
+                                       taudict[site][j] * (1.0 + taup * hashrandn(site, 'tau', times_stable_amp[j], seed))
                                        for j in range(len(times))
                                       ), float))
             atten = np.exp(-taus/(EP + 2.0*np.sin(el_angles)))
@@ -520,7 +520,7 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True, frca
             phase = np.fromiter((2 * np.pi * hashrand(site, 'phase', time, seed) for time in times_stable_phase),float)
             gainR = gainR * np.exp(1j*phase)
             gainL = gainL * np.exp(1j*phase)
-            
+
 
         # D Term errors
         dR = dL = 0.0
@@ -561,14 +561,14 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True, frca
 
         out[site] = j_matrices
 
-        if caltable_path: 
-            obs_tmp.tarr[i]['dr'] = dR 
-            obs_tmp.tarr[i]['dl'] = dL   
+        if caltable_path:
+            obs_tmp.tarr[i]['dr'] = dR
+            obs_tmp.tarr[i]['dl'] = dL
             datatable = []
-            for j in range(len(times)): 
+            for j in range(len(times)):
                 datatable.append(np.array((times[j], gainR[j], gainL[j]), dtype=DTCAL))
             datatables[site] = np.array(datatable)
-                                
+
     # Save a calibration table with the synthetic gains and dterms added
     if caltable_path and len(datatables)>0:
         caltable = ehtim.caltable.Caltable(obs_tmp.ra, obs_tmp.dec, obs_tmp.rf, obs_tmp.bw, datatables, obs_tmp.tarr, source=obs_tmp.source, mjd=obs_tmp.mjd, timetype=obs_tmp.timetype)
@@ -685,7 +685,7 @@ def make_jones_inverse(obs, opacitycal=True, dcal=True, frcal=True):
 
 def add_jones_and_noise(obs, add_th_noise=True,
                         opacitycal=True, ampcal=True, phasecal=True, dcal=True, frcal=True, rlgaincal=True,
-                        stabilize_scan_phase=False, stabilize_scan_amp=False, 
+                        stabilize_scan_phase=False, stabilize_scan_amp=False,
                         taup=GAINPDEF, gainp=GAINPDEF, gain_offset=GAINPDEF, dterm_offset=DTERMPDEF,
                         caltable_path=None, seed=False):
 
@@ -911,7 +911,7 @@ def apply_jones_inverse(obs, opacitycal=True, dcal=True, frcal=True, verbose=Tru
 
 # The old noise generating function.
 def add_noise(obs, add_th_noise=True, opacitycal=True, ampcal=True, phasecal=True,
-              stabilize_scan_amp=False, stabilize_scan_phase=False, 
+              stabilize_scan_amp=False, stabilize_scan_phase=False,
               taup=GAINPDEF, gainp=GAINPDEF, gain_offset=GAINPDEF,
               seed=False):
 

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -215,8 +215,8 @@ def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
     if im.pa != 0.0:
         c = np.cos(-im.pa)
         s = np.sin(-im.pa)
-        u = uv[:,0]
-        v = uv[:,1]
+        u = np.copy(uv[:,0])
+        v = np.copy(uv[:,1])
         uv[:,0] = c * u - s * v
         uv[:,1] = s * u + c * v
 

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -212,6 +212,13 @@ def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
     uv = np.array(uv)
     if uv.shape[1] != 2:
         raise Exception("When given as a list of uv points, the obs should be a list of pairs of u-v coordinates!")
+    if im.pa != 0.0:
+        c = np.cos(-im.pa)
+        s = np.sin(-im.pa)
+        u = uv[:,0]
+        v = uv[:,1]
+        uv[:,0] = c * u - s * v
+        uv[:,1] = s * u + c * v
 
 #    umin = np.min(np.sqrt(uv[:,0]**2 + uv[:,1]**2))
 #    umax = np.max(np.sqrt(uv[:,0]**2 + uv[:,1]**2))

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -264,9 +264,13 @@ def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
                     obsdata.append(None)
             else:
                 # FFT for visibilities
-                imarr = imvec.reshape(im.ydim, im.xdim)
-                imarr = np.pad(imarr, ((padvalx1,padvalx2),(padvaly1,padvaly2)), 'constant', constant_values=0.0)
-                vis_im = np.fft.fftshift(np.fft.fft2(np.fft.ifftshift(imarr)))
+                if pol in im.cached_fft:
+                    vis_im = im.cached_fft[pol]
+                else:
+                    imarr = imvec.reshape(im.ydim, im.xdim)
+                    imarr = np.pad(imarr, ((padvalx1,padvalx2),(padvaly1,padvaly2)), 'constant', constant_values=0.0)
+                    vis_im = np.fft.fftshift(np.fft.fft2(np.fft.ifftshift(imarr)))
+                    im.cached_fft[pol] = vis_im
 
                 # Sample the visibilities
                 # default is cubic spline interpolation

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -178,7 +178,7 @@ def make_uvpoints(array, ra, dec, rf, bw, tint, tadv, tstart, tstop, polrep='sto
 # Observe w/o noise
 ##################################################################################################
 
-def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
+def sample_vis(im_org, uv, sgrscat=False, polrep_obs='stokes',
                ttype="nfft", cache=False, fft_pad_factor=2, zero_empty_pol=True):
 
     """Observe a image on given baselines with no noise.
@@ -201,10 +201,10 @@ def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
     from ehtim.obsdata import Obsdata
 
     if polrep_obs=='stokes':
-        im = im.switch_polrep('stokes','I')
+        im = im_org.switch_polrep('stokes','I')
         pollist = ['I','Q','U','V'] #TODO what if we have to I image?
     elif polrep_obs=='circ':
-        im = im.switch_polrep('circ','RR')
+        im = im_org.switch_polrep('circ','RR')
         pollist = ['RR','LL','RL','LR'] #TODO what if we have to RR image?
     else:
         raise Exception("only 'stokes' and 'circ' are supported polreps!")
@@ -271,14 +271,14 @@ def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
                     obsdata.append(None)
             else:
                 # FFT for visibilities
-                if pol in im.cached_fft:
-                    vis_im = im.cached_fft[pol]
+                if pol in im_org.cached_fft:
+                    vis_im = im_org.cached_fft[pol]
                 else:
                     imarr = imvec.reshape(im.ydim, im.xdim)
                     imarr = np.pad(imarr, ((padvalx1,padvalx2),(padvaly1,padvaly2)), 'constant', constant_values=0.0)
                     vis_im = np.fft.fftshift(np.fft.fft2(np.fft.ifftshift(imarr)))
                     if cache == 'auto':
-                        im.cached_fft[pol] = vis_im
+                        im_org.cached_fft[pol] = vis_im
 
                 # Sample the visibilities
                 # default is cubic spline interpolation

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -213,8 +213,8 @@ def sample_vis(im, uv, sgrscat=False, polrep_obs='stokes',
     if uv.shape[1] != 2:
         raise Exception("When given as a list of uv points, the obs should be a list of pairs of u-v coordinates!")
     if im.pa != 0.0:
-        c = np.cos(-im.pa)
-        s = np.sin(-im.pa)
+        c = np.cos(im.pa)
+        s = np.sin(im.pa)
         u = np.copy(uv[:,0])
         v = np.copy(uv[:,1])
         uv[:,0] = c * u - s * v


### PR DESCRIPTION
This makes some of the ehtim usages faster.

The idea is to add two attributes/members in the Image class: one called "pa" for *logical* position angle, and one called "cached_fft" for cached (uniform) FFT array.

When sample_vis() is first called upon an image, if ttype='fast' (hence uniform FFT) is used, then sample_vis() automatically saves the transformed image in "cached_fft".  And then it always uses "cached_fft" to sample the visibility.  If a user sets "pa" to non-zero, then sample_vis() also rotates uv according to pa to get the proper visibility.

To ensure backward compatibility, I also added a "cache" keyword to sample_vis() so that it only caches the transformed image if asked explicitly.