### PR TITLE
update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ ephem
 future
 h5py
 html
+ipython
 matplotlib
 networkx
 numpy
@@ -11,5 +12,4 @@ pyfits
 pynfft
 requests
 scipy
-skimage
-
+scikit-image


### PR DESCRIPTION
Fixes `skimage` and `No module named IPython` errors.


```
Downloading https://files.pythonhosted.org/packages/3b/ee/edbfa69ba7b7d9726e634bfbeefd04b5a1764e9e74867ec916113eeaf4a1/skimage-0.0.tar.gz
  Complete output from command python setup.py egg_info:

  *** Please install the `scikit-image` package (instead of `skimage`) ***
```