### PR TITLE
Bug Fixes for eht-imaging for 2021 project (1 minor and 1 major)

### DIFF
--- a/ehtim/io/load.py
+++ b/ehtim/io/load.py
@@ -25,6 +25,7 @@ from builtins import object
 
 import numpy as np
 import astropy.io.fits as fits
+import astropy.time as atime
 import datetime
 import os
 import copy
@@ -1257,6 +1258,12 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
 
     mjd = int(np.min(jds) - 2400000.5)
     times = (jds - 2400000.5 - mjd) * 24.0
+
+    # If this field exists in the header then we will use this as our MJD and not
+    # what is computed above
+    if "DATE-OBS" in header.keys():
+        jd = atime.Time(datetime.datetime.strptime(header["DATE-OBS"], "%Y-%m-%d")).jd
+        mjd = jd - 2400000.5
 
     try:
         scantable = []

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -383,6 +383,13 @@ class Obsdata(object):
                                 lr = dat['lrvis'].copy()
                                 dat['rlvis'] = np.conj(lr)
                                 dat['lrvis'] = np.conj(rl)
+                                
+                                # You also have to switch the errors for the coherency!
+                                rlerr = dat['rlsigma'].copy()
+                                lrerr = dat['lrsigma'].copy()
+                                dat["rlsigma"] = lrerr
+                                dat["lrsigma"] = rlerr
+
                             else:
                                 raise Exception("polrep must be either 'stokes' or 'circ'")
 
@@ -439,7 +446,14 @@ class Obsdata(object):
             rl = dat['rlvis'].copy()
             lr = dat['lrvis'].copy()
             dat['rlvis'][ordermask] = np.conj(lr[ordermask])
-            dat['lrvis'][ordermask] = np.conj(rl[ordermask])            
+            dat['lrvis'][ordermask] = np.conj(rl[ordermask])
+
+            # Also need to switch error matrix
+            rle = dat['rlsigma'].copy()
+            lre = dat['lrsigma'].copy()
+            dat['rlsigma'][ordermask] = lre[ordermask]
+            dat['lrsigma'][ordermask] = rle[ordermask]
+
         else:
             raise Exception("polrep must be either 'stokes' or 'circ'")
 
@@ -543,8 +557,15 @@ class Obsdata(object):
                         data[f] = np.hstack((self.data['rlvis'], np.conj(self.data['lrvis'])))
                     elif f == 'lrvis':
                         data[f] = np.hstack((self.data['lrvis'], np.conj(self.data['rlvis'])))
+
+                    # ALSO SWITCH THE ERRORS!                    
                 else:
                     raise Exception("polrep must be either 'stokes' or 'circ'")
+            # The conjugate baselines need the transpose error terms.
+            elif f == "rlsigma":
+                data[f] = np.hstack((self.data["rlsigma"], self.data["lrsigma"]))
+            elif f == "lrsigma":
+                data[f] = np.hstack((self.data["lrsigma"], self.data["rlsigma"]))
 
             else:
                 data[f] = np.hstack((self.data[f], self.data[f]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ipython
 matplotlib
 networkx
 numpy
-pandas < '2'
+pandas < 2
 paramsurvey[ray]
 requests
 scipy


### PR DESCRIPTION
Hi eht-imaging team,

I and others (primarily others) found a few bugs in eht-imaging that this pull-request attempts to fix.

The first is relatively minor and adds a check to read the MJD optionally from the uvfits `DATE-OBS` entry in the header. This is used for some CASA pipelines that modify the `PZERO5` time offset so the mjd is scrambled.

The second bug fix is more critical and is an error in eht-imaging and could lead to the wrong errors getting assigned to the cross-hand polarization products. When the eht does baseline re-ordering so that everything is consistent, it currently does not also transpose the error matrix. This means that the error for RL and LR gets swapped.
You can see this most easily in data that has a missing feed. For example, consider the baseline JCMT-GLT where JCMT has only the RCP product. Then the coherency and error look like

```
 coherency = [[a+ib c+id]
               [NaN NaN]]

error =  [ [e  f],
         [NaN NaN]
``` 

Now if we use `obs.reorder_baselines()` to swap the ordering to GLT-JCMT, the result looks like

```
 coherency = [[a-ib NaN]
            [c-ib NaN]]

error = [ [e   f],
         [NaN NaN]

```

I found three instances where this occurred in the code, but I may have missed more. 

