### PR TITLE
remove pynfft from the requirements only for macOS AppleSilicon machines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
                             "requests",
                             "future",
                             "networkx", 
-                            "pynfft",
+                            "pynfft; platform_system!='Darwin' or platform_machine!='arm64'",
                             "paramsurvey"
                            ],
           classifiers=[


### PR DESCRIPTION
Happy newyear @achael !

I noticed that recently ehtim included pynfft as its requirement in setup.py. This is a natural addition for many users but has created a challenging situation for macOS users with Apple Silicon CPUs, as pynfft cannot be installed with the standard way through package managing systems. Currently users need to manually edit setup.py or alternatively manually install pynfft using Rohan Dahale's recipe. 

As a consequence, this had made it impossible for users to use ehtim from some other languages, even if they don't use pynfft at all --- an obvious example I know of is Julia and its Comrade ecosystem which relies on micromamba and ultimately pip for the installation of python packages including ehtim. Comrade.jl can't load uvfits files at Apple Silicon machines because of this.

I went through [PEP508](https://peps.python.org/pep-0508/#environment-markers) document and learned that we can avoid this situation by a single line of addition to setup.py. I tested this in both intel/M3 MacBook, and it worked.
"""python
          install_requires=["numpy>=1.24,<2.0",
                            "scipy>=1.9.3,<1.14",
                            "astropy>=5.0.4",
                            "matplotlib>=3.7.3",
                            "skyfield",
                            "h5py",
                            "pandas",
                            "requests",
                            "future",
                            "networkx", 
                            "pynfft; platform_system!='Darwin' or platform_machine!='arm64'",
                            "paramsurvey"
                           ]
"""

Here I want to make a pull request so that ehtim is easily installable for Apple Silicon users. Please check and merge it if this looks reasonable. 