### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/scripts/cli_blur_comp.py
+++ b/scripts/cli_blur_comp.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 import glob
 import subprocess
@@ -56,7 +58,7 @@ def generate_metricmtx(fpath_, directory_):
     return (metric_mtx, fracsteps, beamparams, imarr)
 
 def generate_graph(metric_mtx, fracsteps, beamparams, imarr):
-    print "Using settings: "
+    print("Using settings: ")
     print_dicts()
     (cliques_fraclevels, im_cliques_fraclevels) = comp.image_agreements(imarr, beamparams, metric_mtx, fracsteps, cutoff=params['cutoff'])
     comp.generate_consistency_plot(cliques_fraclevels, im_cliques_fraclevels, zoom=params['zoom'], fov=params['fov'], show=True)
@@ -65,7 +67,7 @@ def print_dicts():
     global dictionaries
     for gk, gv in dictionaries.iteritems():
         for key, value in gv.iteritems() :
-            print key, value
+            print(key, value)
 
 #### CLI function
 # before any customization can be allowed, the metric_mtx must be generated.
@@ -103,7 +105,7 @@ while 1:
         continue
 
     elif user_input in ['r', 'R']:
-        print 'Generating the graph...'
+        print('Generating the graph...')
         generate_graph(METRIC_MTX, FRACSTEPS, BEAMPARAMS, IMARR)
 
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/achael/eht-imaging on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./ehtim/parloop.py:82:19: F821 undefined name 'KeyboardInterruptError'
            raise KeyboardInterruptError()
                  ^
./ehtim/io/oifits.py:711:110: F821 undefined name 'key'
                    errors.append("eff_wave and eff_band are of different lengths for wavelength table '%s'"%key)
                                                                                                             ^
./scripts/imaging.py:124:33: F821 undefined name 'gaussprior'
imgr = eh.imager.Imager(obs_sc, gaussprior, prior_im=gaussprior, data_term=data_term, maxit=150, clipfloor=-1., norm_reg=True, systematic_noise=systematic_noise, reg_term = reg_term, ttype='nfft')
                                ^
./scripts/imaging.py:124:54: F821 undefined name 'gaussprior'
imgr = eh.imager.Imager(obs_sc, gaussprior, prior_im=gaussprior, data_term=data_term, maxit=150, clipfloor=-1., norm_reg=True, systematic_noise=systematic_noise, reg_term = reg_term, ttype='nfft')
                                                     ^
./scripts/imaging.py:134:33: F821 undefined name 'gaussprior'
imgr = eh.imager.Imager(obs_sc, gaussprior, prior_im=gaussprior, data_term={'vis':imgr.dat_terms_last()['amp']*10, 'cphase':imgr.dat_terms_last()['cphase']*10, 'logcamp':imgr.dat_terms_last()['logcamp']*10}, maxit=100, clipfloor=-1., norm_reg=True, systematic_noise=systematic_noise, reg_term = reg_term, ttype='nfft')
                                ^
./scripts/imaging.py:134:54: F821 undefined name 'gaussprior'
imgr = eh.imager.Imager(obs_sc, gaussprior, prior_im=gaussprior, data_term={'vis':imgr.dat_terms_last()['amp']*10, 'cphase':imgr.dat_terms_last()['cphase']*10, 'logcamp':imgr.dat_terms_last()['logcamp']*10}, maxit=100, clipfloor=-1., norm_reg=True, systematic_noise=systematic_noise, reg_term = reg_term, ttype='nfft')
                                                     ^
./scripts/imaging.py:174:8: F821 undefined name 'realdata'
    if realdata:
       ^
./scripts/cli_blur_comp.py:59:28: E999 SyntaxError: invalid syntax
    print "Using settings: "
                           ^
./scripts/imgsum.py:67:88: F821 undefined name 'snrcut'
    kwargs = {'commentstr':opt.c, 'outdir':outdir,'ebar':ebar,'cfun':opt.cfun,'snrcut':snrcut,
                                                                                       ^
1     E999 SyntaxError: invalid syntax
8     F821 undefined name 'key'
9
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
