### PR TITLE
fix list vs numpy array bug in movie loader

### DIFF
--- a/ehtim/movie.py
+++ b/ehtim/movie.py
@@ -1807,7 +1807,7 @@ def merge_im_list(imlist, framedur=-1, interp=ehc.INTERP_DEFAULT, bounds_error=e
     for pol in list(movdict.keys()):
         if pol == newmov.pol_prim:
             continue
-        polframes = movdict[pol]
+        polframes = np.array(movdict[pol])
         if len(polframes):
             polframes = polframes.reshape((newmov.nframes, newmov.ydim, newmov.xdim))
             newmov.add_pol_movie(polframes, pol)


### PR DESCRIPTION
The merge_im_list(...) function in movie.py has a call to .reshape(...) on polframes which assumes it is a numpy array. This commit/PR ensures type(polframes) == np.array. 