### PR TITLE
Vectorize Scatter() for 2x speedup

### DIFF
--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -497,14 +497,14 @@ class ScatteringModel(object):
                 EA_im_U = (EA_Image.uvec).reshape(Ny,Nx)
             if len(Unscattered_Image.vvec):
                 EA_im_V = (EA_Image.vvec).reshape(Ny,Nx)
+            rx = np.arange(Nx)[np.newaxis, :]  # (1, Nx)
+            ry = np.arange(Ny)[:, np.newaxis]  # (Ny, 1)
             # Note: signs are negative to match the linearized approximation. The choice
             # shouldn't matter (-phi has the same power spectrum as phi), but getting the
             # *relative* sign for x- and y-directions correct is important.
-            rx = np.arange(Nx)[np.newaxis, :]  # (1, Nx)
-            ry = np.arange(Ny)[:, np.newaxis]  # (Ny, 1)
-            scale = rF**2.0 / self.observer_screen_distance / Unscattered_Image.psize
-            rxp = np.round(rx - scale * phi_Gradient_x).astype(int) % Nx
-            ryp = np.round(ry - scale * phi_Gradient_y).astype(int) % Ny
+            pixel_deflection = rF**2.0 / self.observer_screen_distance / Unscattered_Image.psize
+            rxp = np.round(rx - pixel_deflection * phi_Gradient_x).astype(int) % Nx
+            ryp = np.round(ry - pixel_deflection * phi_Gradient_y).astype(int) % Ny
             AI = EA_im[ryp, rxp]
             if len(Unscattered_Image.qvec):
                 AI_Q = EA_im_Q[ryp, rxp]

--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -499,9 +499,7 @@ class ScatteringModel(object):
                 EA_im_V = (EA_Image.vvec).reshape(Ny,Nx)
             rx = np.arange(Nx)[np.newaxis, :]  # (1, Nx)
             ry = np.arange(Ny)[:, np.newaxis]  # (Ny, 1)
-            # Note: signs are negative to match the linearized approximation. The choice
-            # shouldn't matter (-phi has the same power spectrum as phi), but getting the
-            # *relative* sign for x- and y-directions correct is important.
+            # Annoyingly, the signs here must be negative to match the other approximation. I'm not sure which is correct, but it really shouldn't matter anyway because -phi has the same power spectrum as phi. However, getting the *relative* sign for the x- and y-directions correct is important.
             pixel_deflection = rF**2.0 / self.observer_screen_distance / Unscattered_Image.psize
             rxp = np.round(rx - pixel_deflection * phi_Gradient_x).astype(int) % Nx
             ryp = np.round(ry - pixel_deflection * phi_Gradient_y).astype(int) % Ny

--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -501,17 +501,18 @@ class ScatteringModel(object):
             if len(Unscattered_Image.vvec):
                 AI_V = np.copy((EA_Image.imvec).reshape(Ny,Nx))
                 EA_im_V = (EA_Image.vvec).reshape(Ny,Nx)
-            for rx in range(Nx):
-                for ry in range(Ny):
-                    # Annoyingly, the signs here must be negative to match the other approximation. I'm not sure which is correct, but it really shouldn't matter anyway because -phi has the same power spectrum as phi. However, getting the *relative* sign for the x- and y-directions correct is important.
-                    rxp = int(np.round(rx - rF**2.0 * phi_Gradient_x[ry,rx]/self.observer_screen_distance/Unscattered_Image.psize))%Nx
-                    ryp = int(np.round(ry - rF**2.0 * phi_Gradient_y[ry,rx]/self.observer_screen_distance/Unscattered_Image.psize))%Ny
-                    AI[ry,rx] = EA_im[ryp,rxp]
-                    if len(Unscattered_Image.qvec):
-                        AI_Q[ry,rx] = EA_im_Q[ryp,rxp]
-                        AI_U[ry,rx] = EA_im_U[ryp,rxp]
-                    if len(Unscattered_Image.vvec):
-                        AI_V[ry,rx] = EA_im_V[ryp,rxp]
+            # Vectorized remapping (replaces nested pixel loop)
+            rx = np.arange(Nx)[np.newaxis, :]  # (1, Nx)
+            ry = np.arange(Ny)[:, np.newaxis]  # (Ny, 1)
+            scale = rF**2.0 / self.observer_screen_distance / Unscattered_Image.psize
+            rxp = np.round(rx - scale * phi_Gradient_x).astype(int) % Nx
+            ryp = np.round(ry - scale * phi_Gradient_y).astype(int) % Ny
+            AI = EA_im[ryp, rxp]
+            if len(Unscattered_Image.qvec):
+                AI_Q = EA_im_Q[ryp, rxp]
+                AI_U = EA_im_U[ryp, rxp]
+            if len(Unscattered_Image.vvec):
+                AI_V = EA_im_V[ryp, rxp]
 
         #Optional: eliminate negative flux
         if Force_Positivity == True:

--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -492,16 +492,14 @@ class ScatteringModel(object):
                     AI_V = (EA_Image.vvec).reshape(Ny,Nx) + rF**2.0 * ( EA_Gradient_x*phi_Gradient_x + EA_Gradient_y*phi_Gradient_y )
         else: #Use Equation 9 of Johnson & Narayan (2016)
             EA_im = (EA_Image.imvec).reshape(Ny,Nx)
-            AI = np.copy((EA_Image.imvec).reshape(Ny,Nx))
             if len(Unscattered_Image.qvec):
-                AI_Q = np.copy((EA_Image.imvec).reshape(Ny,Nx))
-                AI_U = np.copy((EA_Image.imvec).reshape(Ny,Nx))
                 EA_im_Q = (EA_Image.qvec).reshape(Ny,Nx)
                 EA_im_U = (EA_Image.uvec).reshape(Ny,Nx)
             if len(Unscattered_Image.vvec):
-                AI_V = np.copy((EA_Image.imvec).reshape(Ny,Nx))
                 EA_im_V = (EA_Image.vvec).reshape(Ny,Nx)
-            # Vectorized remapping (replaces nested pixel loop)
+            # Note: signs are negative to match the linearized approximation. The choice
+            # shouldn't matter (-phi has the same power spectrum as phi), but getting the
+            # *relative* sign for x- and y-directions correct is important.
             rx = np.arange(Nx)[np.newaxis, :]  # (1, Nx)
             ry = np.arange(Ny)[:, np.newaxis]  # (Ny, 1)
             scale = rF**2.0 / self.observer_screen_distance / Unscattered_Image.psize


### PR DESCRIPTION
And save a few copy() operations as well for a small memory win.

Previously the implementation of [equation 9](https://arxiv.org/pdf/1606.06315) looped over every `(rx, ry)` and computed the new coordinates one pixel at a time. This works, but Python loops are slow, and we can instead have Numpy operate on the entire matrix at once. (This isn't an algorithmic improvement, but means we're pushing as much work as possible down into C).

Depending on hardware, problem size, numpy backend, etc, solving eq 9 can be made around 100-250x faster this way. See this gist for a runnable repro: https://gist.github.com/jberg5/c26bd60101507318d0d8fb8d03891ea4. On a GCP c2-standard-4, that script gives the following:

| Size | Loop | Vectorized | Speedup |
|------|------|------------|---------|
| 64×64 | 20.0ms | 0.15ms | **137x** |
| 128×128 | 80.0ms | 0.54ms | **148x** |
| 256×256 | 325.8ms | 2.5ms | **130x** |
| 512×512 | 1356ms | 10.9ms | **124x** |

However, this routine only accounted for 50-60% of the total Scatter() runtime, so the overall speedup isn't going to be quite that dramatic.

As a very low-tech sanity check, I printed out some timing from [example_scattering.py](https://github.com/achael/eht-imaging/blob/main/examples/example_scattering.py)

```python
# Now approximate the ensemble-average image by averaging 100 realizations of the scattering
start = time.time()
im_scatt_List = [sm.Scatter(im,so.MakeEpsilonScreen(im.xdim,im.ydim,rngseed=j),DisplayImage=False) for j in range(100)]
print(f"Scatter list took {time.time()-start:.3f}s")
```

Running `python example_scattering.py` from main reports:
```
Scatter list took 7.608s
```

And from my branch:
```
Scatter list took 3.633s
```

To test correctness, I confirmed that the output is numerically identical (verified via ensemble average flux and direct array comparison).