### PR TITLE
(joseph-dev) Added functions for file load-in and scan selection

### DIFF
--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -4665,3 +4665,78 @@ def load_maps(arrfile, obsspec, ifile, qfile=0, ufile=0, vfile=0,
     return ehtim.io.load.load_obs_maps(arrfile, obsspec, ifile,
                                        qfile=qfile, ufile=ufile, vfile=vfile,
                                        src=src, mjd=mjd, ampcal=ampcal, phasecal=phasecal)
+
+def load_obs(
+				fname, 					
+				polrep='stokes', 		
+            	flipbl=False, 				
+            	remove_nan=False, 
+            	force_singlepol=None, 
+            	channel=all, 
+            	IF=all, 
+            	allow_singlepol=True,
+            	flux=1.0,
+            	obsspec=None, 
+            	ifile=None, 
+            	qfile=None, 
+            	ufile=None, 
+            	vfile=None,
+              	src=ehc.SOURCE_DEFAULT, 
+              	mjd=ehc.MJD_DEFAULT, 
+              	ampcal=False, 
+              	phasecal=False
+    ):
+    """Smart obs read-in, detects file type and loads appropriately.
+
+       Args:
+           fname (str): path to input text file
+           polrep (str): load data as either 'stokes' or 'circ'
+           flipbl (bool): flip baseline phases if True.
+           remove_nan (bool): True to remove nans from missing polarizations
+           polrep (str): load data as either 'stokes' or 'circ'
+           force_singlepol (str): 'R' or 'L' to load only 1 polarization
+           channel (list): list of channels to average in the import. channel=all averages all
+           IF (list): list of IFs to  average in  the import. IF=all averages all IFS
+           flux (float): normalization total flux
+           obsspec (str): path to input obs spec file
+           ifile (str): path to input Stokes I data file
+           qfile (str): path to input Stokes Q data file
+           ufile (str): path to input Stokes U data file
+           vfile (str): path to input Stokes V data file
+           src (str): source name
+           mjd (int): integer observation  MJD
+           ampcal (bool): True if amplitude calibrated
+           phasecal (bool): True if phase calibrated
+
+       Returns:
+           obs (Obsdata): Obsdata object loaded from file
+    """
+
+
+    ## grab file ending ##
+    fname_extension = fname.split('.')[-1]
+    print(f"Extension is {fname_extension}.")
+
+    ## check extension ##
+    if fname_extension.lower() == 'uvfits':
+    	return load_uvfits(fname, flipbl=flipbl, remove_nan=remove_nan, force_singlepol=force_singlepol, channel=channel, IF=IF, polrep=polrep, allow_singlepol=allow_singlepol)
+
+    elif fname_extension.lower() in ['txt', 'text']:
+    	return load_txt(fname, polrep=polrep)
+
+    elif fname_extension.lower() == 'oifits':
+    	return load_oifits(fname, flux=flux)
+
+
+    else:
+    	if obsspec is not None and ifile is None:
+    		print("You have provided a value for <obsspec> but no value for <ifile>")
+    		return 
+    	elif obsspec is None and ifile is not None:
+    		print("You have provided a value for <ifile> but no value for <obsspec>")
+    		return 
+
+    	elif obsspec is not None and ifile is not None:
+    		return load_maps(fname, obsspec, ifile, qfile=qfile, ufile=ufile, vfile=vfile,
+              src=src, mjd=mjd, ampcal=ampcal, phasecal=phasecal)
+

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -532,6 +532,36 @@ class Obsdata(object):
 
         return splitlist
 
+
+    def getClosestScan(self, time, splitObs=None):
+        """Split observation by scan and grab scan closest to timestamp
+
+           Args:
+                time (float): Time (GMST) you want to find the scan closest to
+                splitObs (bool): a list of Obsdata objects, output from split_obs, to save time
+
+            Returns:
+                (Obsdata): Obsdata object composed of scan closest to time
+        """
+
+        ## check if splitObs has been passed in alread ##
+        if splitObs is None:
+            splitObs = self.split_obs()
+
+        ## check for the scan with the closest start time to time arg ##
+        ## TODO: allow user to choose start time, end time, or mid-time
+        closest_index = 0
+        delta_t = 1e22
+        for s, s_obs in enumerate(splitObs):
+            dt = abs(s_obs.tstart - time)
+            if dt < delta_t:
+                delta_t = dt 
+                closest_index = s 
+
+        print(f"Using scan with time {splitObs[closest_index].tstart}.")
+        return splitObs[closest_index]
+
+
     def bllist(self, conj=False):
         """Group the data in a list of same baseline datatables.
 
@@ -4667,24 +4697,24 @@ def load_maps(arrfile, obsspec, ifile, qfile=0, ufile=0, vfile=0,
                                        src=src, mjd=mjd, ampcal=ampcal, phasecal=phasecal)
 
 def load_obs(
-				fname, 					
-				polrep='stokes', 		
-            	flipbl=False, 				
-            	remove_nan=False, 
-            	force_singlepol=None, 
-            	channel=all, 
-            	IF=all, 
-            	allow_singlepol=True,
-            	flux=1.0,
-            	obsspec=None, 
-            	ifile=None, 
-            	qfile=None, 
-            	ufile=None, 
-            	vfile=None,
-              	src=ehc.SOURCE_DEFAULT, 
-              	mjd=ehc.MJD_DEFAULT, 
-              	ampcal=False, 
-              	phasecal=False
+                fname,                  
+                polrep='stokes',        
+                flipbl=False,               
+                remove_nan=False, 
+                force_singlepol=None, 
+                channel=all, 
+                IF=all, 
+                allow_singlepol=True,
+                flux=1.0,
+                obsspec=None, 
+                ifile=None, 
+                qfile=None, 
+                ufile=None, 
+                vfile=None,
+                src=ehc.SOURCE_DEFAULT, 
+                mjd=ehc.MJD_DEFAULT, 
+                ampcal=False, 
+                phasecal=False
     ):
     """Smart obs read-in, detects file type and loads appropriately.
 
@@ -4719,24 +4749,24 @@ def load_obs(
 
     ## check extension ##
     if fname_extension.lower() == 'uvfits':
-    	return load_uvfits(fname, flipbl=flipbl, remove_nan=remove_nan, force_singlepol=force_singlepol, channel=channel, IF=IF, polrep=polrep, allow_singlepol=allow_singlepol)
+        return load_uvfits(fname, flipbl=flipbl, remove_nan=remove_nan, force_singlepol=force_singlepol, channel=channel, IF=IF, polrep=polrep, allow_singlepol=allow_singlepol)
 
     elif fname_extension.lower() in ['txt', 'text']:
-    	return load_txt(fname, polrep=polrep)
+        return load_txt(fname, polrep=polrep)
 
     elif fname_extension.lower() == 'oifits':
-    	return load_oifits(fname, flux=flux)
+        return load_oifits(fname, flux=flux)
 
 
     else:
-    	if obsspec is not None and ifile is None:
-    		print("You have provided a value for <obsspec> but no value for <ifile>")
-    		return 
-    	elif obsspec is None and ifile is not None:
-    		print("You have provided a value for <ifile> but no value for <obsspec>")
-    		return 
+        if obsspec is not None and ifile is None:
+            print("You have provided a value for <obsspec> but no value for <ifile>")
+            return 
+        elif obsspec is None and ifile is not None:
+            print("You have provided a value for <ifile> but no value for <obsspec>")
+            return 
 
-    	elif obsspec is not None and ifile is not None:
-    		return load_maps(fname, obsspec, ifile, qfile=qfile, ufile=ufile, vfile=vfile,
+        elif obsspec is not None and ifile is not None:
+            return load_maps(fname, obsspec, ifile, qfile=qfile, ufile=ufile, vfile=vfile,
               src=src, mjd=mjd, ampcal=ampcal, phasecal=phasecal)
 


### PR DESCRIPTION
Two functions added:

- `load_obs()`: takes in any observation file (or in the case of MAPS, multiple files) and uses the extension and input arguments to determine how to load the file. For `uvfits`, `txt`, and `oifits` files, extension is used and passed to the corresponding function. For MAPS, it checks for two additional arguments, `obsspec` and `ifile`. The function has knowledge of all the arguments for `load_uvfits()`, `load_txt()`, `load_oifits()`, and `load_maps()`, and the arguments can be passed to `load_obs()` as if you were using the legacy function calls. Example usage: `ehtim.obsdata.load_obs("./sample_data.uvfits")`, `ehtim.obsdata.load_obs("./sample_data.txt", polrep='stokes')`. Tested on `txt` and `uvfits` files, but I couldn't get my hands on any oifits or MAPS files quickly.
- `getClosestScan()`: returns the scan of an observation closest in time to the argument. Uses `obs.split_obs()` to get a list of scans for an observation, and then checks each scan's `tstart` value to figure out which is closest in time to the argument. If you want to save time, you can preload the output of `split_obs` to `getClosestScan()` as an argument and it will skip generating it. Time is input in GMST. Example usage: `obs.getClosestScan(4)` and `obs.getClosestScan(4, splitObs=obs.split_obs())`. Tested on sample data file in `data/`. 