### PR TITLE
Add GitHub Actions CI with ruff lint, pytest, and codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev-backend]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: git fetch origin ${{ github.base_ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - name: Ruff check (changed files only)
+        run: |
+          FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- '*.py' || true)
+          if [ -n "$FILES" ]; then
+            echo "$FILES" | xargs ruff check
+          else
+            echo "No Python files changed"
+          fi
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - run: pip install -e ".[dev]"
+      - run: pytest tests/test_imager_history.py --cov --cov-branch --cov-report=xml
+      - uses: codecov/codecov-action@v4
+        if: matrix.python-version == '3.12'
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: false


### PR DESCRIPTION
- Adds GitHub Actions CI workflow triggered on PRs to `dev-backend`
- Ruff lint on changed Python files only (avoids legacy code noise)
- Pytest on Python 3.10 + 3.12 with coverage upload to Codecov
- Timeouts and pip caching for efficiency

This PR requires #218 (pyproject.toml) to be merged first, since `pip install -e ".[dev]"` needs pyproject.toml for the dev dependencies.

- Ruff checks only changed files, not the full codebase -- existing code will not block PRs
- Tests run only `test_imager_history.py` for now -- the only proper pytest file. Will expand as legacy test scripts are converted (task 0.2)
- Codecov uploads only from the Python 3.12 run to avoid duplicate reports

Implements task 0.3 from #212.