### PR TITLE
Minor updates regarding uvfits loading/saving

### DIFF
--- a/ehtim/io/load.py
+++ b/ehtim/io/load.py
@@ -1060,7 +1060,7 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False, allow_singlepol=Tru
                     force_singlepol=None, channel=all, IF=all, remove_nan=False):
     """Load observation data from a uvfits file.
        Args:
-           fname (str): path to input text file
+           fname (str or HDUList): path to input text file or HDUList object
            polrep (str): load data as either 'stokes' or 'circ'
            flipbl (bool): flip baseline phases if True.
            allow_singlepol (bool): If True and polrep='stokes',
@@ -1075,11 +1075,15 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False, allow_singlepol=Tru
     if not(polrep in ['stokes', 'circ']):
         raise Exception("polrep should be 'stokes' or 'circ' in load_uvfits")
     if not(force_singlepol is None or force_singlepol is False) and polrep != 'stokes':
-        raise Exception("force_singlepol is incompatible with polrep!='stokes' in load_uvfits")
+        raise Exception(
+            "force_singlepol is incompatible with polrep!='stokes' in load_uvfits")
 
     # Load the uvfits file
-    print("Loading uvfits: ", filename)
-    hdulist = fits.open(filename)
+    if isinstance(filename, fits.HDUList):
+        hdulist = filename.copy()
+    else:
+        print("Loading uvfits: ", filename)
+        hdulist = fits.open(filename)
     header = hdulist[0].header
     data = hdulist[0].data
 
@@ -1279,7 +1283,27 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False, allow_singlepol=Tru
         print("Warning: removing flagged data present!")
 
     # Obs Times
-    jds = data['DATE'][mask].astype('d') + data['_DATE'][mask].astype('d')
+    paridx = data.parnames.index("DATE")+1
+    if "PSCAL%d"%(paridx) in header.keys():
+        jd1scal = header["PSCAL%d"%(paridx)]
+    else:
+        jd1scal = 1.0
+    if "PZERO%d"%(paridx) in header.keys():
+        jd1zero = header["PZERO%d"%(paridx)]
+    else:
+        jd1zero = 0.0
+    if "PSCAL%d"%(paridx) in header.keys():
+        jd2scal = header["PSCAL%d"%(paridx+1)]
+    else:
+        jd2scal = 1.0
+    if "PZERO%d"%(paridx+1) in header.keys():
+        jd2zero = header["PZERO%d"%(paridx+1)]
+    else:
+        jd2zero = 0.0
+    
+    jds = jd1scal * data['DATE'][mask].astype('d') + jd1zero
+    jds += jd2scal * data['_DATE'][mask].astype('d') + jd2zero
+
     mjd = int(np.min(jds) - 2400000.5)
     times = (jds - 2400000.5 - mjd) * 24.0
 

--- a/ehtim/io/save.py
+++ b/ehtim/io/save.py
@@ -430,7 +430,7 @@ def save_obs_uvfits(obs, fname=None, force_singlepol=None, polrep_out='circ'):
     header['OBSDEC'] = obs.dec
     header['OBJECT'] = obs.source
     header['MJD'] = float(obs.mjd)
-    header['DATE-OBS'] = Time(obs.mjd + MJD_0, format='jd', scale='utc', out_subfmt='date').iso
+    header['DATE-OBS'] = Time(obs.mjd + MJD_0, format='jd', scale='utc').iso[0:10]
     header['BSCALE'] = 1.0
     header['BZERO'] = 0.0
     header['BUNIT'] = 'JY'

--- a/ehtim/io/save.py
+++ b/ehtim/io/save.py
@@ -472,13 +472,13 @@ def save_obs_uvfits(obs, fname, force_singlepol=None, polrep_out='circ'):
     header['CRPIX7'] = 1.e0
     header['CROTA7'] = 0.e0
     header['PTYPE1'] = 'UU---SIN'
-    header['PSCAL1'] = 1.0/obs.rf
+    header['PSCAL1'] = 1.0
     header['PZERO1'] = 0.e0
     header['PTYPE2'] = 'VV---SIN'
-    header['PSCAL2'] = 1.0/obs.rf
+    header['PSCAL2'] = 1.0
     header['PZERO2'] = 0.e0
     header['PTYPE3'] = 'WW---SIN'
-    header['PSCAL3'] = 1.0/obs.rf
+    header['PSCAL3'] = 1.0
     header['PZERO3'] = 0.e0
     header['PTYPE4'] = 'BASELINE'
     header['PSCAL4'] = 1.e0
@@ -528,8 +528,8 @@ def save_obs_uvfits(obs, fname, force_singlepol=None, polrep_out='circ'):
     tau2 = obsdata['tau2']
 
     # uv are in lightseconds
-    u = obsdata['u']
-    v = obsdata['v']
+    u = obsdata['u']/obs.rf
+    v = obsdata['v']/obs.rf
 
     # rr, ll, lr, rl, weights
 

--- a/ehtim/io/save.py
+++ b/ehtim/io/save.py
@@ -401,7 +401,7 @@ def save_obs_txt(obs, fname):
     return
 
 
-def save_obs_uvfits(obs, fname, force_singlepol=None, polrep_out='circ'):
+def save_obs_uvfits(obs, fname=None, force_singlepol=None, polrep_out='circ'):
     """Save observation data to uvfits.
        To save Stokes I as a single polarization (e.g., only RR) set force_singlepol='R' or 'L'
     """
@@ -815,9 +815,11 @@ def save_obs_uvfits(obs, fname, force_singlepol=None, polrep_out='circ'):
             print("No NX table in saved uvfits")
 
     # Write final HDUList to file
-    hdulist_new.writeto(fname, overwrite=True)
-
-    return
+    if fname is None:
+        return hdulist_new.copy()
+    else:
+        hdulist_new.writeto(fname, overwrite=True)
+        return None
 
 
 def save_obs_oifits(obs, fname, flux=1.0):

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -4614,7 +4614,7 @@ def load_uvfits(fname, flipbl=False, remove_nan=False, force_singlepol=None,
     """Load observation data from a uvfits file.
 
        Args:
-           fname (str): path to input text file
+           fname (str or HDUList): path to input text file or HDUList object
            flipbl (bool): flip baseline phases if True.
            remove_nan (bool): True to remove nans from missing polarizations
            polrep (str): load data as either 'stokes' or 'circ'

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -4480,22 +4480,25 @@ class Obsdata(object):
 
         return
 
-    def save_uvfits(self, fname, force_singlepol=False, polrep_out='circ'):
+    def save_uvfits(self, fname=None, force_singlepol=False, polrep_out='circ'):
         """Save visibility data to uvfits file.
-
            Args:
-                fname (str): path to output text file
+                fname (str): path to output text file. If not specified, return HDUList.
                 force_singlepol (str): if 'R' or 'L', will interpret stokes I field as 'RR' or 'LL'
                 polrep_out (str): 'circ' or 'stokes': how data should be stored in the uvfits file
         """
 
         if (force_singlepol is not False) and (self.polrep != 'stokes'):
-            raise Exception("force_singlepol is incompatible with polrep!='stokes'")
+            raise Exception(
+                "force_singlepol is incompatible with polrep!='stokes'")
 
-        ehtim.io.save.save_obs_uvfits(self, fname,
-                                      force_singlepol=force_singlepol, polrep_out=polrep_out)
+        output = ehtim.io.save.save_obs_uvfits(
+            self, fname, force_singlepol=force_singlepol, polrep_out=polrep_out)
 
-        return
+        if fname is None:
+            return output
+        else:
+            return
 
     def save_oifits(self, fname, flux=1.0):
         """ Save visibility data to oifits. Polarization data is NOT saved.


### PR DESCRIPTION
Hey @achael 

Here are some minor updates for uvfits loading/saving.
- fix uvw scaling
The current save_uvfits function scales the uvw's unit by setting up PSCAL/PZERO. This apparently works fine when we save uvfits and load it again (actually because of a bug in astropy.io.fits --- it will scale your uvw coordiantes but keep PSCAL and PZERO rather than resetting it). This won't work if we want to directly work with hdulist rather than save/load uvfits files, since obsdata.load_uvfits don't attempt to load PSCAL/PZERO for uvw coordinates. This fix modifies the location of scaling. PSCAL/PZERO for uv coordinates will be 1.0/0.0 respectively. Instead u, v will be directly normalized by rf. I checked existing uvfits from ehtim and confirmed that this fix won't affect existing ehtim-produced uvfits.

- allow directly load/save HDUList object for load/save_uvfits functions
This allows to use HDUList to pass data to other libraries. I confirmed that this will give the exact same obs object. 
hdulist =obs.save_uvfits()
obs2 = obs.load_uvfits(hdulist)

- Fix a minor issue around the header "DATE-OBS"
I made a minor fix to mitigate an error around "DATE-OBS" due to a recent astropy update in Time class. 