### PR TITLE
Updating `ehtim` to be compatible with `scipy>1.14`

### DIFF
--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -1070,8 +1070,16 @@ class Image(object):
             if np.any(np.imag(imvec) != 0):
                 return interp_imvec(np.real(imvec)) + 1j * interp_imvec(np.imag(imvec))
 
-            interpfunc = scipy.interpolate.interp2d(y, x, np.reshape(imvec, (self.ydim, self.xdim)),
-                                                    kind=interp)
+
+            # interpfunc = scipy.interpolate.interp2d(y, x, np.reshape(imvec, (self.ydim, self.xdim)),
+                                                    # kind=interp) ## DEPRECATED. commented out for legacy
+
+            ## new code to be compatible with scipy 1.14+
+            interp_order = {"linear": 1, "quadratic": 2, "cubic": 3}.get(interp, 1)
+            grid_z = np.reshape(imvec, (self.ydim, self.xdim))
+            interpfunc = scipy.interpolate.RectBivariateSpline(y, x, grid_z, kx=interp_order, ky=interp_order)
+
+
             tmpimg = interpfunc(ytarget, xtarget)
             tmpimg[np.abs(xtarget) > fov_x / 2., :] = 0.0
             tmpimg[:, np.abs(ytarget) > fov_y / 2.] = 0.0


### PR DESCRIPTION
## Summary 

`scipy` has recently deprecated the `scipy.interpolate.interp2d` function as of version 1.14 (see my issue here: https://github.com/achael/eht-imaging/issues/192) [Instructions](https://docs.scipy.org/doc/scipy/tutorial/interpolate/interp_transition_guide.html#interp-transition-guide) are given for moving to the new functions, chiefly, `scipy.interpolate.RectBivariateSpline`. I implemented this in `ehtim` to return functionality primarily to the `regrid_image` method in the `Image` class, which relies on `interp2d`. 

## Changes

Previously, interpolation in `regrid_image` was done via

```python
interpfunc = scipy.interpolate.interp2d(y, x, np.reshape(imvec, (self.ydim, self.xdim)),
                                                    kind=interp) 
```

The new version of `scipy` requires we use `RectBivariateSpline`, which operates a little bit differently than `interp2d`. Also, the `interp` keyword of `regrid_image` can no longer be passed directly to `interp2d`, as `RectBivariateSpline` requires the order of the interpolation to be an integer. The new code reads:

```python
interp_order = {"linear": 1, "quadratic": 2, "cubic": 3}.get(interp, 1)
grid_z = np.reshape(imvec, (self.ydim, self.xdim))
interpfunc = scipy.interpolate.RectBivariateSpline(y, x, grid_z, kx=interp_order, ky=interp_order)
```

## Tests

I tested these changes using the following script:

```python
import sys
sys.path.append('../')

import ehtim as eh

import matplotlib.pyplot as plt
import numpy as np

## load the image
im = eh.image.load_txt('../models/avery_sgra_eofn.txt')
im.display()
input()



## resize image 
im_resize = im.regrid_image(300*eh.RADPERUAS, 128)
im_resize.display()
input()
```

This code works in the current version of `ehtim` on systems with `scipy<1.14` but breaks if `scipy>=1.14`. However, with the changes, this script works in the new version of `scipy` and is also backwards compatible, so it will not break even if you do have `scipy<1.14` installed.