### PR TITLE
fixing timestamp problem with scan long coherent averaging

### DIFF
--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -924,13 +924,14 @@ class Obsdata(object):
 
         return  out
 
-    def avg_coherent(self, inttime, scan_avg=False):
+    def avg_coherent(self, inttime, scan_avg=False,round_s=0.1):
 
         """Coherently average data along u,v tracks in chunks of length inttime (sec)
 
            Args:
                 inttime (float): coherent integration time in seconds
                 scan_avg (bool): if True, average over scans in self.scans instead of intime
+                round_s (float): time rounding off in seconds
 
            Returns:
                 (Obsdata): Obsdata object containing averaged data
@@ -944,7 +945,7 @@ class Obsdata(object):
             print('No averaging done!')
             return self.copy()
 
-        vis_avg = coh_avg_vis(self,dt=inttime,return_type='rec',err_type='predicted',scan_avg=scan_avg)
+        vis_avg = coh_avg_vis(self,dt=inttime,return_type='rec',err_type='predicted',scan_avg=scan_avg,round_s=round_s)
 
         arglist, argdict = self.obsdata_args()
         arglist[DATPOS] = vis_avg

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -924,7 +924,7 @@ class Obsdata(object):
 
         return  out
 
-    def avg_coherent(self, inttime, scan_avg=False,round_s=0.1):
+    def avg_coherent(self, inttime, scan_avg=False,round_s=0.1,match_by_scans=False):
 
         """Coherently average data along u,v tracks in chunks of length inttime (sec)
 
@@ -932,6 +932,7 @@ class Obsdata(object):
                 inttime (float): coherent integration time in seconds
                 scan_avg (bool): if True, average over scans in self.scans instead of intime
                 round_s (float): time rounding off in seconds
+                match_by_scans (bool): should the timestamps be global for scans
 
            Returns:
                 (Obsdata): Obsdata object containing averaged data
@@ -945,7 +946,7 @@ class Obsdata(object):
             print('No averaging done!')
             return self.copy()
 
-        vis_avg = coh_avg_vis(self,dt=inttime,return_type='rec',err_type='predicted',scan_avg=scan_avg,round_s=round_s)
+        vis_avg = coh_avg_vis(self,dt=inttime,return_type='rec',err_type='predicted',scan_avg=scan_avg,round_s=round_s,match_by_scans=match_by_scans)
 
         arglist, argdict = self.obsdata_args()
         arglist[DATPOS] = vis_avg

--- a/ehtim/statistics/dataframes.py
+++ b/ehtim/statistics/dataframes.py
@@ -147,6 +147,7 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
             scan_starttimes = obs.mjd+np.asarray(scan_starttimes)/24.
             dic_scan_starttime = dict(zip(range(1,len(obs.scans)+1),scan_starttimes))
             vis['scan'] = list(pd.cut(vis.time, bins,labels=labs))
+            vis = vis[vis['scan']>0].copy()
             vis['mjd']= list(map(lambda x: dic_scan_starttime[x], vis['scan']))
             grouping=['tau1','tau2','polarization','band','baseline','t1','t2','scan']
             aggregated = {'mjd': np.min,

--- a/ehtim/statistics/dataframes.py
+++ b/ehtim/statistics/dataframes.py
@@ -151,9 +151,7 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
             grouping=['tau1','tau2','polarization','band','baseline','t1','t2','scan']
             aggregated = {'mjd': np.min,
         'number': lambda x: len(x), 'u':np.mean, 'v':np.mean,'tint': np.sum}
-            aggregated['time']=(aggregated['mjd']-obs.mjd)*24.
-            aggregated['datetime']= Time(aggregated['mjd'], format='mjd').datetime
-
+            
         if err_type not in ['measured', 'predicted']:
             print("Error type can only be 'predicted' or 'measured'! Assuming 'predicted'.")
             err_type='predicted'
@@ -202,6 +200,9 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
 
         #ACTUAL AVERAGING
         vis_avg = vis.groupby(grouping).agg(aggregated).reset_index()
+        if scan_avg==True:
+            vis_avg['time']=(vis_avg['mjd']-obs.mjd)*24.
+            vis_avg['datetime']= Time(vis_avg['mjd'], format='mjd').datetime
         
         if err_type=='measured':
             vis_avg[sig1] = [0.5*(x[1][1]-x[1][0]) for x in list(vis_avg['dummy'])]


### PR DESCRIPTION
This fixes a timestamp problem with scan long coherent averaging. The timestamp of scan-averaged data is now corresponding to a GLOBAL beginning of the scan (whether parsed from vex file or inferred from the data itself with obsdata.add_scans) and not to the beginning of recording for an INDIVIDUAL baseline. This allows to occasionally recover few percent more closure quantities in the scan-averaged data. 