### PR TITLE
Add rectangular image tests + fix bugs found by them

### DIFF
--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -784,7 +784,6 @@ def chisqgrad_vis_fft(vis_arr, A, vis, sigma):
     grad_arr = grad_arr * (im_info.npad * im_info.npad)
 
     # extract relevant cells and flatten
-    # TODO or is x<-->y??
     out = np.real(grad_arr[im_info.padvaly1:-im_info.padvaly2,
                            im_info.padvalx1:-im_info.padvalx2].flatten())
 
@@ -822,7 +821,6 @@ def chisqgrad_amp_fft(vis_arr, A, amp, sigma):
     grad_arr = grad_arr * (im_info.npad * im_info.npad)
 
     # extract relevent cells and flatten
-    # TODO or is x<-->y??
     out = np.real(grad_arr[im_info.padvaly1:-im_info.padvaly2,
                            im_info.padvalx1:-im_info.padvalx2].flatten())
 
@@ -860,7 +858,6 @@ def chisqgrad_bs_fft(vis_arr, A, bis, sigma):
     grad_arr = grad_arr * (im_info.npad * im_info.npad)
 
     # extract relevant cells and flatten
-    # TODO or is x<-->y??
     out = np.real(grad_arr[im_info.padvaly1:-im_info.padvaly2,
                            im_info.padvalx1:-im_info.padvalx2].flatten())
     return out
@@ -904,7 +901,6 @@ def chisqgrad_cphase_fft(vis_arr, A, clphase, sigma):
     grad_arr = grad_arr * (im_info.npad * im_info.npad)
 
     # extract relevant cells and flatten
-    # TODO or is x<-->y??
     out = np.imag(grad_arr[im_info.padvaly1:-im_info.padvaly2,
                            im_info.padvalx1:-im_info.padvalx2].flatten())
 
@@ -1025,7 +1021,6 @@ def chisqgrad_camp_fft(vis_arr, A, clamp, sigma):
     grad_arr = grad_arr * (im_info.npad * im_info.npad)
 
     # extract relevant cells and flatten
-    # TODO or is x<-->y??
     out = np.real(grad_arr[im_info.padvaly1:-im_info.padvaly2,
                            im_info.padvalx1:-im_info.padvalx2].flatten())
 
@@ -1071,7 +1066,6 @@ def chisqgrad_logcamp_fft(vis_arr, A, log_clamp, sigma):
     grad_arr = grad_arr * (im_info.npad * im_info.npad)
 
     # extract relevant cells and flatten
-    # TODO or is x<-->y??
     out = np.real(grad_arr[im_info.padvaly1:-im_info.padvaly2,
                            im_info.padvalx1:-im_info.padvalx2].flatten())
 
@@ -1195,7 +1189,6 @@ def chisqgrad_logamp_fft(vis_arr, A, amp, sigma):
     grad_arr = grad_arr * (im_info.npad * im_info.npad)
 
     # extract relevent cells and flatten
-    # TODO or is x<-->y??
     out = np.real(grad_arr[im_info.padvaly1:-im_info.padvaly2,
                            im_info.padvalx1:-im_info.padvalx2].flatten())
 

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -2529,7 +2529,7 @@ def sgauss(imvec, xdim, ydim, psize, major, minor, PA):
     sigxy_prime = (lambda2 - lambda1)*np.cos(phi)*np.sin(phi)
 
     # we get the dimensions and image vector
-    im = imvec.reshape(xdim, ydim)
+    im = imvec.reshape(ydim, xdim)
     xlist, ylist = np.meshgrid(range(xdim), range(ydim))
     xlist = xlist - (xdim-1)/2.0
     ylist = ylist - (ydim-1)/2.0
@@ -2571,7 +2571,7 @@ def sgauss_grad(imvec, xdim, ydim, psize, major, minor, PA):
     sigxy_prime = (lambda2 - lambda1)*np.cos(phi)*np.sin(phi)
 
     # we get the dimensions and image vector
-    im = imvec.reshape(xdim, ydim)
+    im = imvec.reshape(ydim, xdim)
     xlist, ylist = np.meshgrid(range(xdim), range(ydim))
     xlist = xlist - (xdim-1)/2.0
     ylist = ylist - (ydim-1)/2.0
@@ -2588,17 +2588,13 @@ def sgauss_grad(imvec, xdim, ydim, psize, major, minor, PA):
     sigyy = (np.sum((yy - y0)**2.*im)/np.sum(im))
     sigxy = (np.sum((xx - x0)*(yy - y0)*im)/np.sum(im))
 
-    # now we compute the gradients of all quantities
-    # gradient of centroid
-    dx0 = (xx - x0) / np.sum(im)
-    dy0 = (yy - y0) / np.sum(im)
-
     # gradients of covariance matrix elements
-    dxx = (((xx - x0)**2. - 2.*(xx - x0)*dx0*im) - sigxx) / np.sum(im)
-
-    dyy = (((yy - y0)**2. - 2.*(yy - y0)*dx0*im) - sigyy) / np.sum(im)
-
-    dxy = (((xx - x0)*(yy - y0) - (yy - y0)*dx0*im - (xx - x0)*dy0*im) - sigxy) / np.sum(im)
+    # d(sig_ab)/d(im_k) = [(a_k - a0)(b_k - b0) - sig_ab] / sum(im)
+    # cross-term through centroid dependence sums to zero by definition of centroid
+    S = np.sum(im)
+    dxx = ((xx - x0)**2. - sigxx) / S
+    dyy = ((yy - y0)**2. - sigyy) / S
+    dxy = ((xx - x0)*(yy - y0) - sigxy) / S
 
     # gradient of the regularizer #this line was CHANGED
     drgauss = (2.*(sigxx - sigxx_prime)*dxx +

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -17,22 +17,13 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
 
-import time
-import numpy as np
-import scipy.optimize as opt
 import matplotlib.pyplot as plt
+import numpy as np
 
-import ehtim.image as image
-import ehtim.observing.obs_helpers as obsh
 import ehtim.const_def as ehc
-
+import ehtim.observing.obs_helpers as obsh
 
 ##################################################################################################
 # Constants & Definitions
@@ -255,7 +246,7 @@ def regularizer(imvec, nprior, mask, flux, xdim, ydim, psize, stype, **kwargs):
         if np.any(np.invert(mask)):
             imvec = embed(imvec, mask, randomfloor=True)
         s = -stv(imvec, xdim, ydim, psize, flux, norm_reg=norm_reg,beam_size=beam_size, epsilon=epsilon)
-    elif stype == "tvlog": 
+    elif stype == "tvlog":
         if np.any(np.invert(mask)):
             imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
         npix = xdim*ydim
@@ -268,7 +259,7 @@ def regularizer(imvec, nprior, mask, flux, xdim, ydim, psize, stype, **kwargs):
         s = -stv2(imvec, xdim, ydim, psize, flux, norm_reg=norm_reg, beam_size=beam_size)
     elif stype == "tv2log":
         if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)      
+            imvec = embed(imvec, mask, randomfloor=True)
         npix = xdim*ydim
         logvec = np.log(imvec)
         logflux = npix*np.abs(np.log(flux/npix))
@@ -335,7 +326,7 @@ def regularizergrad(imvec, nprior, mask, flux, xdim, ydim, psize, stype, **kwarg
         logflux = npix*np.abs(np.log(flux/npix))
         s = -stvgrad(logvec, xdim, ydim, psize, logflux, norm_reg=norm_reg,beam_size=beam_size, epsilon=epsilon)
         s = s / imvec
-        s = s[mask]        
+        s = s[mask]
     elif stype == "tv2":
         if np.any(np.invert(mask)):
             imvec = embed(imvec, mask, randomfloor=True)
@@ -349,7 +340,7 @@ def regularizergrad(imvec, nprior, mask, flux, xdim, ydim, psize, stype, **kwarg
         logflux = npix*np.abs(np.log(flux/npix))
         s = -stv2grad(logvec, xdim, ydim, psize, logflux, norm_reg=norm_reg, beam_size=beam_size)
         s = s / imvec
-        s = s[mask]        
+        s = s[mask]
     elif stype == "compact":
         if np.any(np.invert(mask)):
             imvec = embed(imvec, mask, randomfloor=True)
@@ -487,7 +478,7 @@ def chisq_bs(imvec, Amatrices, bis, sigma):
     bisamples = (np.dot(Amatrices[0], imvec) *
                  np.dot(Amatrices[1], imvec) *
                  np.dot(Amatrices[2], imvec))
-    chisq = np.sum(np.abs(((bis - bisamples)/sigma))**2)/(2.*len(bis))
+    chisq = np.sum(np.abs((bis - bisamples)/sigma)**2)/(2.*len(bis))
     return chisq
 
 
@@ -503,7 +494,7 @@ def chisqgrad_bs(imvec, Amatrices, bis, sigma):
     pt2 = wdiff * np.dot(Amatrices[0], imvec) * np.dot(Amatrices[2], imvec)
     pt3 = wdiff * np.dot(Amatrices[0], imvec) * np.dot(Amatrices[1], imvec)
     out = (np.dot(pt1, Amatrices[0]) +
-           np.dot(pt2, Amatrices[1]) + 
+           np.dot(pt2, Amatrices[1]) +
            np.dot(pt3, Amatrices[2]))
 
     out = -np.real(out) / len(bis)
@@ -624,7 +615,7 @@ def chisqgrad_camp(imvec, Amatrices, clamp, sigma):
     pt2 = pp/i2
     pt3 = -pp/i3
     pt4 = -pp/i4
-            
+
     out = (np.dot(pt1, Amatrices[0]) +
            np.dot(pt2, Amatrices[1]) +
            np.dot(pt3, Amatrices[2]) +
@@ -654,7 +645,7 @@ def chisqgrad_logcamp(imvec, Amatrices, log_clamp, sigma):
     i3 = np.dot(Amatrices[2], imvec)
     i4 = np.dot(Amatrices[3], imvec)
     log_clamp_samples = (np.log(np.abs(i1)) +
-                         np.log(np.abs(i2)) - 
+                         np.log(np.abs(i2)) -
                          np.log(np.abs(i3)) -
                          np.log(np.abs(i4)))
 
@@ -755,7 +746,7 @@ def chisqgrad_logamp(imvec, A, amp, sigma):
     i1 = np.dot(A, imvec)
     amp_samples = np.abs(i1)
 
-    pp = ((np.log(amp) - np.log(amp_samples))) / (logsigma**2) / i1
+    pp = (np.log(amp) - np.log(amp_samples)) / (logsigma**2) / i1
     out = (-2.0/len(amp)) * np.real(np.dot(pp, A))
     return out
 
@@ -844,7 +835,7 @@ def chisq_bs_fft(vis_arr, A, bis, sigma):
     im_info, sampler_info_list, gridder_info_list = A
     bisamples = obsh.sampler(vis_arr, sampler_info_list, sample_type="bs")
 
-    return np.sum(np.abs(((bis - bisamples)/sigma))**2)/(2.*len(bis))
+    return np.sum(np.abs((bis - bisamples)/sigma)**2)/(2.*len(bis))
 
 
 def chisqgrad_bs_fft(vis_arr, A, bis, sigma):
@@ -1195,7 +1186,7 @@ def chisqgrad_logamp_fft(vis_arr, A, amp, sigma):
     # gradient FT
     logsigma = sigma / amp
     pulsefac = sampler_info_list[0].pulsefac
-    wdiff_vec = (-2.0/len(amp)*((np.log(amp) - np.log(amp_samples))) /
+    wdiff_vec = (-2.0/len(amp)*(np.log(amp) - np.log(amp_samples)) /
                  (logsigma**2) / samples.conj()) * pulsefac.conj()
 
     # Setup and perform the inverse FFT
@@ -1334,7 +1325,7 @@ def chisq_bs_nfft(imvec, A, bis, sigma):
 
     # compute chi^2
     bisamples = samples1*samples2*samples3
-    chisq = np.sum(np.abs(((bis - bisamples)/sigma))**2)/(2.*len(bis))
+    chisq = np.sum(np.abs((bis - bisamples)/sigma)**2)/(2.*len(bis))
     return chisq
 
 
@@ -2036,7 +2027,7 @@ def chisqgrad_logamp_nfft(imvec, A, amp, sigma):
 
     # gradient vec for adjoint FT
     logsigma = sigma / amp
-    wdiff_vec = (-2.0/len(amp)*((np.log(amp) - np.log(amp_samples))) /
+    wdiff_vec = (-2.0/len(amp)*(np.log(amp) - np.log(amp_samples)) /
                  (logsigma**2) / samples.conj()) * pulsefac.conj()
     plan.f = wdiff_vec
     plan.adjoint()
@@ -2457,8 +2448,8 @@ def scompactgrad(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_siz
     x0 = np.sum(np.sum(im * xxpsize))/flux
     y0 = np.sum(np.sum(im * yypsize))/flux
 
-    term1 = np.sum(np.sum(im * ((xxpsize - x0))))
-    term2 = np.sum(np.sum(im * ((yypsize - y0))))
+    term1 = np.sum(np.sum(im * (xxpsize - x0)))
+    term2 = np.sum(np.sum(im * (yypsize - y0)))
 
     grad = -2*xxpsize*term1 - 2*yypsize*term2 + (xxpsize - x0)**2 + (yypsize - y0)**2
 
@@ -2708,7 +2699,7 @@ def chisqdata_amp(Obsdata, Prior, mask, pol='I', **kwargs):
 
     else:  # TODO -- pre-computed  with not stokes I?
         print("Using pre-computed amplitude table in amplitude chi^2!")
-        if not type(Obsdata.amp) in [np.ndarray, np.recarray]:
+        if type(Obsdata.amp) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed amplitude table is not a numpy rec array!")
         data_arr = Obsdata.amp
 
@@ -2748,7 +2739,7 @@ def chisqdata_bs(Obsdata, Prior, mask, pol='I', **kwargs):
 
     else:  # TODO -- pre-computed  with not stokes I?
         print("Using pre-computed bispectrum table in cphase chi^2!")
-        if not type(Obsdata.bispec) in [np.ndarray, np.recarray]:
+        if type(Obsdata.bispec) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed bispectrum table is not a numpy rec array!")
         biarr = Obsdata.bispec
         # reduce to a minimal set
@@ -2800,7 +2791,7 @@ def chisqdata_cphase(Obsdata, Prior, mask, pol='I', **kwargs):
                                       count=count, uv_min=uv_min, snrcut=snrcut)
     else:  # TODO precomputed with not Stokes I
         print("Using pre-computed cphase table in cphase chi^2!")
-        if not type(Obsdata.cphase) in [np.ndarray, np.recarray]:
+        if type(Obsdata.cphase) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed closure phase table is not a numpy rec array!")
         clphasearr = Obsdata.cphase
         # reduce to a minimal set
@@ -2907,7 +2898,7 @@ def chisqdata_camp(Obsdata, Prior, mask, pol='I', **kwargs):
                                         vtype=vtype, ctype='camp', debias=debias, snrcut=snrcut)
     else:  # TODO -- pre-computed  with not stokes I?
         print("Using pre-computed closure amplitude table in closure amplitude chi^2!")
-        if not type(Obsdata.camp) in [np.ndarray, np.recarray]:
+        if type(Obsdata.camp) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed closure amplitude table is not a numpy rec array!")
         clamparr = Obsdata.camp
         # reduce to a minimal set
@@ -2956,7 +2947,7 @@ def chisqdata_logcamp(Obsdata, Prior, mask, pol='I', **kwargs):
                                         vtype=vtype, ctype='logcamp', debias=debias, snrcut=snrcut)
     else:  # TODO -- pre-computed  with not stokes I?
         print("Using pre-computed log closure amplitude table in log closure amplitude chi^2!")
-        if not type(Obsdata.logcamp) in [np.ndarray, np.recarray]:
+        if type(Obsdata.logcamp) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed log closure amplitude table is not a numpy rec array!")
         clamparr = Obsdata.logcamp
         # reduce to a minimal set
@@ -3110,7 +3101,7 @@ def chisqdata_amp_fft(Obsdata, Prior, pol='I', **kwargs):
         data_arr = Obsdata.unpack(['t1', 't2', 'u', 'v', vtype, atype, etype], debias=debias)
     else:  # TODO -- pre-computed  with not stokes I?
         print("Using pre-computed amplitude table in amplitude chi^2!")
-        if not type(Obsdata.amp) in [np.ndarray, np.recarray]:
+        if type(Obsdata.amp) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed amplitude table is not a numpy rec array!")
         data_arr = Obsdata.amp
 
@@ -3159,7 +3150,7 @@ def chisqdata_bs_fft(Obsdata, Prior, pol='I', **kwargs):
         biarr = Obsdata.bispectra(mode="all", vtype=vtype, count=count, snrcut=snrcut)
     else:  # TODO -- pre-computed  with not stokes I?
         print("Using pre-computed bispectrum table in cphase chi^2!")
-        if not type(Obsdata.bispec) in [np.ndarray, np.recarray]:
+        if type(Obsdata.bispec) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed bispectrum table is not a numpy rec array!")
         biarr = Obsdata.bispec
         # reduce to a minimal set
@@ -3222,7 +3213,7 @@ def chisqdata_cphase_fft(Obsdata, Prior, pol='I', **kwargs):
                                       count=count, uv_min=uv_min, snrcut=snrcut)
     else:  # TODO precomputed with not Stokes I
         print("Using pre-computed cphase table in cphase chi^2!")
-        if not type(Obsdata.cphase) in [np.ndarray, np.recarray]:
+        if type(Obsdata.cphase) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed closure phase table is not a numpy rec array!")
         clphasearr = Obsdata.cphase
         # reduce to a minimal set
@@ -3366,7 +3357,7 @@ def chisqdata_camp_fft(Obsdata, Prior, pol='I', **kwargs):
                                         vtype=vtype, ctype='camp', debias=debias, snrcut=snrcut)
     else:  # TODO -- pre-computed  with not stokes I?
         print("Using pre-computed closure amplitude table in closure amplitude chi^2!")
-        if not type(Obsdata.camp) in [np.ndarray, np.recarray]:
+        if type(Obsdata.camp) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed closure amplitude table is not a numpy rec array!")
         clamparr = Obsdata.camp
         # reduce to a minimal set
@@ -3428,7 +3419,7 @@ def chisqdata_logcamp_fft(Obsdata, Prior, pol='I', **kwargs):
                                         vtype=vtype, ctype='logcamp', debias=debias, snrcut=snrcut)
     else:  # TODO -- pre-computed  with not stokes I?
         print("Using pre-computed log closure amplitude table in log closure amplitude chi^2!")
-        if not type(Obsdata.logcamp) in [np.ndarray, np.recarray]:
+        if type(Obsdata.logcamp) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed log closure amplitude table is not a numpy rec array!")
         clamparr = Obsdata.logcamp
         # reduce to a minimal set
@@ -3615,7 +3606,7 @@ def chisqdata_amp_nfft(Obsdata, Prior, pol='I', **kwargs):
         data_arr = Obsdata.unpack(['t1', 't2', 'u', 'v', vtype, atype, etype], debias=debias)
     else:  # TODO -- pre-computed  with not stokes I?
         print("Using pre-computed amplitude table in amplitude chi^2!")
-        if not type(Obsdata.amp) in [np.ndarray, np.recarray]:
+        if type(Obsdata.amp) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed amplitude table is not a numpy rec array!")
         data_arr = Obsdata.amp
 
@@ -3641,7 +3632,7 @@ def chisqdata_bs_nfft(Obsdata, Prior, pol='I', **kwargs):
         raise Exception("NFFT doesn't work with odd image dimensions!")
 
     # unpack keyword args
-    # systematic_noise = kwargs.get('systematic_noise',0.) 
+    # systematic_noise = kwargs.get('systematic_noise',0.)
     maxset = kwargs.get('maxset', False)
     if maxset:
         count = 'max'
@@ -3659,7 +3650,7 @@ def chisqdata_bs_nfft(Obsdata, Prior, pol='I', **kwargs):
         biarr = Obsdata.bispectra(mode="all", vtype=vtype, count=count, snrcut=snrcut)
     else:  # TODO -- pre-computed  with not stokes I?
         print("Using pre-computed bispectrum table in cphase chi^2!")
-        if not type(Obsdata.bispec) in [np.ndarray, np.recarray]:
+        if type(Obsdata.bispec) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed bispectrum table is not a numpy rec array!")
         biarr = Obsdata.bispec
         # reduce to a minimal set
@@ -3716,7 +3707,7 @@ def chisqdata_cphase_nfft(Obsdata, Prior, pol='I', **kwargs):
                                       count=count, uv_min=uv_min, snrcut=snrcut)
     else:  # TODO precomputed with not Stokes I
         print("Using pre-computed cphase table in cphase chi^2!")
-        if not type(Obsdata.cphase) in [np.ndarray, np.recarray]:
+        if type(Obsdata.cphase) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed closure phase table is not a numpy rec array!")
         clphasearr = Obsdata.cphase
         # reduce to a minimal set
@@ -3847,7 +3838,7 @@ def chisqdata_camp_nfft(Obsdata, Prior, pol='I', **kwargs):
                                         vtype=vtype, ctype='camp', debias=debias, snrcut=snrcut)
     else:  # TODO -- pre-computed  with not stokes I?
         print("Using pre-computed closure amplitude table in closure amplitude chi^2!")
-        if not type(Obsdata.camp) in [np.ndarray, np.recarray]:
+        if type(Obsdata.camp) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed closure amplitude table is not a numpy rec array!")
         clamparr = Obsdata.camp
         # reduce to a minimal set
@@ -3902,7 +3893,7 @@ def chisqdata_logcamp_nfft(Obsdata, Prior, pol='I', **kwargs):
                                         vtype=vtype, ctype='logcamp', debias=debias, snrcut=snrcut)
     else:  # TODO -- pre-computed  with not stokes I?
         print("Using pre-computed log closure amplitude table in log closure amplitude chi^2!")
-        if not type(Obsdata.logcamp) in [np.ndarray, np.recarray]:
+        if type(Obsdata.logcamp) not in [np.ndarray, np.recarray]:
             raise Exception("pre-computed log closure amplitude table is not a numpy rec array!")
         clamparr = Obsdata.logcamp
         # reduce to a minimal set
@@ -4053,9 +4044,9 @@ def plot_i(im, Prior, nit, chi2_dict, **kwargs):
     plt.yticks(yticks[0], yticks[1])
     plt.xlabel(r'Relative RA ($\mu$as)')
     plt.ylabel(r'Relative Dec ($\mu$as)')
-    plotstr = str(pol) + " : step: %i  " % nit
+    plotstr = str(pol) + f" : step: {nit}  "
     for key in chi2_dict.keys():
-        plotstr += r"$\chi^2_{%s}$: %0.2f  " % (key, chi2_dict[key])
+        plotstr += rf"$\chi^2_{{{key}}}$: {chi2_dict[key]:0.2f}  "
     plt.title(plotstr, fontsize=18)
 
 ##################################################################################################
@@ -4084,6 +4075,6 @@ def embed(imvec, mask, clipfloor=0., randomfloor=False):
     return out
 
 
-    
+
 
 

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -785,8 +785,8 @@ def chisqgrad_vis_fft(vis_arr, A, vis, sigma):
 
     # extract relevant cells and flatten
     # TODO or is x<-->y??
-    out = np.real(grad_arr[im_info.padvalx1:-im_info.padvalx2,
-                           im_info.padvaly1:-im_info.padvaly2].flatten())
+    out = np.real(grad_arr[im_info.padvaly1:-im_info.padvaly2,
+                           im_info.padvalx1:-im_info.padvalx2].flatten())
 
     return out
 
@@ -823,8 +823,8 @@ def chisqgrad_amp_fft(vis_arr, A, amp, sigma):
 
     # extract relevent cells and flatten
     # TODO or is x<-->y??
-    out = np.real(grad_arr[im_info.padvalx1:-im_info.padvalx2,
-                           im_info.padvaly1:-im_info.padvaly2].flatten())
+    out = np.real(grad_arr[im_info.padvaly1:-im_info.padvaly2,
+                           im_info.padvalx1:-im_info.padvalx2].flatten())
 
     return out
 
@@ -861,8 +861,8 @@ def chisqgrad_bs_fft(vis_arr, A, bis, sigma):
 
     # extract relevant cells and flatten
     # TODO or is x<-->y??
-    out = np.real(grad_arr[im_info.padvalx1:-im_info.padvalx2,
-                           im_info.padvaly1:-im_info.padvaly2].flatten())
+    out = np.real(grad_arr[im_info.padvaly1:-im_info.padvaly2,
+                           im_info.padvalx1:-im_info.padvalx2].flatten())
     return out
 
 
@@ -905,8 +905,8 @@ def chisqgrad_cphase_fft(vis_arr, A, clphase, sigma):
 
     # extract relevant cells and flatten
     # TODO or is x<-->y??
-    out = np.imag(grad_arr[im_info.padvalx1:-im_info.padvalx2,
-                           im_info.padvaly1:-im_info.padvaly2].flatten())
+    out = np.imag(grad_arr[im_info.padvaly1:-im_info.padvaly2,
+                           im_info.padvalx1:-im_info.padvalx2].flatten())
 
     return out
 
@@ -982,8 +982,8 @@ def chisqgrad_cphase_diag_fft(imvec, A, clphase_diag, sigma):
     grad_arr = grad_arr * (im_info.npad * im_info.npad)
 
     # extract relevant cells and flatten
-    deriv = np.imag(grad_arr[im_info.padvalx1:-im_info.padvalx2,
-                             im_info.padvaly1:-im_info.padvaly2].flatten())
+    deriv = np.imag(grad_arr[im_info.padvaly1:-im_info.padvaly2,
+                             im_info.padvalx1:-im_info.padvalx2].flatten())
     deriv *= 1.0/np.float(len(clphase_diag))
 
     return deriv
@@ -1026,8 +1026,8 @@ def chisqgrad_camp_fft(vis_arr, A, clamp, sigma):
 
     # extract relevant cells and flatten
     # TODO or is x<-->y??
-    out = np.real(grad_arr[im_info.padvalx1:-im_info.padvalx2,
-                           im_info.padvaly1:-im_info.padvaly2].flatten())
+    out = np.real(grad_arr[im_info.padvaly1:-im_info.padvaly2,
+                           im_info.padvalx1:-im_info.padvalx2].flatten())
 
     return out
 
@@ -1072,8 +1072,8 @@ def chisqgrad_logcamp_fft(vis_arr, A, log_clamp, sigma):
 
     # extract relevant cells and flatten
     # TODO or is x<-->y??
-    out = np.real(grad_arr[im_info.padvalx1:-im_info.padvalx2,
-                           im_info.padvaly1:-im_info.padvaly2].flatten())
+    out = np.real(grad_arr[im_info.padvaly1:-im_info.padvaly2,
+                           im_info.padvalx1:-im_info.padvalx2].flatten())
 
     return out
 
@@ -1152,8 +1152,8 @@ def chisqgrad_logcamp_diag_fft(imvec, A, log_clamp_diag, sigma):
     grad_arr = grad_arr * (im_info.npad * im_info.npad)
 
     # extract relevant cells and flatten
-    deriv = np.real(grad_arr[im_info.padvalx1:-im_info.padvalx2,
-                             im_info.padvaly1:-im_info.padvaly2].flatten())
+    deriv = np.real(grad_arr[im_info.padvaly1:-im_info.padvaly2,
+                             im_info.padvalx1:-im_info.padvalx2].flatten())
     deriv *= 1.0/np.float(len(log_clamp_diag))
 
     return deriv
@@ -1196,8 +1196,8 @@ def chisqgrad_logamp_fft(vis_arr, A, amp, sigma):
 
     # extract relevent cells and flatten
     # TODO or is x<-->y??
-    out = np.real(grad_arr[im_info.padvalx1:-im_info.padvalx2,
-                           im_info.padvaly1:-im_info.padvaly2].flatten())
+    out = np.real(grad_arr[im_info.padvaly1:-im_info.padvaly2,
+                           im_info.padvalx1:-im_info.padvalx2].flatten())
 
     return out
 

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -16,36 +16,31 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
 
 try:
-    from sgp4.api import Satrec, WGS72
     import skyfield.api
+    from sgp4.api import WGS72, Satrec
 except ImportError:
     print("Warning: skyfield not installed: cannot simulate space VLBI")
-    
+
 try:
     from pynfft.nfft import NFFT
 except ImportError:
     print("Warning: No NFFT installed!")
 
-import astropy.time as at
-import astropy.coordinates as coords
-import numpy as np
+import copy
 import itertools as it
+import sys
+import warnings
+
+import astropy.time as at
+import numpy as np
 import scipy.ndimage as nd
 import scipy.spatial.distance
-import copy
-import sys
 
 import ehtim.const_def as ehc
 
-import warnings
 warnings.filterwarnings("ignore", message="divide by zero encountered in double_scalars")
 
 ##################################################################################################
@@ -56,7 +51,7 @@ warnings.filterwarnings("ignore", message="divide by zero encountered in double_
 def compute_uv_coordinates(array, site1, site2, time, mjd, ra, dec, rf, timetype='UTC',
                            elevmin=ehc.ELEV_LOW,  elevmax=ehc.ELEV_HIGH, no_elevcut_space=False,
                            fix_theta_GMST=False, earthshadow_space=True):
-                           
+
     """Compute u,v coordinates for an array at a given time for a source at a given ra,dec,rf
     """
 
@@ -74,10 +69,10 @@ def compute_uv_coordinates(array, site1, site2, time, mjd, ra, dec, rf, timetype
         raise Exception("site1, site2, and time not the same dimension in compute_uv_coordinates!")
 
     if ra>24 or ra<0:
-        raise Exception('RA %.2f in compute_uv_coordinates should be in decimal hours from 0 to 24!'%ra)
+        raise Exception(f'RA {ra:.2f} in compute_uv_coordinates should be in decimal hours from 0 to 24!')
     if dec>180 or dec<-180:
-        raise Exception('DEC %.2f in compute_uv_coordinates should be in decimal degrees from -180 to 180!'%dec)
-                
+        raise Exception(f'DEC {dec:.2f} in compute_uv_coordinates should be in decimal degrees from -180 to 180!')
+
     # Source vector
     sourcevec = np.array([np.cos(dec*ehc.DEGREE), 0, np.sin(dec*ehc.DEGREE)])
     projU = np.cross(np.array([0, 0, 1]), sourcevec)
@@ -99,7 +94,7 @@ def compute_uv_coordinates(array, site1, site2, time, mjd, ra, dec, rf, timetype
     fracmjd = np.floor(mjd) + time/24.
     dto = (at.Time(fracmjd, format='mjd')).datetime
     theta = np.mod((time_sidereal - ra)*ehc.HOUR, 2*np.pi)
-    if type(fix_theta_GMST) != bool:
+    if not isinstance(fix_theta_GMST, bool):
         theta = np.mod((fix_theta_GMST - ra)*ehc.HOUR, 2*np.pi)
 
     i1 = np.array([array.tkey[site] for site in site1])
@@ -119,13 +114,13 @@ def compute_uv_coordinates(array, site1, site2, time, mjd, ra, dec, rf, timetype
     for satname in satnames:
         sat = satdict[satname]
 
-        mask1 = (site1==satname)    
-        c1 = orbit_skyfield(sat, fracmjd[mask1], whichout='itrs')          
+        mask1 = (site1==satname)
+        c1 = orbit_skyfield(sat, fracmjd[mask1], whichout='itrs')
         coord1[mask1] = c1.T
-        mask2 = (site2==satname)    
+        mask2 = (site2==satname)
         c2 = orbit_skyfield(sat, fracmjd[mask2], whichout='itrs')
         coord2[mask2] = c2.T
-         
+
     # Satellites: old method
     """
     if np.any(spacemask1):
@@ -136,10 +131,10 @@ def compute_uv_coordinates(array, site1, site2, time, mjd, ra, dec, rf, timetype
         site1space_fracmjdlist = fracmjd[spacemask1]
         site1space_dtolist = dto[spacemask1]
         coord1space = []
-        
+
         for k in range(len(site1space_list)):
 
-            
+
             # old method with pyephem
 
             site1space = site1space_list[k]
@@ -154,7 +149,7 @@ def compute_uv_coordinates(array, site1, site2, time, mjd, ra, dec, rf, timetype
             c1 = coords.EarthLocation.from_geodetic(lon, lat, elev, ellipsoid=None)
             c1 = np.array((c1.x.value, c1.y.value, c1.z.value))
             coord1space.append(c1)
-            
+
         coord1space = np.array(coord1space)
         coord1[spacemask1] = coord1space
 
@@ -182,12 +177,12 @@ def compute_uv_coordinates(array, site1, site2, time, mjd, ra, dec, rf, timetype
             # pyephem doesn't use an ellipsoid earth model!
             c2 = coords.EarthLocation.from_geodetic(lon, lat, elev, ellipsoid=None)
             c2 = np.array((c2.x.value, c2.y.value, c2.z.value))
-            coord2space.append(c2)            
+            coord2space.append(c2)
 
         coord2space = np.array(coord2space)
         coord2[spacemask2] = coord2space
     """
-    
+
     # rotate the station coordinates with the earth
     coord1 = earthrot(coord1, theta)
     coord2 = earthrot(coord2, theta)
@@ -197,19 +192,19 @@ def compute_uv_coordinates(array, site1, site2, time, mjd, ra, dec, rf, timetype
     v = np.dot((coord1 - coord2)/wvl, projV)  # v (lambda)
 
     # mask out below elevation cut
-    mask_elev_1 = elevcut(coord1, sourcevec, elevmin=elevmin, elevmax=elevmax) 
+    mask_elev_1 = elevcut(coord1, sourcevec, elevmin=elevmin, elevmax=elevmax)
     mask_elev_2 = elevcut(coord2, sourcevec, elevmin=elevmin, elevmax=elevmax)
-    
+
     # do NOT apply elevation cut for space orbiters
-    if no_elevcut_space:    
+    if no_elevcut_space:
         mask_elev_1[spacemask1] = 1
         mask_elev_2[spacemask2] = 1
-    
+
 
 
     # apply elevation mask
     mask = mask_elev_1 * mask_elev_2
-    
+
     if earthshadow_space:
         spacevecs1 = coord1[spacemask1]
         spacevecs2 = coord2[spacemask2]
@@ -371,7 +366,7 @@ def make_closure_amplitude(blue1, blue2, red1, red2, vtype,
        vtype is the  visibility type
     """
 
-    if not (ctype in ['camp', 'logcamp']):
+    if ctype not in ['camp', 'logcamp']:
         raise Exception("closure amplitude type must be 'camp' or 'logcamp'!")
 
     if polrep == 'stokes':
@@ -830,7 +825,7 @@ def ticks(axisdim, psize, nticks=8):
         axisdim += 1
     if nticks % 2:
         nticks -= 1
-    tickspacing = float((axisdim-1))/nticks
+    tickspacing = float(axisdim-1)/nticks
     ticklocs = np.arange(0, axisdim+1, tickspacing) - 0.5
     ticklabels = np.around(psize * np.arange((axisdim-1)/2.0, -
                                              (axisdim)/2.0, -tickspacing), decimals=1)
@@ -945,7 +940,7 @@ def rastring(ra):
     h = int(ra)
     m = int((ra-h)*60.)
     s = (ra-h-m/60.)*3600.
-    out = "%2i h %2i m %2.4f s" % (h, m, s)
+    out = f"{h:2d} h {m:2d} m {s:2.4f} s"
 
     return out
 
@@ -957,7 +952,7 @@ def decstring(dec):
     deg = int(dec)
     m = int((abs(dec)-abs(deg))*60.)
     s = (abs(dec)-abs(deg)-m/60.)*3600.
-    out = "%2i deg %2i m %2.4f s" % (deg, m, s)
+    out = f"{deg:2d} deg {m:2d} m {s:2.4f} s"
 
     return out
 
@@ -971,7 +966,7 @@ def gmtstring(gmt):
     h = int(gmt)
     m = int((gmt-h)*60.)
     s = (gmt-h-m/60.)*3600.
-    out = "%02i:%02i:%2.4f" % (h, m, s)
+    out = f"{h:02d}:{m:02d}:{s:2.4f}"
 
     return out
 
@@ -1170,7 +1165,7 @@ def reduce_tri_minimal(obs, datarr):
     """
 
     # time sort or not
-    if not (type(datarr) is list):
+    if type(datarr) is not list:
         datalist = []
         dtype = datarr.dtype
         for key, group in it.groupby(datarr, lambda x: x['time']):
@@ -1222,7 +1217,7 @@ def reduce_quad_minimal(obs, datarr, ctype='camp'):
         raise Exception("ctype must be 'camp' or 'logcamp'")
 
     # time sort or not
-    if not (type(datarr) is list):
+    if type(datarr) is not list:
         datalist = []
         dtype = datarr.dtype
         for key, group in it.groupby(datarr, lambda x: x['time']):
@@ -1333,7 +1328,7 @@ def uimage(iimage, mimage, chiimage):
 ##################################################################################################
 # FFT & NFFT helper functions
 ##################################################################################################
-class NFFTInfo(object):
+class NFFTInfo:
     def __init__(self, xdim, ydim, psize, pulse, npad, p_rad, uv):
         self.xdim = int(xdim)
         self.ydim = int(ydim)
@@ -1358,14 +1353,14 @@ class NFFTInfo(object):
                               for i in range(self.uvdim)), 'c16')
         self.pulsefac = (pulses*phases)
 
-class SamplerInfo(object):
+class SamplerInfo:
     def __init__(self, order, uv, pulsefac):
         self.order = int(order)
         self.uv = uv
         self.pulsefac = pulsefac
 
 
-class GridderInfo(object):
+class GridderInfo:
     def __init__(self, npad, func, p_rad, coords, weights):
         self.npad = int(npad)
         self.conv_func = func
@@ -1374,7 +1369,7 @@ class GridderInfo(object):
         self.weights = weights
 
 
-class ImInfo(object):
+class ImInfo:
     def __init__(self, xdim, ydim, npad, psize, pulse):
         self.xdim = int(xdim)
         self.ydim = int(ydim)
@@ -1448,7 +1443,9 @@ def fft_imvec(imvec, im_info):
     padvaly2 = im_info.padvaly2
 
     imarr = imvec.reshape(ydim, xdim)
-    imarr = np.pad(imarr, ((padvalx1, padvalx2), (padvaly1, padvaly2)),
+    # imarr.shape is (ydim, xdim). First axis (rows) is y, second (cols) is x.
+    # So padvaly pads the y-axis and padvalx pads the x-axis.
+    imarr = np.pad(imarr, ((padvaly1, padvaly2), (padvalx1, padvalx2)),
                    'constant', constant_values=0.0)
 
     if imarr.shape[0] != imarr.shape[1]:
@@ -1539,7 +1536,7 @@ def make_gridder_and_sampler_info(im_info, uv, conv_func=ehc.GRIDDER_CONV_FUNC_D
     p_rad is the pixel radius inside wich the conv_func is nonzero
     """
 
-    if not (conv_func in ['pillbox', 'gaussian', 'cubic']):
+    if conv_func not in ['pillbox', 'gaussian', 'cubic']:
         raise Exception("conv_func must be either 'pillbox', 'gaussian', or, 'cubic'")
 
     npad = im_info.npad
@@ -1682,7 +1679,7 @@ def prog_msg(nscan, totscans, msgtype='bar', nscan_last=0):
         if progress > progress_last:
             for i in range(progress_last+1, progress+1):
                 message_line = ''.join(message_all[i])
-                message_line = '%03i' % int(complete_percent) + message_line
+                message_line = f'{int(complete_percent):03d}' + message_line
                 print(message_line)
 
     elif msgtype == 'eht':
@@ -1693,7 +1690,7 @@ def prog_msg(nscan, totscans, msgtype='bar', nscan_last=0):
         if progress > progress_last:
             for i in range(progress_last+1, progress+1):
                 message_line = ''.join(message_all[i])
-                message_line = '%03i' % int(complete_percent) + message_line
+                message_line = f'{int(complete_percent):03d}' + message_line
                 print(message_line)
 
     elif msgtype == 'dots':
@@ -1705,41 +1702,41 @@ def prog_msg(nscan, totscans, msgtype='bar', nscan_last=0):
         printstr = "\rScan %0"+ndigit+"i/%i : %i%% done . . ."
         sys.stdout.write(printstr % barparams)
         sys.stdout.flush()
-        
-def sat_skyfield_from_elements(satname, epoch_mjd, perigee_mjd, 
+
+def sat_skyfield_from_elements(satname, epoch_mjd, perigee_mjd,
                                period_days, eccentricity,
                                inclination, arg_perigee, long_ascending):
-                              
+
     """skyfield EarthSatellite object from keplerian orbital elements
        perfect keplerian orbit is assumed, no derivatives
        epoch, pericenter given in mjd
        period given in days
        inclination, arg_perigee, long_ascending given in degrees
     """
-    
-    if not(0<=eccentricity<1): 
+
+    if not(0<=eccentricity<1):
         raise Exception("eccentricity must be between 0 and 1")
-    if not(0<=inclination<=180): 
+    if not(0<=inclination<=180):
         raise Exception("inclination must be between 0 and 180")
-    if not(0<=arg_perigee<=180): 
+    if not(0<=arg_perigee<=180):
         raise Exception("arg_perigee must be between 0 and 180")
-    if not(0<=long_ascending<=360): 
+    if not(0<=long_ascending<=360):
         raise Exception("arg_perigee must be between 0 and 360")
 
     satrec = Satrec()
-    ts = skyfield.api.load.timescale()                                
+    ts = skyfield.api.load.timescale()
     ref_mjd = 33281. # mjd 1949 December 31 00:00 UT
     epoch_wrt_ref = epoch_mjd - ref_mjd
 
     inclination_rad = inclination*ehc.DEGREE
-    arg_perigee_rad = arg_perigee*ehc.DEGREE 
+    arg_perigee_rad = arg_perigee*ehc.DEGREE
     long_ascending_rad = long_ascending*ehc.DEGREE
-    
+
     mean_motion = 2*np.pi/(period_days*24.*60.) # radians/minute
 
     mean_anomaly = mean_motion*(epoch_mjd - perigee_mjd)
     mean_anomaly = np.mod(mean_anomaly, 2*np.pi)
-    
+
     satrec.sgp4init(
         WGS72,           # gravity model
         'i',             # 'a' = old AFSPC mode, 'i' = improved mode
@@ -1756,9 +1753,9 @@ def sat_skyfield_from_elements(satname, epoch_mjd, perigee_mjd,
         long_ascending_rad,    # nodeo: right ascension of ascending node (radians)
     )
     sat_skyfield = skyfield.api.EarthSatellite.from_satrec(satrec, ts)
-            
+
     return sat_skyfield
-    
+
 def sat_skyfield_from_tle(satname, line1, line2):
     ts = skyfield.api.load.timescale()
     sat_skyfield = skyfield.api.EarthSatellite(line1, line2, satname, ts)
@@ -1767,17 +1764,17 @@ def sat_skyfield_from_tle(satname, line1, line2):
 def sat_skyfield_from_ephementry(satname, ephem, epoch_mjd):
     if len(ephem[satname])==3: # TLE
         line1 = ephem[satname][1]
-        line2 = ephem[satname][2]            
+        line2 = ephem[satname][2]
         sat = sat_skyfield_from_tle(satname, line1, line2)
     elif len(ephem[satname])==6: #keplerian elements
         elements = ephem[satname]
         sat = sat_skyfield_from_elements(satname, epoch_mjd,
                                          elements[0],elements[1],elements[2],elements[3],elements[4],elements[5])
     else:
-        raise Exception("ephemeris format not recognized for %s"%satellite)    
+        raise Exception(f"ephemeris format not recognized for {satname}")
 
     return sat
-                                                                         
+
 def orbit_skyfield(sat, fracmjds, whichout='itrs'):
 
     """uses skyfield to propagate a earth satellite orbit and return x,y,z coordinates in co-rotating earth frame
@@ -1785,7 +1782,7 @@ def orbit_skyfield(sat, fracmjds, whichout='itrs'):
        times is a list of fractional mjds
        whichout is 'itrs' (co-rotating) or 'gcrs' (fixed x-axis to equinox)
     """
-    
+
     #fractional days of orbit in jd
     mjd_to_jd = 2400000.5
     ts = skyfield.api.load.timescale()
@@ -1793,18 +1790,18 @@ def orbit_skyfield(sat, fracmjds, whichout='itrs'):
 
     # propagate orbit
     time_data = sat.at(t)
-    
+
     if whichout=='gcrs':
         # GCRS coordinates in km
         positions = time_data.xyz.m
-        
+
     elif whichout=='itrs':
         # get coordinates in earth frame (WGS84 ellipsiod)
         geographic_position = skyfield.api.wgs84.geographic_position_of(time_data)
         positions = geographic_position.itrs_xyz.m
 
     else:
-        raise Excption("orbit_skyfield whichout must be 'itrs' or 'gcrs'")
-        
-    return positions        
+        raise Exception("orbit_skyfield whichout must be 'itrs' or 'gcrs'")
+
+    return positions
 

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -16,26 +16,24 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
 
+import copy
 import time as ttime
+
+import numpy as np
 import scipy.ndimage as nd
 from scipy.interpolate import interp1d
-import numpy as np
-import copy
+
 try:
     from pynfft.nfft import NFFT
 except ImportError:
     pass
     #print("Warning: No NFFT installed!")
 
-from . import obs_helpers as obsh
 import ehtim.const_def as ehc
+
+from . import obs_helpers as obsh
 
 ##################################################################################################
 # Generate U-V Points
@@ -98,7 +96,7 @@ def make_uvpoints(array, ra, dec, rf, bw, tint, tadv, tstart, tstop,
         for i2 in range(len(array.tarr)):
             if (i1 != i2 and
                 i1 < i2 and  # This is the right condition for uvfits save order
-                not ((i2, i1) in blpairs)):  # This cuts out the conjugate baselines
+                (i2, i1) not in blpairs):  # This cuts out the conjugate baselines
 
                 blpairs.append((i1, i2))
 
@@ -107,9 +105,9 @@ def make_uvpoints(array, ra, dec, rf, bw, tint, tadv, tstart, tstop,
                 site2 = array.tarr[i2]['site']
                 coord1 = ((array.tarr[i1]['x'], array.tarr[i1]['y'], array.tarr[i1]['z']))
                 coord2 = ((array.tarr[i2]['x'], array.tarr[i2]['y'], array.tarr[i2]['z']))
-                
+
                 # Optical Depth
-                if type(tau) == dict:
+                if isinstance(tau, dict):
                     try:
                         tau1 = tau[site1]
                         tau2 = tau[site2]
@@ -248,7 +246,8 @@ def sample_vis(im_org, uv, sgrscat=False, polrep_obs='stokes',
             padvaly2 += 1
 
         imarr = im.imvec.reshape(im.ydim, im.xdim)
-        imarr = np.pad(imarr, ((padvalx1, padvalx2), (padvaly1, padvaly2)),
+        # imarr.shape is (ydim, xdim): first axis is y, second is x.
+        imarr = np.pad(imarr, ((padvaly1, padvaly2), (padvalx1, padvalx2)),
                        'constant', constant_values=0.0)
         npad = imarr.shape[0]
         if imarr.shape[0] != imarr.shape[1]:
@@ -280,7 +279,7 @@ def sample_vis(im_org, uv, sgrscat=False, polrep_obs='stokes',
                     vis_im = im_org.cached_fft[pol]
                 else:
                     imarr = imvec.reshape(im.ydim, im.xdim)
-                    imarr = np.pad(imarr, ((padvalx1, padvalx2), (padvaly1, padvaly2)),
+                    imarr = np.pad(imarr, ((padvaly1, padvaly2), (padvalx1, padvalx2)),
                                    'constant', constant_values=0.0)
                     vis_im = np.fft.fftshift(np.fft.fft2(np.fft.ifftshift(imarr)))
                     if cache == 'auto':
@@ -383,8 +382,8 @@ def sample_vis(im_org, uv, sgrscat=False, polrep_obs='stokes',
 def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
                frcal=True, rlgaincal=True,
                stabilize_scan_phase=False, stabilize_scan_amp=False, neggains=False,
-               taup=ehc.GAINPDEF, 
-               gainp=ehc.GAINPDEF, gain_offset=ehc.GAINPDEF, 
+               taup=ehc.GAINPDEF,
+               gainp=ehc.GAINPDEF, gain_offset=ehc.GAINPDEF,
                phase_std=-1,
                dterm_offset=ehc.DTERMPDEF,
                rlratio_std=0., rlphase_std=0.,
@@ -403,36 +402,36 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
            stabilize_scan_phase (bool): if True, random phase errors are constant over scans
            stabilize_scan_amp (bool): if True, random amplitude errors are constant over scans
            neggains (bool): if True, force the applied gains to be <1
-           
+
            taup (float): the fractional std. dev. of the random error on the opacities
            gainp (float): the fractional std. dev. of the random error on the gains
-                          or a dict giving one std. dev. per site      
+                          or a dict giving one std. dev. per site
 
            gain_offset (float): the base gain offset at all sites,
                                 or a dict giving one gain offset per site
-           phase_std (float): std. dev. of LCP phase, 
+           phase_std (float): std. dev. of LCP phase,
                               or a dict giving one std. dev. per site
-                              a negative value samples from uniform                                          
+                              a negative value samples from uniform
            dterm_offset (float): the base std. dev. of random additive error at all sites,
                                 or a dict giving one std. dev. per site
 
            rlratio_std (float): the fractional std. dev. of the R/L gain offset
-                                or a dict giving one std. dev. per site                                          
-           rlphase_std (float): std. dev. of R/L phase offset, 
                                 or a dict giving one std. dev. per site
-                                a negative value samples from uniform                                          
-                                                                            
+           rlphase_std (float): std. dev. of R/L phase offset,
+                                or a dict giving one std. dev. per site
+                                a negative value samples from uniform
+
            sigmat (float): temporal std for a Gaussian Process used to generate gains.
                            If sigmat=None then an iid gain noise is applied.
            phasesigmat (float): temporal std for a Gaussian Process used to generate phases.
-                                If phasesigmat=None then an iid gain noise is applied.                           
+                                If phasesigmat=None then an iid gain noise is applied.
            rlgsigmat (float): temporal std deviation for a Gaussian Process used to generate R/L gain ratios.
                            If rlgsigmat=None then an iid gain noise is applied.
            rlpsigmat (float): temporal std deviation for a Gaussian Process used to generate R/L phase diff.
                            If rlpsigmat=None then an iid gain noise is applied.
-                                                      
+
            caltable_path (string): If not None, path and prefix for saving the applied caltable
-           seed : a seed for the random number generators, uses system time if false                           
+           seed : a seed for the random number generators, uses system time if false
        Returns:
            (dict): a nested dictionary of matrices indexed by the site, then by the time
     """
@@ -458,11 +457,11 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
             if len(sites_in) >= nsites:
                 break
 
-            if (not len(sites_in)) or (not bl['t1'] in sites_in):
+            if (not len(sites_in)) or (bl['t1'] not in sites_in):
                 taudict[bl['t1']] = np.append(taudict[bl['t1']], bl['tau1'])
                 sites_in = np.append(sites_in, bl['t1'])
 
-            if (not len(sites_in)) or (not bl['t2'] in sites_in):
+            if (not len(sites_in)) or (bl['t2'] not in sites_in):
                 taudict[bl['t2']] = np.append(taudict[bl['t2']], bl['tau2'])
                 sites_in = np.append(sites_in, bl['t2'])
 
@@ -520,60 +519,60 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
         par_angles = obsh.par_angle(hr_angles, latlon[:, 0], dec*ehc.DEGREE)
 
         # gain offset: time independent part
-        if type(gain_offset) == dict:
+        if isinstance(gain_offset, dict):
             goff = gain_offset[site]
         else:
             goff = gain_offset
 
         # gain_mult: time dependent part
-        if type(gainp) == dict:
+        if isinstance(gainp, dict):
             gain_mult = gainp[site]
         else:
             gain_mult = gainp
 
         # phase mult - phase std deviation (-1 = uniform)
-        if type(phase_std) == dict:
+        if isinstance(phase_std, dict):
             phase_mult = phase_std[site]
         else:
             phase_mult = phase_std
-                                
+
         # gainratio_mult: time dependent R/L gain offset
-        if type(rlratio_std) == dict:
+        if isinstance(rlratio_std, dict):
             gainratio_mult = rlratio_std[site]
         else:
             gainratio_mult = rlratio_std
-                            
+
         # phasediff_mult: time dependent R-L phase offset
-        if type(rlphase_std) == dict:
+        if isinstance(rlphase_std, dict):
             phasediff_mult = rlphase_std[site]
         else:
             phasediff_mult = rlphase_std
-            
+
         # correlation timescales
-        if type(sigmat) == dict:
+        if isinstance(sigmat, dict):
             sigt_g = sigmat[site]
         else:
             sigt_g = sigmat
 
-        if type(phasesigmat) == dict:
+        if isinstance(phasesigmat, dict):
             sigt_p = phasesigmat[site]
         else:
             sigt_p = phasesigmat
 
-        if type(rlgsigmat) == dict:
+        if isinstance(rlgsigmat, dict):
             sigt_rlg = rlgsigmat[site]
         else:
             sigt_rlg = rlgsigmat
 
-        if type(rlpsigmat) == dict:
+        if isinstance(rlpsigmat, dict):
             sigt_rlp = rlpsigmat[site]
         else:
             sigt_rlp = rlpsigmat
-                                                            
+
         # Amplitude gains
         gainR = gainL = np.ones(len(times))
         if not ampcal:
-     
+
             # mean LCP gain
             gainL_constant = goff * obsh.hashrandn(site, 'gain', str(goff), seed)
 
@@ -581,7 +580,7 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
             if neggains:
                 gainL_constant = -np.abs(gainL_constant)
 
-            # LCP gain 
+            # LCP gain
             if sigt_g is None: # iid sampling in time
 
                 gainL = np.sqrt(np.abs(np.fromiter((
@@ -592,9 +591,9 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
 
             elif sigt_g <=0: # single sample in time
 
-                gainL = np.sqrt(np.abs(np.fromiter(((1.0 + gainL_constant) 
+                gainL = np.sqrt(np.abs(np.fromiter(((1.0 + gainL_constant)
                                        for time in times_stable_amp), float)))
-                                
+
             else: # correlated sampling in time
                 scan_start_times = scans[:, 0]
                 cov = obsh.rbf_kernel_covariance(scan_start_times, sigt_g)
@@ -611,41 +610,41 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
                 gain_RLratio = 1.
             else:
                 if sigt_rlg is None: #iid sampling in time
-                
+
                     gain_RLratio = np.abs(np.fromiter((
-                      (1.0 + gainratio_mult * obsh.hashrandn(site, 'gainratio', str(time), 
-                                                             str(gainratio_mult), seed))                
-                      for time in times_stable_amp), float))  
-                      
+                      (1.0 + gainratio_mult * obsh.hashrandn(site, 'gainratio', str(time),
+                                                             str(gainratio_mult), seed))
+                      for time in times_stable_amp), float))
+
                 elif sigt_rlg <=0: # single sample in time
                     gain_RLratio = np.abs(np.fromiter((
                       (1.0 + gainratio_mult * obsh.hashrandn(site, 'gainratio',
-                                                             str(gainratio_mult), seed))                
-                      for time in times_stable_amp), float))  
-                                                                      
+                                                             str(gainratio_mult), seed))
+                      for time in times_stable_amp), float))
+
                 else: #correlated sampling in time
                     scan_start_times = scans[:, 0]
                     cov = obsh.rbf_kernel_covariance(scan_start_times, sigt_rlg)
                     randRLx = obsh.hashmultivariaterandn(len(scan_start_times), cov, site,
-                                                         'gainratio', str(time), str(gainratio_mult), 
-                                                         seed) 
-                    gain_RLratio = np.abs(1.0 + gainratio_mult * randRLx)    
+                                                         'gainratio', str(time), str(gainratio_mult),
+                                                         seed)
+                    gain_RLratio = np.abs(1.0 + gainratio_mult * randRLx)
                     gainRLratio_interpolateor = interp1d(scan_start_times, gain_RLratio, kind='zero')
-                    gain_RLratio = gainRLratio_interpolateor(times_stable_amp)   
-                                                                            
-            # RCP gain                
+                    gain_RLratio = gainRLratio_interpolateor(times_stable_amp)
+
+            # RCP gain
             gainR = gain_RLratio * gainL
-                
+
             # enforce gains < 1
-            # TODO -- will this mess up gain offset priors? 
+            # TODO -- will this mess up gain offset priors?
             if neggains:
                 gainR = np.exp(-np.abs(np.log(gainR)))
                 gainL = np.exp(-np.abs(np.log(gainL)))
-                    
+
         # Opacity attenuation of amplitude gain
         if not opacitycal:
             taus = np.abs(np.fromiter((
-                (taudict[site][j]) * 
+                (taudict[site][j]) *
                 (1.0 + taup * obsh.hashrandn(site, 'tau', times_stable_amp[j], seed))
                 for j in range(len(times))), float))
             atten = np.exp(-taus/(ehc.EP + 2.0*np.sin(el_angles)))
@@ -656,44 +655,44 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
         # Atmospheric Phase
         if not phasecal:
 
-            # Gaussian distribution of LCP phase 
-            if phase_mult >=0: 
+            # Gaussian distribution of LCP phase
+            if phase_mult >=0:
 
-                if sigt_p is None: #iid sampling in time                                                 
+                if sigt_p is None: #iid sampling in time
                     phaseL = np.fromiter((phase_mult * obsh.hashrandn(site, 'phase', str(time),
-                                                                      str(phase_mult), seed)               
+                                                                      str(phase_mult), seed)
                                           for time in times_stable_phase), float)
-                                          
+
                 elif sigt_p <=0: # single sample in time
-                    phaseL = np.fromiter((phase_mult * obsh.hashrandn(site, 'phase', 
-                                                                      str(phase_mult), seed)               
-                                          for time in times_stable_phase), float)                
+                    phaseL = np.fromiter((phase_mult * obsh.hashrandn(site, 'phase',
+                                                                      str(phase_mult), seed)
+                                          for time in times_stable_phase), float)
                 else: #correlated sampling in time
                     scan_start_times = scans[:, 0]
                     cov = obsh.rbf_kernel_covariance(scan_start_times, sigt_p)
                     phaseL = phase_mult* obsh.hashmultivariaterandn(len(scan_start_times), cov, site,
-                                                                   'phase', str(time), str(phase_mult), 
-                                                                    seed) 
+                                                                   'phase', str(time), str(phase_mult),
+                                                                    seed)
                     phaseL_interpolateor = interp1d(scan_start_times, phaseL, kind='zero')
-                    phaseL = phaseL_interpolateor(times_stable_phase)   
-                    
+                    phaseL = phaseL_interpolateor(times_stable_phase)
+
             # flat distribution of LCP phase, iid in time
             # TODO correlated sampling with flat phases?
-            else:                        
+            else:
 
                 phaseL = np.fromiter((2 * np.pi * obsh.hashrand(site, 'phase', time, seed)
-                                     for time in times_stable_phase), float)           
-                
+                                     for time in times_stable_phase), float)
+
             # R-L phase offset
             if rlgaincal:
-                phaseRLdiff = 0.                 
+                phaseRLdiff = 0.
             else:
                 # Gaussian distributed phase difference
-                if phasediff_mult >=0: 
+                if phasediff_mult >=0:
                     if sigt_rlp is None: #iid sampling in time
                         phaseRLdiff = np.fromiter((phasediff_mult *
                                                    obsh.hashrandn(site, 'phasediff', str(time),
-                                                                  str(phasediff_mult), seed)               
+                                                                  str(phasediff_mult), seed)
                                                    for time in times_stable_phase), float)
                     elif sigt_rlp <=0: # single sample in time
                         phaseRLdiff = np.fromiter((phasediff_mult *
@@ -703,22 +702,22 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
                     else: #correlated sampling in time
                         scan_start_times = scans[:, 0]
                         cov = obsh.rbf_kernel_covariance(scan_start_times, sigt_rlp)
-                        phaseRLdiff = phasediff_mult * obsh.hashmultivariaterandn(len(scan_start_times), 
-                                                                                  cov, site, 'phasediff', 
-                                                                                  str(time), str(phasediff_mult), 
-                                                                                  seed) 
+                        phaseRLdiff = phasediff_mult * obsh.hashmultivariaterandn(len(scan_start_times),
+                                                                                  cov, site, 'phasediff',
+                                                                                  str(time), str(phasediff_mult),
+                                                                                  seed)
                         phaseRL_interpolateor = interp1d(scan_start_times, phaseRLdiff, kind='zero')
-                        phaseRLdiff = phaseRL_interpolateor(times_stable_phase)   
-                                                         
+                        phaseRLdiff = phaseRL_interpolateor(times_stable_phase)
+
                 # flat distribution phase difference, iid in time
-                # TODO correlated sampling with flat phases?                
-                else:                        
+                # TODO correlated sampling with flat phases?
+                else:
                     phaseRLdiff = np.fromiter((2 * np.pi * obsh.hashrand(site, 'phase', time, seed)
-                                              for time in times_stable_phase), float) 
+                                              for time in times_stable_phase), float)
                     phaseRLdiff -= np.pi
-            
-            # Complex gains                                             
-            gainL = gainL * np.exp(1j*phaseL)            
+
+            # Complex gains
+            gainL = gainL * np.exp(1j*phaseL)
             gainR = gainR * np.exp(1j*(phaseL + phaseRLdiff))
 
 
@@ -727,7 +726,7 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
         if not dcal:
 
             # D terms are always time-independent
-            if type(dterm_offset) == dict:
+            if isinstance(dterm_offset, dict):
                 doff = dterm_offset[site]
             else:
                 doff = dterm_offset
@@ -757,7 +756,7 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
 
         # Assemble the Jones Matrices and save to dictionary
         j_matrices = {times[j]: np.array([
-            [np.exp(-1j*fr_angle[j])*gainR[j], 
+            [np.exp(-1j*fr_angle[j])*gainR[j],
              np.exp(1j*(fr_angle[j]+fr_angle_D[j]))*dR*gainR[j]],
             [np.exp(-1j*(fr_angle[j]+fr_angle_D[j]))*dL*gainL[j],
              np.exp(1j*fr_angle[j])*gainL[j]]
@@ -822,11 +821,11 @@ def make_jones_inverse(obs, opacitycal=True, dcal=True, frcal=True):
             if len(sites_in) >= nsites:
                 break
 
-            if (not len(sites_in)) or (not bl['t1'] in sites_in):
+            if (not len(sites_in)) or (bl['t1'] not in sites_in):
                 taudict[bl['t1']] = np.append(taudict[bl['t1']], bl['tau1'])
                 sites_in = np.append(sites_in, bl['t1'])
 
-            if (not len(sites_in)) or (not bl['t2'] in sites_in):
+            if (not len(sites_in)) or (bl['t2'] not in sites_in):
                 taudict[bl['t2']] = np.append(taudict[bl['t2']], bl['tau2'])
                 sites_in = np.append(sites_in, bl['t2'])
         if len(sites_in) < nsites:
@@ -908,8 +907,8 @@ def add_jones_and_noise(obs, add_th_noise=True,
                         frcal=True, rlgaincal=True,
                         stabilize_scan_phase=False, stabilize_scan_amp=False,
                         neggains=False,
-                        taup=ehc.GAINPDEF, 
-                        gainp=ehc.GAINPDEF,gain_offset=ehc.GAINPDEF, 
+                        taup=ehc.GAINPDEF,
+                        gainp=ehc.GAINPDEF,gain_offset=ehc.GAINPDEF,
                         phase_std=-1,
                         dterm_offset=ehc.DTERMPDEF,
                         rlratio_std=0., rlphase_std=0.,
@@ -933,33 +932,33 @@ def add_jones_and_noise(obs, add_th_noise=True,
 
            taup (float): the fractional std. dev. of the random error on the opacities
            gainp (float): the fractional std. dev. of the random error on the gains
-                          or a dict giving one std. dev. per site      
+                          or a dict giving one std. dev. per site
 
            gain_offset (float): the base gain offset at all sites,
                                 or a dict giving one gain offset per site
-           phase_std (float): std. dev. of LCP phase, 
+           phase_std (float): std. dev. of LCP phase,
                               or a dict giving one std. dev. per site
-                              a negative value samples from uniform                                          
+                              a negative value samples from uniform
            dterm_offset (float): the base std. dev. of random additive error at all sites,
                                 or a dict giving one std. dev. per site
 
            rlratio_std (float): the fractional std. dev. of the R/L gain offset
-                                or a dict giving one std. dev. per site                                          
-           rlphase_std (float): std. dev. of R/L phase offset, 
                                 or a dict giving one std. dev. per site
-                                a negative value samples from uniform                                          
-                                                                            
+           rlphase_std (float): std. dev. of R/L phase offset,
+                                or a dict giving one std. dev. per site
+                                a negative value samples from uniform
+
            sigmat (float): temporal std for a Gaussian Process used to generate gains.
                            If sigmat=None then an iid gain noise is applied.
            phasesigmat (float): temporal std for a Gaussian Process used to generate phases.
-                                If phasesigmat=None then an iid gain noise is applied.                           
+                                If phasesigmat=None then an iid gain noise is applied.
            rlgsigmat (float): temporal std deviation for a Gaussian Process used to generate R/L gain ratios.
                            If rlgsigmat=None then an iid gain noise is applied.
            rlpsigmat (float): temporal std deviation for a Gaussian Process used to generate R/L phase diff.
                            If rlpsigmat=None then an iid gain noise is applied.
-                           
+
            caltable_path (string): If not None, path and prefix for saving the applied caltable
-           seed (int): seeds the random component of the noise terms. DO NOT set to 0!                                          
+           seed (int): seeds the random component of the noise terms. DO NOT set to 0!
            verbose (bool): print updates and warnings
        Returns:
            (np.array): an observation  data array
@@ -967,7 +966,7 @@ def add_jones_and_noise(obs, add_th_noise=True,
 
     if verbose:
         print("Applying Jones Matrices to data . . . ")
-        
+
     # Build Jones Matrices
     jm_dict = make_jones(obs,
                          ampcal=ampcal, opacitycal=opacitycal, phasecal=phasecal,
@@ -975,7 +974,7 @@ def add_jones_and_noise(obs, add_th_noise=True,
                          stabilize_scan_phase=stabilize_scan_phase,
                          stabilize_scan_amp=stabilize_scan_amp, neggains=neggains,
                          taup=taup,
-                         gainp=gainp, gain_offset=gain_offset, 
+                         gainp=gainp, gain_offset=gain_offset,
                          phase_std=phase_std,
                          dterm_offset=dterm_offset,
                          rlratio_std=rlratio_std, rlphase_std=rlphase_std,
@@ -1202,8 +1201,8 @@ def apply_jones_inverse(obs, opacitycal=True, dcal=True, frcal=True, verbose=Tru
 def add_noise(obs, add_th_noise=True, opacitycal=True, ampcal=True, phasecal=True,
               stabilize_scan_amp=False, stabilize_scan_phase=False,
               neggains=False,
-              taup=ehc.GAINPDEF, gain_offset=ehc.GAINPDEF, gainp=ehc.GAINPDEF, 
-              caltable_path=None, seed=False, sigmat=None, 
+              taup=ehc.GAINPDEF, gain_offset=ehc.GAINPDEF, gainp=ehc.GAINPDEF,
+              caltable_path=None, seed=False, sigmat=None,
               verbose=True):
     """Add thermal noise and gain & phase calibration errors to a dataset.
        Old routine replaced by add_jones_and_noise.
@@ -1227,13 +1226,13 @@ def add_noise(obs, add_th_noise=True, opacitycal=True, ampcal=True, phasecal=Tru
            seed (int): seeds the random component of the noise terms. DO NOT set to 0!
            sigmat (float): temporal std for a Gaussian Process used to generate gains.
                            NOT SUPPORTED for add_noise
-                           
+
            verbose (bool): print updates and warnings
        Returns:
            (np.array): an observation data array
     """
 
-    if caltable_path: 
+    if caltable_path:
         print("caltable saving not implemented for old add_noise function!")
     if verbose:
         print("Adding gain + phase errors to data and applying a priori calibration . . . ")
@@ -1326,7 +1325,7 @@ def add_noise(obs, add_th_noise=True, opacitycal=True, ampcal=True, phasecal=Tru
     # Add gain and opacity fluctuations to the TRUE noise
     if not ampcal:
         # Amplitude gain
-        if type(gain_offset) == dict:
+        if isinstance(gain_offset, dict):
             goff1 = np.fromiter((gain_offset[sites[i, 0]] for i in range(len(times))), float)
             goff2 = np.fromiter((gain_offset[sites[i, 1]] for i in range(len(times))), float)
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,3 +109,26 @@ def obs_noisy(gauss_im, eht_array):
 def gauss_prior(gauss_im):
     """A blurred copy of the Gaussian image suitable for use as a prior."""
     return gauss_im.blur_circ(30 * eh.RADPERUAS)
+
+
+@pytest.fixture(scope="session")
+def make_rect_image():
+    """Factory fixture: construct a Gaussian image with arbitrary (xdim, ydim)."""
+    import numpy as np
+
+    def _factory(xdim, ydim, psize=None):
+        if psize is None:
+            psize = 200 * eh.RADPERUAS / max(xdim, ydim)
+        image_arr = np.zeros((ydim, xdim))
+        for i in range(ydim):
+            for j in range(xdim):
+                x = (j - xdim / 2) * psize
+                y = (i - ydim / 2) * psize
+                sigma = 50 * eh.RADPERUAS
+                image_arr[i, j] = np.exp(-(x**2 + y**2) / (2 * sigma**2))
+        image_arr /= image_arr.sum()
+        return eh.image.Image(
+            image_arr, psize, 17.761, -29.0,
+            polrep="stokes", pol_prim="I", rf=230e9,
+        )
+    return _factory

--- a/tests/test_chisquared.py
+++ b/tests/test_chisquared.py
@@ -56,24 +56,6 @@ FFT_INTERP_ORDER = 3
 RNG_SEED = 4
 
 
-def _make_rect_image(xdim, ydim, psize=None):
-    """Construct a Gaussian image with arbitrary (xdim, ydim) dimensions."""
-    if psize is None:
-        psize = 200 * eh.RADPERUAS / max(xdim, ydim)
-    image_arr = np.zeros((ydim, xdim))
-    for i in range(ydim):
-        for j in range(xdim):
-            x = (j - xdim / 2) * psize
-            y = (i - ydim / 2) * psize
-            sigma = 50 * eh.RADPERUAS
-            image_arr[i, j] = np.exp(-(x**2 + y**2) / (2 * sigma**2))
-    image_arr /= image_arr.sum()
-    return eh.image.Image(
-        image_arr, psize, 17.761, -29.0,
-        polrep="stokes", pol_prim="I", rf=230e9,
-    )
-
-
 @pytest.fixture(scope="module")
 def chisq_setup(sgra_im_small, eht_array):
     """Set up observation and test image for chi-squared comparison tests.
@@ -111,9 +93,9 @@ def chisq_setup(sgra_im_small, eht_array):
 
 
 @pytest.fixture(scope="module")
-def chisq_setup_rect(eht_array):
+def chisq_setup_rect(eht_array, make_rect_image):
     """Set up 32x48 rectangular Gaussian image observation for chi-squared tests."""
-    im = _make_rect_image(32, 48)
+    im = make_rect_image(32, 48)
     im.imvec = im.imvec * 2.0 / im.total_flux()  # normalize to 2 Jy
 
     obs = im.observe(

--- a/tests/test_chisquared.py
+++ b/tests/test_chisquared.py
@@ -94,9 +94,9 @@ def chisq_setup(sgra_im_small, eht_array):
     prior = prior.add_gauss(im.total_flux(), (50 * eh.RADPERUAS, 50 * eh.RADPERUAS, 0, 0, 0))
 
     im2 = prior.copy()
-    rng = np.random.RandomState(RNG_SEED)
-    im2.imvec *= 1.0 + (rng.rand(len(im2.imvec)) - 0.5) / 10.0
-    im2.imvec += rng.rand(len(im2.imvec)) / 10.0 * im.imvec
+    rng = np.random.default_rng(RNG_SEED)
+    im2.imvec *= 1.0 + (rng.random(len(im2.imvec)) - 0.5) / 10.0
+    im2.imvec += rng.random(len(im2.imvec)) / 10.0 * im.imvec
 
     mask = im2.imvec > 0
     test_imvec = im2.imvec[mask] if np.any(~mask) else im2.imvec
@@ -125,9 +125,9 @@ def chisq_setup_rect(eht_array):
     prior = im.copy()
 
     im2 = prior.copy()
-    rng = np.random.RandomState(RNG_SEED)
-    im2.imvec *= 1.0 + (rng.rand(len(im2.imvec)) - 0.5) / 10.0
-    im2.imvec += rng.rand(len(im2.imvec)) / 10.0 * im.imvec
+    rng = np.random.default_rng(RNG_SEED)
+    im2.imvec *= 1.0 + (rng.random(len(im2.imvec)) - 0.5) / 10.0
+    im2.imvec += rng.random(len(im2.imvec)) / 10.0 * im.imvec
 
     mask = im2.imvec > 0
     test_imvec = im2.imvec[mask] if np.any(~mask) else im2.imvec

--- a/tests/test_chisquared.py
+++ b/tests/test_chisquared.py
@@ -1,13 +1,13 @@
 """Tests for chi-squared consistency across transform types (direct, fast, nfft).
 
 Verifies that chi-squared values and gradients agree between DFT, FFT, and NFFT
-for all standard data types.
+for all standard data types. All tests use a 32x48 image so xdim != ydim
+exercises the rectangular-image code paths (rect subsumes square).
 """
 
 import numpy as np
 import pytest
 
-import ehtim as eh
 from ehtim.imaging.imager_utils import chisq, chisqdata, chisqgrad
 
 # Observation parameters (must match conftest.py)
@@ -23,10 +23,10 @@ DATATERMS = ["vis", "bs", "amp", "cphase", "camp", "logcamp"]
 # Transform type pairs to compare
 TTYPE_PAIRS = [("direct", "fast"), ("direct", "nfft"), ("nfft", "fast")]
 
-# NFFT max gradient tolerance is much wider at 32x32 resolution
+# NFFT max gradient tolerance is much wider at this resolution
 GRAD_MAX_TOL_NFFT = 10.0
 
-# Tolerances (calibrated on 32x32 SgrA image)
+# Tolerances (calibrated on 32x48 synthetic Gaussian)
 CHISQ_FRAC_TOL = 0.01
 GRAD_MEDIAN_TOL = 0.05
 GRAD_MAX_TOL = 0.25
@@ -57,44 +57,14 @@ RNG_SEED = 4
 
 
 @pytest.fixture(scope="module")
-def chisq_setup(sgra_im_small, eht_array):
+def chisq_setup(eht_array, make_rect_image):
     """Set up observation and test image for chi-squared comparison tests.
 
-    Uses a single DFT observation as ground truth. The chi-squared functions
-    are then evaluated with different transform matrices (direct, fast, nfft)
-    on the same data, testing that the transform approximations agree.
+    Uses a 32x48 synthetic Gaussian image so xdim != ydim exercises the
+    rectangular-image code paths. A single DFT observation serves as ground
+    truth; chi-squared is then evaluated with different transform matrices
+    (direct, fast, nfft), testing that the transform approximations agree.
     """
-    im = sgra_im_small
-
-    obs = im.observe(
-        eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
-        sgrscat=False, ampcal=True, phasecal=False,
-        ttype="direct", add_th_noise=False,
-    )
-
-    prior = eh.image.make_square(obs, im.xdim, im.xdim * im.psize)
-    prior = prior.add_gauss(im.total_flux(), (50 * eh.RADPERUAS, 50 * eh.RADPERUAS, 0, 0, 0))
-
-    im2 = prior.copy()
-    rng = np.random.default_rng(RNG_SEED)
-    im2.imvec *= 1.0 + (rng.random(len(im2.imvec)) - 0.5) / 10.0
-    im2.imvec += rng.random(len(im2.imvec)) / 10.0 * im.imvec
-
-    mask = im2.imvec > 0
-    test_imvec = im2.imvec[mask] if np.any(~mask) else im2.imvec
-
-    return {
-        "obs": obs,
-        "prior": prior,
-        "test_imvec": test_imvec,
-        "mask": mask,
-        "im": im,
-    }
-
-
-@pytest.fixture(scope="module")
-def chisq_setup_rect(eht_array, make_rect_image):
-    """Set up 32x48 rectangular Gaussian image observation for chi-squared tests."""
     im = make_rect_image(32, 48)
     im.imvec = im.imvec * 2.0 / im.total_flux()  # normalize to 2 Jy
 
@@ -214,56 +184,3 @@ def _gradient_comparison(chisq_setup, dtype, pair):
     frac_diff = np.abs((grad_a - grad_b) / (np.abs(grad_a) + compare_floor))
     print(f"  {dtype} {ttype_a}-{ttype_b}: grad median={np.median(frac_diff):.6f} max={np.max(frac_diff):.6f}")
     return np.median(frac_diff), np.max(frac_diff)
-
-
-# ---------------------------------------------------------------------------
-# Rectangular image tests (xdim != ydim)
-# ---------------------------------------------------------------------------
-
-
-class TestChisqConsistencyRect:
-    """Chi-squared values agree across transform types on rectangular images."""
-
-    @pytest.mark.parametrize("dtype", DATATERMS)
-    @pytest.mark.parametrize("pair", TTYPE_PAIRS, ids=lambda p: f"{p[0]}-{p[1]}")
-    def test_chisq_values(self, chisq_setup_rect, dtype, pair):
-        ttype_a, ttype_b = pair
-        if "nfft" in (ttype_a, ttype_b):
-            pytest.importorskip("pynfft")
-        obs = chisq_setup_rect["obs"]
-        prior = chisq_setup_rect["prior"]
-        mask = chisq_setup_rect["mask"]
-        test_imvec = chisq_setup_rect["test_imvec"]
-
-        cdata_a = chisqdata(obs, prior, mask, dtype, ttype=ttype_a, **_chisq_kwargs(ttype_a))
-        cdata_b = chisqdata(obs, prior, mask, dtype, ttype=ttype_b, **_chisq_kwargs(ttype_b))
-
-        chi_a = chisq(test_imvec, cdata_a[2], cdata_a[0], cdata_a[1], dtype, ttype=ttype_a, mask=mask)
-        chi_b = chisq(test_imvec, cdata_b[2], cdata_b[0], cdata_b[1], dtype, ttype=ttype_b, mask=mask)
-
-        frac_diff = abs((chi_a - chi_b) / abs(chi_a))
-        print(f"  {dtype} {ttype_a}-{ttype_b} (rect): chisq frac diff = {frac_diff:.6f}")
-        assert frac_diff < CHISQ_FRAC_TOL, (
-            f"{dtype} {ttype_a}-{ttype_b} (rect): chisq frac diff = {frac_diff:.6f}"
-        )
-
-
-class TestChisqGradConsistencyRect:
-    """Chi-squared gradients agree across transform types on rectangular images."""
-
-    @pytest.mark.parametrize("dtype", DATATERMS)
-    @pytest.mark.parametrize("pair", TTYPE_PAIRS, ids=lambda p: f"{p[0]}-{p[1]}")
-    def test_grad_median_frac_diff(self, chisq_setup_rect, dtype, pair):
-        median_frac, _ = _gradient_comparison(chisq_setup_rect, dtype, pair)
-        assert median_frac < GRAD_MEDIAN_TOL, (
-            f"{dtype} {pair[0]}-{pair[1]} (rect): grad median frac diff = {median_frac:.6f}"
-        )
-
-    @pytest.mark.parametrize("dtype", DATATERMS)
-    @pytest.mark.parametrize("pair", TTYPE_PAIRS, ids=lambda p: f"{p[0]}-{p[1]}")
-    def test_grad_max_frac_diff(self, chisq_setup_rect, dtype, pair):
-        _, max_frac = _gradient_comparison(chisq_setup_rect, dtype, pair)
-        tol = GRAD_MAX_TOL_NFFT if "nfft" in pair else GRAD_MAX_TOL
-        assert max_frac < tol, (
-            f"{dtype} {pair[0]}-{pair[1]} (rect): grad max frac diff = {max_frac:.6f}"
-        )

--- a/tests/test_chisquared.py
+++ b/tests/test_chisquared.py
@@ -52,6 +52,9 @@ P_RAD = 12
 CONV_FUNC = "gaussian"
 FFT_INTERP_ORDER = 3
 
+# Random seed for image perturbation in fixtures
+RNG_SEED = 4
+
 
 def _make_rect_image(xdim, ydim, psize=None):
     """Construct a Gaussian image with arbitrary (xdim, ydim) dimensions."""
@@ -91,7 +94,7 @@ def chisq_setup(sgra_im_small, eht_array):
     prior = prior.add_gauss(im.total_flux(), (50 * eh.RADPERUAS, 50 * eh.RADPERUAS, 0, 0, 0))
 
     im2 = prior.copy()
-    rng = np.random.RandomState(42)
+    rng = np.random.RandomState(RNG_SEED)
     im2.imvec *= 1.0 + (rng.rand(len(im2.imvec)) - 0.5) / 10.0
     im2.imvec += rng.rand(len(im2.imvec)) / 10.0 * im.imvec
 
@@ -122,7 +125,7 @@ def chisq_setup_rect(eht_array):
     prior = im.copy()
 
     im2 = prior.copy()
-    rng = np.random.RandomState(4)
+    rng = np.random.RandomState(RNG_SEED)
     im2.imvec *= 1.0 + (rng.rand(len(im2.imvec)) - 0.5) / 10.0
     im2.imvec += rng.rand(len(im2.imvec)) / 10.0 * im.imvec
 

--- a/tests/test_chisquared.py
+++ b/tests/test_chisquared.py
@@ -53,6 +53,24 @@ CONV_FUNC = "gaussian"
 FFT_INTERP_ORDER = 3
 
 
+def _make_rect_image(xdim, ydim, psize=None):
+    """Construct a Gaussian image with arbitrary (xdim, ydim) dimensions."""
+    if psize is None:
+        psize = 200 * eh.RADPERUAS / max(xdim, ydim)
+    image_arr = np.zeros((ydim, xdim))
+    for i in range(ydim):
+        for j in range(xdim):
+            x = (j - xdim / 2) * psize
+            y = (i - ydim / 2) * psize
+            sigma = 50 * eh.RADPERUAS
+            image_arr[i, j] = np.exp(-(x**2 + y**2) / (2 * sigma**2))
+    image_arr /= image_arr.sum()
+    return eh.image.Image(
+        image_arr, psize, 17.761, -29.0,
+        polrep="stokes", pol_prim="I", rf=230e9,
+    )
+
+
 @pytest.fixture(scope="module")
 def chisq_setup(sgra_im_small, eht_array):
     """Set up observation and test image for chi-squared comparison tests.
@@ -74,6 +92,37 @@ def chisq_setup(sgra_im_small, eht_array):
 
     im2 = prior.copy()
     rng = np.random.RandomState(42)
+    im2.imvec *= 1.0 + (rng.rand(len(im2.imvec)) - 0.5) / 10.0
+    im2.imvec += rng.rand(len(im2.imvec)) / 10.0 * im.imvec
+
+    mask = im2.imvec > 0
+    test_imvec = im2.imvec[mask] if np.any(~mask) else im2.imvec
+
+    return {
+        "obs": obs,
+        "prior": prior,
+        "test_imvec": test_imvec,
+        "mask": mask,
+        "im": im,
+    }
+
+
+@pytest.fixture(scope="module")
+def chisq_setup_rect(eht_array):
+    """Set up 32x48 rectangular Gaussian image observation for chi-squared tests."""
+    im = _make_rect_image(32, 48)
+    im.imvec = im.imvec * 2.0 / im.total_flux()  # normalize to 2 Jy
+
+    obs = im.observe(
+        eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
+        sgrscat=False, ampcal=True, phasecal=False,
+        ttype="direct", add_th_noise=False,
+    )
+
+    prior = im.copy()
+
+    im2 = prior.copy()
+    rng = np.random.RandomState(4)
     im2.imvec *= 1.0 + (rng.rand(len(im2.imvec)) - 0.5) / 10.0
     im2.imvec += rng.rand(len(im2.imvec)) / 10.0 * im.imvec
 
@@ -180,3 +229,56 @@ def _gradient_comparison(chisq_setup, dtype, pair):
     frac_diff = np.abs((grad_a - grad_b) / (np.abs(grad_a) + compare_floor))
     print(f"  {dtype} {ttype_a}-{ttype_b}: grad median={np.median(frac_diff):.6f} max={np.max(frac_diff):.6f}")
     return np.median(frac_diff), np.max(frac_diff)
+
+
+# ---------------------------------------------------------------------------
+# Rectangular image tests (xdim != ydim)
+# ---------------------------------------------------------------------------
+
+
+class TestChisqConsistencyRect:
+    """Chi-squared values agree across transform types on rectangular images."""
+
+    @pytest.mark.parametrize("dtype", DATATERMS)
+    @pytest.mark.parametrize("pair", TTYPE_PAIRS, ids=lambda p: f"{p[0]}-{p[1]}")
+    def test_chisq_values(self, chisq_setup_rect, dtype, pair):
+        ttype_a, ttype_b = pair
+        if "nfft" in (ttype_a, ttype_b):
+            pytest.importorskip("pynfft")
+        obs = chisq_setup_rect["obs"]
+        prior = chisq_setup_rect["prior"]
+        mask = chisq_setup_rect["mask"]
+        test_imvec = chisq_setup_rect["test_imvec"]
+
+        cdata_a = chisqdata(obs, prior, mask, dtype, ttype=ttype_a, **_chisq_kwargs(ttype_a))
+        cdata_b = chisqdata(obs, prior, mask, dtype, ttype=ttype_b, **_chisq_kwargs(ttype_b))
+
+        chi_a = chisq(test_imvec, cdata_a[2], cdata_a[0], cdata_a[1], dtype, ttype=ttype_a, mask=mask)
+        chi_b = chisq(test_imvec, cdata_b[2], cdata_b[0], cdata_b[1], dtype, ttype=ttype_b, mask=mask)
+
+        frac_diff = abs((chi_a - chi_b) / abs(chi_a))
+        print(f"  {dtype} {ttype_a}-{ttype_b} (rect): chisq frac diff = {frac_diff:.6f}")
+        assert frac_diff < CHISQ_FRAC_TOL, (
+            f"{dtype} {ttype_a}-{ttype_b} (rect): chisq frac diff = {frac_diff:.6f}"
+        )
+
+
+class TestChisqGradConsistencyRect:
+    """Chi-squared gradients agree across transform types on rectangular images."""
+
+    @pytest.mark.parametrize("dtype", DATATERMS)
+    @pytest.mark.parametrize("pair", TTYPE_PAIRS, ids=lambda p: f"{p[0]}-{p[1]}")
+    def test_grad_median_frac_diff(self, chisq_setup_rect, dtype, pair):
+        median_frac, _ = _gradient_comparison(chisq_setup_rect, dtype, pair)
+        assert median_frac < GRAD_MEDIAN_TOL, (
+            f"{dtype} {pair[0]}-{pair[1]} (rect): grad median frac diff = {median_frac:.6f}"
+        )
+
+    @pytest.mark.parametrize("dtype", DATATERMS)
+    @pytest.mark.parametrize("pair", TTYPE_PAIRS, ids=lambda p: f"{p[0]}-{p[1]}")
+    def test_grad_max_frac_diff(self, chisq_setup_rect, dtype, pair):
+        _, max_frac = _gradient_comparison(chisq_setup_rect, dtype, pair)
+        tol = GRAD_MAX_TOL_NFFT if "nfft" in pair else GRAD_MAX_TOL
+        assert max_frac < tol, (
+            f"{dtype} {pair[0]}-{pair[1]} (rect): grad max frac diff = {max_frac:.6f}"
+        )

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -47,10 +47,59 @@ TSTOP_HR = 24
 BW_HZ = 4e9
 
 
+def _make_rect_image(xdim, ydim, psize=None):
+    """Construct a Gaussian image with arbitrary (xdim, ydim) dimensions."""
+    if psize is None:
+        psize = 200 * eh.RADPERUAS / max(xdim, ydim)
+    image_arr = np.zeros((ydim, xdim))
+    for i in range(ydim):
+        for j in range(xdim):
+            x = (j - xdim / 2) * psize
+            y = (i - ydim / 2) * psize
+            sigma = 50 * eh.RADPERUAS
+            image_arr[i, j] = np.exp(-(x**2 + y**2) / (2 * sigma**2))
+    image_arr /= image_arr.sum()
+    return eh.image.Image(
+        image_arr, psize, 17.761, -29.0,
+        polrep="stokes", pol_prim="I", rf=230e9,
+    )
+
+
 @pytest.fixture(scope="module")
 def grad_setup(m87_im_small, eht_array):
     """Set up observation and test image for gradient verification."""
     im = m87_im_small
+
+    obs = im.observe(
+        eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
+        sgrscat=False, ampcal=True, phasecal=True,
+        ttype="direct", add_th_noise=False,
+    )
+
+    prior = im.copy()
+    im2 = prior.copy()
+
+    rng = np.random.RandomState(42)
+    im2.imvec *= 1.0 + (rng.rand(len(im2.imvec)) - 0.5) / 10.0
+    im2.imvec += (1.0 + (rng.rand(len(im2.imvec)) - 0.5) / 10.0) * np.mean(im2.imvec)
+
+    mask = im2.imvec > 0.5 * np.median(im2.imvec)
+    test_imvec = im2.imvec[mask] if np.any(~mask) else im2.imvec
+
+    return {
+        "obs": obs,
+        "prior": prior,
+        "test_imvec": test_imvec,
+        "mask": mask,
+        "im": im,
+    }
+
+
+@pytest.fixture(scope="module")
+def grad_setup_rect(eht_array):
+    """Set up observation and test image from 32x48 rectangular Gaussian."""
+    im = _make_rect_image(32, 48)
+    im.imvec = im.imvec * 2.0 / im.total_flux()  # normalize to 2 Jy
 
     obs = im.observe(
         eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
@@ -179,3 +228,50 @@ def _reg_gradient_check(grad_setup, rtype):
     compare_floor = np.min(np.abs(grad_sampled)) * 1e-20 + 1e-100
     frac_diff = np.abs((grad_numeric - grad_sampled) / (np.abs(grad_sampled) + compare_floor))
     return np.median(frac_diff), np.max(frac_diff)
+
+
+# ---------------------------------------------------------------------------
+# Rectangular image tests (xdim != ydim)
+# ---------------------------------------------------------------------------
+
+
+class TestChisqGradientFiniteDiffRect:
+    """Analytic chi-squared gradients match numeric finite differences on rectangular images."""
+
+    @pytest.mark.parametrize("dtype", DATATERMS)
+    @pytest.mark.parametrize("ttype", TTYPES)
+    def test_median_frac_diff(self, grad_setup_rect, dtype, ttype):
+        if ttype == "nfft":
+            pytest.importorskip("pynfft")
+        median_frac, _ = _chisq_gradient_check(grad_setup_rect, dtype, ttype)
+        assert median_frac < CHISQ_GRAD_MEDIAN_TOL, (
+            f"{dtype} ({ttype}) rect median fractional gradient diff = {median_frac:.6f}"
+        )
+
+    @pytest.mark.parametrize("dtype", DATATERMS)
+    @pytest.mark.parametrize("ttype", TTYPES)
+    def test_max_frac_diff(self, grad_setup_rect, dtype, ttype):
+        if ttype == "nfft":
+            pytest.importorskip("pynfft")
+        _, max_frac = _chisq_gradient_check(grad_setup_rect, dtype, ttype)
+        assert max_frac < CHISQ_GRAD_MAX_TOL, (
+            f"{dtype} ({ttype}) rect max fractional gradient diff = {max_frac:.6f}"
+        )
+
+
+class TestRegularizerGradientFiniteDiffRect:
+    """Analytic regularizer gradients match numeric finite differences on rectangular images."""
+
+    @pytest.mark.parametrize("rtype", REGULARIZERS)
+    def test_median_frac_diff(self, grad_setup_rect, rtype):
+        median_frac, _ = _reg_gradient_check(grad_setup_rect, rtype)
+        assert median_frac < REG_GRAD_MEDIAN_TOL, (
+            f"{rtype} rect median fractional gradient diff = {median_frac:.6f}"
+        )
+
+    @pytest.mark.parametrize("rtype", REGULARIZERS)
+    def test_max_frac_diff(self, grad_setup_rect, rtype):
+        _, max_frac = _reg_gradient_check(grad_setup_rect, rtype)
+        assert max_frac < REG_GRAD_MAX_TOL, (
+            f"{rtype} rect max fractional gradient diff = {max_frac:.6f}"
+        )

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -1,7 +1,8 @@
 """Tests for analytic gradient correctness via numeric finite differences.
 
 Verifies that analytic chi-squared gradients and regularizer gradients
-match numeric finite differences computed element-wise.
+match numeric finite differences computed element-wise. All tests use a
+32x48 image so xdim != ydim exercises the rectangular-image code paths.
 """
 
 import numpy as np
@@ -16,7 +17,7 @@ DATATERMS = ["vis", "bs", "amp", "cphase", "camp", "logcamp"]
 REGULARIZERS = ["simple", "gs", "l1w", "tv", "tv2"]
 TTYPES = ["direct"]  # expand to ["direct", "fast", "nfft"] to test other transforms
 
-# Tolerances (calibrated on 32x32 M87 image with relative step size)
+# Tolerances (calibrated on 32x48 synthetic Gaussian with relative step size)
 CHISQ_GRAD_MEDIAN_TOL = 0.001
 CHISQ_GRAD_MAX_TOL = 0.01
 REG_GRAD_MEDIAN_TOL = 0.01
@@ -48,38 +49,11 @@ BW_HZ = 4e9
 
 
 @pytest.fixture(scope="module")
-def grad_setup(m87_im_small, eht_array):
-    """Set up observation and test image for gradient verification."""
-    im = m87_im_small
+def grad_setup(eht_array, make_rect_image):
+    """Set up observation and test image from 32x48 synthetic Gaussian.
 
-    obs = im.observe(
-        eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
-        sgrscat=False, ampcal=True, phasecal=True,
-        ttype="direct", add_th_noise=False,
-    )
-
-    prior = im.copy()
-    im2 = prior.copy()
-
-    rng = np.random.default_rng(RNG_SEED)
-    im2.imvec *= 1.0 + (rng.random(len(im2.imvec)) - 0.5) / 10.0
-    im2.imvec += (1.0 + (rng.random(len(im2.imvec)) - 0.5) / 10.0) * np.mean(im2.imvec)
-
-    mask = im2.imvec > 0.5 * np.median(im2.imvec)
-    test_imvec = im2.imvec[mask] if np.any(~mask) else im2.imvec
-
-    return {
-        "obs": obs,
-        "prior": prior,
-        "test_imvec": test_imvec,
-        "mask": mask,
-        "im": im,
-    }
-
-
-@pytest.fixture(scope="module")
-def grad_setup_rect(eht_array, make_rect_image):
-    """Set up observation and test image from 32x48 rectangular Gaussian."""
+    Uses xdim != ydim so the rectangular-image code paths are exercised.
+    """
     im = make_rect_image(32, 48)
     im.imvec = im.imvec * 2.0 / im.total_flux()  # normalize to 2 Jy
 
@@ -210,50 +184,3 @@ def _reg_gradient_check(grad_setup, rtype):
     compare_floor = np.min(np.abs(grad_sampled)) * 1e-20 + 1e-100
     frac_diff = np.abs((grad_numeric - grad_sampled) / (np.abs(grad_sampled) + compare_floor))
     return np.median(frac_diff), np.max(frac_diff)
-
-
-# ---------------------------------------------------------------------------
-# Rectangular image tests (xdim != ydim)
-# ---------------------------------------------------------------------------
-
-
-class TestChisqGradientFiniteDiffRect:
-    """Analytic chi-squared gradients match numeric finite differences on rectangular images."""
-
-    @pytest.mark.parametrize("dtype", DATATERMS)
-    @pytest.mark.parametrize("ttype", TTYPES)
-    def test_median_frac_diff(self, grad_setup_rect, dtype, ttype):
-        if ttype == "nfft":
-            pytest.importorskip("pynfft")
-        median_frac, _ = _chisq_gradient_check(grad_setup_rect, dtype, ttype)
-        assert median_frac < CHISQ_GRAD_MEDIAN_TOL, (
-            f"{dtype} ({ttype}) rect median fractional gradient diff = {median_frac:.6f}"
-        )
-
-    @pytest.mark.parametrize("dtype", DATATERMS)
-    @pytest.mark.parametrize("ttype", TTYPES)
-    def test_max_frac_diff(self, grad_setup_rect, dtype, ttype):
-        if ttype == "nfft":
-            pytest.importorskip("pynfft")
-        _, max_frac = _chisq_gradient_check(grad_setup_rect, dtype, ttype)
-        assert max_frac < CHISQ_GRAD_MAX_TOL, (
-            f"{dtype} ({ttype}) rect max fractional gradient diff = {max_frac:.6f}"
-        )
-
-
-class TestRegularizerGradientFiniteDiffRect:
-    """Analytic regularizer gradients match numeric finite differences on rectangular images."""
-
-    @pytest.mark.parametrize("rtype", REGULARIZERS)
-    def test_median_frac_diff(self, grad_setup_rect, rtype):
-        median_frac, _ = _reg_gradient_check(grad_setup_rect, rtype)
-        assert median_frac < REG_GRAD_MEDIAN_TOL, (
-            f"{rtype} rect median fractional gradient diff = {median_frac:.6f}"
-        )
-
-    @pytest.mark.parametrize("rtype", REGULARIZERS)
-    def test_max_frac_diff(self, grad_setup_rect, rtype):
-        _, max_frac = _reg_gradient_check(grad_setup_rect, rtype)
-        assert max_frac < REG_GRAD_MAX_TOL, (
-            f"{rtype} rect max fractional gradient diff = {max_frac:.6f}"
-        )

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -79,9 +79,9 @@ def grad_setup(m87_im_small, eht_array):
     prior = im.copy()
     im2 = prior.copy()
 
-    rng = np.random.RandomState(42)
-    im2.imvec *= 1.0 + (rng.rand(len(im2.imvec)) - 0.5) / 10.0
-    im2.imvec += (1.0 + (rng.rand(len(im2.imvec)) - 0.5) / 10.0) * np.mean(im2.imvec)
+    rng = np.random.default_rng(42)
+    im2.imvec *= 1.0 + (rng.random(len(im2.imvec)) - 0.5) / 10.0
+    im2.imvec += (1.0 + (rng.random(len(im2.imvec)) - 0.5) / 10.0) * np.mean(im2.imvec)
 
     mask = im2.imvec > 0.5 * np.median(im2.imvec)
     test_imvec = im2.imvec[mask] if np.any(~mask) else im2.imvec
@@ -110,9 +110,9 @@ def grad_setup_rect(eht_array):
     prior = im.copy()
     im2 = prior.copy()
 
-    rng = np.random.RandomState(42)
-    im2.imvec *= 1.0 + (rng.rand(len(im2.imvec)) - 0.5) / 10.0
-    im2.imvec += (1.0 + (rng.rand(len(im2.imvec)) - 0.5) / 10.0) * np.mean(im2.imvec)
+    rng = np.random.default_rng(42)
+    im2.imvec *= 1.0 + (rng.random(len(im2.imvec)) - 0.5) / 10.0
+    im2.imvec += (1.0 + (rng.random(len(im2.imvec)) - 0.5) / 10.0) * np.mean(im2.imvec)
 
     mask = im2.imvec > 0.5 * np.median(im2.imvec)
     test_imvec = im2.imvec[mask] if np.any(~mask) else im2.imvec

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -26,7 +26,7 @@ REG_GRAD_MAX_TOL = 0.10
 # Numeric gradient parameters
 # ---------------------------------------------------------------------------
 N_GRAD_SAMPLES = 100
-GRAD_SEED = 42
+RNG_SEED = 4
 GRAD_DX_REL = 1e-8    # relative step size per pixel
 GRAD_DX_FLOOR = 1e-12  # absolute minimum step size
 
@@ -47,24 +47,6 @@ TSTOP_HR = 24
 BW_HZ = 4e9
 
 
-def _make_rect_image(xdim, ydim, psize=None):
-    """Construct a Gaussian image with arbitrary (xdim, ydim) dimensions."""
-    if psize is None:
-        psize = 200 * eh.RADPERUAS / max(xdim, ydim)
-    image_arr = np.zeros((ydim, xdim))
-    for i in range(ydim):
-        for j in range(xdim):
-            x = (j - xdim / 2) * psize
-            y = (i - ydim / 2) * psize
-            sigma = 50 * eh.RADPERUAS
-            image_arr[i, j] = np.exp(-(x**2 + y**2) / (2 * sigma**2))
-    image_arr /= image_arr.sum()
-    return eh.image.Image(
-        image_arr, psize, 17.761, -29.0,
-        polrep="stokes", pol_prim="I", rf=230e9,
-    )
-
-
 @pytest.fixture(scope="module")
 def grad_setup(m87_im_small, eht_array):
     """Set up observation and test image for gradient verification."""
@@ -79,7 +61,7 @@ def grad_setup(m87_im_small, eht_array):
     prior = im.copy()
     im2 = prior.copy()
 
-    rng = np.random.default_rng(42)
+    rng = np.random.default_rng(RNG_SEED)
     im2.imvec *= 1.0 + (rng.random(len(im2.imvec)) - 0.5) / 10.0
     im2.imvec += (1.0 + (rng.random(len(im2.imvec)) - 0.5) / 10.0) * np.mean(im2.imvec)
 
@@ -96,9 +78,9 @@ def grad_setup(m87_im_small, eht_array):
 
 
 @pytest.fixture(scope="module")
-def grad_setup_rect(eht_array):
+def grad_setup_rect(eht_array, make_rect_image):
     """Set up observation and test image from 32x48 rectangular Gaussian."""
-    im = _make_rect_image(32, 48)
+    im = make_rect_image(32, 48)
     im.imvec = im.imvec * 2.0 / im.total_flux()  # normalize to 2 Jy
 
     obs = im.observe(
@@ -110,7 +92,7 @@ def grad_setup_rect(eht_array):
     prior = im.copy()
     im2 = prior.copy()
 
-    rng = np.random.default_rng(42)
+    rng = np.random.default_rng(RNG_SEED)
     im2.imvec *= 1.0 + (rng.random(len(im2.imvec)) - 0.5) / 10.0
     im2.imvec += (1.0 + (rng.random(len(im2.imvec)) - 0.5) / 10.0) * np.mean(im2.imvec)
 
@@ -179,7 +161,7 @@ def _chisq_gradient_check(grad_setup, dtype, ttype):
     grad_exact = chisqgrad(test_imvec, cdata[2], cdata[0], cdata[1], dtype, ttype=ttype, mask=mask)
     y0 = chisq(test_imvec, cdata[2], cdata[0], cdata[1], dtype, ttype=ttype, mask=mask)
 
-    rng = np.random.default_rng(GRAD_SEED)
+    rng = np.random.default_rng(RNG_SEED)
     sample_idx = rng.choice(len(test_imvec), size=N_GRAD_SAMPLES, replace=False)
 
     grad_numeric = np.zeros(N_GRAD_SAMPLES)
@@ -213,7 +195,7 @@ def _reg_gradient_check(grad_setup, rtype):
     y0 = iu.regularizer(test_imvec, nprior, mask, flux, im.xdim, im.ydim, im.psize, rtype, **kwargs)
     grad_exact = iu.regularizergrad(test_imvec, nprior, mask, flux, im.xdim, im.ydim, im.psize, rtype, **kwargs)
 
-    rng = np.random.default_rng(GRAD_SEED)
+    rng = np.random.default_rng(RNG_SEED)
     sample_idx = rng.choice(len(test_imvec), size=N_GRAD_SAMPLES, replace=False)
 
     grad_numeric = np.zeros(N_GRAD_SAMPLES)

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -11,6 +11,35 @@ import ehtim as eh
 from ehtim.imaging.imager_backend import compute_embed
 
 
+def _make_image(xdim, ydim, psize=None):
+    """Construct a Gaussian image with arbitrary (xdim, ydim)."""
+    if psize is None:
+        psize = 200 * eh.RADPERUAS / max(xdim, ydim)
+    image_arr = np.zeros((ydim, xdim))
+    # Add a 2D Gaussian centered at the middle
+    for i in range(ydim):
+        for j in range(xdim):
+            x = (j - xdim / 2) * psize
+            y = (i - ydim / 2) * psize
+            sigma = 50 * eh.RADPERUAS
+            image_arr[i, j] = np.exp(-(x**2 + y**2) / (2 * sigma**2))
+    image_arr /= image_arr.sum()
+    return eh.image.Image(
+        image_arr, psize, 17.761, -29.0,
+        polrep="stokes", pol_prim="I", rf=230e9,
+    )
+
+
+# Parametrize over square, tall, and wide images
+IMAGE_SHAPES = [
+    (32, 32),  # square
+    (32, 48),  # tall (ydim > xdim)
+    (48, 32),  # wide (xdim > ydim)
+    (31, 31),  # odd square
+    (31, 33),  # odd rectangular
+]
+
+
 class TestComputeEmbed:
     """Tests for compute_embed (extracted from Imager.set_embed)."""
 
@@ -67,15 +96,15 @@ class TestComputeEmbed:
         np.testing.assert_array_equal(embed_mask, imgr._embed_mask)
         np.testing.assert_array_equal(coord_matrix, imgr._coord_matrix)
 
-    def test_odd_dimensions(self):
-        """Odd image dimensions are handled correctly."""
-        im = eh.image.make_empty(31, 200 * eh.RADPERUAS, 0.0, 0.0)
-        im = im.add_gauss(1.0, (50 * eh.RADPERUAS, 50 * eh.RADPERUAS, 0, 0, 0))
+    @pytest.mark.parametrize("xdim,ydim", IMAGE_SHAPES)
+    def test_shapes(self, xdim, ydim):
+        """Backend handles square, rectangular, and odd-dim images correctly."""
+        im = _make_image(xdim, ydim)
         embed_mask, coord_matrix = compute_embed(
             im.imvec, im.xdim, im.ydim, im.psize, clipfloor=0.0,
         )
-        assert embed_mask.shape == (31 * 31,)
-        assert coord_matrix.shape == (31 * 31, 2)
+        assert embed_mask.shape == (xdim * ydim,)
+        assert coord_matrix.shape == (xdim * ydim, 2)
 
     def test_coord_matrix_units(self, gauss_im):
         """Coordinate matrix values are in radians (scaled by psize)."""

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -10,26 +10,6 @@ import pytest
 import ehtim as eh
 from ehtim.imaging.imager_backend import compute_embed
 
-
-def _make_image(xdim, ydim, psize=None):
-    """Construct a Gaussian image with arbitrary (xdim, ydim)."""
-    if psize is None:
-        psize = 200 * eh.RADPERUAS / max(xdim, ydim)
-    image_arr = np.zeros((ydim, xdim))
-    # Add a 2D Gaussian centered at the middle
-    for i in range(ydim):
-        for j in range(xdim):
-            x = (j - xdim / 2) * psize
-            y = (i - ydim / 2) * psize
-            sigma = 50 * eh.RADPERUAS
-            image_arr[i, j] = np.exp(-(x**2 + y**2) / (2 * sigma**2))
-    image_arr /= image_arr.sum()
-    return eh.image.Image(
-        image_arr, psize, 17.761, -29.0,
-        polrep="stokes", pol_prim="I", rf=230e9,
-    )
-
-
 # Parametrize over square, tall, and wide images
 IMAGE_SHAPES = [
     (32, 32),  # square
@@ -97,9 +77,9 @@ class TestComputeEmbed:
         np.testing.assert_array_equal(coord_matrix, imgr._coord_matrix)
 
     @pytest.mark.parametrize("xdim,ydim", IMAGE_SHAPES)
-    def test_shapes(self, xdim, ydim):
+    def test_shapes(self, make_rect_image, xdim, ydim):
         """Backend handles square, rectangular, and odd-dim images correctly."""
-        im = _make_image(xdim, ydim)
+        im = make_rect_image(xdim, ydim)
         embed_mask, coord_matrix = compute_embed(
             im.imvec, im.xdim, im.ydim, im.psize, clipfloor=0.0,
         )

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -1,7 +1,8 @@
 """Tests for ehtim regularizer functions.
 
 Verifies that all regularizer types return finite values and that
-analytic gradients match numeric finite differences.
+analytic gradients match numeric finite differences. All tests use a
+32x48 image so xdim != ydim exercises the rectangular-image code paths.
 """
 
 import numpy as np
@@ -10,7 +11,7 @@ import pytest
 import ehtim as eh
 import ehtim.imaging.imager_utils as iu
 
-# Tolerances for gradient checks (calibrated on 32x32 SgrA image)
+# Tolerances for gradient checks (calibrated on 32x48 synthetic Gaussian)
 MEDIAN_FRAC_TOL = 0.05
 MAX_FRAC_TOL = 0.6
 
@@ -36,21 +37,11 @@ GRAD_DX_FLOOR = 1e-12  # absolute minimum step size
 
 
 @pytest.fixture(scope="module")
-def reg_setup(sgra_im_small):
-    """Set up regularizer test data from 32x32 SgrA image."""
-    im = sgra_im_small.copy()
-    im.pulse = eh.observing.pulses.deltaPulse2D
-    mask = im.imvec > 0
-    imvec = im.imvec
-    nprior = np.ones_like(imvec)
-    nprior = nprior / np.sum(nprior)
-    flux = im.total_flux() * 0.95
-    return im, imvec, nprior, mask, flux
+def reg_setup(make_rect_image):
+    """Set up regularizer test data from 32x48 synthetic Gaussian.
 
-
-@pytest.fixture(scope="module")
-def reg_setup_rect(make_rect_image):
-    """Set up regularizer test data from 32x48 rectangular Gaussian image."""
+    Uses xdim != ydim so the rectangular-image code paths are exercised.
+    """
     im = make_rect_image(32, 48)
     im.pulse = eh.observing.pulses.deltaPulse2D
     mask = im.imvec > 0
@@ -129,41 +120,3 @@ def _gradient_check(reg_setup, rtype):
     compare_floor = np.min(np.abs(grad_exact_sampled)) * 1e-20 + 1e-100
     frac_diff = np.abs((grad_numeric - grad_exact_sampled) / (np.abs(grad_exact_sampled) + compare_floor))
     return np.median(frac_diff), np.max(frac_diff)
-
-
-# ---------------------------------------------------------------------------
-# Rectangular image tests (xdim != ydim)
-# ---------------------------------------------------------------------------
-
-
-class TestRegularizerValuesRect:
-    """All regularizer types return finite values on rectangular (32x48) images."""
-
-    @pytest.mark.parametrize("rtype", iu.REGULARIZERS)
-    @pytest.mark.parametrize("norm_reg", [True, False], ids=["normalized", "unnormalized"])
-    def test_returns_finite(self, reg_setup_rect, rtype, norm_reg):
-        im, imvec, nprior, mask, flux = reg_setup_rect
-        val = iu.regularizer(
-            imvec, nprior, mask, flux,
-            im.xdim, im.ydim, im.psize, rtype,
-            **_reg_kwargs(rtype, norm_reg=norm_reg),
-        )
-        assert np.isfinite(val), f"{rtype} (norm_reg={norm_reg}, rect) returned {val}"
-
-
-class TestRegularizerGradientsRect:
-    """Analytic regularizer gradients match numeric finite differences on rectangular images."""
-
-    @pytest.mark.parametrize("rtype", iu.REGULARIZERS)
-    def test_median_frac_diff(self, reg_setup_rect, rtype):
-        median_frac, _ = _gradient_check(reg_setup_rect, rtype)
-        assert median_frac < MEDIAN_FRAC_TOL, (
-            f"{rtype} rect median fractional gradient diff = {median_frac:.6f}"
-        )
-
-    @pytest.mark.parametrize("rtype", iu.REGULARIZERS)
-    def test_max_frac_diff(self, reg_setup_rect, rtype):
-        _, max_frac = _gradient_check(reg_setup_rect, rtype)
-        assert max_frac < MAX_FRAC_TOL, (
-            f"{rtype} rect max fractional gradient diff = {max_frac:.6f}"
-        )

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -30,31 +30,9 @@ RGAUSS_PA = np.pi / 3
 # Numeric gradient parameters
 # ---------------------------------------------------------------------------
 N_GRAD_SAMPLES = 100
-GRAD_SEED = 42
+RNG_SEED = 4
 GRAD_DX_REL = 1e-8    # relative step size per pixel
 GRAD_DX_FLOOR = 1e-12  # absolute minimum step size
-
-
-def _make_rect_image(xdim, ydim, psize=None):
-    """Construct a Gaussian image with arbitrary (xdim, ydim) dimensions.
-
-    Used for rectangular image test variants (xdim != ydim) to exercise
-    code paths that might assume square images.
-    """
-    if psize is None:
-        psize = 200 * eh.RADPERUAS / max(xdim, ydim)
-    image_arr = np.zeros((ydim, xdim))
-    for i in range(ydim):
-        for j in range(xdim):
-            x = (j - xdim / 2) * psize
-            y = (i - ydim / 2) * psize
-            sigma = 50 * eh.RADPERUAS
-            image_arr[i, j] = np.exp(-(x**2 + y**2) / (2 * sigma**2))
-    image_arr /= image_arr.sum()
-    return eh.image.Image(
-        image_arr, psize, 17.761, -29.0,
-        polrep="stokes", pol_prim="I", rf=230e9,
-    )
 
 
 @pytest.fixture(scope="module")
@@ -71,9 +49,9 @@ def reg_setup(sgra_im_small):
 
 
 @pytest.fixture(scope="module")
-def reg_setup_rect():
+def reg_setup_rect(make_rect_image):
     """Set up regularizer test data from 32x48 rectangular Gaussian image."""
-    im = _make_rect_image(32, 48)
+    im = make_rect_image(32, 48)
     im.pulse = eh.observing.pulses.deltaPulse2D
     mask = im.imvec > 0
     imvec = im.imvec
@@ -136,7 +114,7 @@ def _gradient_check(reg_setup, rtype):
     y0 = iu.regularizer(imvec, nprior, mask, flux, im.xdim, im.ydim, im.psize, rtype, **kwargs)
     grad_exact = iu.regularizergrad(imvec, nprior, mask, flux, im.xdim, im.ydim, im.psize, rtype, **kwargs)
 
-    rng = np.random.default_rng(GRAD_SEED)
+    rng = np.random.default_rng(RNG_SEED)
     sample_idx = rng.choice(len(imvec), size=N_GRAD_SAMPLES, replace=False)
 
     grad_numeric = np.zeros(N_GRAD_SAMPLES)

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -35,10 +35,45 @@ GRAD_DX_REL = 1e-8    # relative step size per pixel
 GRAD_DX_FLOOR = 1e-12  # absolute minimum step size
 
 
+def _make_rect_image(xdim, ydim, psize=None):
+    """Construct a Gaussian image with arbitrary (xdim, ydim) dimensions.
+
+    Used for rectangular image test variants (xdim != ydim) to exercise
+    code paths that might assume square images.
+    """
+    if psize is None:
+        psize = 200 * eh.RADPERUAS / max(xdim, ydim)
+    image_arr = np.zeros((ydim, xdim))
+    for i in range(ydim):
+        for j in range(xdim):
+            x = (j - xdim / 2) * psize
+            y = (i - ydim / 2) * psize
+            sigma = 50 * eh.RADPERUAS
+            image_arr[i, j] = np.exp(-(x**2 + y**2) / (2 * sigma**2))
+    image_arr /= image_arr.sum()
+    return eh.image.Image(
+        image_arr, psize, 17.761, -29.0,
+        polrep="stokes", pol_prim="I", rf=230e9,
+    )
+
+
 @pytest.fixture(scope="module")
 def reg_setup(sgra_im_small):
     """Set up regularizer test data from 32x32 SgrA image."""
     im = sgra_im_small.copy()
+    im.pulse = eh.observing.pulses.deltaPulse2D
+    mask = im.imvec > 0
+    imvec = im.imvec
+    nprior = np.ones_like(imvec)
+    nprior = nprior / np.sum(nprior)
+    flux = im.total_flux() * 0.95
+    return im, imvec, nprior, mask, flux
+
+
+@pytest.fixture(scope="module")
+def reg_setup_rect():
+    """Set up regularizer test data from 32x48 rectangular Gaussian image."""
+    im = _make_rect_image(32, 48)
     im.pulse = eh.observing.pulses.deltaPulse2D
     mask = im.imvec > 0
     imvec = im.imvec
@@ -116,3 +151,41 @@ def _gradient_check(reg_setup, rtype):
     compare_floor = np.min(np.abs(grad_exact_sampled)) * 1e-20 + 1e-100
     frac_diff = np.abs((grad_numeric - grad_exact_sampled) / (np.abs(grad_exact_sampled) + compare_floor))
     return np.median(frac_diff), np.max(frac_diff)
+
+
+# ---------------------------------------------------------------------------
+# Rectangular image tests (xdim != ydim)
+# ---------------------------------------------------------------------------
+
+
+class TestRegularizerValuesRect:
+    """All regularizer types return finite values on rectangular (32x48) images."""
+
+    @pytest.mark.parametrize("rtype", iu.REGULARIZERS)
+    @pytest.mark.parametrize("norm_reg", [True, False], ids=["normalized", "unnormalized"])
+    def test_returns_finite(self, reg_setup_rect, rtype, norm_reg):
+        im, imvec, nprior, mask, flux = reg_setup_rect
+        val = iu.regularizer(
+            imvec, nprior, mask, flux,
+            im.xdim, im.ydim, im.psize, rtype,
+            **_reg_kwargs(rtype, norm_reg=norm_reg),
+        )
+        assert np.isfinite(val), f"{rtype} (norm_reg={norm_reg}, rect) returned {val}"
+
+
+class TestRegularizerGradientsRect:
+    """Analytic regularizer gradients match numeric finite differences on rectangular images."""
+
+    @pytest.mark.parametrize("rtype", iu.REGULARIZERS)
+    def test_median_frac_diff(self, reg_setup_rect, rtype):
+        median_frac, _ = _gradient_check(reg_setup_rect, rtype)
+        assert median_frac < MEDIAN_FRAC_TOL, (
+            f"{rtype} rect median fractional gradient diff = {median_frac:.6f}"
+        )
+
+    @pytest.mark.parametrize("rtype", iu.REGULARIZERS)
+    def test_max_frac_diff(self, reg_setup_rect, rtype):
+        _, max_frac = _gradient_check(reg_setup_rect, rtype)
+        assert max_frac < MAX_FRAC_TOL, (
+            f"{rtype} rect max fractional gradient diff = {max_frac:.6f}"
+        )


### PR DESCRIPTION
Addresses review feedback from #224 by adding rectangular image tests (xdim != ydim) across all test files. Rectangular tests exposed multiple real bugs in the FFT code that only manifest on rectangular images. All bugs are fixed here.

## Test coverage

After fixture collapse in 930de08 (per Andrew's review feedback), all chisq / gradient / regularizer tests run on a 32x48 synthetic Gaussian via `make_rect_image(32, 48)`, so rectangular image code paths are always exercised. Rect subsumes the square case, so separate square/rect classes were redundant.

| File | Coverage | Fixture |
|---|---|---|
| test_imager_backend.py | 5 parametrized shapes for `compute_embed` (square, tall, wide, odd square, odd rect) | `make_rect_image` factory |
| test_regularizers.py | 24 value + gradient checks over 12 regularizers | `reg_setup` |
| test_gradients.py | 22 chisq + regularizer gradient finite-diff checks | `grad_setup` |
| test_chisquared.py | 54 cross-ttype comparisons (6 dtypes x 3 ttype pairs x 3 tests) | `chisq_setup` |

`make_rect_image` is a factory fixture in conftest.py consolidated from 4 previously copy-pasted helpers. Test count: 213 total (+4 vs dev-backend — 5 new `compute_embed` shape tests replace 1 old `test_odd_dimensions`).

## Bug fixes exposed by rectangular tests

**1. `sgauss` / `sgauss_grad` reshape order (imager_utils.py)**
- `imvec.reshape(xdim, ydim)` -> `reshape(ydim, xdim)` (lines 2523, 2565)
- Caused rgauss regularizer to crash on rectangular images with shape mismatch
- Invisible for square images because xdim == ydim

**2. `sgauss_grad` incorrect analytic formula (imager_utils.py)**
- Original had extra `-2*(xx-x0)*dx0*im` term in dxx/dyy/dxy gradients
- Correct formula: `d(sigxx)/d(im_k) = ((x_k-x0)^2 - sigxx)/S` (cross-term through centroid sums to zero by definition)
- Verified numerically: new formula matches finite-difference to 1e-8 across 150 configurations (5 shapes x 2 centers x 5 PAs x 3 major/minor ratios). Old had per-pixel errors ~0.02.

**3. FFT padding axis swap (obs_helpers.py, obs_simulate.py)**
- `np.pad(imarr, ((padvalx1, padvalx2), (padvaly1, padvaly2)), ...)` pads ROWS (axis 0 = ydim) with padvalx but padvalx was computed from xdim
- Swapped to `((padvaly1, padvaly2), (padvalx1, padvalx2))` so each dimension is padded correctly
- Invisible on square because padvalx == padvaly; on rect it produced non-square padded arrays and triggered the explicit "FFT padding did not return a square image!" exception
- Verified with point-source test: DFT and FFT agree to machine precision (1e-16) for all shapes

**4. FFT gradient slicing axis swap (imager_utils.py, 9 functions)**
- `grad_arr[padvalx1:-padvalx2, padvaly1:-padvaly2]` sliced axis 0 (rows = ydim) using padvalx
- Swapped to `[padvaly1:-padvaly2, padvalx1:-padvalx2]`
- TODO comment `# or is x<-->y??` in original code is now resolved and removed

**5. Typo fixes (obs_helpers.py)**
- `Excption` -> `Exception` in orbit_skyfield error path
- `satellite` -> `satname` (undefined variable) in sat_skyfield_from_ephementry error path


- **Stale TODO comments** removed from 7 `chisqgrad_*_fft` functions
- **Named seed constant** `RNG_SEED = 4` added and used consistently across all test files
- **RNG API migration** from legacy `np.random.RandomState` to modern `np.random.default_rng`
- **Helper consolidation**: `_make_rect_image` moved from 4 duplicates to a single `make_rect_image` factory fixture in conftest.py
- **Phase factor verified** in obs_simulate.py with point-source test (machine precision agreement DFT vs FFT on rectangular images)

## Lint

Pre-existing ruff issues in obs_helpers.py and obs_simulate.py were auto-fixed (imports, format specifiers, isinstance checks). Formatting only, no logic changes.

## Related

- Implements task 2.8 in #212
- Addresses review feedback on #224
