### PR TITLE
Fix duplicate maxit kwarg in test_imager_history fixtures

### DIFF
--- a/tests/test_imager_history.py
+++ b/tests/test_imager_history.py
@@ -31,14 +31,14 @@ def _make_test_imager(**kwargs):
         add_th_noise=False, ampcal=True, phasecal=True,
         ttype="direct",
     )
-    return Imager(
-        obs, im, prior_im=im,
+    defaults = dict(
         data_term={"vis": 1},
         reg_term={"simple": 1, "flux": 100},
         ttype="direct",
         maxit=5,
-        **kwargs,
     )
+    defaults.update(kwargs)
+    return Imager(obs, im, prior_im=im, **defaults)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- `_make_test_imager()` hardcoded `maxit=5` as a positional kwarg alongside `**kwargs`, causing `TypeError` when callers (e.g., `TestAfterTwoRuns`) also passed `maxit`
- Fix: use a defaults dict with `.update(kwargs)` so callers can override any default cleanly

## Before

```
35 errors in TestAfterTwoRuns, TestMaxsetBugFix — all TypeError: got multiple values for keyword argument 'maxit'
```

## After

```
73 passed, 0 errors
```

## How to test

```bash
cd eht-imaging
python -m pytest tests/test_imager_history.py -q
```