### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM continuumio/miniconda2
 
 # install gcc and common build dependencies
-RUN apt-get update \
+RUN apt-get --allow-releaseinfo-change update -y \
  && apt-get install -y \
       build-essential \
       pylint


### PR DESCRIPTION
When a new version of Debian is released, it will change the current stable to oldstable and this causes the docker build to fail on step 2 while running `apt-get update` and gives the following error

```
Reading package lists...
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
```

This PR adds the flag `--allow-releaseinfo-change` which fixes these errors and the docker image finishes building successfully

I will also note that I found this by looking at https://github.com/achael/eht-imaging/issues/131 but this issue was fixed by https://github.com/achael/eht-imaging/commit/b61f511d2b72a1fa1b5907853f3c8cb838446907 so #131 can be closed