### PR TITLE
fixed bug in beamparams

### DIFF
--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -2364,7 +2364,8 @@ class Image(object):
                       plotp=False, nvec=20, pcut=0.1, log_offset=False,
                       label_type='ticks', has_title=True,
                       has_cbar=True, only_cbar=False, cbar_lims=(), cbar_unit = ('Jy', 'pixel'),
-                      export_pdf="", pdf_pad_inches=0.0, show=True, beamparams=None, cbar_orientation="vertical"):
+                      export_pdf="", pdf_pad_inches=0.0, show=True, beamparams=None, cbar_orientation="vertical",
+                      scale_lw=1, beam_lw=1):
 
         """Display the image.
 
@@ -2659,7 +2660,7 @@ class Image(object):
                 beamimage = beamimage.add_gauss(1, beamparams)
                 halflevel = 0.5*np.max(beamimage.imvec)
                 beamimarr = (beamimage.imvec).reshape(beamimage.ydim,beamimage.xdim)
-                plt.contour(beamimarr, levels=[halflevel], colors='w', linewidths=1)
+                plt.contour(beamimarr, levels=[halflevel], colors='w', linewidths=beam_lw)
 
             if has_cbar:
                 plt.colorbar(im, fraction=0.046, pad=0.04, label=unit, orientation=cbar_orientation)
@@ -2687,7 +2688,7 @@ class Image(object):
             fov_scale = int( math.ceil(fov_uas * roughfactor / 10.0 ) ) * 10 # round around 1/3 the fov to nearest 10
             start = self.xdim * roughfactor / 3.0 # select the start location
             end = start + fov_scale/fov_uas * self.xdim # determine the end location based on the size of the bar
-            plt.plot([start, end], [self.ydim-start, self.ydim-start], color="white", lw=1) # plot line
+            plt.plot([start, end], [self.ydim-start, self.ydim-start], color="white", lw=scale_lw) # plot line
             plt.text(x=(start+end)/2.0, y=self.ydim-start+self.ydim/30, s= str(fov_scale) + " $\mu$as", color="white", ha="center", va="center", fontsize=12)
             ax = plt.gca()
             ax.axes.get_xaxis().set_visible(False)
@@ -2707,7 +2708,7 @@ class Image(object):
             f.savefig(export_pdf, bbox_inches='tight', pad_inches = pdf_pad_inches)
 
         return f
-
+        
     def overlay_display(self, im_list, color_coding = np.array([[1, 0, 1], [0, 1, 0]]),
                               export_pdf="", show=True, f=False,
                               shift=[0,0], final_fov=False,

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -2401,7 +2401,7 @@ class Image(object):
         else:
             interp = 'linear'
 
-        if not(beamparams is None or (beamparams==False).any()):
+        if not(beamparams is None or (beamparams==False)):
             if beamparams[0]>self.fovx() or beamparams[1]>self.fovx():
                 raise Exception("beam FWHM must be smaller than fov!")
 
@@ -2511,7 +2511,7 @@ class Image(object):
             else:
                 im = plt.imshow(imarr, cmap=plt.get_cmap(cfun), interpolation=interp)
 
-            if not(beamparams is None or (beamparams==False).any()):
+            if not(beamparams is None or (beamparams==False)):
                 beamparams = [beamparams[0], beamparams[1], beamparams[2],
                               -.35*self.fovx(), -.35*self.fovy()]
                 beamimage = self.copy()


### PR DESCRIPTION
There was a bug in ehtim.image.display() that prevented the beam from being plotted correctly on the image if beamparams was passed directly to it. 