### PR TITLE
Move docker base image to conda3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda2
+FROM continuumio/miniconda3
 
 # install gcc and common build dependencies
 RUN apt-get update \
@@ -14,4 +14,4 @@ COPY . .
 # https://stackoverflow.com/questions/37604289/tkinter-tclerror-no-display-name-and-no-display-environment-variable
 RUN conda install -y -c conda-forge pynfft \
  && pip install -r requirements.txt \
- && echo "backend: Agg" >> /opt/conda/lib/python2.7/site-packages/matplotlib/mpl-data/matplotlibrc
+ && echo "backend: Agg" >> /opt/conda/lib/python3.9/site-packages/matplotlib/mpl-data/matplotlibrc

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ astropy
 ephem
 future
 h5py
-html
+html; python_version < '3.1'
 ipython
 matplotlib
 networkx


### PR DESCRIPTION
This migrates the docker image to the python 3 

Python has the html package included in the standard library so I also changed the requirements.txt file to only install html when using python 2