### PR TITLE
Add tests/conftest.py with shared pytest fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ tutorials/tutorial_results/*
 !ehtim/tests/test_*.py
 !tests/
 !tests/test_*.py
+!tests/conftest.py
 
 .ipynb_checkpoints
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 
 import os
 
-import numpy as np
 import pytest
 
 import ehtim as eh
@@ -77,6 +76,7 @@ def obs_fast(gauss_im, eht_array):
 @pytest.fixture(scope="session")
 def obs_nfft(gauss_im, eht_array):
     """Noise-free observation of Gaussian image using NFFT."""
+    pytest.importorskip("pynfft")
     return gauss_im.observe(
         eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
         ampcal=True, phasecal=True, ttype="nfft", add_th_noise=False,
@@ -89,6 +89,7 @@ def obs_noisy(gauss_im, eht_array):
     return gauss_im.observe(
         eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
         ampcal=True, phasecal=True, ttype="direct", add_th_noise=True,
+        seed=42,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,98 @@
+"""Shared pytest fixtures for eht-imaging tests."""
+
+import os
+
+import numpy as np
+import pytest
+
+import ehtim as eh
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_ROOT = os.path.join(os.path.dirname(__file__), "..")
+ARRAY_DIR = os.path.join(_ROOT, "arrays")
+MODEL_DIR = os.path.join(_ROOT, "models")
+
+# ---------------------------------------------------------------------------
+# Common observation parameters
+# ---------------------------------------------------------------------------
+
+TINT_SEC = 5
+TADV_SEC = 600
+TSTART_HR = 0
+TSTOP_HR = 24
+BW_HZ = 4e9
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def eht_array():
+    """Load the EHT 2017 array."""
+    return eh.array.load_txt(os.path.join(ARRAY_DIR, "EHT2017.txt"))
+
+
+@pytest.fixture(scope="session")
+def gauss_im():
+    """Create a 32x32 Gaussian test image (synthetic, no file dependency)."""
+    im = eh.image.make_empty(32, 200 * eh.RADPERUAS, 17.761, -29.0, rf=230e9)
+    im = im.add_gauss(1.0, (50 * eh.RADPERUAS, 50 * eh.RADPERUAS, 0, 0, 0))
+    return im
+
+
+@pytest.fixture(scope="session")
+def sgra_im():
+    """Load the avery_sgra model image."""
+    return eh.image.load_txt(os.path.join(MODEL_DIR, "avery_sgra_eofn.txt"))
+
+
+@pytest.fixture(scope="session")
+def m87_im():
+    """Load the jason_mad M87 model image."""
+    return eh.image.load_txt(os.path.join(MODEL_DIR, "jason_mad_eofn.txt"))
+
+
+@pytest.fixture(scope="session")
+def obs_direct(gauss_im, eht_array):
+    """Noise-free observation of Gaussian image using direct FT."""
+    return gauss_im.observe(
+        eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
+        ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+    )
+
+
+@pytest.fixture(scope="session")
+def obs_fast(gauss_im, eht_array):
+    """Noise-free observation of Gaussian image using FFT."""
+    return gauss_im.observe(
+        eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
+        ampcal=True, phasecal=True, ttype="fast", add_th_noise=False,
+    )
+
+
+@pytest.fixture(scope="session")
+def obs_nfft(gauss_im, eht_array):
+    """Noise-free observation of Gaussian image using NFFT."""
+    return gauss_im.observe(
+        eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
+        ampcal=True, phasecal=True, ttype="nfft", add_th_noise=False,
+    )
+
+
+@pytest.fixture(scope="session")
+def obs_noisy(gauss_im, eht_array):
+    """Noisy observation of Gaussian image using direct FT."""
+    return gauss_im.observe(
+        eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
+        ampcal=True, phasecal=True, ttype="direct", add_th_noise=True,
+    )
+
+
+@pytest.fixture(scope="session")
+def gauss_prior(gauss_im):
+    """A blurred copy of the Gaussian image suitable for use as a prior."""
+    return gauss_im.blur_circ(30 * eh.RADPERUAS)


### PR DESCRIPTION
## Summary

- Adds `tests/conftest.py` with session scoped pytest fixtures shared across all test files
- Whitelists `conftest.py` in `.gitignore` (previously only `test_*.py` was allowed)

## Fixtures provided

| Fixture | Description |
|---------|-------------|
| `eht_array` | EHT 2017 array (8 stations) |
| `gauss_im` | 32x32 Gaussian test image (synthetic, 1 Jy, 50 μas FWHM) |
| `sgra_im` | Loaded avery_sgra model image |
| `m87_im` | Loaded jason_mad M87 model image |
| `obs_direct` | Noise-free observation via direct FT (1030 visibilities) |
| `obs_fast` | Noise-free observation via FFT (1030 visibilities) |
| `obs_nfft` | Noise-free observation via NFFT (1030 visibilities) |
| `obs_noisy` | Noisy observation via direct FT |
| `gauss_prior` | Blurred Gaussian image for use as imaging prior |

All fixtures are `scope="session"` so they are computed once per test run.

## How to test

```bash
cd eht-imaging
python -m pytest tests/test_imager_history.py -q
```

Existing tests still pass (38/73 — the 35 `TestAfterTwoRuns` errors are pre-existing, tracked separately).

Implements task 0.1 from #212.