### PR TITLE
fixing bug in caltable to deal with single float rather than array

### DIFF
--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -798,6 +798,8 @@ def make_caltable(obs, gains, sites, times):
     return caltable
 
 def relaxed_interp1d(x, y, **kwargs):
+    try: len(x)
+    except TypeError:x=np.asarray([x]); y=np.asarray([y])#allows to run on a single float number
     if len(x) == 1:
         x = np.array([-0.5, 0.5]) + x[0]
         y = np.array([ 1.0, 1.0]) * y[0]


### PR DESCRIPTION
Fixed a bug in relaxed_interp1d to allow to process single number as well as array. Noticed during imaging J1924 poor coverage day with the fiducial script, may happen with very sparse coverage.