### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ paramsurvey[ray]
 requests
 scipy
 scikit-image
+numpy < '2'
 
 
 # pynfft requires external dependency; install with Conda.


### PR DESCRIPTION
Numpy versions greater than 1 causes the following error on import of `ehtim`

```ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject```

[Here's the numpy 2.0 release notes](https://numpy.org/doc/stable/release/2.0.0-notes.html#required-changes-for-custom-legacy-user-dtypes) for reference.

__Update:__

This seems to be because `pandas<2` does not support `numpy@2.0.`
