### PR TITLE
Prevent pandas 2 from being installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ipython
 matplotlib
 networkx
 numpy
-pandas
+pandas < '2'
 paramsurvey[ray]
 requests
 scipy


### PR DESCRIPTION
I noticed that pandas 2 seems to break eht-imaging averaging and probably some other stuff. We should fix the averaging, but in the meantime, this will prevent someone from installing the wrong version of pandas. 