### PR TITLE
Removed IPython from import.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ The package contains several primary classes for loading, simulating, and manipu
 Installation
 ------------
 
-The latest stable version (`1.2.2 <https://github.com/achael/eht-imaging/releases/tag/v1.2.2>`_) is available on `PyPi <https://pypi.org/project/ehtim/>`_. Simply install pip and run
+The latest stable version (`1.2.3 <https://github.com/achael/eht-imaging/releases/tag/v1.2.3>`_) is available on `PyPi <https://pypi.org/project/ehtim/>`_. Simply install pip and run
 
 .. code-block:: bash
 

--- a/ehtim/modeling/modeling_utils.py
+++ b/ehtim/modeling/modeling_utils.py
@@ -46,7 +46,7 @@ from ehtim.const_def import *
 from ehtim.observing.obs_helpers import *
 from ehtim.statistics.dataframes import *
 
-from IPython import display
+#from IPython import display
 
 ##################################################################################################
 # Constants & Definitions

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ if __name__ == "__main__":
                             "ephem",
                             "h5py",
                             "pandas",
+                            "requests"
                           # "pynfft",   # optional (but highly recommended)
                           # "networkx", # optional, only needed if using image_agreements()
                           # "requests", # optional; only needed if using dynamical imaging


### PR DESCRIPTION
I had been trying to use ehtim on a very barebones computer and I noticed I was getting an import error. It looks like the new modeling package had an extraneous IPython import. Since ehtim doesn't require IPython as a dependency it errors out giving 

```
  ) <class 'ModuleNotFoundError'>
  ModuleNotFoundError("No module named 'IPython'")
    File "/opt/hostedtoolcache/Python/3.10.1/x64/lib/python3.10/site-packages/ehtim/__init__.py", line 19, in <module>
      from ehtim.modeling.modeling_utils import modeler_func
    File "/opt/hostedtoolcache/Python/3.10.1/x64/lib/python3.10/site-packages/ehtim/modeling/modeling_utils.py", line 49, in <module>
      from IPython import display
```

Looking at the code, it doesn't appear display is used anywhere, so my guess is that this is an old import. Rather than include another dependency I think we should just kill the import. 