### PR TITLE
add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM continuumio/miniconda2
+
+# install gcc and common build dependencies
+RUN apt-get update \
+ && apt-get install -y \
+      build-essential \
+      pylint
+
+WORKDIR /eht-imaging
+
+COPY . .
+
+# install dependencies and fix tkinter error
+# https://stackoverflow.com/questions/37604289/tkinter-tclerror-no-display-name-and-no-display-environment-variable
+RUN pip install -r requirements.txt \
+ && conda install -y -c conda-forge pynfft \
+ && echo "backend: Agg" >> /opt/conda/lib/python2.7/site-packages/matplotlib/mpl-data/matplotlibrc


### PR DESCRIPTION
Adds a dockerfile. https://www.docker.com/
Docker basically lets you configure a development environment as code so no one needs to install python/pip/conda on their computers. I wanted to add this in to encourage more people to contribute, it should let people get up and running in 2 minutes.

Building the image:
```
docker build -t eht-imaging .
```

Running the image:

```
docker run -v "$(pwd)":/eht-imaging -it eht-imaging:latest bash
```

At this point you're ready to develop or can cd into `./examples` and run `python example.py`.