### PR TITLE
Added splitting scans when array changes in add_scans

### DIFF
--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -1634,7 +1634,7 @@ class Obsdata(object):
 
         return
 
-    def add_scans(self, info='self', filepath='', dt=0.0165, margin=0.0001):
+    def add_scans(self, info='self', filepath='', dt=0.0165, margin=0.0001,split_subarray=False):
         """Compute scans and add self.scans to Obsdata object.
 
             Args:
@@ -1680,6 +1680,23 @@ class Obsdata(object):
         else:
             print("Parameter 'info' can only assume values 'self', 'txt' or 'vex'! ")
             scanlist = None
+
+        #Split scan in 2 wherever the array changed
+        if split_subarray:
+            timelist=self.tlist()
+            prev_array=[]
+            for cou in range(len(timelist)):
+                current_array=np.unique([timelist[cou]['t1'],timelist[cou]['t2']])
+                if set(current_array)==set(prev_array):
+                    continue
+                split_time=timelist[cou]['time'][0]
+                prev_array=current_array
+                if split_time-margin in scanlist[:,0]:
+                    continue
+                index=np.where(split_time>=scanlist.T[0])[0][-1]
+                scanlist=np.insert(scanlist,index,scanlist[index],axis=0)
+                scanlist[index,1]=split_time-margin
+                scanlist[index+1,0]=split_time+margin
 
         self.scans = scanlist
 


### PR DESCRIPTION
I added the split_subarray option in add_scans so that scan averaging is done for the same length of time regardless of what length of the scan the baseline is present for. By default, it is turned off, so any previous code should act the same. The plots show the behavior before and after.
![Zoomed](https://github.com/user-attachments/assets/35dd0821-76ae-470b-9167-7f887e6dd41b)
![Zoomed_fixed](https://github.com/user-attachments/assets/bf3179f8-9d48-43ae-8961-5937db0eb4b1)
