### PR TITLE
Extract make_chisq_dict + make_chisqgrad_dict into pure backend functions

### DIFF
--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -35,6 +35,9 @@ import ehtim.imaging.imager_utils as imutils
 import ehtim.imaging.multifreq_imager_utils as mfutils
 import ehtim.imaging.pol_imager_utils as polutils
 from ehtim.imaging.imager_backend import (
+    DATATERMS,
+    DATATERMS_POL,
+    POLARIZATION_MODES,
     compute_chisq_dict,
     compute_chisqgrad_dict,
     compute_embed,
@@ -52,9 +55,6 @@ NHIST = 50   # number of steps to store for hessian approx
 MAXLS = 40   # maximum number of line search steps in BFGS-B
 STOP = 1e-6  # convergence criterion
 EPS = 1e-8
-
-DATATERMS = ['vis', 'bs', 'amp', 'cphase', 'cphase_diag', 'camp', 'logcamp', 'logcamp_diag']
-DATATERMS_POL = ['pvis', 'm', 'vvis']
 
 REGULARIZERS = ['gs', 'tv', 'tvlog','tv2', 'tv2log', 'l1', 'l1w', 'lA', 'patch',
                 'flux', 'cm', 'simple', 'compact', 'compact2', 'rgauss']
@@ -87,7 +87,6 @@ REGPARAMS_DEFAULT = {'major':50*ehc.RADPERUAS,
                      'alpha_A':1.0,
                      'epsilon_tv':0.0}
 
-POLARIZATION_MODES = ['P','QU','IP','IQU','V','IV','IQUV','IPV'] # TODO: treatment of V may be inconsistent
 MEANPOL_INIT = 0.2 # mean initial polarization if not in initial image
 SIGMAPOL_INIT = 1.e-2 # perturbations to initial polarization if not in initial image
 
@@ -1087,7 +1086,6 @@ class Imager:
             imcur, sorted(self.dat_term_next.keys()), self._data_tuples,
             self.obslist_next, self._logfreqratio_list, self.mf_next,
             self.pol_next, self._ttype, self._embed_mask,
-            DATATERMS, DATATERMS_POL, POLARIZATION_MODES,
         )
 
     def make_chisqgrad_dict(self, imcur):
@@ -1099,7 +1097,6 @@ class Imager:
             self.obslist_next, self._logfreqratio_list, self.mf_next,
             self.pol_next, self._ttype, self._embed_mask,
             self._which_solve, self._nimage,
-            DATATERMS, DATATERMS_POL, POLARIZATION_MODES,
         )
 
     def make_reg_dict(self, imcur):

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -35,6 +35,7 @@ import ehtim.imaging.imager_utils as imutils
 import ehtim.imaging.multifreq_imager_utils as mfutils
 import ehtim.imaging.pol_imager_utils as polutils
 from ehtim.imaging.imager_backend import (
+    compute_chisq_dict,
     compute_embed,
     embed_imarr,
     make_initarr,
@@ -1081,46 +1082,12 @@ class Imager:
         """Make a dictionary of current chi^2 term values
            input is image array transformed to bounded values
         """
-
-        chi2_dict = {}
-        for dname in sorted(self.dat_term_next.keys()):
-            # Loop over all observations in the list
-            for i, obs in enumerate(self.obslist_next):
-                if len(self.obslist_next)==1:
-                    dname_key = dname
-                else:
-                    dname_key = dname + (f'_{i}')
-
-                # get data products
-                (data, sigma, A) = self._data_tuples[dname_key]
-
-                # get current multifrequency image
-                if self.mf_next:
-                    logfreqratio = self._logfreqratio_list[i]
-                    imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
-                else:
-                    imcur_nu = imcur
-
-                # Polarization chi^2 terms
-                if dname in DATATERMS_POL:
-                    chi2 = polutils.polchisq(imcur_nu, A, data, sigma, dname,
-                                             ttype=self._ttype, mask=self._embed_mask)
-
-                # Single Polarization chi^2 terms
-                elif dname in DATATERMS:
-                    if self.pol_next in POLARIZATION_MODES:
-                        imcur_nu_I = imcur_nu[0]
-                    else:
-                        imcur_nu_I = imcur_nu
-                    chi2 = imutils.chisq(imcur_nu, A, data, sigma, dname,
-                                         ttype=self._ttype, mask=self._embed_mask)
-
-                else:
-                    raise Exception(f"data term {dname} not recognized!")
-
-                chi2_dict[dname_key] = chi2
-
-        return chi2_dict
+        return compute_chisq_dict(
+            imcur, sorted(self.dat_term_next.keys()), self._data_tuples,
+            self.obslist_next, self._logfreqratio_list, self.mf_next,
+            self.pol_next, self._ttype, self._embed_mask,
+            DATATERMS, DATATERMS_POL, POLARIZATION_MODES,
+        )
 
     def make_chisqgrad_dict(self, imcur):
         """Make a dictionary of current chi^2 term gradient values

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -36,6 +36,7 @@ import ehtim.imaging.multifreq_imager_utils as mfutils
 import ehtim.imaging.pol_imager_utils as polutils
 from ehtim.imaging.imager_backend import (
     compute_chisq_dict,
+    compute_chisqgrad_dict,
     compute_embed,
     embed_imarr,
     make_initarr,
@@ -1093,64 +1094,13 @@ class Imager:
         """Make a dictionary of current chi^2 term gradient values
            input is image array transformed to bounded values
         """
-        chi2grad_dict = {}
-        for dname in sorted(self.dat_term_next.keys()):
-            # Loop over all observations in the list
-            for i, obs in enumerate(self.obslist_next):
-                if len(self.obslist_next)==1:
-                    dname_key = dname
-                else:
-                    dname_key = dname + (f'_{i}')
-
-                # get data products
-                (data, sigma, A) = self._data_tuples[dname_key]
-
-                # get current multifrequency image
-                if self.mf_next:
-                    logfreqratio = self._logfreqratio_list[i]
-                    imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
-                else:
-                    imcur_nu = imcur
-
-                # Polarimetric chi^2 gradients
-                if dname in DATATERMS_POL:
-                    if self.mf_next:
-                        pol_solve = self._which_solve[0:4]
-                    else:
-                        pol_solve = self._which_solve
-                    chi2grad = polutils.polchisqgrad(imcur_nu, A, data, sigma, dname,
-                                                     ttype=self._ttype, mask=self._embed_mask,
-                                                     pol_solve=pol_solve)
-
-                # Single polarization chi^2 gradients
-                elif dname in DATATERMS:
-                    if self.pol_next in POLARIZATION_MODES: # polarization
-                        imcur_nu_I = imcur_nu[0]
-                    else:
-                        imcur_nu_I = imcur_nu
-
-                    chi2grad = imutils.chisqgrad(imcur_nu_I, A, data, sigma, dname,
-                                                 ttype=self._ttype, mask=self._embed_mask)
-
-                    # If imaging Stokes I with polarization simultaneously, bundle the gradient
-                    if self.pol_next in POLARIZATION_MODES:
-                        chi2grad = np.array((chi2grad,
-                                             np.zeros(self._nimage),
-                                             np.zeros(self._nimage),
-                                             np.zeros(self._nimage)))
-
-                else:
-                    raise Exception(f"data term {dname} not recognized!")
-
-                # If multifrequency imaging,
-                # transform the image gradients for all the solved quantities
-                if self.mf_next:
-                    logfreqratio = self._logfreqratio_list[i]
-                    chi2grad = mfutils.mf_all_grads_chain(chi2grad, imcur_nu, imcur, logfreqratio)
-
-                chi2grad_dict[dname_key] = np.array(chi2grad)
-
-        return chi2grad_dict
+        return compute_chisqgrad_dict(
+            imcur, sorted(self.dat_term_next.keys()), self._data_tuples,
+            self.obslist_next, self._logfreqratio_list, self.mf_next,
+            self.pol_next, self._ttype, self._embed_mask,
+            self._which_solve, self._nimage,
+            DATATERMS, DATATERMS_POL, POLARIZATION_MODES,
+        )
 
     def make_reg_dict(self, imcur):
         """Make a dictionary of current regularizer values

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -474,3 +474,106 @@ def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist_next,
             chi2_dict[dname_key] = chi2
 
     return chi2_dict
+
+
+def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist_next,
+                           logfreqratio_list, mf_next, pol_next, ttype, embed_mask,
+                           which_solve, nimage,
+                           dataterms, dataterms_pol, polarization_modes):
+    """Compute chi^2 gradient for each data term across all observations.
+
+    Parameters
+    ----------
+    imcur : np.ndarray
+        Current image array transformed to bounded values.
+    dat_term_keys : list of str
+        Data term names to evaluate, already sorted.
+    data_tuples : dict
+        Pre-computed data products keyed by dname or dname_i,
+        each value is a (data, sigma, A) tuple.
+    obslist_next : list
+        List of Obsdata objects (one per frequency/epoch).
+    logfreqratio_list : list of float
+        Log frequency ratios log(nu_i/reffreq); one per obs.
+    mf_next : bool
+        Whether multifrequency imaging is enabled.
+    pol_next : str
+        Polarization mode string.
+    ttype : str
+        Transform type ('direct', 'fast', 'nfft').
+    embed_mask : np.ndarray of bool
+        Pixel embedding mask.
+    which_solve : np.ndarray of int
+        Binary flags for which parameters are solved.
+    nimage : int
+        Number of active pixels (sum of embed_mask).
+    dataterms : list of str
+        Single-polarization data term names.
+    dataterms_pol : list of str
+        Polarimetric data term names.
+    polarization_modes : list of str
+        Polarization modes that bundle Stokes I with other terms.
+
+    Returns
+    -------
+    chi2grad_dict : dict
+        Mapping from dname (or dname_i for multi-obs) to chi^2 gradient array.
+    """
+    chi2grad_dict = {}
+    # Zero row reused in the polarization-bundled Stokes-I gradient; safe to share
+    # because np.array((...)) below copies into a new (4, nimage) array each time.
+    zero_row = np.zeros(nimage)
+    for dname in dat_term_keys:
+        # Loop over all observations in the list
+        for i, obs in enumerate(obslist_next):
+            if len(obslist_next) == 1:
+                dname_key = dname
+            else:
+                dname_key = dname + (f'_{i}')
+
+            # get data products
+            (data, sigma, A) = data_tuples[dname_key]
+
+            # get current multifrequency image
+            if mf_next:
+                logfreqratio = logfreqratio_list[i]
+                imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
+            else:
+                imcur_nu = imcur
+
+            # Polarimetric chi^2 gradients
+            if dname in dataterms_pol:
+                if mf_next:
+                    pol_solve = which_solve[0:4]
+                else:
+                    pol_solve = which_solve
+                chi2grad = polutils.polchisqgrad(imcur_nu, A, data, sigma, dname,
+                                                 ttype=ttype, mask=embed_mask,
+                                                 pol_solve=pol_solve)
+
+            # Single polarization chi^2 gradients
+            elif dname in dataterms:
+                if pol_next in polarization_modes:  # polarization
+                    imcur_nu_I = imcur_nu[0]
+                else:
+                    imcur_nu_I = imcur_nu
+
+                chi2grad = imutils.chisqgrad(imcur_nu_I, A, data, sigma, dname,
+                                             ttype=ttype, mask=embed_mask)
+
+                # If imaging Stokes I with polarization simultaneously, bundle the gradient
+                if pol_next in polarization_modes:
+                    chi2grad = np.array((chi2grad, zero_row, zero_row, zero_row))
+
+            else:
+                raise Exception(f"data term {dname} not recognized!")
+
+            # If multifrequency imaging,
+            # transform the image gradients for all the solved quantities
+            if mf_next:
+                logfreqratio = logfreqratio_list[i]
+                chi2grad = mfutils.mf_all_grads_chain(chi2grad, imcur_nu, imcur, logfreqratio)
+
+            chi2grad_dict[dname_key] = np.array(chi2grad)
+
+    return chi2grad_dict

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -20,6 +20,7 @@
 import numpy as np
 
 import ehtim.imaging.imager_utils as imutils
+import ehtim.imaging.multifreq_imager_utils as mfutils
 import ehtim.imaging.pol_imager_utils as polutils
 
 
@@ -394,3 +395,82 @@ def compute_embed(imvec, xdim, ydim, psize, clipfloor):
     coord_matrix = coord[embed_mask]
 
     return embed_mask, coord_matrix
+
+
+def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist_next,
+                       logfreqratio_list, mf_next, pol_next, ttype, embed_mask,
+                       dataterms, dataterms_pol, polarization_modes):
+    """Compute chi^2 value for each data term across all observations.
+
+    Parameters
+    ----------
+    imcur : np.ndarray
+        Current image array transformed to bounded values.
+    dat_term_keys : list of str
+        Data term names to evaluate, already sorted.
+    data_tuples : dict
+        Pre-computed data products keyed by dname or dname_i,
+        each value is a (data, sigma, A) tuple.
+    obslist_next : list
+        List of Obsdata objects (one per frequency/epoch).
+    logfreqratio_list : list of float
+        Log frequency ratios log(nu_i/reffreq); one per obs.
+    mf_next : bool
+        Whether multifrequency imaging is enabled.
+    pol_next : str
+        Polarization mode string.
+    ttype : str
+        Transform type ('direct', 'fast', 'nfft').
+    embed_mask : np.ndarray of bool
+        Pixel embedding mask.
+    dataterms : list of str
+        Single-polarization data term names.
+    dataterms_pol : list of str
+        Polarimetric data term names.
+    polarization_modes : list of str
+        Polarization modes that bundle Stokes I with other terms.
+
+    Returns
+    -------
+    chi2_dict : dict
+        Mapping from dname (or dname_i for multi-obs) to chi^2 scalar.
+    """
+    chi2_dict = {}
+    for dname in dat_term_keys:
+        # Loop over all observations in the list
+        for i, obs in enumerate(obslist_next):
+            if len(obslist_next) == 1:
+                dname_key = dname
+            else:
+                dname_key = dname + (f'_{i}')
+
+            # get data products
+            (data, sigma, A) = data_tuples[dname_key]
+
+            # get current multifrequency image
+            if mf_next:
+                logfreqratio = logfreqratio_list[i]
+                imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
+            else:
+                imcur_nu = imcur
+
+            # Polarization chi^2 terms
+            if dname in dataterms_pol:
+                chi2 = polutils.polchisq(imcur_nu, A, data, sigma, dname,
+                                         ttype=ttype, mask=embed_mask)
+
+            # Single Polarization chi^2 terms
+            elif dname in dataterms:
+                if pol_next in polarization_modes:
+                    imcur_nu_I = imcur_nu[0]
+                else:
+                    imcur_nu_I = imcur_nu
+                chi2 = imutils.chisq(imcur_nu_I, A, data, sigma, dname,
+                                     ttype=ttype, mask=embed_mask)
+
+            else:
+                raise Exception(f"data term {dname} not recognized!")
+
+            chi2_dict[dname_key] = chi2
+
+    return chi2_dict

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -397,8 +397,8 @@ def compute_embed(imvec, xdim, ydim, psize, clipfloor):
     return embed_mask, coord_matrix
 
 
-def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist_next,
-                       logfreqratio_list, mf_next, pol_next, ttype, embed_mask,
+def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist,
+                       logfreqratio_list, mf, pol, ttype, embed_mask,
                        dataterms, dataterms_pol, polarization_modes):
     """Compute chi^2 value for each data term across all observations.
 
@@ -411,13 +411,13 @@ def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist_next,
     data_tuples : dict
         Pre-computed data products keyed by dname or dname_i,
         each value is a (data, sigma, A) tuple.
-    obslist_next : list
+    obslist : list
         List of Obsdata objects (one per frequency/epoch).
     logfreqratio_list : list of float
         Log frequency ratios log(nu_i/reffreq); one per obs.
-    mf_next : bool
+    mf : bool
         Whether multifrequency imaging is enabled.
-    pol_next : str
+    pol : str
         Polarization mode string.
     ttype : str
         Transform type ('direct', 'fast', 'nfft').
@@ -438,8 +438,8 @@ def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist_next,
     chi2_dict = {}
     for dname in dat_term_keys:
         # Loop over all observations in the list
-        for i, obs in enumerate(obslist_next):
-            if len(obslist_next) == 1:
+        for i, obs in enumerate(obslist):
+            if len(obslist) == 1:
                 dname_key = dname
             else:
                 dname_key = dname + (f'_{i}')
@@ -448,7 +448,7 @@ def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist_next,
             (data, sigma, A) = data_tuples[dname_key]
 
             # get current multifrequency image
-            if mf_next:
+            if mf:
                 logfreqratio = logfreqratio_list[i]
                 imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
             else:
@@ -461,7 +461,7 @@ def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist_next,
 
             # Single Polarization chi^2 terms
             elif dname in dataterms:
-                if pol_next in polarization_modes:
+                if pol in polarization_modes:
                     imcur_nu_I = imcur_nu[0]
                 else:
                     imcur_nu_I = imcur_nu
@@ -476,8 +476,8 @@ def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist_next,
     return chi2_dict
 
 
-def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist_next,
-                           logfreqratio_list, mf_next, pol_next, ttype, embed_mask,
+def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist,
+                           logfreqratio_list, mf, pol, ttype, embed_mask,
                            which_solve, nimage,
                            dataterms, dataterms_pol, polarization_modes):
     """Compute chi^2 gradient for each data term across all observations.
@@ -491,13 +491,13 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist_next,
     data_tuples : dict
         Pre-computed data products keyed by dname or dname_i,
         each value is a (data, sigma, A) tuple.
-    obslist_next : list
+    obslist : list
         List of Obsdata objects (one per frequency/epoch).
     logfreqratio_list : list of float
         Log frequency ratios log(nu_i/reffreq); one per obs.
-    mf_next : bool
+    mf : bool
         Whether multifrequency imaging is enabled.
-    pol_next : str
+    pol : str
         Polarization mode string.
     ttype : str
         Transform type ('direct', 'fast', 'nfft').
@@ -525,8 +525,8 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist_next,
     zero_row = np.zeros(nimage)
     for dname in dat_term_keys:
         # Loop over all observations in the list
-        for i, obs in enumerate(obslist_next):
-            if len(obslist_next) == 1:
+        for i, obs in enumerate(obslist):
+            if len(obslist) == 1:
                 dname_key = dname
             else:
                 dname_key = dname + (f'_{i}')
@@ -535,7 +535,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist_next,
             (data, sigma, A) = data_tuples[dname_key]
 
             # get current multifrequency image
-            if mf_next:
+            if mf:
                 logfreqratio = logfreqratio_list[i]
                 imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
             else:
@@ -543,7 +543,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist_next,
 
             # Polarimetric chi^2 gradients
             if dname in dataterms_pol:
-                if mf_next:
+                if mf:
                     pol_solve = which_solve[0:4]
                 else:
                     pol_solve = which_solve
@@ -553,7 +553,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist_next,
 
             # Single polarization chi^2 gradients
             elif dname in dataterms:
-                if pol_next in polarization_modes:  # polarization
+                if pol in polarization_modes:  # polarization
                     imcur_nu_I = imcur_nu[0]
                 else:
                     imcur_nu_I = imcur_nu
@@ -562,7 +562,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist_next,
                                              ttype=ttype, mask=embed_mask)
 
                 # If imaging Stokes I with polarization simultaneously, bundle the gradient
-                if pol_next in polarization_modes:
+                if pol in polarization_modes:
                     chi2grad = np.array((chi2grad, zero_row, zero_row, zero_row))
 
             else:
@@ -570,7 +570,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist_next,
 
             # If multifrequency imaging,
             # transform the image gradients for all the solved quantities
-            if mf_next:
+            if mf:
                 logfreqratio = logfreqratio_list[i]
                 chi2grad = mfutils.mf_all_grads_chain(chi2grad, imcur_nu, imcur, logfreqratio)
 

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -23,6 +23,12 @@ import ehtim.imaging.imager_utils as imutils
 import ehtim.imaging.multifreq_imager_utils as mfutils
 import ehtim.imaging.pol_imager_utils as polutils
 
+# Data term and polarization-mode names recognized by the chi^2 dispatchers.
+# Imported by ehtim.imager for backward compatibility.
+DATATERMS = ['vis', 'bs', 'amp', 'cphase', 'cphase_diag', 'camp', 'logcamp', 'logcamp_diag']
+DATATERMS_POL = ['pvis', 'm', 'vvis']
+POLARIZATION_MODES = ['P', 'QU', 'IP', 'IQU', 'V', 'IV', 'IQUV', 'IPV']  # TODO: treatment of V may be inconsistent
+
 
 def embed_imarr(imarr, mask, clipfloor=0., randomfloor=False):
     """Embeds a multidimensional image array into the size of boolean embed mask
@@ -398,8 +404,7 @@ def compute_embed(imvec, xdim, ydim, psize, clipfloor):
 
 
 def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist,
-                       logfreqratio_list, mf, pol, ttype, embed_mask,
-                       dataterms, dataterms_pol, polarization_modes):
+                       logfreqratio_list, mf, pol, ttype, embed_mask):
     """Compute chi^2 value for each data term across all observations.
 
     Parameters
@@ -423,12 +428,6 @@ def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist,
         Transform type ('direct', 'fast', 'nfft').
     embed_mask : np.ndarray of bool
         Pixel embedding mask.
-    dataterms : list of str
-        Single-polarization data term names.
-    dataterms_pol : list of str
-        Polarimetric data term names.
-    polarization_modes : list of str
-        Polarization modes that bundle Stokes I with other terms.
 
     Returns
     -------
@@ -455,13 +454,13 @@ def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist,
                 imcur_nu = imcur
 
             # Polarization chi^2 terms
-            if dname in dataterms_pol:
+            if dname in DATATERMS_POL:
                 chi2 = polutils.polchisq(imcur_nu, A, data, sigma, dname,
                                          ttype=ttype, mask=embed_mask)
 
             # Single Polarization chi^2 terms
-            elif dname in dataterms:
-                if pol in polarization_modes:
+            elif dname in DATATERMS:
+                if pol in POLARIZATION_MODES:
                     imcur_nu_I = imcur_nu[0]
                 else:
                     imcur_nu_I = imcur_nu
@@ -478,8 +477,7 @@ def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist,
 
 def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist,
                            logfreqratio_list, mf, pol, ttype, embed_mask,
-                           which_solve, nimage,
-                           dataterms, dataterms_pol, polarization_modes):
+                           which_solve, nimage):
     """Compute chi^2 gradient for each data term across all observations.
 
     Parameters
@@ -507,12 +505,6 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist,
         Binary flags for which parameters are solved.
     nimage : int
         Number of active pixels (sum of embed_mask).
-    dataterms : list of str
-        Single-polarization data term names.
-    dataterms_pol : list of str
-        Polarimetric data term names.
-    polarization_modes : list of str
-        Polarization modes that bundle Stokes I with other terms.
 
     Returns
     -------
@@ -542,7 +534,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist,
                 imcur_nu = imcur
 
             # Polarimetric chi^2 gradients
-            if dname in dataterms_pol:
+            if dname in DATATERMS_POL:
                 if mf:
                     pol_solve = which_solve[0:4]
                 else:
@@ -552,8 +544,8 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist,
                                                  pol_solve=pol_solve)
 
             # Single polarization chi^2 gradients
-            elif dname in dataterms:
-                if pol in polarization_modes:  # polarization
+            elif dname in DATATERMS:
+                if pol in POLARIZATION_MODES:  # polarization
                     imcur_nu_I = imcur_nu[0]
                 else:
                     imcur_nu_I = imcur_nu
@@ -562,7 +554,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist,
                                              ttype=ttype, mask=embed_mask)
 
                 # If imaging Stokes I with polarization simultaneously, bundle the gradient
-                if pol in polarization_modes:
+                if pol in POLARIZATION_MODES:
                     chi2grad = np.array((chi2grad, zero_row, zero_row, zero_row))
 
             else:

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -16,30 +16,19 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import range
-
-import string
-import time
-import copy
-import numpy as np
-import scipy.optimize as opt
-import scipy.ndimage as ndF
-import scipy.ndimage.filters as filt
 import matplotlib.pyplot as plt
+import numpy as np
+
 try:
     from pynfft.nfft import NFFT
+    _HAS_NFFT = True
 except ImportError:
-    pass
-    #print("Warning: No NFFT installed! Cannot use nfft functions")
+    NFFT = None
+    _HAS_NFFT = False
 
-import ehtim.image as image
-from ehtim.const_def import *
-from ehtim.observing.obs_helpers import *
-from ehtim.imaging.imager_utils import embed
+from ehtim.const_def import FFT_PAD_DEFAULT, GRIDDER_P_RAD_DEFAULT, RADPERAS
 from ehtim.imager import embed_imarr
+from ehtim.observing.obs_helpers import NFFTInfo, ftmatrix, ticks
 
 TANWIDTH_M = 0.5
 TANWIDTH_V = 1
@@ -61,8 +50,8 @@ nit = 0 # global variable to track the iteration number in the plotting callback
 # P = M = RL = Q+iU = I \rho cos(\psi) e^(i\phi)
 # \phi = 2\chi = 2*EVPA
 # m = abs(Q+iU)/I = I \rho cos(\psi)
-# rho = Sqrt(Q^2 + U^2 + V^2)/I 
-# V = I \rho sin(\psi) 
+# rho = Sqrt(Q^2 + U^2 + V^2)/I
+# V = I \rho sin(\psi)
 # v = V/I = \rho sin(\psi)
 # imarr = (I, \rho, \phi, \psi)
 
@@ -74,7 +63,7 @@ def make_i_image(imarr):
     """return total intensity image
     """
     return imarr[0]
-    
+
 def make_p_image(imarr):
     """construct a polarimetric image P = RL = Q + iU
     """
@@ -93,7 +82,7 @@ def make_m_image(imarr):
     return mimage
 
 def make_chi_image(imarr):
-    """construct an EVPA image 
+    """construct an EVPA image
     """
     # NOTE! We replaced EVPA chi with phi=2chi in the imarr
     chiimage = 0.5*imarr[2]
@@ -101,12 +90,12 @@ def make_chi_image(imarr):
     return chiimage
 
 def make_psi_image(imarr):
-    """construct a circular polarization angle image 
+    """construct a circular polarization angle image
     """
     psiimage = imarr[3]
 
     return psiimage
-    
+
 def make_q_image(imarr):
     """construct an image of stokes Q
     """
@@ -121,7 +110,7 @@ def make_u_image(imarr):
     """
     # NOTE! We replaced EVPA chi with phi=2chi in the imarr
     uimage = imarr[0] * imarr[1] * np.sin(imarr[2]) *  np.cos(imarr[3])
-    
+
     return uimage
 
 def make_v_image(imarr):
@@ -129,44 +118,44 @@ def make_v_image(imarr):
     """
 
     vimage = imarr[0] * imarr[1] * np.sin(imarr[3])
-        
+
     return vimage
 
 def make_vf_image(imarr):
     """construct an image of stokes V/I
     """
-    
+
     vfimage = imarr[1] * np.sin(imarr[3])
-        
+
     return vfimage
 
 def polcv(imarr):
-    """change of variables rho(rho') from range (-inf, inf) to (0,1) 
+    r"""change of variables rho(rho') from range (-inf, inf) to (0,1)
        and \psi(\psi') from range (-inf, inf) to (-pi/2, pi/2)
-       input is solver values, output is physical values               
+       input is solver values, output is physical values
     """
-    
+
     rho_prime =  imarr[1]
     rho = 0.5 + np.arctan(rho_prime/TANWIDTH_M)/np.pi
-    
+
     psi_prime = imarr[3]
     psi = np.arctan(psi_prime/TANWIDTH_PSI)
-    
+
     out = np.array((imarr[0], rho, imarr[2], psi))
     return out
 
 def polcv_r(imarr):
-    """Reverse change of variables rho'(rho) from range (0,1) to (-inf, inf)
+    r"""Reverse change of variables rho'(rho) from range (0,1) to (-inf, inf)
        and \psi'(\psi) from range (-pi/2, pi/2) to (-inf, inf)
-       input is physical values, output is solver values               
+       input is physical values, output is solver values
     """
-    
+
     rho = imarr[1]
     rho_prime = TANWIDTH_M*np.tan(np.pi*(rho - 0.5))
 
     psi = imarr[3]
     psi_prime = TANWIDTH_PSI*np.tan(psi)
-    
+
     out = np.array((imarr[0], rho_prime, imarr[2], psi_prime))
 
     return out
@@ -176,37 +165,37 @@ def polcv_chain(imarr):
        input is solver values
     """
     out = np.ones(imarr.shape)
-    
+
     rho_prime = imarr[1]
     out[1] = 1 / (TANWIDTH_M*np.pi*(1 + (rho_prime/TANWIDTH_M)**2))
-    
+
     psi_prime = imarr[3]
     out[3] =  1 / (TANWIDTH_PSI*(1 + (psi_prime/TANWIDTH_PSI)**2))
     return out
-           
-               
+
+
 def mcv(imarr):
     """change of variables m(n') from range (-inf, inf) to (0,1)
-       input is solver values, output is physical values        
+       input is solver values, output is physical values
     """
-    
+
     vfrac = imarr[3] # when using this transform, we interpret transformed imarr[3] as mfrac=\rho sin(\psi)
     mfrac_max = 1-np.abs(vfrac)
     if np.any(mfrac_max>1):
         raise Exception("mfrac_max>1 in mcv!")
-        
+
     mfrac_prime =  imarr[1]
     mfrac = mfrac_max*(0.5 + np.arctan(mfrac_prime/TANWIDTH_M)/np.pi)
-    
+
     rho = np.sqrt(mfrac**2 + vfrac**2)
     psi = np.arcsin(vfrac/rho)
-        
+
     out = np.array((imarr[0], rho, imarr[2], psi))
     return out
 
 def mcv_r(imarr):
     """Reverse change of variables m'(m) from range (0,1-|v|) to (-inf, inf)
-       input is physical values, output is solver values    
+       input is physical values, output is solver values
     """
     rho = imarr[1]
     psi = imarr[3]
@@ -215,58 +204,58 @@ def mcv_r(imarr):
     mfrac_max = 1-np.abs(vfrac)
     if np.any(mfrac_max>1):
         raise Exception("mfrac_max>1 in mcv!")
-                
+
     mfrac_prime = TANWIDTH_M*np.tan(np.pi*(mfrac/mfrac_max - 0.5))
     out = np.array((imarr[0], mfrac_prime, imarr[2], vfrac))
     return out
-    
+
 # TODO WE ARE GOING TO HAVE TO CHECK ALL OF THESE NUMERICALLY
 def mcv_chain(imarr):
     """chain rule terms drho/dm' and dpsi/dv' for mcv
        input is solver values
     """
     out = np.ones(imarr.shape)
-    
+
     vfrac = imarr[3] # when using this transform, we interpret transformed imarr[3] as mfrac=\rho sin(\psi)
     mfrac_max = 1-np.abs(vfrac)
     if np.any(mfrac_max>1):
         raise Exception("mfrac_max>1 in mcv!")
-        
+
     mfrac_prime =  imarr[1]
     mfrac = mfrac_max*(0.5 + np.arctan(mfrac_prime/TANWIDTH_M)/np.pi)
-    
+
     rho = np.sqrt(mfrac**2 + vfrac**2)
     psi = np.arcsin(vfrac/rho)
 
     dm_dmprime = mfrac_max / (TANWIDTH_M*np.pi*(1 + (mfrac_prime/TANWIDTH_M)**2))
-        
+
     drho_dm = mfrac / rho                # drho/dm holding v constant
     drho_dmprime = drho_dm * dm_dmprime
     out[1] = drho_dmprime
 
-    # we only use mcv when holding v constant, so dF/imarr[3]=0  
+    # we only use mcv when holding v constant, so dF/imarr[3]=0
     #dpsi_dm = -vfrac/ (rho*rho)         # dpsi/dm holding v constant # TODO CHECK
     #dpsi_dmprime = dpsi_dm * dm_dmprime
-    #out[3] = dpsi_dmprime   
-    out[3] = np.zeros(out[3].shape)  
-        
+    #out[3] = dpsi_dmprime
+    out[3] = np.zeros(out[3].shape)
+
     return out
-           
+
 def vcv(imarr):
     """change of variables for v(v') from range (-inf,inf) to (-1+|m|,1-|m|) while keeping m=P/I fixed
        input is solver values, output is physical values"""
-    
+
     mfrac = imarr[1] # when using this transform, we interpret transformed imarr[1] as mfrac=\rho cos(\psi)
     vfrac_max = 1-np.abs(mfrac)
     if np.any(vfrac_max>1):
         raise Exception("vfrac_max>1 in vcv!")
-            
+
     vfrac_prime = imarr[3]
-    vfrac = 2*vfrac_max*np.arctan(vfrac_prime/TANWIDTH_V)/np.pi    
-    
+    vfrac = 2*vfrac_max*np.arctan(vfrac_prime/TANWIDTH_V)/np.pi
+
     rho = np.sqrt(mfrac**2 + vfrac**2)
     psi = np.arcsin(vfrac/rho)
-    
+
     out = np.array((imarr[0], rho, imarr[2], psi))
     return out
 
@@ -280,9 +269,9 @@ def vcv_r(imarr):
     vfrac_max = 1-np.abs(mfrac)
     if np.any(vfrac_max>1):
         raise Exception("vfrac_max>1 in vcv_r!")
-    
+
     vfrac_prime = TANWIDTH_V*np.tan(np.pi*vfrac/(2*vfrac_max))
-    out = np.array((imarr[0], mfrac, imarr[2], vfrac_prime))   
+    out = np.array((imarr[0], mfrac, imarr[2], vfrac_prime))
     return out
 
 # TODO WE ARE GOING TO HAVE TO CHECK ALL OF THESE NUMERICALLY
@@ -291,28 +280,28 @@ def vcv_chain(imarr):
        input is solver values
     """
     out = np.ones(imarr.shape)
-    
+
     mfrac = imarr[1] # when using this transform, we interpret transformed imarr[1] as mfrac=\rho cos(\psi)
     vfrac_max = 1-np.abs(mfrac)
     if np.any(vfrac_max>1):
         raise Exception("vfrac_max>1 in vcv_r!")
 
-    vfrac_prime = imarr[3]    
-    vfrac = 2*vfrac_max*np.arctan(vfrac_prime/TANWIDTH_V)/np.pi        
+    vfrac_prime = imarr[3]
+    vfrac = 2*vfrac_max*np.arctan(vfrac_prime/TANWIDTH_V)/np.pi
     rho = np.sqrt(mfrac**2 + vfrac**2)
     psi = np.arcsin(vfrac/rho)
-    
+
     dv_dvprime = 2. * vfrac_max / (TANWIDTH_V*np.pi*(1 + (vfrac_prime/TANWIDTH_V)**2))
 
-    # we only use mcv when holding v constant, so dF/imarr[1]=0      
+    # we only use mcv when holding v constant, so dF/imarr[1]=0
     #drho_dv = rhofrac / v                # drho/dv holding m constant
     #drho_dvprime = drho_dv * dv_dvprime
     #out[1] = drho_dvprime
-    out[1] = np.zeros(out[3].shape)  
-        
+    out[1] = np.zeros(out[3].shape)
+
     dpsi_dv = mfrac / (rho*rho)          # dpsi/dv holding m constant # TODO CHECK
     dpsi_dvprime = dpsi_dv * dv_dvprime
-    out[3] = dpsi_dvprime       
+    out[3] = dpsi_dvprime
     return out
 
 
@@ -324,23 +313,23 @@ def polchisq(imarr, A, data, sigma, dtype, ttype='direct', mask=[]):
     """return the chi^2 for the appropriate dtype
     """
 
-    chisq = 1 
-    if not dtype in DATATERMS_POL:
+    chisq = 1
+    if dtype not in DATATERMS_POL:
         return chisq
     if ttype not in ['direct','nfft']:
         raise Exception("Possible ttype values for polchisq are 'nfft' and 'direct'!")
-        
+
     if ttype == 'direct':
         # linear
         if dtype == 'pvis':
             chisq = chisq_p(imarr, A, data, sigma)
         elif dtype == 'm':
             chisq = chisq_m(imarr, A, data, sigma)
-            
+
         # circular
         elif dtype == 'vvis':
-            chisq = chisq_vvis(imarr, A, data, sigma)        
-            
+            chisq = chisq_vvis(imarr, A, data, sigma)
+
     elif ttype== 'fast':
         raise Exception("FFT not yet implemented in polchisq!")
 
@@ -353,21 +342,21 @@ def polchisq(imarr, A, data, sigma, dtype, ttype='direct', mask=[]):
             chisq = chisq_p_nfft(imarr, A, data, sigma)
         elif dtype == 'm':
             chisq = chisq_m_nfft(imarr, A, data, sigma)
-            
+
         # circular
         elif dtype == 'vvis':
-            chisq = chisq_vvis_nfft(imarr, A, data, sigma)        
+            chisq = chisq_vvis_nfft(imarr, A, data, sigma)
 
     return chisq
 
 def polchisqgrad(imarr, A, data, sigma, dtype, ttype='direct',mask=[],
                  pol_solve=POL_SOLVE_DEFAULT):
-    
+
     """return the chi^2 gradient for the appropriate dtype
     """
 
     chisqgrad = np.zeros(imarr.shape)
-    if not dtype in DATATERMS_POL:
+    if dtype not in DATATERMS_POL:
         return chisqgrad
     if ttype not in ['direct','nfft']:
         raise Exception("Possible ttype values for polchisqgrad are 'nfft' and 'direct'!")
@@ -379,18 +368,18 @@ def polchisqgrad(imarr, A, data, sigma, dtype, ttype='direct',mask=[],
         elif dtype == 'm':
             chisqgrad = chisqgrad_m(imarr, A, data, sigma, pol_solve)
 
-            
+
         # circular
         elif dtype == 'vvis':
             chisqgrad = chisqgrad_vvis(imarr, A, data, sigma, pol_solve)
-                
+
     elif ttype== 'fast':
         raise Exception("FFT not yet implemented in polchisqgrad!")
 
     elif ttype== 'nfft':
         if len(mask)>0 and np.any(np.invert(mask)):
             imarr = embed_imarr(imarr, mask, randomfloor=RANDOMFLOOR)
-      
+
         # linear
         if dtype == 'pvis':
             chisqgrad = chisqgrad_p_nfft(imarr, A, data, sigma, pol_solve)
@@ -401,7 +390,7 @@ def polchisqgrad(imarr, A, data, sigma, dtype, ttype='direct',mask=[],
         # circular
         elif dtype == 'vvis':
             chisqgrad = chisqgrad_vvis_nfft(imarr, A, data, sigma, pol_solve)
-            
+
         if len(mask)>0 and np.any(np.invert(mask)):
             chisqgrad = chisqgrad[:,mask]
 
@@ -409,15 +398,15 @@ def polchisqgrad(imarr, A, data, sigma, dtype, ttype='direct',mask=[],
 
 
 def polregularizer(imarr, priorarr, mask, flux, pflux, vflux, xdim, ydim, psize, stype, **kwargs):
-    # NOTE: priorarr is currently not used in any regularizer 
-    
+    # NOTE: priorarr is currently not used in any regularizer
+
     norm_reg = kwargs.get('norm_reg', NORM_REGULARIZER)
     beam_size = kwargs.get('beam_size',1)
-    
+
     reg = 0
-    if not stype in REGULARIZERS_POL:
+    if stype not in REGULARIZERS_POL:
         return reg
-            
+
     # linear
     if stype == "msimple":
         reg = -sm(imarr, flux, norm_reg=norm_reg)
@@ -426,11 +415,11 @@ def polregularizer(imarr, priorarr, mask, flux, pflux, vflux, xdim, ydim, psize,
     elif stype == "ptv":
         if np.any(np.invert(mask)):
             imarr = embed_imarr(imarr, mask, randomfloor=RANDOMFLOOR)
-        reg = -stv_pol(imarr, flux, xdim, ydim, psize, 
+        reg = -stv_pol(imarr, flux, xdim, ydim, psize,
                        norm_reg=norm_reg, beam_size=beam_size)
     # circular
     elif stype == 'vflux':
-        reg = -svflux(imarr, vflux, norm_reg=norm_reg)    
+        reg = -svflux(imarr, vflux, norm_reg=norm_reg)
     elif stype == "l1v":
         reg = -sl1v(imarr, vflux, norm_reg=norm_reg)
     elif stype == "l2v":
@@ -438,26 +427,26 @@ def polregularizer(imarr, priorarr, mask, flux, pflux, vflux, xdim, ydim, psize,
     elif stype == "vtv":
         if np.any(np.invert(mask)):
             imarr = embed_imarr(imarr, mask, randomfloor=RANDOMFLOOR)
-        reg = -stv_v(imarr, vflux, xdim, ydim, psize, 
+        reg = -stv_v(imarr, vflux, xdim, ydim, psize,
                      norm_reg=norm_reg, beam_size=beam_size)
     elif stype == "vtv2":
         if np.any(np.invert(mask)):
             imarr = embed_imarr(imarr, mask, randomfloor=RANDOMFLOOR)
-        reg = -stv2_v(imarr, vflux, xdim, ydim, psize, 
-                      norm_reg=norm_reg, beam_size=beam_size)                               
+        reg = -stv2_v(imarr, vflux, xdim, ydim, psize,
+                      norm_reg=norm_reg, beam_size=beam_size)
 
 
     return reg
 
 def polregularizergrad(imarr, priorarr, mask, flux, pflux, vflux, xdim, ydim, psize, stype, **kwargs):
-    # NOTE: priorarr is currently not used in any regularizer 
-    
+    # NOTE: priorarr is currently not used in any regularizer
+
     norm_reg = kwargs.get('norm_reg', NORM_REGULARIZER)
     beam_size = kwargs.get('beam_size',1)
     pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT)
     reggrad = np.zeros(imarr.shape)
-    
-    if not stype in REGULARIZERS_POL:
+
+    if stype not in REGULARIZERS_POL:
         return reggrad
 
     # linear
@@ -476,11 +465,11 @@ def polregularizergrad(imarr, priorarr, mask, flux, pflux, vflux, xdim, ydim, ps
 
     # circular
     elif stype == 'vflux':
-        reggrad = -svfluxgrad(imarr, vflux, pol_solve=pol_solve, norm_reg=norm_reg)        
+        reggrad = -svfluxgrad(imarr, vflux, pol_solve=pol_solve, norm_reg=norm_reg)
     elif stype == "l1v":
         reggrad = -sl1vgrad(imarr, vflux, pol_solve=pol_solve, norm_reg=norm_reg)
     elif stype == "l2v":
-        reggrad = -sl2vgrad(imarr, vflux, pol_solve=pol_solve, norm_reg=norm_reg)    
+        reggrad = -sl2vgrad(imarr, vflux, pol_solve=pol_solve, norm_reg=norm_reg)
     elif stype == "vtv":
         if np.any(np.invert(mask)):
             imarr = embed_imarr(imarr, mask, randomfloor=RANDOMFLOOR)
@@ -488,11 +477,11 @@ def polregularizergrad(imarr, priorarr, mask, flux, pflux, vflux, xdim, ydim, ps
                               pol_solve=pol_solve, norm_reg=norm_reg, beam_size=beam_size)
         if np.any(np.invert(mask)):
             reggrad = reggrad[:,mask]
-            
+
     elif stype == "vtv2":
         if np.any(np.invert(mask)):
             imarr = embed_imarr(imarr, mask, randomfloor=RANDOMFLOOR)
-        reggrad = -stv2_v_grad(imarr, vflux, xdim, ydim, psize, 
+        reggrad = -stv2_v_grad(imarr, vflux, xdim, ydim, psize,
                                pol_solve=pol_solve, norm_reg=norm_reg, beam_size=beam_size)
         if np.any(np.invert(mask)):
             reggrad = reggrad[:,mask]
@@ -510,7 +499,7 @@ def polchisqdata(Obsdata, Prior, mask, dtype, **kwargs):
     (data, sigma, A) = (False, False, False)
     if ttype not in ['direct','nfft']:
         raise Exception("Possible ttype values for polchisqdata are 'nfft' and 'direct'!")
-        
+
     if ttype=='direct':
         if dtype == 'pvis':
             (data, sigma, A) = chisqdata_pvis(Obsdata, Prior, mask)
@@ -518,7 +507,7 @@ def polchisqdata(Obsdata, Prior, mask, dtype, **kwargs):
             (data, sigma, A) = chisqdata_m(Obsdata, Prior, mask)
         elif dtype == 'vvis':
             (data, sigma, A) = chisqdata_vvis(Obsdata, Prior, mask)
-            
+
     elif ttype=='fast':
         raise Exception("FFT not yet implemented in polchisqdata!")
 
@@ -529,7 +518,7 @@ def polchisqdata(Obsdata, Prior, mask, dtype, **kwargs):
             (data, sigma, A) = chisqdata_m_nfft(Obsdata, Prior, mask, **kwargs)
         elif dtype == 'vvis':
             (data, sigma, A) = chisqdata_vvis_nfft(Obsdata, Prior, mask, **kwargs)
-        
+
     return (data, sigma, A)
 
 
@@ -542,8 +531,8 @@ def chisq_p(imarr, Amatrix, p, sigmap):
     """
 
     pimage = make_p_image(imarr)
-    psamples = np.dot(Amatrix, pimage) 
-    chisq =  np.sum(np.abs((p - psamples))**2/(sigmap**2)) / (2*len(p))   
+    psamples = np.dot(Amatrix, pimage)
+    chisq =  np.sum(np.abs(p - psamples)**2/(sigmap**2)) / (2*len(p))
     return chisq
 
 def chisqgrad_p(imarr, Amatrix, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
@@ -556,7 +545,7 @@ def chisqgrad_p(imarr, Amatrix, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
     mimage = make_m_image(imarr)
     chiimage = make_chi_image(imarr)
     psiimage = make_psi_image(imarr)
-    
+
     psamples = np.dot(Amatrix, pimage)
     pdiff = (p - psamples) / (sigmap**2)
 
@@ -580,7 +569,7 @@ def chisqgrad_p(imarr, Amatrix, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
         gradm = -np.real(iimage * np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, pdiff)) / len(p)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
         gradout[3] = gradpsi
-        
+
     return gradout
 
 def chisq_m(imarr, Amatrix, m, sigmam):
@@ -590,20 +579,20 @@ def chisq_m(imarr, Amatrix, m, sigmam):
     iimage = make_i_image(imarr)
     pimage = make_p_image(imarr)
     msamples = np.dot(Amatrix, pimage) / np.dot(Amatrix, iimage)
-    chisq = np.sum(np.abs((m - msamples))**2/(sigmam**2)) / (2*len(m))   
+    chisq = np.sum(np.abs(m - msamples)**2/(sigmam**2)) / (2*len(m))
     return chisq
-    
+
 def chisqgrad_m(imarr, Amatrix, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
     """The gradient of the polarimetric ratio chisq
     """
     gradout = np.zeros(imarr.shape)
-        
+
     iimage = make_i_image(imarr)
     pimage = make_p_image(imarr)
     mimage = make_m_image(imarr)
     chiimage = make_chi_image(imarr)
     psiimage = make_psi_image(imarr)
-    
+
     isamples = np.dot(Amatrix, iimage)
     psamples = np.dot(Amatrix, pimage)
     msamples = psamples/isamples
@@ -618,17 +607,17 @@ def chisqgrad_m(imarr, Amatrix, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
         gradm = -np.real(iimage*np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, mdiff)) / len(m)
         gradrho = gradm * np.cos(psiimage)
         gradout[1] = gradrho
-        
+
     if pol_solve[2]!=0:
         gradchi = -2 * np.imag(pimage.conj() * np.dot(Amatrix.conj().T, mdiff)) / len(m)
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
-        
+
     if pol_solve[3]!=0:
         gradm = -np.real(iimage*np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, mdiff)) / len(m)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
         gradout[3] = gradpsi
-        
+
 
     return gradout
 
@@ -638,23 +627,23 @@ def chisq_vvis(imarr, Amatrix, v, sigmav):
     """
 
     vimage = make_v_image(imarr)
-    vsamples = np.dot(Amatrix, vimage) 
-    chisq =  np.sum(np.abs((v - vsamples))**2/(sigmav**2)) / (2*len(v))   
+    vsamples = np.dot(Amatrix, vimage)
+    chisq =  np.sum(np.abs(v - vsamples)**2/(sigmav**2)) / (2*len(v))
     return chisq
 
 def chisqgrad_vvis(imarr, Amatrix, v, sigmav, pol_solve=POL_SOLVE_DEFAULT_V):
     """V visibility chi-squared gradient
     """
-    
+
     gradout = np.zeros(imarr.shape)
-    
+
     iimage = make_i_image(imarr)
     vimage = make_v_image(imarr)
     vfimage = make_vf_image(imarr)
     psiimage = make_psi_image(imarr)
-        
+
     vsamples = np.dot(Amatrix, vimage)
-    vdiff = (v - vsamples) / (sigmav**2)        
+    vdiff = (v - vsamples) / (sigmav**2)
 
     if pol_solve[0]!=0:
         gradi = -np.real(vfimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
@@ -664,7 +653,7 @@ def chisqgrad_vvis(imarr, Amatrix, v, sigmav, pol_solve=POL_SOLVE_DEFAULT_V):
         gradv = -np.real(iimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
         gradrho = gradv*np.sin(psiimage)
         gradout[1] = gradrho
-        
+
     if pol_solve[3]!=0:
         gradv = -np.real(iimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
         gradpsi = gradv * (vfimage/np.tan(psiimage))
@@ -679,7 +668,7 @@ def chisq_p_nfft(imarr, A, p, sigmap):
     """P visibility chi-squared
     """
     pimage = make_p_image(imarr)
-    
+
     #get nfft object
     nfft_info = A[0]
     plan = nfft_info.plan
@@ -691,7 +680,7 @@ def chisq_p_nfft(imarr, A, p, sigmap):
     psamples = plan.f.copy()*pulsefac
 
     #compute chi^2
-    chisq =  np.sum(np.abs((p - psamples))**2/(sigmap**2)) / (2*len(p))   
+    chisq =  np.sum(np.abs(p - psamples)**2/(sigmap**2)) / (2*len(p))
 
     return chisq
 
@@ -699,19 +688,19 @@ def chisqgrad_p_nfft(imarr, A, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
     """P visibility chi-squared gradient
     """
     gradout = np.zeros(imarr.shape)
-    
+
     iimage = make_i_image(imarr)
     pimage = make_p_image(imarr)
     mimage = make_m_image(imarr)
     chiimage = make_chi_image(imarr)
     psiimage = make_psi_image(imarr)
-            
+
     #get nfft object
     nfft_info = A[0]
     plan = nfft_info.plan
     pulsefac = nfft_info.pulsefac
 
-    #compute uniform --> nonuniform transform 
+    #compute uniform --> nonuniform transform
     plan.f_hat = pimage.copy().reshape((nfft_info.ydim,nfft_info.xdim)).T
     plan.trafo()
     psamples = plan.f.copy()*pulsefac
@@ -721,25 +710,25 @@ def chisqgrad_p_nfft(imarr, A, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
     plan.f = pdiff_vec
     plan.adjoint()
     ppart = (plan.f_hat.copy().T).reshape(nfft_info.xdim*nfft_info.ydim)
-    
+
     if pol_solve[0]!=0:
         gradi = np.real(mimage * np.exp(-2j*chiimage) * ppart)
         gradout[0] = gradi
 
     if pol_solve[1]!=0:
-        gradm = np.real(iimage*np.exp(-2j*chiimage) *ppart) 
-        gradrho = gradm * np.cos(psiimage)        
+        gradm = np.real(iimage*np.exp(-2j*chiimage) *ppart)
+        gradrho = gradm * np.cos(psiimage)
         gradout[1] = gradrho
-        
+
     if pol_solve[2]!=0:
         gradchi = 2 * np.imag(pimage.conj() * ppart)
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
-        
+
     if pol_solve[3]!=0:
-        gradm = np.real(iimage*np.exp(-2j*chiimage) *ppart) 
+        gradm = np.real(iimage*np.exp(-2j*chiimage) *ppart)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
-        gradout[3] = gradpsi     
+        gradout[3] = gradpsi
 
 
     return gradout
@@ -750,7 +739,7 @@ def chisq_m_nfft(imarr, A, m, sigmam):
     """
     iimage = make_i_image(imarr)
     pimage = make_p_image(imarr)
-    
+
     #get nfft object
     nfft_info = A[0]
     plan = nfft_info.plan
@@ -767,20 +756,20 @@ def chisq_m_nfft(imarr, A, m, sigmam):
 
     #compute chi^2
     msamples = psamples/isamples
-    chisq = np.sum(np.abs((m - msamples))**2/(sigmam**2)) / (2*len(m))   
+    chisq = np.sum(np.abs(m - msamples)**2/(sigmam**2)) / (2*len(m))
     return chisq
 
 def chisqgrad_m_nfft(imarr, A, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
     """Polarimetric ratio chi-squared gradient
     """
     gradout = np.zeros(imarr.shape)
-    
+
     iimage = make_i_image(imarr)
     pimage = make_p_image(imarr)
     mimage = make_m_image(imarr)
     chiimage = make_chi_image(imarr)
     psiimage = make_psi_image(imarr)
-    
+
     #get nfft object
     nfft_info = A[0]
     plan = nfft_info.plan
@@ -802,27 +791,27 @@ def chisqgrad_m_nfft(imarr, A, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
     mpart = (plan.f_hat.copy().T).reshape(nfft_info.xdim*nfft_info.ydim)
 
     if pol_solve[0]!=0: #TODO -- check!!
-        plan.f = mdiff_vec * msamples.conj() 
+        plan.f = mdiff_vec * msamples.conj()
         plan.adjoint()
         mpart2 = (plan.f_hat.copy().T).reshape(nfft_info.xdim*nfft_info.ydim)
-        
+
         gradi = (np.real(mimage * np.exp(-2j*chiimage) * mpart) - np.real(mpart2))
         gradout[0] = gradi
 
     if pol_solve[1]!=0:
-        gradm = np.real(iimage*np.exp(-2j*chiimage) * mpart) 
-        gradrho = gradm * np.cos(psiimage)        
+        gradm = np.real(iimage*np.exp(-2j*chiimage) * mpart)
+        gradrho = gradm * np.cos(psiimage)
         gradout[1] = gradrho
-        
+
     if pol_solve[2]!=0:
         gradchi = 2 * np.imag(pimage.conj() * mpart)
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
 
     if pol_solve[3]!=0:
-        gradm = np.real(iimage*np.exp(-2j*chiimage) * mpart)     
+        gradm = np.real(iimage*np.exp(-2j*chiimage) * mpart)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
-        gradout[3] = gradpsi     
+        gradout[3] = gradpsi
 
     return gradout
 
@@ -831,7 +820,7 @@ def chisq_vvis_nfft(imarr, A, v, sigmav):
     """V visibility chi-squared
     """
     vimage = make_v_image(imarr)
-    
+
     #get nfft object
     nfft_info = A[0]
     plan = nfft_info.plan
@@ -843,7 +832,7 @@ def chisq_vvis_nfft(imarr, A, v, sigmav):
     vsamples = plan.f.copy()*pulsefac
 
     #compute chi^2
-    chisq =  np.sum(np.abs((v - vsamples))**2/(sigmav**2)) / (2*len(v))   
+    chisq =  np.sum(np.abs(v - vsamples)**2/(sigmav**2)) / (2*len(v))
 
     return chisq
 
@@ -851,12 +840,12 @@ def chisqgrad_vvis_nfft(imarr, A, v, sigmav,pol_solve=POL_SOLVE_DEFAULT):
     """V visibility chi-squared gradient
     """
     gradout = np.zeros(imarr.shape)
-    
+
     iimage = make_i_image(imarr)
     vimage = make_v_image(imarr)
     vfimage = make_vf_image(imarr)
     psiimage = make_psi_image(imarr)
-        
+
     #get nfft object
     nfft_info = A[0]
     plan = nfft_info.plan
@@ -878,14 +867,14 @@ def chisqgrad_vvis_nfft(imarr, A, v, sigmav,pol_solve=POL_SOLVE_DEFAULT):
     if pol_solve[0]!=0:
         gradi = np.real(vfimage*vpart)
         gradout[0] = gradi
-        
+
     if pol_solve[1]!=0:
-        gradv = np.real(iimage*vpart) 
+        gradv = np.real(iimage*vpart)
         gradrho = gradv*np.sin(psiimage)
         gradout[1] = gradrho
-        
+
     if pol_solve[3]!=0:
-        gradv = np.real(iimage*vpart) 
+        gradv = np.real(iimage*vpart)
         gradpsi = gradv * (vfimage/np.tan(psiimage))
         gradout[3] = gradpsi
 
@@ -898,11 +887,13 @@ def chisqgrad_vvis_nfft(imarr, A, v, sigmav,pol_solve=POL_SOLVE_DEFAULT):
 def sm(imarr, flux, norm_reg=NORM_REGULARIZER):
     """I log m entropy
     """
-    if norm_reg: norm = flux
-    else: norm = 1
+    if norm_reg:
+        norm = flux
+    else:
+        norm = 1
 
     iimage = make_i_image(imarr)
-    mimage = make_m_image(imarr) 
+    mimage = make_m_image(imarr)
     S = -np.sum(iimage * np.log(mimage))
     return S/norm
 
@@ -911,39 +902,43 @@ def smgrad(imarr, flux, pol_solve=POL_SOLVE_DEFAULT,
     """I log m entropy gradient
     """
     gradout = np.zeros(imarr.shape)
-    
-    if norm_reg: norm = flux
-    else: norm = 1
+
+    if norm_reg:
+        norm = flux
+    else:
+        norm = 1
 
     iimage = make_i_image(imarr)
-    mimage = make_m_image(imarr) 
+    mimage = make_m_image(imarr)
     psiimage = make_psi_image(imarr)
 
     if pol_solve[0]!=0:
         gradi = -np.log(mimage)
-        outgrad[0] = gradi
-        
+        gradout[0] = gradi
+
     if pol_solve[1]!=0:
         gradm = -iimage / mimage
-        gradrho = gradm * np.cos(psiimage)        
+        gradrho = gradm * np.cos(psiimage)
         gradout[1] = gradrho
-    
+
     if pol_solve[3]!=0:
         gradm = -iimage / mimage
         gradpsi = gradm * (-mimage*np.tan(psiimage))
         gradout[3] = gradpsi
-            
+
     return gradout/norm
-          
+
 def shw(imarr, flux, norm_reg=NORM_REGULARIZER):
     """Holdaway-Wardle polarimetric entropy
     """
-    
-    if norm_reg: norm = flux
-    else: norm = 1
+
+    if norm_reg:
+        norm = flux
+    else:
+        norm = 1
 
     iimage = make_i_image(imarr)
-    mimage = make_m_image(imarr) 
+    mimage = make_m_image(imarr)
     S = -np.sum(iimage * (((1+mimage)/2) * np.log((1+mimage)/2) + ((1-mimage)/2) * np.log((1-mimage)/2)))
     return S/norm
 
@@ -952,37 +947,42 @@ def shwgrad(imarr, flux,pol_solve=POL_SOLVE_DEFAULT,
     """Gradient of the Holdaway-Wardle polarimetric entropy
     """
     gradout = np.zeros(imarr.shape)
-    
-    if norm_reg: norm = flux
-    else: norm = 1
+
+    if norm_reg:
+        norm = flux
+    else:
+        norm = 1
 
     iimage = make_i_image(imarr)
-    mimage = make_m_image(imarr) 
+    mimage = make_m_image(imarr)
     psiimage = make_psi_image(imarr)
 
     if pol_solve[0]!=0:
         gradi =  -(((1+mimage)/2) * np.log((1+mimage)/2) + ((1-mimage)/2) * np.log((1-mimage)/2))
         gradout[0] = gradi
-        
+
     if pol_solve[1]!=0:
         gradm = -iimage * np.arctanh(mimage)
-        gradrho = gradm * np.cos(psiimage)        
+        gradrho = gradm * np.cos(psiimage)
         gradout[1] = gradrho
 
     if pol_solve[3]!=0:
         gradm = -iimage * np.arctanh(mimage)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
-        gradout[3] = gradpsi     
-                
+        gradout[3] = gradpsi
+
     return gradout/norm
 
-def stv_pol(imarr, flux, nx, ny, psize, 
+def stv_pol(imarr, flux, nx, ny, psize,
             norm_reg=NORM_REGULARIZER, beam_size=None):
     """Total variation of I*m*exp(2Ichi)"""
-    
-    if beam_size is None: beam_size = psize
-    if norm_reg: norm = flux*psize / beam_size
-    else: norm = 1
+
+    if beam_size is None:
+        beam_size = psize
+    if norm_reg:
+        norm = flux*psize / beam_size
+    else:
+        norm = 1
 
     pimage = make_p_image(imarr)
     im = pimage.reshape(ny, nx)
@@ -993,14 +993,17 @@ def stv_pol(imarr, flux, nx, ny, psize,
     S = -np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2))
     return S/norm
 
-def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT, 
+def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT,
              norm_reg=NORM_REGULARIZER, beam_size=None):
     """Total variation entropy gradient"""
     gradout = np.zeros(imarr.shape)
-    
-    if beam_size is None: beam_size = psize
-    if norm_reg: norm = flux*psize / beam_size
-    else: norm = 1
+
+    if beam_size is None:
+        beam_size = psize
+    if norm_reg:
+        norm = flux*psize / beam_size
+    else:
+        norm = 1
 
     iimage = make_i_image(imarr)
     pimage = make_p_image(imarr)
@@ -1015,7 +1018,7 @@ def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT,
     im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
     im_r1l2 = np.roll(np.roll(impad, 1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
     im_l1r2 = np.roll(np.roll(impad, 1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
-    
+
     # Denominators
     d1 = np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2)
     d2 = np.sqrt(np.abs(im_r1 - im)**2 + np.abs(im_r1l2 - im_r1)**2)
@@ -1035,7 +1038,7 @@ def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT,
         m2 = np.abs(im) - np.abs(im_r1)*np.cos(2*(np.angle(im) - np.angle(im_r1)))
         m3 = np.abs(im) - np.abs(im_r2)*np.cos(2*(np.angle(im) - np.angle(im_r2)))
         gradm = -iimage*(m1/d1 + m2/d2 + m3/d3).flatten()
-        gradrho = gradm * np.cos(psiimage)        
+        gradrho = gradm * np.cos(psiimage)
         gradout[1] = gradrho
 
     # dS/dchi numerators
@@ -1054,8 +1057,8 @@ def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT,
         m3 = np.abs(im) - np.abs(im_r2)*np.cos(2*(np.angle(im) - np.angle(im_r2)))
         gradm = -iimage*(m1/d1 + m2/d2 + m3/d3).flatten()
         gradpsi = gradm * (-mimage*np.tan(psiimage))
-        gradout[3] = gradpsi     
-                
+        gradout[3] = gradpsi
+
     return gradout/norm
 
 ###############################################################
@@ -1064,11 +1067,13 @@ def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT,
 def svflux(imarr, vflux, norm_reg=NORM_REGULARIZER):
     """Total flux constraint
     """
-    if norm_reg: norm = np.abs(vflux)**2
-    else: norm = 1
-    
-    vimage = make_v_image(imarr) 
-    
+    if norm_reg:
+        norm = np.abs(vflux)**2
+    else:
+        norm = 1
+
+    vimage = make_v_image(imarr)
+
     out = -(np.sum(vimage) - vflux)**2
     return out/norm
 
@@ -1077,17 +1082,19 @@ def svfluxgrad(imarr, vflux,  pol_solve=POL_SOLVE_DEFAULT_V, norm_reg=NORM_REGUL
     """Total flux constraint gradient
     """
     gradout = np.zeros(imarr.shape)
-    
-    if norm_reg: norm = np.abs(vflux)**2
-    else: norm = 1
-    
-    iimage = make_i_image(imarr)  
+
+    if norm_reg:
+        norm = np.abs(vflux)**2
+    else:
+        norm = 1
+
+    iimage = make_i_image(imarr)
     vimage = make_v_image(imarr)
     vfimage = make_vf_image(imarr)
-    psiimage = make_psi_image(imarr) 
+    psiimage = make_psi_image(imarr)
     grad = -2*(np.sum(vimage) - vflux)*np.ones(len(vimage))
 
-        
+
     # dS/dI Numerators
     if pol_solve[0]!=0:
         gradi = (vimage/iimage)*grad
@@ -1097,22 +1104,24 @@ def svfluxgrad(imarr, vflux,  pol_solve=POL_SOLVE_DEFAULT_V, norm_reg=NORM_REGUL
     if pol_solve[1]!=0:
         gradv = iimage*grad
         gradrho = gradv*np.sin(psiimage)
-        gradout[1] = gradrho         
-            
+        gradout[1] = gradrho
+
     if pol_solve[3]!=0:
         gradv = iimage*grad
         gradpsi = gradv * (vfimage/np.tan(psiimage))
         gradout[3] = gradpsi
 
-    return gradoutout/norm
-    
+    return gradout/norm
+
 def sl1v(imarr, vflux, norm_reg=NORM_REGULARIZER):
     """L1 norm regularizer on V
     """
-    if norm_reg: norm = np.abs(vflux)
-    else: norm = 1
+    if norm_reg:
+        norm = np.abs(vflux)
+    else:
+        norm = 1
 
-    vimage = make_v_image(imarr) 
+    vimage = make_v_image(imarr)
     l1 = -np.sum(np.abs(vimage))
     return l1/norm
 
@@ -1121,17 +1130,19 @@ def sl1vgrad(imarr, vflux, pol_solve=POL_SOLVE_DEFAULT_V,  norm_reg=NORM_REGULAR
     """L1 norm gradient
     """
     gradout = np.zeros(imarr.shape)
-        
-    if norm_reg: norm = np.abs(vflux)
-    else: norm = 1
-     
-    iimage = make_i_image(imarr)  
+
+    if norm_reg:
+        norm = np.abs(vflux)
+    else:
+        norm = 1
+
+    iimage = make_i_image(imarr)
     vimage = make_v_image(imarr)
     vfimage = make_vf_image(imarr)
-    psiimage = make_psi_image(imarr) 
-    
+    psiimage = make_psi_image(imarr)
+
     grad = -np.sign(vimage)
-    
+
     # dS/dI Numerators
     if pol_solve[0]!=0:
         gradi = vfimage*grad
@@ -1142,21 +1153,23 @@ def sl1vgrad(imarr, vflux, pol_solve=POL_SOLVE_DEFAULT_V,  norm_reg=NORM_REGULAR
         gradv = iimage*grad
         gradrho = gradv*np.sin(psiimage)
         gradout[1] = gradrho
-        
+
     if pol_solve[3]!=0:
         gradv = iimage*grad
         gradpsi = gradv * (vfimage/np.tan(psiimage))
         gradout[3] = gradpsi
-    
+
     return gradout/norm
-    
+
 def sl2v(imarr, vflux, norm_reg=NORM_REGULARIZER):
     """L1 norm regularizer on V
     """
-    if norm_reg: norm = np.abs(vflux**2)
-    else: norm = 1
+    if norm_reg:
+        norm = np.abs(vflux**2)
+    else:
+        norm = 1
 
-    vimage = make_v_image(imarr) 
+    vimage = make_v_image(imarr)
     l2 = -np.sum((vimage)**2)
     return l2/norm
 
@@ -1165,15 +1178,17 @@ def sl2vgrad(imarr, vflux,pol_solve=POL_SOLVE_DEFAULT_V, norm_reg=NORM_REGULARIZ
     """L2 norm gradient
     """
     gradout = np.zeros(imarr.shape)
-    
-    if norm_reg: norm = np.abs(vflux**2)
-    else: norm = 1
- 
-    iimage = make_i_image(imarr)  
+
+    if norm_reg:
+        norm = np.abs(vflux**2)
+    else:
+        norm = 1
+
+    iimage = make_i_image(imarr)
     vimage = make_v_image(imarr)
-    vfimage = make_vf_image(imarr)    
-    psiimage = make_psi_image(imarr) 
-    
+    vfimage = make_vf_image(imarr)
+    psiimage = make_psi_image(imarr)
+
     grad = -2*vimage
 
     # dS/dI Numerators
@@ -1185,22 +1200,25 @@ def sl2vgrad(imarr, vflux,pol_solve=POL_SOLVE_DEFAULT_V, norm_reg=NORM_REGULARIZ
     if pol_solve[1]!=0:
         gradv = iimage*grad
         gradrho = gradv*np.sin(psiimage)
-        gradout[1] = gradrho         
+        gradout[1] = gradrho
 
     if pol_solve[3]!=0:
         gradv = iimage*grad
         gradpsi = gradv * (vfimage/np.tan(psiimage))
         gradout[3] = gradpsi
 
-    return gradout/norm    
+    return gradout/norm
 
-def stv_v(imarr, vflux, nx, ny, psize, 
+def stv_v(imarr, vflux, nx, ny, psize,
           norm_reg=NORM_REGULARIZER, beam_size=None, epsilon=0.):
     """Total variation of I*vfrac"""
-    
-    if beam_size is None: beam_size = psize
-    if norm_reg: norm = np.abs(vflux)*psize / beam_size
-    else: norm = 1
+
+    if beam_size is None:
+        beam_size = psize
+    if norm_reg:
+        norm = np.abs(vflux)*psize / beam_size
+    else:
+        norm = 1
 
     vimage = make_v_image(imarr)
     im = vimage.reshape(ny, nx)
@@ -1211,22 +1229,25 @@ def stv_v(imarr, vflux, nx, ny, psize,
     S = -np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2+epsilon))
     return S/norm
 
-def stv_v_grad(imarr, vflux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT_V, 
+def stv_v_grad(imarr, vflux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT_V,
                norm_reg=NORM_REGULARIZER, beam_size=None, epsilon=0.):
     """Total variation gradient"""
     gradout = np.zeros(imarr.shape)
-    
-    if beam_size is None: beam_size = psize
-    if norm_reg: norm = np.abs(vflux)*psize / beam_size
-    else: norm = 1
+
+    if beam_size is None:
+        beam_size = psize
+    if norm_reg:
+        norm = np.abs(vflux)*psize / beam_size
+    else:
+        norm = 1
 
     iimage = make_i_image(imarr)
     vimage = make_v_image(imarr)
     vfimage = make_vf_image(imarr)
-    psiimage = make_psi_image(imarr) 
-    
+    psiimage = make_psi_image(imarr)
+
     im = vimage.reshape(ny, nx)
-    
+
     impad = np.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
     im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
@@ -1252,17 +1273,17 @@ def stv_v_grad(imarr, vflux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT_V,
 
     # add terms together and return
     grad = -(g1 + g2 + g3).flatten()
-    
+
     # dS/dI Numerators
     if pol_solve[0]!=0:
         gradi = vfimage*grad
         gradout[0] = gradi
-     
+
     # dS/dv numerators
     if pol_solve[1]!=0:
         gradv = iimage*grad
         gradrho = gradv*np.sin(psiimage)
-        gradout[1] = gradrho         
+        gradout[1] = gradrho
 
     if pol_solve[3]!=0:
         gradv = iimage*grad
@@ -1275,7 +1296,7 @@ def stv2_v(imarr, vflux, nx, ny, psize,
            norm_reg=NORM_REGULARIZER, beam_size=None):
     """Squared Total variation of I*vfrac
     """
-    
+
     if beam_size is None:
         beam_size = psize
     if norm_reg:
@@ -1285,14 +1306,14 @@ def stv2_v(imarr, vflux, nx, ny, psize,
 
     vimage = make_v_image(imarr)
     im = vimage.reshape(ny, nx)
-    
+
     impad = np.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
     im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
     out = -np.sum((im_l1 - im)**2 + (im_l2 - im)**2)
     return out/norm
 
-def stv2_v_grad(imarr, vflux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT_V, 
+def stv2_v_grad(imarr, vflux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT_V,
                norm_reg=NORM_REGULARIZER, beam_size=None):
     """Squared Total variation gradient
     """
@@ -1307,10 +1328,10 @@ def stv2_v_grad(imarr, vflux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT_V,
     iimage = make_i_image(imarr)
     vimage = make_v_image(imarr)
     vfimage = make_vf_image(imarr)
-    psiimage = make_psi_image(imarr) 
-    
+    psiimage = make_psi_image(imarr)
+
     im = vimage.reshape(ny, nx)
-    
+
     impad = np.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
     im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
@@ -1331,7 +1352,7 @@ def stv2_v_grad(imarr, vflux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT_V,
 
     # add together terms and return
     grad = -2*(g1 + g2 + g3).flatten()
-    
+
     # dS/dI Numerators
     if pol_solve[0]!=0:
         gradi = vfimage*grad
@@ -1341,8 +1362,8 @@ def stv2_v_grad(imarr, vflux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT_V,
     if pol_solve[1]!=0:
         gradv = iimage*grad
         gradrho = gradv*np.sin(psiimage)
-        gradout[1] = gradrho         
-        
+        gradout[1] = gradrho
+
     if pol_solve[3]!=0:
         gradv = iimage*grad
         gradpsi = gradv * (vfimage/np.tan(psiimage))
@@ -1467,9 +1488,9 @@ def plot_m(polarr, Prior, nit, chi2_dict, **kwargs):
     scale = kwargs.get('scale',None)
     dynamic_range = kwargs.get('dynamic_range',1.e5)
     gamma = kwargs.get('dynamic_range',.5)
-    
+
     plt.ion()
-    plt.pause(1.e-6)    
+    plt.pause(1.e-6)
     plt.clf()
 
     # unpack
@@ -1496,7 +1517,7 @@ def plot_m(polarr, Prior, nit, chi2_dict, **kwargs):
     thin = int(round(Prior.xdim/nvec))
     mask = imarr > pcut * np.max(im)
     mask2 = mask[::thin, ::thin]
-    
+
     # Get vectors and ratio from current image
     x = np.array([[i for i in range(Prior.xdim)] for j in range(Prior.ydim)])[::thin, ::thin][mask2]
     y = np.array([[j for i in range(Prior.xdim)] for j in range(Prior.ydim)])[::thin, ::thin][mask2]
@@ -1506,7 +1527,7 @@ def plot_m(polarr, Prior, nit, chi2_dict, **kwargs):
     b = np.cos(np.angle(q+1j*u)/2).reshape(Prior.ydim, Prior.xdim)[::thin, ::thin][mask2]
     m = (np.abs(q + 1j*u)/im).reshape(Prior.ydim, Prior.xdim)
     m[~mask] = 0
-        
+
     # Stokes I plot
     plt.subplot(121)
     plt.imshow(imarr, cmap=plt.get_cmap('afmhot'), interpolation='gaussian')
@@ -1521,10 +1542,10 @@ def plot_m(polarr, Prior, nit, chi2_dict, **kwargs):
     yticks = ticks(Prior.ydim, Prior.psize/RADPERAS/1e-6)
     plt.xticks(xticks[0], xticks[1])
     plt.yticks(yticks[0], yticks[1])
-    plt.xlabel('Relative RA ($\mu$as)')
-    plt.ylabel('Relative Dec ($\mu$as)')
+    plt.xlabel(r'Relative RA ($\mu$as)')
+    plt.ylabel(r'Relative Dec ($\mu$as)')
     plt.title('Stokes I')
-    
+
     # Ratio plot
     plt.subplot(122)
     plt.imshow(m, cmap=plt.get_cmap('winter'), interpolation='gaussian', vmin=0, vmax=1)
@@ -1537,14 +1558,14 @@ def plot_m(polarr, Prior, nit, chi2_dict, **kwargs):
 
     plt.xticks(xticks[0], xticks[1])
     plt.yticks(yticks[0], yticks[1])
-    plt.xlabel('Relative RA ($\mu$as)')
-    plt.ylabel('Relative Dec ($\mu$as)')
-    plt.title('m (above %i %% max flux)' % int(pcut*100))
+    plt.xlabel(r'Relative RA ($\mu$as)')
+    plt.ylabel(r'Relative Dec ($\mu$as)')
+    plt.title(f'm (above {int(pcut*100)} % max flux)')
 
     # Create title
-    plotstr = "step: %i  " % nit
+    plotstr = f"step: {nit}  "
     for key in chi2_dict.keys():
-        plotstr += "$\chi^2_{%s}$: %0.2f  " % (key, chi2_dict[key])
+        plotstr += rf"$\chi^2_{{{key}}}$: {chi2_dict[key]:0.2f}  "
     plt.suptitle(plotstr, fontsize=18)
 
 

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -610,7 +610,7 @@ def chisqgrad_m(imarr, Amatrix, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
     mdiff = (m - msamples) / (isamples.conj() * sigmam**2)
 
     if pol_solve[0]!=0:
-        gradi = (-np.real(   * np.dot(Amatrix.conj().T, mdiff)) / len(m) + 
+        gradi = (-np.real(mimage * np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, mdiff)) / len(m) +
                   np.real(np.dot(Amatrix.conj().T, msamples.conj() * mdiff)) / len(m))
         gradout[0] = gradi
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,15 @@ def gauss_im():
 
 
 @pytest.fixture(scope="session")
+def gauss_im_pol(gauss_im):
+    """Polarized Gaussian image: Stokes I plus scaled Q, U, V."""
+    im = gauss_im.copy()
+    im.add_qu(0.10 * im.imarr(), 0.05 * im.imarr())
+    im.add_v(0.02 * im.imarr())
+    return im
+
+
+@pytest.fixture(scope="session")
 def sgra_im():
     """Load the avery_sgra model image."""
     return eh.image.load_txt(os.path.join(MODEL_DIR, "avery_sgra_eofn.txt"))
@@ -168,11 +177,16 @@ def initialize_imager():
     either a single obs or a list of obs.
     """
     def _factory(obs, im, data_term, pol="I", ttype="direct",
-                 mf=False, mf_order=0, debias=True, snrcut=0.0):
-        imgr = eh.imager.Imager(
-            obs, im, prior_im=im, flux=im.total_flux(),
+                 mf=False, mf_order=0, debias=True, snrcut=0.0,
+                 transform=None):
+        imgr_kw = dict(
             data_term=data_term, ttype=ttype, pol=pol,
             debias=debias, snrcut=snrcut,
+        )
+        if transform is not None:
+            imgr_kw["transform"] = transform
+        imgr = eh.imager.Imager(
+            obs, im, prior_im=im, flux=im.total_flux(), **imgr_kw,
         )
 
         # Mirror the early steps of make_image() so init_imager has the right state.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,15 +141,20 @@ def make_rect_image():
 
 @pytest.fixture(scope="session")
 def observe(eht_array):
-    """Factory fixture: noise-free observation with project-standard defaults.
+    """Factory fixture: observation with project-standard defaults.
 
-    Closes over `eht_array`. Tests call as `observe(im)` or override
-    `ttype`, `tstart`, `tstop` as needed.
+    Closes over `eht_array`. Tests call as `observe(im)` for noise-free output,
+    or `observe(im, seed=42)` to enable thermal noise with a deterministic seed.
     """
-    def _factory(im, ttype="direct", tstart=TSTART_HR, tstop=TSTOP_HR):
+    def _factory(im, ttype="direct", tstart=TSTART_HR, tstop=TSTOP_HR, seed=None):
+        kwargs = dict(
+            ampcal=True, phasecal=True, ttype=ttype,
+            add_th_noise=seed is not None,
+        )
+        if seed is not None:
+            kwargs["seed"] = seed
         return im.observe(
-            eht_array, TINT_SEC, TADV_SEC, tstart, tstop, BW_HZ,
-            ampcal=True, phasecal=True, ttype=ttype, add_th_noise=False,
+            eht_array, TINT_SEC, TADV_SEC, tstart, tstop, BW_HZ, **kwargs,
         )
     return _factory
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,11 @@ import os
 import pytest
 
 import ehtim as eh
+from ehtim.imaging.imager_backend import (
+    POLARIZATION_MODES,
+    transform_imarr,
+    unpack_imarr,
+)
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -131,4 +136,50 @@ def make_rect_image():
             image_arr, psize, 17.761, -29.0,
             polrep="stokes", pol_prim="I", rf=230e9,
         )
+    return _factory
+
+
+@pytest.fixture(scope="session")
+def observe(eht_array):
+    """Factory fixture: noise-free observation with project-standard defaults.
+
+    Closes over `eht_array`. Tests call as `observe(im)` or override
+    `ttype`, `tstart`, `tstop` as needed.
+    """
+    def _factory(im, ttype="direct", tstart=TSTART_HR, tstop=TSTOP_HR):
+        return im.observe(
+            eht_array, TINT_SEC, TADV_SEC, tstart, tstop, BW_HZ,
+            ampcal=True, phasecal=True, ttype=ttype, add_th_noise=False,
+        )
+    return _factory
+
+
+@pytest.fixture(scope="session")
+def initialize_imager():
+    """Factory fixture: build an Imager and run init_imager.
+
+    Returns (imgr, imcur) where imcur is the unpacked + transformed image
+    array ready to pass into make_chisq_dict / compute_chisq_dict. Accepts
+    either a single obs or a list of obs.
+    """
+    def _factory(obs, im, data_term, pol="I", ttype="direct",
+                 mf=False, mf_order=0):
+        imgr = eh.imager.Imager(
+            obs, im, prior_im=im, flux=im.total_flux(),
+            data_term=data_term, ttype=ttype, pol=pol,
+        )
+
+        # Mirror the early steps of make_image() so init_imager has the right state.
+        imgr.mf_next = mf
+        imgr.mf_order = mf_order
+        if pol in POLARIZATION_MODES:
+            imgr.prior_next = imgr.prior_next.switch_polrep(polrep_out="stokes", pol_prim_out="I")
+            imgr.init_next = imgr.init_next.switch_polrep(polrep_out="stokes", pol_prim_out="I")
+        imgr.check_params()
+        imgr.check_limits()
+        imgr.init_imager()
+
+        imcur = unpack_imarr(imgr._xinit, imgr._xarr, imgr._which_solve)
+        imcur = transform_imarr(imcur, imgr.transform_next, imgr._which_solve)
+        return imgr, imcur
     return _factory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,10 +168,11 @@ def initialize_imager():
     either a single obs or a list of obs.
     """
     def _factory(obs, im, data_term, pol="I", ttype="direct",
-                 mf=False, mf_order=0):
+                 mf=False, mf_order=0, debias=True, snrcut=0.0):
         imgr = eh.imager.Imager(
             obs, im, prior_im=im, flux=im.total_flux(),
             data_term=data_term, ttype=ttype, pol=pol,
+            debias=debias, snrcut=snrcut,
         )
 
         # Mirror the early steps of make_image() so init_imager has the right state.

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -11,6 +11,7 @@ import ehtim as eh
 from ehtim.imager import DATATERMS, DATATERMS_POL, POLARIZATION_MODES
 from ehtim.imaging.imager_backend import (
     compute_chisq_dict,
+    compute_chisqgrad_dict,
     compute_embed,
     transform_imarr,
     unpack_imarr,
@@ -142,6 +143,17 @@ def _call_backend_chisq_dict(imgr, imcur):
         imcur, sorted(imgr.dat_term_next.keys()), imgr._data_tuples,
         imgr.obslist_next, imgr._logfreqratio_list, imgr.mf_next,
         imgr.pol_next, imgr._ttype, imgr._embed_mask,
+        DATATERMS, DATATERMS_POL, POLARIZATION_MODES,
+    )
+
+
+def _call_backend_chisqgrad_dict(imgr, imcur):
+    """Call compute_chisqgrad_dict with args pulled from an initialized Imager."""
+    return compute_chisqgrad_dict(
+        imcur, sorted(imgr.dat_term_next.keys()), imgr._data_tuples,
+        imgr.obslist_next, imgr._logfreqratio_list, imgr.mf_next,
+        imgr.pol_next, imgr._ttype, imgr._embed_mask,
+        imgr._which_solve, imgr._nimage,
         DATATERMS, DATATERMS_POL, POLARIZATION_MODES,
     )
 
@@ -278,3 +290,150 @@ class TestComputeChisqDict:
         imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100}, ttype=ttype)
         result = _call_backend_chisq_dict(imgr, imcur)
         assert np.isfinite(result["vis"])
+
+
+class TestComputeChisqgradDict:
+    """Tests for compute_chisqgrad_dict (extracted from Imager.make_chisqgrad_dict)."""
+
+    def test_stokes_i_single_term(self, gauss_im, eht_array):
+        """Stokes I gradient has shape (nimage,) and is finite."""
+        obs = gauss_im.observe(
+            eht_array, 5, 600, 0, 24, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100})
+        result = _call_backend_chisqgrad_dict(imgr, imcur)
+        assert set(result.keys()) == {"vis"}
+        assert result["vis"].shape == (imgr._nimage,)
+        assert np.all(np.isfinite(result["vis"]))
+
+    def test_multiple_dataterms(self, gauss_im, eht_array):
+        """Multiple gradient entries, all finite, correct shape."""
+        obs = gauss_im.observe(
+            eht_array, 5, 600, 0, 24, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        data_term = {"vis": 100, "amp": 10, "cphase": 5}
+        imgr, imcur = _initialize_imager(obs, gauss_im, data_term)
+        result = _call_backend_chisqgrad_dict(imgr, imcur)
+        assert set(result.keys()) == set(data_term.keys())
+        for v in result.values():
+            assert v.shape == (imgr._nimage,)
+            assert np.all(np.isfinite(v))
+
+    def test_matches_imager(self, gauss_im, eht_array):
+        """Backend output == Imager.make_chisqgrad_dict output (tight tol)."""
+        obs = gauss_im.observe(
+            eht_array, 5, 600, 0, 24, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100, "cphase": 10})
+
+        method_result = imgr.make_chisqgrad_dict(imcur)
+        backend_result = _call_backend_chisqgrad_dict(imgr, imcur)
+
+        assert method_result.keys() == backend_result.keys()
+        for key in method_result:
+            np.testing.assert_allclose(method_result[key], backend_result[key],
+                                       rtol=1e-15, atol=0)
+
+    def test_multiple_observations(self, gauss_im, eht_array):
+        """Two observations — one gradient entry per obs."""
+        obs1 = gauss_im.observe(
+            eht_array, 5, 600, 0, 12, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        obs2 = gauss_im.observe(
+            eht_array, 5, 600, 12, 24, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        imgr, imcur = _initialize_imager(
+            [obs1, obs2], gauss_im, {"vis": 100},
+        )
+        result = _call_backend_chisqgrad_dict(imgr, imcur)
+        assert set(result.keys()) == {"vis_0", "vis_1"}
+        for v in result.values():
+            assert v.shape == (imgr._nimage,)
+            assert np.all(np.isfinite(v))
+
+    def test_multifrequency(self, gauss_im, eht_array):
+        """Multifrequency imaging — exercises mf_all_grads_chain branch."""
+        im_lo = gauss_im.copy()
+        im_lo.rf = 230e9
+        im_hi = gauss_im.copy()
+        im_hi.rf = 345e9
+        obs_lo = im_lo.observe(
+            eht_array, 5, 600, 0, 24, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        obs_hi = im_hi.observe(
+            eht_array, 5, 600, 0, 24, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        imgr, imcur = _initialize_imager(
+            [obs_lo, obs_hi], im_lo, {"vis": 100}, mf=True, mf_order=1,
+        )
+        assert imgr.mf_next is True
+
+        result = _call_backend_chisqgrad_dict(imgr, imcur)
+        assert set(result.keys()) == {"vis_0", "vis_1"}
+        for v in result.values():
+            assert np.all(np.isfinite(v))
+
+    def test_polarimetric_stokes_i_bundled(self, gauss_im, eht_array):
+        """pol='IP' with DATATERMS entry: Stokes-I gradient is bundled (4, nimage)."""
+        im = gauss_im.copy()
+        qimage = 0.1 * im.imarr()
+        uimage = 0.05 * im.imarr()
+        im.add_qu(qimage, uimage)
+
+        obs = im.observe(
+            eht_array, 5, 600, 0, 24, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        imgr, imcur = _initialize_imager(
+            obs, im, {"vis": 100, "pvis": 100}, pol="IP",
+        )
+        backend_result = _call_backend_chisqgrad_dict(imgr, imcur)
+        assert set(backend_result.keys()) == {"vis", "pvis"}
+        # Stokes-I gradient is bundled: (chi2grad_I, 0, 0, 0)
+        assert backend_result["vis"].shape == (4, imgr._nimage)
+        assert np.all(np.isfinite(backend_result["vis"]))
+        # Polarimetric gradient is also 4-component
+        assert backend_result["pvis"].shape[0] == 4
+        assert np.all(np.isfinite(backend_result["pvis"]))
+
+        # Verify wrapper matches.
+        method_result = imgr.make_chisqgrad_dict(imcur)
+        assert method_result.keys() == backend_result.keys()
+        for key in method_result:
+            np.testing.assert_allclose(method_result[key], backend_result[key],
+                                       rtol=1e-15, atol=0)
+
+    @pytest.mark.parametrize("ttype", ["direct", "fast", "nfft"])
+    def test_all_ttypes(self, gauss_im, eht_array, ttype):
+        """Backend works for all three transform types."""
+        if ttype == "nfft":
+            pytest.importorskip("pynfft")
+        obs = gauss_im.observe(
+            eht_array, 5, 600, 0, 24, 4e9,
+            ampcal=True, phasecal=True, ttype=ttype, add_th_noise=False,
+        )
+        imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100}, ttype=ttype)
+        result = _call_backend_chisqgrad_dict(imgr, imcur)
+        assert np.all(np.isfinite(result["vis"]))
+
+
+def test_chisq_and_chisqgrad_share_keys(gauss_im, eht_array):
+    """Cross-cutting invariant: chisq and chisqgrad dicts share the same key set."""
+    obs = gauss_im.observe(
+        eht_array, 5, 600, 0, 24, 4e9,
+        ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+    )
+    imgr, imcur = _initialize_imager(
+        obs, gauss_im, {"vis": 100, "amp": 10, "cphase": 5},
+    )
+    chisq = _call_backend_chisq_dict(imgr, imcur)
+    chisqgrad = _call_backend_chisqgrad_dict(imgr, imcur)
+    assert set(chisq.keys()) == set(chisqgrad.keys())
+

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -134,12 +134,14 @@ class TestComputeChisqDict:
     """Tests for compute_chisq_dict (extracted from Imager.make_chisq_dict)."""
 
     def test_stokes_i_single_term(self, gauss_im, observe, initialize_imager):
-        """Stokes I, single data term — returns one finite chi^2."""
+        """Stokes I 'vis' chi^2 on the truth image is ~0 (noise-free, perfect fit)."""
         obs = observe(gauss_im)
         imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100})
         result = _call_backend_chisq_dict(imgr, imcur)
         assert set(result.keys()) == {"vis"}
-        assert np.isfinite(result["vis"])
+        # Truth image + add_th_noise=False -> data exactly equals predicted vis,
+        # so chi^2 should be at machine-precision zero.
+        assert result["vis"] < 1e-20
 
     def test_multiple_dataterms(self, gauss_im, observe, initialize_imager):
         """Multiple data terms — one entry per term, all finite."""
@@ -242,13 +244,14 @@ class TestComputeChisqgradDict:
     """Tests for compute_chisqgrad_dict (extracted from Imager.make_chisqgrad_dict)."""
 
     def test_stokes_i_single_term(self, gauss_im, observe, initialize_imager):
-        """Stokes I gradient has shape (nimage,) and is finite."""
+        """Stokes I 'vis' gradient on the truth image is ~0 (chi^2 at minimum)."""
         obs = observe(gauss_im)
         imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100})
         result = _call_backend_chisqgrad_dict(imgr, imcur)
         assert set(result.keys()) == {"vis"}
         assert result["vis"].shape == (imgr._nimage,)
-        assert np.all(np.isfinite(result["vis"]))
+        # Truth image is the chi^2 minimum so gradient should be machine-precision zero.
+        assert np.max(np.abs(result["vis"])) < 1e-10
 
     def test_multiple_dataterms(self, gauss_im, observe, initialize_imager):
         """Multiple gradient entries, all finite, correct shape."""

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -8,8 +8,8 @@ import numpy as np
 import pytest
 
 import ehtim as eh
-from ehtim.imager import DATATERMS, DATATERMS_POL, POLARIZATION_MODES
 from ehtim.imaging.imager_backend import (
+    POLARIZATION_MODES,
     compute_chisq_dict,
     compute_chisqgrad_dict,
     compute_embed,
@@ -163,7 +163,6 @@ def _call_backend_chisq_dict(imgr, imcur):
         imcur, sorted(imgr.dat_term_next.keys()), imgr._data_tuples,
         imgr.obslist_next, imgr._logfreqratio_list, imgr.mf_next,
         imgr.pol_next, imgr._ttype, imgr._embed_mask,
-        DATATERMS, DATATERMS_POL, POLARIZATION_MODES,
     )
 
 
@@ -174,7 +173,6 @@ def _call_backend_chisqgrad_dict(imgr, imcur):
         imgr.obslist_next, imgr._logfreqratio_list, imgr.mf_next,
         imgr.pol_next, imgr._ttype, imgr._embed_mask,
         imgr._which_solve, imgr._nimage,
-        DATATERMS, DATATERMS_POL, POLARIZATION_MODES,
     )
 
 

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -36,6 +36,24 @@ POL_FRAC_U = 0.05
 # (NumPy 1.24+ inhomogeneous-array, deprecated `np.float`); tracked separately.
 PER_TERM_DATATERMS = ["vis", "amp", "bs", "cphase", "camp", "logcamp"]
 
+# Polarimetric data terms with required (pol, transform) per term.
+PER_TERM_POL_CASES = [
+    ("pvis", "IP", ["log", "mcv"]),
+    ("m",    "IP", ["log", "mcv"]),
+    ("vvis", "IV", ["log", "vcv"]),
+]
+
+# `chisqgrad_m` has a typo at pol_imager_utils.py:613 (missing operand before
+# the `*` inside np.real); the m-gradient path raises TypeError. Tracked
+# separately; only the gradient is broken, the chi^2 path works.
+PER_TERM_POL_GRAD_CASES = [
+    ("pvis", "IP", ["log", "mcv"]),
+    pytest.param("m", "IP", ["log", "mcv"], marks=pytest.mark.xfail(
+        reason="chisqgrad_m typo: np.real(   * np.dot(...)) at pol_imager_utils.py:613",
+        raises=TypeError, strict=True)),
+    ("vvis", "IV", ["log", "vcv"]),
+]
+
 # Noisy-truth bounds: snrcut=3 keeps the linearized error-propagation valid
 # for closure quantities; the (lo, hi) range is empirical over 20 seeds.
 NOISY_SNRCUT = 3.0
@@ -170,6 +188,34 @@ class TestComputeChisqDict:
         assert set(result.keys()) == {dterm}
         assert NOISY_CHISQ_LO < result[dterm] < NOISY_CHISQ_HI
 
+    @pytest.mark.parametrize("dterm,pol,transform", PER_TERM_POL_CASES)
+    def test_chisq_zero_on_truth_no_debias_pol(self, gauss_im_pol, observe,
+                                                initialize_imager,
+                                                dterm, pol, transform):
+        """chi^2 on a polarized truth image is ~0 (noise-free, no debias)."""
+        obs = observe(gauss_im_pol)
+        imgr, imcur = initialize_imager(
+            obs, gauss_im_pol, {dterm: 1},
+            pol=pol, transform=transform, debias=False,
+        )
+        result = _call_backend_chisq_dict(imgr, imcur)
+        assert set(result.keys()) == {dterm}
+        assert result[dterm] < 1e-10
+
+    @pytest.mark.parametrize("dterm,pol,transform", PER_TERM_POL_CASES)
+    def test_chisq_near_unity_on_noisy_truth_pol(self, gauss_im_pol, observe,
+                                                  initialize_imager,
+                                                  dterm, pol, transform):
+        """chi^2 on noisy polarized truth is ~1 for every pol data term."""
+        obs = observe(gauss_im_pol, seed=42)
+        imgr, imcur = initialize_imager(
+            obs, gauss_im_pol, {dterm: 1},
+            pol=pol, transform=transform, snrcut=NOISY_SNRCUT,
+        )
+        result = _call_backend_chisq_dict(imgr, imcur)
+        assert set(result.keys()) == {dterm}
+        assert NOISY_CHISQ_LO < result[dterm] < NOISY_CHISQ_HI
+
     def test_multiple_dataterms(self, gauss_im, observe, initialize_imager):
         """Multiple data terms — one entry per term, all finite."""
         obs = observe(gauss_im)
@@ -291,6 +337,34 @@ class TestComputeChisqgradDict:
         result = _call_backend_chisqgrad_dict(imgr, imcur)
         assert set(result.keys()) == {dterm}
         assert result[dterm].shape == (imgr._nimage,)
+        assert np.all(np.isfinite(result[dterm]))
+
+    @pytest.mark.parametrize("dterm,pol,transform", PER_TERM_POL_GRAD_CASES)
+    def test_grad_zero_on_truth_no_debias_pol(self, gauss_im_pol, observe,
+                                               initialize_imager,
+                                               dterm, pol, transform):
+        """Gradient on polarized truth is ~0 (noise-free, no debias)."""
+        obs = observe(gauss_im_pol)
+        imgr, imcur = initialize_imager(
+            obs, gauss_im_pol, {dterm: 1},
+            pol=pol, transform=transform, debias=False,
+        )
+        result = _call_backend_chisqgrad_dict(imgr, imcur)
+        assert set(result.keys()) == {dterm}
+        assert np.max(np.abs(result[dterm])) < 1e-10
+
+    @pytest.mark.parametrize("dterm,pol,transform", PER_TERM_POL_GRAD_CASES)
+    def test_grad_finite_on_noisy_truth_pol(self, gauss_im_pol, observe,
+                                             initialize_imager,
+                                             dterm, pol, transform):
+        """Gradient on noisy polarized truth is finite for every pol term."""
+        obs = observe(gauss_im_pol, seed=42)
+        imgr, imcur = initialize_imager(
+            obs, gauss_im_pol, {dterm: 1},
+            pol=pol, transform=transform, snrcut=NOISY_SNRCUT,
+        )
+        result = _call_backend_chisqgrad_dict(imgr, imcur)
+        assert set(result.keys()) == {dterm}
         assert np.all(np.isfinite(result[dterm]))
 
     def test_multiple_dataterms(self, gauss_im, observe, initialize_imager):

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -26,6 +26,29 @@ IMAGE_SHAPES = [
     (31, 33),  # odd rectangular
 ]
 
+# Observation parameters (match conftest.py convention)
+TINT_SEC = 5
+TADV_SEC = 600
+TSTART_HR = 0
+TSTOP_HR = 24
+BW_HZ = 4e9
+
+# Multifrequency test frequencies
+REFFREQ_HZ = 230e9
+MF_ALT_FREQ_HZ = 345e9
+
+# Synthetic polarization fractions for polarimetric tests
+POL_FRAC_Q = 0.1
+POL_FRAC_U = 0.05
+
+
+def _observe(im, eht_array, ttype="direct", tstart=TSTART_HR, tstop=TSTOP_HR):
+    """Noise-free observation with project-standard defaults."""
+    return im.observe(
+        eht_array, TINT_SEC, TADV_SEC, tstart, tstop, BW_HZ,
+        ampcal=True, phasecal=True, ttype=ttype, add_th_noise=False,
+    )
+
 
 class TestComputeEmbed:
     """Tests for compute_embed (extracted from Imager.set_embed)."""
@@ -63,10 +86,7 @@ class TestComputeEmbed:
 
     def test_matches_imager(self, gauss_im, eht_array):
         """Backend compute_embed matches Imager.set_embed exactly."""
-        obs = gauss_im.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
+        obs = _observe(gauss_im, eht_array)
         imgr = eh.imager.Imager(obs, gauss_im, gauss_im, gauss_im.total_flux(),
                                 ttype="direct")
 
@@ -163,10 +183,7 @@ class TestComputeChisqDict:
 
     def test_stokes_i_single_term(self, gauss_im, eht_array):
         """Stokes I, single data term — returns one finite chi^2."""
-        obs = gauss_im.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
+        obs = _observe(gauss_im, eht_array)
         imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100})
         result = _call_backend_chisq_dict(imgr, imcur)
         assert set(result.keys()) == {"vis"}
@@ -174,10 +191,7 @@ class TestComputeChisqDict:
 
     def test_multiple_dataterms(self, gauss_im, eht_array):
         """Multiple data terms — one entry per term, all finite."""
-        obs = gauss_im.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
+        obs = _observe(gauss_im, eht_array)
         data_term = {"vis": 100, "amp": 10, "cphase": 5}
         imgr, imcur = _initialize_imager(obs, gauss_im, data_term)
         result = _call_backend_chisq_dict(imgr, imcur)
@@ -187,10 +201,7 @@ class TestComputeChisqDict:
 
     def test_matches_imager(self, gauss_im, eht_array):
         """Backend output == Imager.make_chisq_dict output (wrapper sanity check)."""
-        obs = gauss_im.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
+        obs = _observe(gauss_im, eht_array)
         imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100, "cphase": 10})
 
         method_result = imgr.make_chisq_dict(imcur)
@@ -202,14 +213,9 @@ class TestComputeChisqDict:
 
     def test_multiple_observations(self, gauss_im, eht_array):
         """Two observations — keys become dname_i, each entry finite."""
-        obs1 = gauss_im.observe(
-            eht_array, 5, 600, 0, 12, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
-        obs2 = gauss_im.observe(
-            eht_array, 5, 600, 12, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
+        tmid = (TSTART_HR + TSTOP_HR) / 2
+        obs1 = _observe(gauss_im, eht_array, tstart=TSTART_HR, tstop=tmid)
+        obs2 = _observe(gauss_im, eht_array, tstart=tmid, tstop=TSTOP_HR)
         imgr, imcur = _initialize_imager(
             [obs1, obs2], gauss_im, {"vis": 100},
         )
@@ -222,19 +228,13 @@ class TestComputeChisqDict:
         """Multifrequency imaging — exercises the mf_next=True branch (image_at_freq)."""
         # Two observations at different frequencies, same source.
         im_lo = gauss_im.copy()
-        im_lo.rf = 230e9
+        im_lo.rf = REFFREQ_HZ
         im_hi = gauss_im.copy()
-        im_hi.rf = 345e9
-        obs_lo = im_lo.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
-        obs_hi = im_hi.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
+        im_hi.rf = MF_ALT_FREQ_HZ
+        obs_lo = _observe(im_lo, eht_array)
+        obs_hi = _observe(im_hi, eht_array)
 
-        # Use im_lo (at reference freq 230 GHz) as the prior.
+        # Use im_lo (at reference freq) as the prior.
         imgr, imcur = _initialize_imager(
             [obs_lo, obs_hi], im_lo, {"vis": 100}, mf=True, mf_order=1,
         )
@@ -255,14 +255,11 @@ class TestComputeChisqDict:
         """
         # Build a polarized image: Q and U scaled from Stokes I at a fixed angle.
         im = gauss_im.copy()
-        qimage = 0.1 * im.imarr()
-        uimage = 0.05 * im.imarr()
+        qimage = POL_FRAC_Q * im.imarr()
+        uimage = POL_FRAC_U * im.imarr()
         im.add_qu(qimage, uimage)
 
-        obs = im.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
+        obs = _observe(im, eht_array)
         imgr, imcur = _initialize_imager(
             obs, im, {"vis": 100, "pvis": 100}, pol="IP",
         )
@@ -283,10 +280,7 @@ class TestComputeChisqDict:
         """Backend works for all three transform types."""
         if ttype == "nfft":
             pytest.importorskip("pynfft")
-        obs = gauss_im.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype=ttype, add_th_noise=False,
-        )
+        obs = _observe(gauss_im, eht_array, ttype=ttype)
         imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100}, ttype=ttype)
         result = _call_backend_chisq_dict(imgr, imcur)
         assert np.isfinite(result["vis"])
@@ -297,10 +291,7 @@ class TestComputeChisqgradDict:
 
     def test_stokes_i_single_term(self, gauss_im, eht_array):
         """Stokes I gradient has shape (nimage,) and is finite."""
-        obs = gauss_im.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
+        obs = _observe(gauss_im, eht_array)
         imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100})
         result = _call_backend_chisqgrad_dict(imgr, imcur)
         assert set(result.keys()) == {"vis"}
@@ -309,10 +300,7 @@ class TestComputeChisqgradDict:
 
     def test_multiple_dataterms(self, gauss_im, eht_array):
         """Multiple gradient entries, all finite, correct shape."""
-        obs = gauss_im.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
+        obs = _observe(gauss_im, eht_array)
         data_term = {"vis": 100, "amp": 10, "cphase": 5}
         imgr, imcur = _initialize_imager(obs, gauss_im, data_term)
         result = _call_backend_chisqgrad_dict(imgr, imcur)
@@ -323,10 +311,7 @@ class TestComputeChisqgradDict:
 
     def test_matches_imager(self, gauss_im, eht_array):
         """Backend output == Imager.make_chisqgrad_dict output (tight tol)."""
-        obs = gauss_im.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
+        obs = _observe(gauss_im, eht_array)
         imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100, "cphase": 10})
 
         method_result = imgr.make_chisqgrad_dict(imcur)
@@ -339,14 +324,9 @@ class TestComputeChisqgradDict:
 
     def test_multiple_observations(self, gauss_im, eht_array):
         """Two observations — one gradient entry per obs."""
-        obs1 = gauss_im.observe(
-            eht_array, 5, 600, 0, 12, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
-        obs2 = gauss_im.observe(
-            eht_array, 5, 600, 12, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
+        tmid = (TSTART_HR + TSTOP_HR) / 2
+        obs1 = _observe(gauss_im, eht_array, tstart=TSTART_HR, tstop=tmid)
+        obs2 = _observe(gauss_im, eht_array, tstart=tmid, tstop=TSTOP_HR)
         imgr, imcur = _initialize_imager(
             [obs1, obs2], gauss_im, {"vis": 100},
         )
@@ -359,17 +339,11 @@ class TestComputeChisqgradDict:
     def test_multifrequency(self, gauss_im, eht_array):
         """Multifrequency imaging — exercises mf_all_grads_chain branch."""
         im_lo = gauss_im.copy()
-        im_lo.rf = 230e9
+        im_lo.rf = REFFREQ_HZ
         im_hi = gauss_im.copy()
-        im_hi.rf = 345e9
-        obs_lo = im_lo.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
-        obs_hi = im_hi.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
+        im_hi.rf = MF_ALT_FREQ_HZ
+        obs_lo = _observe(im_lo, eht_array)
+        obs_hi = _observe(im_hi, eht_array)
         imgr, imcur = _initialize_imager(
             [obs_lo, obs_hi], im_lo, {"vis": 100}, mf=True, mf_order=1,
         )
@@ -383,14 +357,11 @@ class TestComputeChisqgradDict:
     def test_polarimetric_stokes_i_bundled(self, gauss_im, eht_array):
         """pol='IP' with DATATERMS entry: Stokes-I gradient is bundled (4, nimage)."""
         im = gauss_im.copy()
-        qimage = 0.1 * im.imarr()
-        uimage = 0.05 * im.imarr()
+        qimage = POL_FRAC_Q * im.imarr()
+        uimage = POL_FRAC_U * im.imarr()
         im.add_qu(qimage, uimage)
 
-        obs = im.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-        )
+        obs = _observe(im, eht_array)
         imgr, imcur = _initialize_imager(
             obs, im, {"vis": 100, "pvis": 100}, pol="IP",
         )
@@ -415,10 +386,7 @@ class TestComputeChisqgradDict:
         """Backend works for all three transform types."""
         if ttype == "nfft":
             pytest.importorskip("pynfft")
-        obs = gauss_im.observe(
-            eht_array, 5, 600, 0, 24, 4e9,
-            ampcal=True, phasecal=True, ttype=ttype, add_th_noise=False,
-        )
+        obs = _observe(gauss_im, eht_array, ttype=ttype)
         imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100}, ttype=ttype)
         result = _call_backend_chisqgrad_dict(imgr, imcur)
         assert np.all(np.isfinite(result["vis"]))
@@ -426,10 +394,7 @@ class TestComputeChisqgradDict:
 
 def test_chisq_and_chisqgrad_share_keys(gauss_im, eht_array):
     """Cross-cutting invariant: chisq and chisqgrad dicts share the same key set."""
-    obs = gauss_im.observe(
-        eht_array, 5, 600, 0, 24, 4e9,
-        ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
-    )
+    obs = _observe(gauss_im, eht_array)
     imgr, imcur = _initialize_imager(
         obs, gauss_im, {"vis": 100, "amp": 10, "cphase": 5},
     )

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -8,7 +8,13 @@ import numpy as np
 import pytest
 
 import ehtim as eh
-from ehtim.imaging.imager_backend import compute_embed
+from ehtim.imager import DATATERMS, DATATERMS_POL, POLARIZATION_MODES
+from ehtim.imaging.imager_backend import (
+    compute_chisq_dict,
+    compute_embed,
+    transform_imarr,
+    unpack_imarr,
+)
 
 # Parametrize over square, tall, and wide images
 IMAGE_SHAPES = [
@@ -95,3 +101,180 @@ class TestComputeEmbed:
         # Coordinates should be within +/- (xdim/2) * psize
         max_coord = (im.xdim // 2) * im.psize
         assert np.all(np.abs(coord_matrix) <= max_coord + im.psize)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for chisq dict tests
+# ---------------------------------------------------------------------------
+
+
+def _initialize_imager(obs, im, data_term, pol="I", ttype="direct",
+                       mf=False, mf_order=0):
+    """Build an Imager and run init_imager so that _data_tuples etc. are populated.
+
+    Accepts either a single obs or a list of obs. Returns (imgr, imcur) where
+    imcur is the unpacked + transformed image array ready to pass into
+    make_chisq_dict / compute_chisq_dict.
+    """
+    imgr = eh.imager.Imager(
+        obs, im, prior_im=im, flux=im.total_flux(),
+        data_term=data_term, ttype=ttype, pol=pol,
+    )
+
+    # Mirror the early steps of make_image() so init_imager has the right state.
+    imgr.mf_next = mf
+    imgr.mf_order = mf_order
+    if pol in POLARIZATION_MODES:
+        imgr.prior_next = imgr.prior_next.switch_polrep(polrep_out="stokes", pol_prim_out="I")
+        imgr.init_next = imgr.init_next.switch_polrep(polrep_out="stokes", pol_prim_out="I")
+    imgr.check_params()
+    imgr.check_limits()
+    imgr.init_imager()
+
+    imcur = unpack_imarr(imgr._xinit, imgr._xarr, imgr._which_solve)
+    imcur = transform_imarr(imcur, imgr.transform_next, imgr._which_solve)
+    return imgr, imcur
+
+
+def _call_backend_chisq_dict(imgr, imcur):
+    """Call compute_chisq_dict with args pulled from an initialized Imager."""
+    return compute_chisq_dict(
+        imcur, sorted(imgr.dat_term_next.keys()), imgr._data_tuples,
+        imgr.obslist_next, imgr._logfreqratio_list, imgr.mf_next,
+        imgr.pol_next, imgr._ttype, imgr._embed_mask,
+        DATATERMS, DATATERMS_POL, POLARIZATION_MODES,
+    )
+
+
+class TestComputeChisqDict:
+    """Tests for compute_chisq_dict (extracted from Imager.make_chisq_dict)."""
+
+    def test_stokes_i_single_term(self, gauss_im, eht_array):
+        """Stokes I, single data term — returns one finite chi^2."""
+        obs = gauss_im.observe(
+            eht_array, 5, 600, 0, 24, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100})
+        result = _call_backend_chisq_dict(imgr, imcur)
+        assert set(result.keys()) == {"vis"}
+        assert np.isfinite(result["vis"])
+
+    def test_multiple_dataterms(self, gauss_im, eht_array):
+        """Multiple data terms — one entry per term, all finite."""
+        obs = gauss_im.observe(
+            eht_array, 5, 600, 0, 24, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        data_term = {"vis": 100, "amp": 10, "cphase": 5}
+        imgr, imcur = _initialize_imager(obs, gauss_im, data_term)
+        result = _call_backend_chisq_dict(imgr, imcur)
+        assert set(result.keys()) == set(data_term.keys())
+        for v in result.values():
+            assert np.isfinite(v)
+
+    def test_matches_imager(self, gauss_im, eht_array):
+        """Backend output == Imager.make_chisq_dict output (wrapper sanity check)."""
+        obs = gauss_im.observe(
+            eht_array, 5, 600, 0, 24, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100, "cphase": 10})
+
+        method_result = imgr.make_chisq_dict(imcur)
+        backend_result = _call_backend_chisq_dict(imgr, imcur)
+
+        assert method_result.keys() == backend_result.keys()
+        for key in method_result:
+            np.testing.assert_array_equal(method_result[key], backend_result[key])
+
+    def test_multiple_observations(self, gauss_im, eht_array):
+        """Two observations — keys become dname_i, each entry finite."""
+        obs1 = gauss_im.observe(
+            eht_array, 5, 600, 0, 12, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        obs2 = gauss_im.observe(
+            eht_array, 5, 600, 12, 24, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        imgr, imcur = _initialize_imager(
+            [obs1, obs2], gauss_im, {"vis": 100},
+        )
+        result = _call_backend_chisq_dict(imgr, imcur)
+        assert set(result.keys()) == {"vis_0", "vis_1"}
+        for v in result.values():
+            assert np.isfinite(v)
+
+    def test_multifrequency(self, gauss_im, eht_array):
+        """Multifrequency imaging — exercises the mf_next=True branch (image_at_freq)."""
+        # Two observations at different frequencies, same source.
+        im_lo = gauss_im.copy()
+        im_lo.rf = 230e9
+        im_hi = gauss_im.copy()
+        im_hi.rf = 345e9
+        obs_lo = im_lo.observe(
+            eht_array, 5, 600, 0, 24, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        obs_hi = im_hi.observe(
+            eht_array, 5, 600, 0, 24, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+
+        # Use im_lo (at reference freq 230 GHz) as the prior.
+        imgr, imcur = _initialize_imager(
+            [obs_lo, obs_hi], im_lo, {"vis": 100}, mf=True, mf_order=1,
+        )
+        assert imgr.mf_next is True
+        assert len(imgr._logfreqratio_list) == 2
+
+        result = _call_backend_chisq_dict(imgr, imcur)
+        assert set(result.keys()) == {"vis_0", "vis_1"}
+        for v in result.values():
+            assert np.isfinite(v)
+
+    def test_polarimetric_stokes_i_bundled(self, gauss_im, eht_array):
+        """pol='IP' with DATATERMS entry: exercises the imcur_nu_I bug fix.
+
+        Prior to the fix, imcur has shape (4, N) and was passed directly to
+        imutils.chisq which would crash with a shape mismatch. After the fix
+        the function slices imcur[0] for single-polarization data terms.
+        """
+        # Build a polarized image: Q and U scaled from Stokes I at a fixed angle.
+        im = gauss_im.copy()
+        qimage = 0.1 * im.imarr()
+        uimage = 0.05 * im.imarr()
+        im.add_qu(qimage, uimage)
+
+        obs = im.observe(
+            eht_array, 5, 600, 0, 24, 4e9,
+            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+        )
+        imgr, imcur = _initialize_imager(
+            obs, im, {"vis": 100, "pvis": 100}, pol="IP",
+        )
+        # The buggy version crashes here with ValueError before returning.
+        backend_result = _call_backend_chisq_dict(imgr, imcur)
+        assert set(backend_result.keys()) == {"vis", "pvis"}
+        for v in backend_result.values():
+            assert np.isfinite(v)
+
+        # Verify the wrapper (imgr.make_chisq_dict) also succeeds and matches.
+        method_result = imgr.make_chisq_dict(imcur)
+        assert method_result.keys() == backend_result.keys()
+        for key in method_result:
+            np.testing.assert_array_equal(method_result[key], backend_result[key])
+
+    @pytest.mark.parametrize("ttype", ["direct", "fast", "nfft"])
+    def test_all_ttypes(self, gauss_im, eht_array, ttype):
+        """Backend works for all three transform types."""
+        if ttype == "nfft":
+            pytest.importorskip("pynfft")
+        obs = gauss_im.observe(
+            eht_array, 5, 600, 0, 24, 4e9,
+            ampcal=True, phasecal=True, ttype=ttype, add_th_noise=False,
+        )
+        imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100}, ttype=ttype)
+        result = _call_backend_chisq_dict(imgr, imcur)
+        assert np.isfinite(result["vis"])

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -143,6 +143,20 @@ class TestComputeChisqDict:
         # so chi^2 should be at machine-precision zero.
         assert result["vis"] < 1e-20
 
+    def test_stokes_i_chi2_near_unity_with_noise(self, gauss_im, observe, initialize_imager):
+        """Stokes I 'vis' chi^2 on the truth image with thermal noise is ~1.
+
+        Catches sigma-normalization / weighting bugs that the noise-free test
+        cannot, since chi^2 = 0 holds regardless of how sigma is scaled when
+        residuals are zero. Empirically chi^2 ~ 1.00 +/- 0.04 across seeds for
+        the EHT2017 array (N ~ 1030 visibilities, theoretical std sqrt(2/N)).
+        """
+        obs = observe(gauss_im, seed=42)
+        imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100})
+        result = _call_backend_chisq_dict(imgr, imcur)
+        assert set(result.keys()) == {"vis"}
+        assert 0.85 < result["vis"] < 1.15
+
     def test_multiple_dataterms(self, gauss_im, observe, initialize_imager):
         """Multiple data terms — one entry per term, all finite."""
         obs = observe(gauss_im)

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -43,16 +43,7 @@ PER_TERM_POL_CASES = [
     ("vvis", "IV", ["log", "vcv"]),
 ]
 
-# `chisqgrad_m` has a typo at pol_imager_utils.py:613 (missing operand before
-# the `*` inside np.real); the m-gradient path raises TypeError. Tracked
-# separately; only the gradient is broken, the chi^2 path works.
-PER_TERM_POL_GRAD_CASES = [
-    ("pvis", "IP", ["log", "mcv"]),
-    pytest.param("m", "IP", ["log", "mcv"], marks=pytest.mark.xfail(
-        reason="chisqgrad_m typo: np.real(   * np.dot(...)) at pol_imager_utils.py:613",
-        raises=TypeError, strict=True)),
-    ("vvis", "IV", ["log", "vcv"]),
-]
+PER_TERM_POL_GRAD_CASES = PER_TERM_POL_CASES
 
 # Noisy-truth bounds: snrcut=3 keeps the linearized error-propagation valid
 # for closure quantities; the (lo, hi) range is empirical over 20 seeds.

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -9,12 +9,9 @@ import pytest
 
 import ehtim as eh
 from ehtim.imaging.imager_backend import (
-    POLARIZATION_MODES,
     compute_chisq_dict,
     compute_chisqgrad_dict,
     compute_embed,
-    transform_imarr,
-    unpack_imarr,
 )
 
 # Parametrize over square, tall, and wide images
@@ -26,13 +23,6 @@ IMAGE_SHAPES = [
     (31, 33),  # odd rectangular
 ]
 
-# Observation parameters (match conftest.py convention)
-TINT_SEC = 5
-TADV_SEC = 600
-TSTART_HR = 0
-TSTOP_HR = 24
-BW_HZ = 4e9
-
 # Multifrequency test frequencies
 REFFREQ_HZ = 230e9
 MF_ALT_FREQ_HZ = 345e9
@@ -40,14 +30,6 @@ MF_ALT_FREQ_HZ = 345e9
 # Synthetic polarization fractions for polarimetric tests
 POL_FRAC_Q = 0.1
 POL_FRAC_U = 0.05
-
-
-def _observe(im, eht_array, ttype="direct", tstart=TSTART_HR, tstop=TSTOP_HR):
-    """Noise-free observation with project-standard defaults."""
-    return im.observe(
-        eht_array, TINT_SEC, TADV_SEC, tstart, tstop, BW_HZ,
-        ampcal=True, phasecal=True, ttype=ttype, add_th_noise=False,
-    )
 
 
 class TestComputeEmbed:
@@ -84,9 +66,9 @@ class TestComputeEmbed:
                 clipfloor=np.max(im.imvec) + 1.0,
             )
 
-    def test_matches_imager(self, gauss_im, eht_array):
+    def test_matches_imager(self, gauss_im, observe):
         """Backend compute_embed matches Imager.set_embed exactly."""
-        obs = _observe(gauss_im, eht_array)
+        obs = observe(gauss_im)
         imgr = eh.imager.Imager(obs, gauss_im, gauss_im, gauss_im.total_flux(),
                                 ttype="direct")
 
@@ -129,34 +111,6 @@ class TestComputeEmbed:
 # ---------------------------------------------------------------------------
 
 
-def _initialize_imager(obs, im, data_term, pol="I", ttype="direct",
-                       mf=False, mf_order=0):
-    """Build an Imager and run init_imager so that _data_tuples etc. are populated.
-
-    Accepts either a single obs or a list of obs. Returns (imgr, imcur) where
-    imcur is the unpacked + transformed image array ready to pass into
-    make_chisq_dict / compute_chisq_dict.
-    """
-    imgr = eh.imager.Imager(
-        obs, im, prior_im=im, flux=im.total_flux(),
-        data_term=data_term, ttype=ttype, pol=pol,
-    )
-
-    # Mirror the early steps of make_image() so init_imager has the right state.
-    imgr.mf_next = mf
-    imgr.mf_order = mf_order
-    if pol in POLARIZATION_MODES:
-        imgr.prior_next = imgr.prior_next.switch_polrep(polrep_out="stokes", pol_prim_out="I")
-        imgr.init_next = imgr.init_next.switch_polrep(polrep_out="stokes", pol_prim_out="I")
-    imgr.check_params()
-    imgr.check_limits()
-    imgr.init_imager()
-
-    imcur = unpack_imarr(imgr._xinit, imgr._xarr, imgr._which_solve)
-    imcur = transform_imarr(imcur, imgr.transform_next, imgr._which_solve)
-    return imgr, imcur
-
-
 def _call_backend_chisq_dict(imgr, imcur):
     """Call compute_chisq_dict with args pulled from an initialized Imager."""
     return compute_chisq_dict(
@@ -179,28 +133,28 @@ def _call_backend_chisqgrad_dict(imgr, imcur):
 class TestComputeChisqDict:
     """Tests for compute_chisq_dict (extracted from Imager.make_chisq_dict)."""
 
-    def test_stokes_i_single_term(self, gauss_im, eht_array):
+    def test_stokes_i_single_term(self, gauss_im, observe, initialize_imager):
         """Stokes I, single data term — returns one finite chi^2."""
-        obs = _observe(gauss_im, eht_array)
-        imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100})
+        obs = observe(gauss_im)
+        imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100})
         result = _call_backend_chisq_dict(imgr, imcur)
         assert set(result.keys()) == {"vis"}
         assert np.isfinite(result["vis"])
 
-    def test_multiple_dataterms(self, gauss_im, eht_array):
+    def test_multiple_dataterms(self, gauss_im, observe, initialize_imager):
         """Multiple data terms — one entry per term, all finite."""
-        obs = _observe(gauss_im, eht_array)
+        obs = observe(gauss_im)
         data_term = {"vis": 100, "amp": 10, "cphase": 5}
-        imgr, imcur = _initialize_imager(obs, gauss_im, data_term)
+        imgr, imcur = initialize_imager(obs, gauss_im, data_term)
         result = _call_backend_chisq_dict(imgr, imcur)
         assert set(result.keys()) == set(data_term.keys())
         for v in result.values():
             assert np.isfinite(v)
 
-    def test_matches_imager(self, gauss_im, eht_array):
+    def test_matches_imager(self, gauss_im, observe, initialize_imager):
         """Backend output == Imager.make_chisq_dict output (wrapper sanity check)."""
-        obs = _observe(gauss_im, eht_array)
-        imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100, "cphase": 10})
+        obs = observe(gauss_im)
+        imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100, "cphase": 10})
 
         method_result = imgr.make_chisq_dict(imcur)
         backend_result = _call_backend_chisq_dict(imgr, imcur)
@@ -209,12 +163,12 @@ class TestComputeChisqDict:
         for key in method_result:
             np.testing.assert_array_equal(method_result[key], backend_result[key])
 
-    def test_multiple_observations(self, gauss_im, eht_array):
+    def test_multiple_observations(self, gauss_im, observe, initialize_imager):
         """Two observations — keys become dname_i, each entry finite."""
-        tmid = (TSTART_HR + TSTOP_HR) / 2
-        obs1 = _observe(gauss_im, eht_array, tstart=TSTART_HR, tstop=tmid)
-        obs2 = _observe(gauss_im, eht_array, tstart=tmid, tstop=TSTOP_HR)
-        imgr, imcur = _initialize_imager(
+        # Split the standard 0-24h observation window in two.
+        obs1 = observe(gauss_im, tstop=12.0)
+        obs2 = observe(gauss_im, tstart=12.0)
+        imgr, imcur = initialize_imager(
             [obs1, obs2], gauss_im, {"vis": 100},
         )
         result = _call_backend_chisq_dict(imgr, imcur)
@@ -222,18 +176,18 @@ class TestComputeChisqDict:
         for v in result.values():
             assert np.isfinite(v)
 
-    def test_multifrequency(self, gauss_im, eht_array):
+    def test_multifrequency(self, gauss_im, observe, initialize_imager):
         """Multifrequency imaging — exercises the mf_next=True branch (image_at_freq)."""
         # Two observations at different frequencies, same source.
         im_lo = gauss_im.copy()
         im_lo.rf = REFFREQ_HZ
         im_hi = gauss_im.copy()
         im_hi.rf = MF_ALT_FREQ_HZ
-        obs_lo = _observe(im_lo, eht_array)
-        obs_hi = _observe(im_hi, eht_array)
+        obs_lo = observe(im_lo)
+        obs_hi = observe(im_hi)
 
         # Use im_lo (at reference freq) as the prior.
-        imgr, imcur = _initialize_imager(
+        imgr, imcur = initialize_imager(
             [obs_lo, obs_hi], im_lo, {"vis": 100}, mf=True, mf_order=1,
         )
         assert imgr.mf_next is True
@@ -244,7 +198,7 @@ class TestComputeChisqDict:
         for v in result.values():
             assert np.isfinite(v)
 
-    def test_polarimetric_stokes_i_bundled(self, gauss_im, eht_array):
+    def test_polarimetric_stokes_i_bundled(self, gauss_im, observe, initialize_imager):
         """pol='IP' with DATATERMS entry: exercises the imcur_nu_I bug fix.
 
         Prior to the fix, imcur has shape (4, N) and was passed directly to
@@ -257,8 +211,8 @@ class TestComputeChisqDict:
         uimage = POL_FRAC_U * im.imarr()
         im.add_qu(qimage, uimage)
 
-        obs = _observe(im, eht_array)
-        imgr, imcur = _initialize_imager(
+        obs = observe(im)
+        imgr, imcur = initialize_imager(
             obs, im, {"vis": 100, "pvis": 100}, pol="IP",
         )
         # The buggy version crashes here with ValueError before returning.
@@ -274,12 +228,12 @@ class TestComputeChisqDict:
             np.testing.assert_array_equal(method_result[key], backend_result[key])
 
     @pytest.mark.parametrize("ttype", ["direct", "fast", "nfft"])
-    def test_all_ttypes(self, gauss_im, eht_array, ttype):
+    def test_all_ttypes(self, gauss_im, observe, initialize_imager, ttype):
         """Backend works for all three transform types."""
         if ttype == "nfft":
             pytest.importorskip("pynfft")
-        obs = _observe(gauss_im, eht_array, ttype=ttype)
-        imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100}, ttype=ttype)
+        obs = observe(gauss_im, ttype=ttype)
+        imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100}, ttype=ttype)
         result = _call_backend_chisq_dict(imgr, imcur)
         assert np.isfinite(result["vis"])
 
@@ -287,30 +241,30 @@ class TestComputeChisqDict:
 class TestComputeChisqgradDict:
     """Tests for compute_chisqgrad_dict (extracted from Imager.make_chisqgrad_dict)."""
 
-    def test_stokes_i_single_term(self, gauss_im, eht_array):
+    def test_stokes_i_single_term(self, gauss_im, observe, initialize_imager):
         """Stokes I gradient has shape (nimage,) and is finite."""
-        obs = _observe(gauss_im, eht_array)
-        imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100})
+        obs = observe(gauss_im)
+        imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100})
         result = _call_backend_chisqgrad_dict(imgr, imcur)
         assert set(result.keys()) == {"vis"}
         assert result["vis"].shape == (imgr._nimage,)
         assert np.all(np.isfinite(result["vis"]))
 
-    def test_multiple_dataterms(self, gauss_im, eht_array):
+    def test_multiple_dataterms(self, gauss_im, observe, initialize_imager):
         """Multiple gradient entries, all finite, correct shape."""
-        obs = _observe(gauss_im, eht_array)
+        obs = observe(gauss_im)
         data_term = {"vis": 100, "amp": 10, "cphase": 5}
-        imgr, imcur = _initialize_imager(obs, gauss_im, data_term)
+        imgr, imcur = initialize_imager(obs, gauss_im, data_term)
         result = _call_backend_chisqgrad_dict(imgr, imcur)
         assert set(result.keys()) == set(data_term.keys())
         for v in result.values():
             assert v.shape == (imgr._nimage,)
             assert np.all(np.isfinite(v))
 
-    def test_matches_imager(self, gauss_im, eht_array):
+    def test_matches_imager(self, gauss_im, observe, initialize_imager):
         """Backend output == Imager.make_chisqgrad_dict output (tight tol)."""
-        obs = _observe(gauss_im, eht_array)
-        imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100, "cphase": 10})
+        obs = observe(gauss_im)
+        imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100, "cphase": 10})
 
         method_result = imgr.make_chisqgrad_dict(imcur)
         backend_result = _call_backend_chisqgrad_dict(imgr, imcur)
@@ -320,12 +274,12 @@ class TestComputeChisqgradDict:
             np.testing.assert_allclose(method_result[key], backend_result[key],
                                        rtol=1e-15, atol=0)
 
-    def test_multiple_observations(self, gauss_im, eht_array):
+    def test_multiple_observations(self, gauss_im, observe, initialize_imager):
         """Two observations — one gradient entry per obs."""
-        tmid = (TSTART_HR + TSTOP_HR) / 2
-        obs1 = _observe(gauss_im, eht_array, tstart=TSTART_HR, tstop=tmid)
-        obs2 = _observe(gauss_im, eht_array, tstart=tmid, tstop=TSTOP_HR)
-        imgr, imcur = _initialize_imager(
+        # Split the standard 0-24h observation window in two.
+        obs1 = observe(gauss_im, tstop=12.0)
+        obs2 = observe(gauss_im, tstart=12.0)
+        imgr, imcur = initialize_imager(
             [obs1, obs2], gauss_im, {"vis": 100},
         )
         result = _call_backend_chisqgrad_dict(imgr, imcur)
@@ -334,15 +288,15 @@ class TestComputeChisqgradDict:
             assert v.shape == (imgr._nimage,)
             assert np.all(np.isfinite(v))
 
-    def test_multifrequency(self, gauss_im, eht_array):
+    def test_multifrequency(self, gauss_im, observe, initialize_imager):
         """Multifrequency imaging — exercises mf_all_grads_chain branch."""
         im_lo = gauss_im.copy()
         im_lo.rf = REFFREQ_HZ
         im_hi = gauss_im.copy()
         im_hi.rf = MF_ALT_FREQ_HZ
-        obs_lo = _observe(im_lo, eht_array)
-        obs_hi = _observe(im_hi, eht_array)
-        imgr, imcur = _initialize_imager(
+        obs_lo = observe(im_lo)
+        obs_hi = observe(im_hi)
+        imgr, imcur = initialize_imager(
             [obs_lo, obs_hi], im_lo, {"vis": 100}, mf=True, mf_order=1,
         )
         assert imgr.mf_next is True
@@ -352,15 +306,15 @@ class TestComputeChisqgradDict:
         for v in result.values():
             assert np.all(np.isfinite(v))
 
-    def test_polarimetric_stokes_i_bundled(self, gauss_im, eht_array):
+    def test_polarimetric_stokes_i_bundled(self, gauss_im, observe, initialize_imager):
         """pol='IP' with DATATERMS entry: Stokes-I gradient is bundled (4, nimage)."""
         im = gauss_im.copy()
         qimage = POL_FRAC_Q * im.imarr()
         uimage = POL_FRAC_U * im.imarr()
         im.add_qu(qimage, uimage)
 
-        obs = _observe(im, eht_array)
-        imgr, imcur = _initialize_imager(
+        obs = observe(im)
+        imgr, imcur = initialize_imager(
             obs, im, {"vis": 100, "pvis": 100}, pol="IP",
         )
         backend_result = _call_backend_chisqgrad_dict(imgr, imcur)
@@ -380,20 +334,20 @@ class TestComputeChisqgradDict:
                                        rtol=1e-15, atol=0)
 
     @pytest.mark.parametrize("ttype", ["direct", "fast", "nfft"])
-    def test_all_ttypes(self, gauss_im, eht_array, ttype):
+    def test_all_ttypes(self, gauss_im, observe, initialize_imager, ttype):
         """Backend works for all three transform types."""
         if ttype == "nfft":
             pytest.importorskip("pynfft")
-        obs = _observe(gauss_im, eht_array, ttype=ttype)
-        imgr, imcur = _initialize_imager(obs, gauss_im, {"vis": 100}, ttype=ttype)
+        obs = observe(gauss_im, ttype=ttype)
+        imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100}, ttype=ttype)
         result = _call_backend_chisqgrad_dict(imgr, imcur)
         assert np.all(np.isfinite(result["vis"]))
 
 
-def test_chisq_and_chisqgrad_share_keys(gauss_im, eht_array):
+def test_chisq_and_chisqgrad_share_keys(gauss_im, observe, initialize_imager):
     """Cross-cutting invariant: chisq and chisqgrad dicts share the same key set."""
-    obs = _observe(gauss_im, eht_array)
-    imgr, imcur = _initialize_imager(
+    obs = observe(gauss_im)
+    imgr, imcur = initialize_imager(
         obs, gauss_im, {"vis": 100, "amp": 10, "cphase": 5},
     )
     chisq = _call_backend_chisq_dict(imgr, imcur)

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -31,6 +31,17 @@ MF_ALT_FREQ_HZ = 345e9
 POL_FRAC_Q = 0.1
 POL_FRAC_U = 0.05
 
+# Data terms covered by per-term parametrized chi^2 / grad tests.
+# Diagonalized variants (cphase_diag, logcamp_diag) hit upstream ehtim bugs
+# (NumPy 1.24+ inhomogeneous-array, deprecated `np.float`); tracked separately.
+PER_TERM_DATATERMS = ["vis", "amp", "bs", "cphase", "camp", "logcamp"]
+
+# Noisy-truth bounds: snrcut=3 keeps the linearized error-propagation valid
+# for closure quantities; the (lo, hi) range is empirical over 20 seeds.
+NOISY_SNRCUT = 3.0
+NOISY_CHISQ_LO = 0.3
+NOISY_CHISQ_HI = 10.0
+
 
 class TestComputeEmbed:
     """Tests for compute_embed (extracted from Imager.set_embed)."""
@@ -133,29 +144,31 @@ def _call_backend_chisqgrad_dict(imgr, imcur):
 class TestComputeChisqDict:
     """Tests for compute_chisq_dict (extracted from Imager.make_chisq_dict)."""
 
-    def test_stokes_i_single_term(self, gauss_im, observe, initialize_imager):
-        """Stokes I 'vis' chi^2 on the truth image is ~0 (noise-free, perfect fit)."""
-        obs = observe(gauss_im)
-        imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100})
-        result = _call_backend_chisq_dict(imgr, imcur)
-        assert set(result.keys()) == {"vis"}
-        # Truth image + add_th_noise=False -> data exactly equals predicted vis,
-        # so chi^2 should be at machine-precision zero.
-        assert result["vis"] < 1e-20
+    @pytest.mark.parametrize("dterm", PER_TERM_DATATERMS)
+    def test_chisq_zero_on_truth_no_debias(self, gauss_im, observe,
+                                            initialize_imager, dterm):
+        """chi^2 on the truth image is ~0 for every data term (noise-free, no debias).
 
-    def test_stokes_i_chi2_near_unity_with_noise(self, gauss_im, observe, initialize_imager):
-        """Stokes I 'vis' chi^2 on the truth image with thermal noise is ~1.
-
-        Catches sigma-normalization / weighting bugs that the noise-free test
-        cannot, since chi^2 = 0 holds regardless of how sigma is scaled when
-        residuals are zero. Empirically chi^2 ~ 1.00 +/- 0.04 across seeds for
-        the EHT2017 array (N ~ 1030 visibilities, theoretical std sqrt(2/N)).
+        Tests forward-model correctness: predicted chi^2 == data when imcur is
+        the truth image and we disable both the noise and debias corrections
+        that would otherwise shift the data away from the raw truth values.
         """
-        obs = observe(gauss_im, seed=42)
-        imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100})
+        obs = observe(gauss_im)
+        imgr, imcur = initialize_imager(obs, gauss_im, {dterm: 1}, debias=False)
         result = _call_backend_chisq_dict(imgr, imcur)
-        assert set(result.keys()) == {"vis"}
-        assert 0.85 < result["vis"] < 1.15
+        assert set(result.keys()) == {dterm}
+        assert result[dterm] < 1e-10
+
+    @pytest.mark.parametrize("dterm", PER_TERM_DATATERMS)
+    def test_chisq_near_unity_on_noisy_truth(self, gauss_im, observe,
+                                              initialize_imager, dterm):
+        """chi^2 on noisy truth is ~1 for every data term (with snrcut)."""
+        obs = observe(gauss_im, seed=42)
+        imgr, imcur = initialize_imager(obs, gauss_im, {dterm: 1},
+                                        snrcut=NOISY_SNRCUT)
+        result = _call_backend_chisq_dict(imgr, imcur)
+        assert set(result.keys()) == {dterm}
+        assert NOISY_CHISQ_LO < result[dterm] < NOISY_CHISQ_HI
 
     def test_multiple_dataterms(self, gauss_im, observe, initialize_imager):
         """Multiple data terms — one entry per term, all finite."""
@@ -257,15 +270,28 @@ class TestComputeChisqDict:
 class TestComputeChisqgradDict:
     """Tests for compute_chisqgrad_dict (extracted from Imager.make_chisqgrad_dict)."""
 
-    def test_stokes_i_single_term(self, gauss_im, observe, initialize_imager):
-        """Stokes I 'vis' gradient on the truth image is ~0 (chi^2 at minimum)."""
+    @pytest.mark.parametrize("dterm", PER_TERM_DATATERMS)
+    def test_grad_zero_on_truth_no_debias(self, gauss_im, observe,
+                                           initialize_imager, dterm):
+        """Gradient on the truth image is ~0 for every data term (noise-free, no debias)."""
         obs = observe(gauss_im)
-        imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100})
+        imgr, imcur = initialize_imager(obs, gauss_im, {dterm: 1}, debias=False)
         result = _call_backend_chisqgrad_dict(imgr, imcur)
-        assert set(result.keys()) == {"vis"}
-        assert result["vis"].shape == (imgr._nimage,)
-        # Truth image is the chi^2 minimum so gradient should be machine-precision zero.
-        assert np.max(np.abs(result["vis"])) < 1e-10
+        assert set(result.keys()) == {dterm}
+        assert result[dterm].shape == (imgr._nimage,)
+        assert np.max(np.abs(result[dterm])) < 1e-10
+
+    @pytest.mark.parametrize("dterm", PER_TERM_DATATERMS)
+    def test_grad_finite_on_noisy_truth(self, gauss_im, observe,
+                                         initialize_imager, dterm):
+        """Gradient on noisy truth is finite for every data term."""
+        obs = observe(gauss_im, seed=42)
+        imgr, imcur = initialize_imager(obs, gauss_im, {dterm: 1},
+                                        snrcut=NOISY_SNRCUT)
+        result = _call_backend_chisqgrad_dict(imgr, imcur)
+        assert set(result.keys()) == {dterm}
+        assert result[dterm].shape == (imgr._nimage,)
+        assert np.all(np.isfinite(result[dterm]))
 
     def test_multiple_dataterms(self, gauss_im, observe, initialize_imager):
         """Multiple gradient entries, all finite, correct shape."""


### PR DESCRIPTION
Extracts the two dictionary-making methods from `Imager` into pure functions in `ehtim/imaging/imager_backend.py` and addresses the review feedback. Implements tasks 1A.2 and 1A.3 from the Phase 1 roadmap in #212.

## Extraction (initial)

| File | Change |
|---|---|
| `ehtim/imaging/imager_backend.py` | `+compute_chisq_dict`, `+compute_chisqgrad_dict`; constants `DATATERMS` / `DATATERMS_POL` / `POLARIZATION_MODES` now live here |
| `ehtim/imager.py` | Method bodies replaced with thin wrappers; constants re-imported for backward compat |
| `tests/conftest.py` | New factory fixtures `observe`, `initialize_imager` |
| `tests/test_imager_backend.py` | New `TestComputeChisqDict` + `TestComputeChisqgradDict` classes |

## Bugs found and fixed in this PR

1. **`make_chisq_dict` was passing bundled polarimetric array to scalar chisq** — `imcur_nu` (shape `(4, N)`) instead of `imcur_nu[0]` (Stokes-I slice) when `pol_next in POLARIZATION_MODES`. `make_chisqgrad_dict` correctly sliced; the value version didn't. Users running `make_image_IP(data_term={'vis': 1000, 'pvis': 500})` would have hit a `ValueError`. Latent since commit 971bf0c (July 2024). Fixed in both method and backend; regression test `test_polarimetric_stokes_i_bundled`.
2. **`chisqgrad_m` typo at `pol_imager_utils.py:613`** — `np.real(   * np.dot(Amatrix.conj().T, mdiff))` had a missing left operand. The `m`-gradient path raised `TypeError` on every call. Derived correct factor `mimage * np.exp(-2j*chiimage)` from `pimage = I·m·exp(2i·chi)`, verified by FD in IMARR space to ~1e-11.
3. **Two more typo bugs** in untested regularizer code paths: `outgrad[0] = gradi` should be `gradout` (line 914 of `smgrad`), and `return gradoutout/norm` should be `gradout` (line 1097 of `vsm_grad`). Both would `NameError` on first call. Fixed.

## Review feedback addressed

- `_next` suffix dropped from backend args (`e81845c`)
- `DATATERMS`/`DATATERMS_POL`/`POLARIZATION_MODES` moved to `imager_backend.py`, re-exported from `imager.py` (`884ff72`)
- `_observe` and `_initialize_imager` moved to `conftest.py` as factory fixtures (`801f8d3`)
- Per-term chi² / grad tests across all 6 single-pol terms (`vis`, `amp`, `bs`, `cphase`, `camp`, `logcamp`) + 3 polarimetric terms (`pvis`, `m`, `vvis`); single uniform bound `(0.3, 10)` with `snrcut=3` works for all (`16adda8`, `0efb571`)
- The `compute_chisq_dict`/`compute_chisqgrad_dict` merge filed as task 2.11 in #212

## Ruff cleanup

`pol_imager_utils.py` had 301 pre-existing ruff errors that surfaced once CI ran ruff on the file (touched here for the `chisqgrad_m` fix). Cleaned in `3404b01`: 237 auto-fixed (whitespace, unsorted imports, unused stdlib imports, `from __future__` no-ops, `(x not in y)` form), 64 manual (E701 one-liners, raw-docstring conversions, `%`-formatting, the explicit-imports replacement, the two typo bugs above). Verified semantics-preserving; full suite passes.

## Test coverage

- **266 tests pass** (up from 213 on dev-backend; net +53 new)
- Three code paths covered: Stokes I, polarimetric (`DATATERMS_POL` + bundled Stokes-I), multifrequency
- Parametrized over all 3 ttypes (direct / fast / nfft) for chi² consistency
- Wrapper parity tests: `imgr.make_chisq*_dict(imcur)` == backend function
- Cross-dict parity test: `chisq` and `chisqgrad` share the same key set
- Per-term invariants:
  - **Noise-free + `debias=False`**: chi² < 1e-10, grad max|.| < 1e-10 (forward-model correctness)
  - **Noisy + `debias=True` + `snrcut=3`**: 0.3 < chi² < 10 (sigma normalization)
- Polarimetric tests use a `gauss_im_pol` fixture (Stokes I + Q + U + V)

## Out-of-scope items filed in #212

- **2.12** — `chisqdata_cphase_diag` / `chisqdata_logcamp_diag` raise `ValueError: inhomogeneous np.array` under NumPy ≥ 1.24; `chisqgrad_logcamp_diag` uses deprecated `np.float`. Diagonalized variants excluded from per-term parametrize.
- **2.14** — `transform_gradients` overwrites the log chain rule for the I-segment when both `log` and `mcv`/`vcv`/`polcv` are in transforms (`imager_backend.py:244` overwrites line 238 because `mcv_chain[0] = 1`). Pre-existing, affects all polarimetric I-segment gradients silently.

## Related

- Implements tasks 1A.2 and 1A.3 in #212
- Follows the Phase 1 extraction pattern from #224
