### PR TITLE
Extract make_reg_dict + make_reggrad_dict; flip debias default

### DIFF
--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -32,28 +32,21 @@ import scipy.optimize as opt
 import ehtim.const_def as ehc
 import ehtim.image
 import ehtim.imaging.imager_utils as imutils
-import ehtim.imaging.multifreq_imager_utils as mfutils
 import ehtim.imaging.pol_imager_utils as polutils
 from ehtim.imaging.imager_backend import (
     DATATERMS,
     DATATERMS_POL,
     POLARIZATION_MODES,
     REGULARIZERS,
-    REGULARIZERS_ALLFREQS_I,
-    REGULARIZERS_CM,
-    REGULARIZERS_CURV,
-    REGULARIZERS_CURV_P,
     REGULARIZERS_ISPECTRAL,
     REGULARIZERS_POL,
     REGULARIZERS_POLSPECTRAL,
-    REGULARIZERS_RM,
-    REGULARIZERS_SPECIND,
-    REGULARIZERS_SPECIND_P,
     REGULARIZERS_SPECTRAL,
     compute_chisq_dict,
     compute_chisqgrad_dict,
     compute_embed,
     compute_reg_dict,
+    compute_reggrad_dict,
     embed_imarr,
     make_initarr,
     pack_imarr,
@@ -1112,142 +1105,15 @@ class Imager:
         """Make a dictionary of current regularizer gradient values
            input is image array transformed to bounded values
         """
-
-        reggrad_dict = {}
-
-        for regname in sorted(self.reg_term_next.keys()):
-
-            # Multifrequency regularizers
-            if self.mf_next:
-
-                # Polarimetric regularizers
-                if regname in REGULARIZERS_POL:
-                    # we only regularize reference frequency image
-                    imcur_pol = imcur[0:4]
-                    prior_pol = self._xprior[0:4]
-                    pol_solve = self._which_solve[0:4]
-                    regp = polutils.polregularizergrad(imcur_pol, prior_pol, self._embed_mask,
-                                                      self.flux_next, self.pflux_next, self.vflux_next,
-                                                      self.prior_next.xdim, self.prior_next.ydim, self.prior_next.psize,
-                                                      regname,
-                                                      norm_reg=self.norm_reg, beam_size=self.beam_size,
-                                                      pol_solve=pol_solve,
-                                                      **self.regparams)
-                    reggrad = np.zeros((len(imcur), self._nimage))
-                    reggrad[0:4] = regp
-
-                # Stokes I regularizers
-                elif regname in REGULARIZERS:
-
-                    # here we regularize images at each frequency
-                    if regname in REGULARIZERS_ALLFREQS_I:
-
-
-                        # TODO move this to checks?
-                        if (not isinstance(self.mf_flux, list)) or len(self.mf_flux)!=len(self.obslist_next):
-                            raise Exception(f"when using regularizer '{regname}', "
-                                            +"self.mf_flux must be a list of same length as self.obslist_next!")
-
-                        regname_base = '_'.join(regname.split('_')[:-1]) # remove the '_mf' tag
-                        for i in range(len(self.obslist_next)): # sum up regularizer gradients at each frequency
-
-                            logfreqratio = self._logfreqratio_list[i]
-                            flux_nu = self.mf_flux[i]
-
-                            imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
-                            prior_nu = mfutils.image_at_freq(self._xprior, logfreqratio)
-
-                            regi = imutils.regularizergrad(imcur_nu, prior_nu, self._embed_mask,
-                                                           flux_nu, self.prior_next.xdim,
-                                                           self.prior_next.ydim, self.prior_next.psize,
-                                                           regname_base,
-                                                           norm_reg=self.norm_reg, beam_size=self.beam_size,
-                                                           **self.regparams)
-                            reggrad_i = mfutils.mf_all_grads_chain(regi, imcur_nu, imcur, logfreqratio)
-                            if i==0:
-                                reggrad = reggrad_i
-                            else:
-                                reggrad += reggrad_i
-
-                    # here we only regularize the reference frequency image
-                    else:
-                        regi = imutils.regularizergrad(imcur[0], self._xprior[0],
-                                                       self._embed_mask, self.flux_next,
-                                                       self.prior_next.xdim, self.prior_next.ydim, self.prior_next.psize,
-                                                       regname,
-                                                       norm_reg=self.norm_reg, beam_size=self.beam_size,
-                                                       **self.regparams)
-                        reggrad = np.zeros((len(imcur), self._nimage))
-                        reggrad[0] = regi
-
-                elif regname in REGULARIZERS_SPECTRAL:
-                    if regname in REGULARIZERS_SPECIND:
-                        idx = 4 if len(imcur) == 10 else 1
-                    elif regname in REGULARIZERS_CURV:
-                        idx = 5 if len(imcur) == 10 else 2
-                    elif regname in REGULARIZERS_SPECIND_P:
-                        idx = 6
-                    elif regname in REGULARIZERS_CURV_P:
-                        idx = 7
-                    elif regname in REGULARIZERS_RM:
-                        idx = 8
-                    elif regname in REGULARIZERS_CM:
-                        idx = 9
-
-                    regmf = mfutils.regularizergrad_mf(imcur[idx], self._xprior[idx], self._embed_mask,
-                                                       self.prior_next.xdim, self.prior_next.ydim, self.prior_next.psize,
-                                                       regname,
-                                                       norm_reg=self.norm_reg, beam_size=self.beam_size,
-                                                       **self.regparams)
-
-                    reggrad = np.zeros((len(imcur), self._nimage))
-                    reggrad[idx] = regmf
-                else:
-                    raise Exception(f"regularizer term {regname} not recognized!")
-
-
-
-            else:
-                # Single-frequency polarimetric regularizer
-                if regname in REGULARIZERS_POL:
-                    reggrad = polutils.polregularizergrad(imcur, self._xprior, self._embed_mask,
-                                                      self.flux_next, self.pflux_next, self.vflux_next,
-                                                      self.prior_next.xdim, self.prior_next.ydim,
-                                                      self.prior_next.psize, regname,
-                                                      norm_reg=self.norm_reg, beam_size=self.beam_size,
-                                                      pol_solve=self._which_solve,
-                                                      **self.regparams)
-
-
-                # Single-frequency, single polarization regularizer
-                elif regname in REGULARIZERS:
-                    if self.pol_next in POLARIZATION_MODES:
-                        imcur0 = imcur[0]
-                        prior0 = self._xprior[0]
-                    else:
-                        imcur0 = imcur
-                        prior0 = self._xprior
-                    reggrad = imutils.regularizergrad(imcur0, prior0, self._embed_mask, self.flux_next,
-                                                      self.prior_next.xdim, self.prior_next.ydim,
-                                                      self.prior_next.psize,
-                                                      regname,
-                                                      norm_reg=self.norm_reg, beam_size=self.beam_size,
-                                                      **self.regparams)
-
-                    # If imaging Stokes I with polarization simultaneously, bundle the gradient
-                    if self.pol_next in POLARIZATION_MODES:
-                        reggrad = np.array((reggrad,
-                                            np.zeros(self._nimage),
-                                            np.zeros(self._nimage),
-                                            np.zeros(self._nimage)))
-
-                else:
-                    raise Exception(f"regularizer term {regname} not recognized!")
-
-            # put regularizer terms in the dictionary
-            reggrad_dict[regname] = reggrad
-
-        return reggrad_dict
+        return compute_reggrad_dict(
+            imcur, sorted(self.reg_term_next.keys()), self._xprior, self._embed_mask,
+            self.flux_next, self.pflux_next, self.vflux_next,
+            self.prior_next.xdim, self.prior_next.ydim, self.prior_next.psize,
+            self.norm_reg, self.beam_size, self.regparams,
+            self.mf_next, self.mf_flux, self.obslist_next,
+            self._logfreqratio_list, self.pol_next,
+            self._which_solve, self._nimage,
+        )
 
     def objfunc(self, imvec):
         """Current objective function.

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -1088,17 +1088,28 @@ class Imager:
             self._which_solve, self._nimage,
         )
 
+    def _full_regparams(self):
+        """Bundle all regularizer params into a single dict for the backend."""
+        return {
+            'flux': self.flux_next,
+            'pflux': self.pflux_next,
+            'vflux': self.vflux_next,
+            'xdim': self.prior_next.xdim,
+            'ydim': self.prior_next.ydim,
+            'psize': self.prior_next.psize,
+            'beam_size': self.beam_size,
+            'mf_flux': self.mf_flux,
+            **self.regparams,
+        }
+
     def make_reg_dict(self, imcur):
         """Make a dictionary of current regularizer values
            input is image array transformed to bounded values
         """
         return compute_reg_dict(
             imcur, sorted(self.reg_term_next.keys()), self._xprior, self._embed_mask,
-            self.flux_next, self.pflux_next, self.vflux_next,
-            self.prior_next.xdim, self.prior_next.ydim, self.prior_next.psize,
-            self.norm_reg, self.beam_size, self.regparams,
-            self.mf_next, self.mf_flux, self.obslist_next,
-            self._logfreqratio_list, self.pol_next,
+            self.mf_next, self.obslist_next, self._logfreqratio_list, self.pol_next,
+            self.norm_reg, self._full_regparams(),
         )
 
     def make_reggrad_dict(self, imcur):
@@ -1107,11 +1118,8 @@ class Imager:
         """
         return compute_reggrad_dict(
             imcur, sorted(self.reg_term_next.keys()), self._xprior, self._embed_mask,
-            self.flux_next, self.pflux_next, self.vflux_next,
-            self.prior_next.xdim, self.prior_next.ydim, self.prior_next.psize,
-            self.norm_reg, self.beam_size, self.regparams,
-            self.mf_next, self.mf_flux, self.obslist_next,
-            self._logfreqratio_list, self.pol_next,
+            self.mf_next, self.obslist_next, self._logfreqratio_list, self.pol_next,
+            self.norm_reg, self._full_regparams(),
             self._which_solve, self._nimage,
         )
 

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -167,7 +167,7 @@ class Imager:
         self.transform_next = np.array([self.transform_next]).flatten() #so we can handle multiple transforms
 
         # Weighting/debiasing/snr cut/systematic noise
-        self.debias_next = kwargs.get('debias', True)
+        self.debias_next = kwargs.get('debias', False)
         snrcut = kwargs.get('snrcut', 0.)
         self.snrcut_next = {key: 0. for key in set(DATATERMS+DATATERMS_POL)}
 

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -38,9 +38,22 @@ from ehtim.imaging.imager_backend import (
     DATATERMS,
     DATATERMS_POL,
     POLARIZATION_MODES,
+    REGULARIZERS,
+    REGULARIZERS_ALLFREQS_I,
+    REGULARIZERS_CM,
+    REGULARIZERS_CURV,
+    REGULARIZERS_CURV_P,
+    REGULARIZERS_ISPECTRAL,
+    REGULARIZERS_POL,
+    REGULARIZERS_POLSPECTRAL,
+    REGULARIZERS_RM,
+    REGULARIZERS_SPECIND,
+    REGULARIZERS_SPECIND_P,
+    REGULARIZERS_SPECTRAL,
     compute_chisq_dict,
     compute_chisqgrad_dict,
     compute_embed,
+    compute_reg_dict,
     embed_imarr,
     make_initarr,
     pack_imarr,
@@ -55,23 +68,6 @@ NHIST = 50   # number of steps to store for hessian approx
 MAXLS = 40   # maximum number of line search steps in BFGS-B
 STOP = 1e-6  # convergence criterion
 EPS = 1e-8
-
-REGULARIZERS = ['gs', 'tv', 'tvlog','tv2', 'tv2log', 'l1', 'l1w', 'lA', 'patch',
-                'flux', 'cm', 'simple', 'compact', 'compact2', 'rgauss']
-REGULARIZERS_POL = ['msimple', 'hw', 'ptv','l1v','l2v','vtv','vtv2','vflux']
-
-REGULARIZERS_ALLFREQS_I = ['flux_mf']
-REGULARIZERS += REGULARIZERS_ALLFREQS_I
-
-REGULARIZERS_SPECIND = ['l2_alpha', 'tv_alpha']
-REGULARIZERS_CURV = ['l2_beta', 'tv_beta']
-REGULARIZERS_SPECIND_P = ['l2_alphap', 'tv_alphap']
-REGULARIZERS_CURV_P = ['l2_betap', 'tv_betap']
-REGULARIZERS_RM = ['l2_rm', 'tv_rm']
-REGULARIZERS_CM = ['l2_cm', 'tv_cm']
-REGULARIZERS_ISPECTRAL = REGULARIZERS_SPECIND + REGULARIZERS_CURV
-REGULARIZERS_POLSPECTRAL = REGULARIZERS_SPECIND_P + REGULARIZERS_CURV_P + REGULARIZERS_RM + REGULARIZERS_CM
-REGULARIZERS_SPECTRAL = REGULARIZERS_ISPECTRAL + REGULARIZERS_POLSPECTRAL
 
 GRIDDER_P_RAD_DEFAULT = 2
 GRIDDER_CONV_FUNC_DEFAULT = 'gaussian'
@@ -1103,121 +1099,14 @@ class Imager:
         """Make a dictionary of current regularizer values
            input is image array transformed to bounded values
         """
-        reg_dict = {}
-
-        for regname in sorted(self.reg_term_next.keys()):
-
-            # Multifrequency regularizers
-            if self.mf_next:
-
-                # Polarimetric regularizers
-                if regname in REGULARIZERS_POL:
-                    # we only regularize the reference frequency image
-                    imcur_pol = imcur[0:4]
-                    prior_pol = self._xprior[0:4]
-                    reg = polutils.polregularizer(imcur_pol, prior_pol, self._embed_mask,
-                                                  self.flux_next, self.pflux_next, self.vflux_next,
-                                                  self.prior_next.xdim, self.prior_next.ydim, self.prior_next.psize,
-                                                  regname,
-                                                  norm_reg=self.norm_reg, beam_size=self.beam_size,
-                                                  **self.regparams)
-
-                # Stokes I regularizers
-                elif regname in REGULARIZERS:
-
-                    # here we regularize images at each frequency
-                    if regname in REGULARIZERS_ALLFREQS_I:
-
-                        # TODO move this to checks?
-                        if (not isinstance(self.mf_flux, list)) or len(self.mf_flux)!=len(self.obslist_next):
-                            raise Exception(f"when using regularizer '{regname}', "
-                                            +"self.mf_flux must be a list of same length as self.obslist_next!")
-
-                        regname_base = '_'.join(regname.split('_')[:-1]) # remove the '_mf' tag
-                        for i in range(len(self.obslist_next)): # sum up regularizer gradients at each frequency
-
-                            logfreqratio = self._logfreqratio_list[i]
-                            flux_nu = self.mf_flux[i]
-
-                            imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
-                            prior_nu = mfutils.image_at_freq(self._xprior, logfreqratio)
-
-                            regi = imutils.regularizer(imcur_nu, prior_nu, self._embed_mask,
-                                                      flux_nu, self.prior_next.xdim,
-                                                      self.prior_next.ydim, self.prior_next.psize,
-                                                      regname_base,
-                                                      norm_reg=self.norm_reg, beam_size=self.beam_size,
-                                                      **self.regparams)
-
-                            if i==0:
-                                reg = regi
-                            else:
-                                reg += regi
-
-                    # here we only regularize the reference frequency image
-                    else:
-                        reg = imutils.regularizer(imcur[0], self._xprior[0], self._embed_mask,
-                                                  self.flux_next, self.prior_next.xdim,
-                                                  self.prior_next.ydim, self.prior_next.psize,
-                                                  regname,
-                                                  norm_reg=self.norm_reg, beam_size=self.beam_size,
-                                                  **self.regparams)
-
-                # Spectral regularizers
-                elif regname in REGULARIZERS_SPECTRAL:
-
-                    if regname in REGULARIZERS_SPECIND:
-                        idx = 4 if len(imcur) == 10 else 1
-                    elif regname in REGULARIZERS_CURV:
-                        idx = 5 if len(imcur) == 10 else 2
-                    elif regname in REGULARIZERS_SPECIND_P:
-                        idx = 6
-                    elif regname in REGULARIZERS_CURV_P:
-                        idx = 7
-                    elif regname in REGULARIZERS_RM:
-                        idx = 8
-                    elif regname in REGULARIZERS_CM:
-                        idx = 9
-
-                    reg = mfutils.regularizer_mf(imcur[idx], self._xprior[idx], self._embed_mask,
-                                                 self.prior_next.xdim, self.prior_next.ydim, self.prior_next.psize,
-                                                 regname,
-                                                 norm_reg=self.norm_reg, beam_size=self.beam_size,
-                                                 **self.regparams)
-                else:
-                    raise Exception(f"regularizer term {regname} not recognized!")
-
-            # Single-frequency polarimetric regularizer
-            elif regname in REGULARIZERS_POL:
-                reg = polutils.polregularizer(imcur, self._xprior, self._embed_mask,
-                                              self.flux_next, self.pflux_next, self.vflux_next,
-                                              self.prior_next.xdim, self.prior_next.ydim, self.prior_next.psize,
-                                              regname,
-                                              norm_reg=self.norm_reg, beam_size=self.beam_size,
-                                              **self.regparams)
-
-            # Single-frequency, single-polarization regularizer
-            elif regname in REGULARIZERS:
-                if self.pol_next in POLARIZATION_MODES:
-                    imcur0 = imcur[0]
-                    prior0 = self._xprior[0]
-                else:
-                    imcur0 = imcur
-                    prior0 = self._xprior
-
-                reg = imutils.regularizer(imcur0, prior0, self._embed_mask,
-                                          self.flux_next,
-                                          self.prior_next.xdim, self.prior_next.ydim, self.prior_next.psize,
-                                          regname,
-                                          norm_reg=self.norm_reg, beam_size=self.beam_size,
-                                          **self.regparams)
-            else:
-                raise Exception(f"regularizer term {regname} not recognized!")
-
-            # put regularizer terms in the dictionary
-            reg_dict[regname] = reg
-
-        return reg_dict
+        return compute_reg_dict(
+            imcur, sorted(self.reg_term_next.keys()), self._xprior, self._embed_mask,
+            self.flux_next, self.pflux_next, self.vflux_next,
+            self.prior_next.xdim, self.prior_next.ydim, self.prior_next.psize,
+            self.norm_reg, self.beam_size, self.regparams,
+            self.mf_next, self.mf_flux, self.obslist_next,
+            self._logfreqratio_list, self.pol_next,
+        )
 
     def make_reggrad_dict(self, imcur):
         """Make a dictionary of current regularizer gradient values

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -592,9 +592,8 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist,
 
 
 def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
-                     flux, pflux, vflux, xdim, ydim, psize,
-                     norm_reg, beam_size, regparams,
-                     mf, mf_flux, obslist, logfreqratio_list, pol):
+                     mf, obslist, logfreqratio_list, pol,
+                     norm_reg, regparams):
     """Compute regularizer value for each regularizer term.
 
     Parameters
@@ -607,36 +606,29 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
         Prior image array (same shape as imcur).
     embed_mask : np.ndarray of bool
         Pixel embedding mask.
-    flux, pflux, vflux : float
-        Total, polarized, and Stokes V fluxes for normalization.
-    xdim, ydim : int
-        Image shape (pixels).
-    psize : float
-        Pixel size (radians).
-    norm_reg : bool
-        Whether to apply per-regularizer normalization.
-    beam_size : float
-        Beam size for compact regularizers.
-    regparams : dict
-        Extra regularizer parameters forwarded as kwargs.
     mf : bool
         Whether multifrequency imaging is enabled.
-    mf_flux : list or None
-        Per-frequency total fluxes for REGULARIZERS_ALLFREQS_I.
-        Required as a list of length len(obslist) when any allfreq-I
-        regularizer is active.
     obslist : list
         List of Obsdata objects (one per frequency/epoch).
     logfreqratio_list : list of float
         Log frequency ratios log(nu_i/reffreq); one per obs.
     pol : str
         Polarization mode string.
+    norm_reg : bool
+        Whether to apply per-regularizer normalization.
+    regparams : dict
+        Bundle of regularizer parameters: must contain `flux`, `pflux`, `vflux`,
+        `xdim`, `ydim`, `psize`, `beam_size`, and `mf_flux` (list of per-freq
+        fluxes, required when any REGULARIZERS_ALLFREQS_I term is active);
+        plus any term-specific kwargs (e.g. `major`, `minor`, `PA`, `alpha_A`,
+        `epsilon_tv`). Spread into the underlying dispatchers as **kwargs.
 
     Returns
     -------
     reg_dict : dict
         Mapping from regname to regularizer scalar.
     """
+    mf_flux = regparams.get('mf_flux')
     reg_dict = {}
 
     for regname in reg_term_keys:
@@ -646,20 +638,15 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
 
             # Polarimetric regularizers
             if regname in REGULARIZERS_POL:
-                # we only regularize the reference frequency image
                 imcur_pol = imcur[0:4]
                 prior_pol = xprior[0:4]
                 reg = polutils.polregularizer(imcur_pol, prior_pol, embed_mask,
-                                              flux, pflux, vflux,
-                                              xdim, ydim, psize,
-                                              regname,
-                                              norm_reg=norm_reg, beam_size=beam_size,
+                                              stype=regname, norm_reg=norm_reg,
                                               **regparams)
 
             # Stokes I regularizers
             elif regname in REGULARIZERS:
 
-                # here we regularize images at each frequency
                 if regname in REGULARIZERS_ALLFREQS_I:
 
                     # TODO move this to checks?
@@ -668,31 +655,21 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
                                         + "mf_flux must be a list of same length as obslist!")
 
                     regname_base = '_'.join(regname.split('_')[:-1])  # remove the '_mf' tag
-                    for i in range(len(obslist)):  # sum up regularizer values at each frequency
+                    for i in range(len(obslist)):
 
                         logfreqratio = logfreqratio_list[i]
-                        flux_nu = mf_flux[i]
-
                         imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
                         prior_nu = mfutils.image_at_freq(xprior, logfreqratio)
 
                         regi = imutils.regularizer(imcur_nu, prior_nu, embed_mask,
-                                                   flux_nu, xdim, ydim, psize,
-                                                   regname_base,
-                                                   norm_reg=norm_reg, beam_size=beam_size,
-                                                   **regparams)
+                                                   stype=regname_base, norm_reg=norm_reg,
+                                                   **{**regparams, 'flux': mf_flux[i]})
 
-                        if i == 0:
-                            reg = regi
-                        else:
-                            reg += regi
+                        reg = regi if i == 0 else reg + regi
 
-                # here we only regularize the reference frequency image
                 else:
                     reg = imutils.regularizer(imcur[0], xprior[0], embed_mask,
-                                              flux, xdim, ydim, psize,
-                                              regname,
-                                              norm_reg=norm_reg, beam_size=beam_size,
+                                              stype=regname, norm_reg=norm_reg,
                                               **regparams)
 
             # Spectral regularizers
@@ -712,9 +689,7 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
                     idx = 9
 
                 reg = mfutils.regularizer_mf(imcur[idx], xprior[idx], embed_mask,
-                                             xdim, ydim, psize,
-                                             regname,
-                                             norm_reg=norm_reg, beam_size=beam_size,
+                                             stype=regname, norm_reg=norm_reg,
                                              **regparams)
             else:
                 raise Exception(f"regularizer term {regname} not recognized!")
@@ -722,10 +697,7 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
         # Single-frequency polarimetric regularizer
         elif regname in REGULARIZERS_POL:
             reg = polutils.polregularizer(imcur, xprior, embed_mask,
-                                          flux, pflux, vflux,
-                                          xdim, ydim, psize,
-                                          regname,
-                                          norm_reg=norm_reg, beam_size=beam_size,
+                                          stype=regname, norm_reg=norm_reg,
                                           **regparams)
 
         # Single-frequency, single-polarization regularizer
@@ -738,60 +710,26 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
                 prior0 = xprior
 
             reg = imutils.regularizer(imcur0, prior0, embed_mask,
-                                      flux, xdim, ydim, psize,
-                                      regname,
-                                      norm_reg=norm_reg, beam_size=beam_size,
+                                      stype=regname, norm_reg=norm_reg,
                                       **regparams)
         else:
             raise Exception(f"regularizer term {regname} not recognized!")
 
-        # put regularizer terms in the dictionary
         reg_dict[regname] = reg
 
     return reg_dict
 
 
 def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
-                         flux, pflux, vflux, xdim, ydim, psize,
-                         norm_reg, beam_size, regparams,
-                         mf, mf_flux, obslist, logfreqratio_list, pol,
+                         mf, obslist, logfreqratio_list, pol,
+                         norm_reg, regparams,
                          which_solve, nimage):
     """Compute regularizer gradient for each regularizer term.
 
     Parameters
     ----------
-    imcur : np.ndarray
-        Current image array transformed to bounded values.
-    reg_term_keys : list of str
-        Regularizer term names to evaluate, already sorted.
-    xprior : np.ndarray
-        Prior image array (same shape as imcur).
-    embed_mask : np.ndarray of bool
-        Pixel embedding mask.
-    flux, pflux, vflux : float
-        Total, polarized, and Stokes V fluxes for normalization.
-    xdim, ydim : int
-        Image shape (pixels).
-    psize : float
-        Pixel size (radians).
-    norm_reg : bool
-        Whether to apply per-regularizer normalization.
-    beam_size : float
-        Beam size for compact regularizers.
-    regparams : dict
-        Extra regularizer parameters forwarded as kwargs.
-    mf : bool
-        Whether multifrequency imaging is enabled.
-    mf_flux : list or None
-        Per-frequency total fluxes for REGULARIZERS_ALLFREQS_I.
-        Required as a list of length len(obslist) when any allfreq-I
-        regularizer is active.
-    obslist : list
-        List of Obsdata objects (one per frequency/epoch).
-    logfreqratio_list : list of float
-        Log frequency ratios log(nu_i/reffreq); one per obs.
-    pol : str
-        Polarization mode string.
+    imcur, reg_term_keys, xprior, embed_mask, mf, obslist, logfreqratio_list,
+    pol, norm_reg, regparams : see compute_reg_dict.
     which_solve : np.ndarray of bool
         Per-Stokes solve mask (used by polregularizergrad).
     nimage : int
@@ -804,6 +742,7 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
         for single-pol, (4, nimage) for pol-bundled, or
         (len(imcur), nimage) for multifrequency.
     """
+    mf_flux = regparams.get('mf_flux')
     reggrad_dict = {}
 
     for regname in reg_term_keys:
@@ -813,15 +752,11 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
 
             # Polarimetric regularizers
             if regname in REGULARIZERS_POL:
-                # we only regularize reference frequency image
                 imcur_pol = imcur[0:4]
                 prior_pol = xprior[0:4]
                 pol_solve = which_solve[0:4]
                 regp = polutils.polregularizergrad(imcur_pol, prior_pol, embed_mask,
-                                                   flux, pflux, vflux,
-                                                   xdim, ydim, psize,
-                                                   regname,
-                                                   norm_reg=norm_reg, beam_size=beam_size,
+                                                   stype=regname, norm_reg=norm_reg,
                                                    pol_solve=pol_solve,
                                                    **regparams)
                 reggrad = np.zeros((len(imcur), nimage))
@@ -830,7 +765,6 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
             # Stokes I regularizers
             elif regname in REGULARIZERS:
 
-                # here we regularize images at each frequency
                 if regname in REGULARIZERS_ALLFREQS_I:
 
                     # TODO move this to checks?
@@ -839,32 +773,21 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
                                         + "mf_flux must be a list of same length as obslist!")
 
                     regname_base = '_'.join(regname.split('_')[:-1])  # remove the '_mf' tag
-                    for i in range(len(obslist)):  # sum up regularizer gradients at each frequency
+                    for i in range(len(obslist)):
 
                         logfreqratio = logfreqratio_list[i]
-                        flux_nu = mf_flux[i]
-
                         imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
                         prior_nu = mfutils.image_at_freq(xprior, logfreqratio)
 
                         regi = imutils.regularizergrad(imcur_nu, prior_nu, embed_mask,
-                                                       flux_nu, xdim, ydim, psize,
-                                                       regname_base,
-                                                       norm_reg=norm_reg, beam_size=beam_size,
-                                                       **regparams)
+                                                       stype=regname_base, norm_reg=norm_reg,
+                                                       **{**regparams, 'flux': mf_flux[i]})
                         reggrad_i = mfutils.mf_all_grads_chain(regi, imcur_nu, imcur, logfreqratio)
-                        if i == 0:
-                            reggrad = reggrad_i
-                        else:
-                            reggrad += reggrad_i
+                        reggrad = reggrad_i if i == 0 else reggrad + reggrad_i
 
-                # here we only regularize the reference frequency image
                 else:
-                    regi = imutils.regularizergrad(imcur[0], xprior[0],
-                                                   embed_mask, flux,
-                                                   xdim, ydim, psize,
-                                                   regname,
-                                                   norm_reg=norm_reg, beam_size=beam_size,
+                    regi = imutils.regularizergrad(imcur[0], xprior[0], embed_mask,
+                                                   stype=regname, norm_reg=norm_reg,
                                                    **regparams)
                     reggrad = np.zeros((len(imcur), nimage))
                     reggrad[0] = regi
@@ -884,9 +807,7 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
                     idx = 9
 
                 regmf = mfutils.regularizergrad_mf(imcur[idx], xprior[idx], embed_mask,
-                                                   xdim, ydim, psize,
-                                                   regname,
-                                                   norm_reg=norm_reg, beam_size=beam_size,
+                                                   stype=regname, norm_reg=norm_reg,
                                                    **regparams)
 
                 reggrad = np.zeros((len(imcur), nimage))
@@ -898,10 +819,7 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
             # Single-frequency polarimetric regularizer
             if regname in REGULARIZERS_POL:
                 reggrad = polutils.polregularizergrad(imcur, xprior, embed_mask,
-                                                      flux, pflux, vflux,
-                                                      xdim, ydim, psize,
-                                                      regname,
-                                                      norm_reg=norm_reg, beam_size=beam_size,
+                                                      stype=regname, norm_reg=norm_reg,
                                                       pol_solve=which_solve,
                                                       **regparams)
 
@@ -913,13 +831,10 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
                 else:
                     imcur0 = imcur
                     prior0 = xprior
-                reggrad = imutils.regularizergrad(imcur0, prior0, embed_mask, flux,
-                                                  xdim, ydim, psize,
-                                                  regname,
-                                                  norm_reg=norm_reg, beam_size=beam_size,
+                reggrad = imutils.regularizergrad(imcur0, prior0, embed_mask,
+                                                  stype=regname, norm_reg=norm_reg,
                                                   **regparams)
 
-                # If imaging Stokes I with polarization simultaneously, bundle the gradient
                 if pol in POLARIZATION_MODES:
                     reggrad = np.array((reggrad,
                                         np.zeros(nimage),
@@ -929,7 +844,6 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
             else:
                 raise Exception(f"regularizer term {regname} not recognized!")
 
-        # put regularizer terms in the dictionary
         reggrad_dict[regname] = reggrad
 
     return reggrad_dict

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -29,6 +29,25 @@ DATATERMS = ['vis', 'bs', 'amp', 'cphase', 'cphase_diag', 'camp', 'logcamp', 'lo
 DATATERMS_POL = ['pvis', 'm', 'vvis']
 POLARIZATION_MODES = ['P', 'QU', 'IP', 'IQU', 'V', 'IV', 'IQUV', 'IPV']  # TODO: treatment of V may be inconsistent
 
+# Regularizer term names recognized by the regularizer dispatchers.
+# Imported by ehtim.imager for backward compatibility.
+REGULARIZERS = ['gs', 'tv', 'tvlog', 'tv2', 'tv2log', 'l1', 'l1w', 'lA', 'patch',
+                'flux', 'cm', 'simple', 'compact', 'compact2', 'rgauss']
+REGULARIZERS_POL = ['msimple', 'hw', 'ptv', 'l1v', 'l2v', 'vtv', 'vtv2', 'vflux']
+
+REGULARIZERS_ALLFREQS_I = ['flux_mf']
+REGULARIZERS += REGULARIZERS_ALLFREQS_I
+
+REGULARIZERS_SPECIND = ['l2_alpha', 'tv_alpha']
+REGULARIZERS_CURV = ['l2_beta', 'tv_beta']
+REGULARIZERS_SPECIND_P = ['l2_alphap', 'tv_alphap']
+REGULARIZERS_CURV_P = ['l2_betap', 'tv_betap']
+REGULARIZERS_RM = ['l2_rm', 'tv_rm']
+REGULARIZERS_CM = ['l2_cm', 'tv_cm']
+REGULARIZERS_ISPECTRAL = REGULARIZERS_SPECIND + REGULARIZERS_CURV
+REGULARIZERS_POLSPECTRAL = REGULARIZERS_SPECIND_P + REGULARIZERS_CURV_P + REGULARIZERS_RM + REGULARIZERS_CM
+REGULARIZERS_SPECTRAL = REGULARIZERS_ISPECTRAL + REGULARIZERS_POLSPECTRAL
+
 
 def embed_imarr(imarr, mask, clipfloor=0., randomfloor=False):
     """Embeds a multidimensional image array into the size of boolean embed mask
@@ -569,3 +588,163 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist,
             chi2grad_dict[dname_key] = np.array(chi2grad)
 
     return chi2grad_dict
+
+
+def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
+                     flux, pflux, vflux, xdim, ydim, psize,
+                     norm_reg, beam_size, regparams,
+                     mf, mf_flux, obslist, logfreqratio_list, pol):
+    """Compute regularizer value for each regularizer term.
+
+    Parameters
+    ----------
+    imcur : np.ndarray
+        Current image array transformed to bounded values.
+    reg_term_keys : list of str
+        Regularizer term names to evaluate, already sorted.
+    xprior : np.ndarray
+        Prior image array (same shape as imcur).
+    embed_mask : np.ndarray of bool
+        Pixel embedding mask.
+    flux, pflux, vflux : float
+        Total, polarized, and Stokes V fluxes for normalization.
+    xdim, ydim : int
+        Image shape (pixels).
+    psize : float
+        Pixel size (radians).
+    norm_reg : bool
+        Whether to apply per-regularizer normalization.
+    beam_size : float
+        Beam size for compact regularizers.
+    regparams : dict
+        Extra regularizer parameters forwarded as kwargs.
+    mf : bool
+        Whether multifrequency imaging is enabled.
+    mf_flux : list or None
+        Per-frequency total fluxes for REGULARIZERS_ALLFREQS_I.
+        Required as a list of length len(obslist) when any allfreq-I
+        regularizer is active.
+    obslist : list
+        List of Obsdata objects (one per frequency/epoch).
+    logfreqratio_list : list of float
+        Log frequency ratios log(nu_i/reffreq); one per obs.
+    pol : str
+        Polarization mode string.
+
+    Returns
+    -------
+    reg_dict : dict
+        Mapping from regname to regularizer scalar.
+    """
+    reg_dict = {}
+
+    for regname in reg_term_keys:
+
+        # Multifrequency regularizers
+        if mf:
+
+            # Polarimetric regularizers
+            if regname in REGULARIZERS_POL:
+                # we only regularize the reference frequency image
+                imcur_pol = imcur[0:4]
+                prior_pol = xprior[0:4]
+                reg = polutils.polregularizer(imcur_pol, prior_pol, embed_mask,
+                                              flux, pflux, vflux,
+                                              xdim, ydim, psize,
+                                              regname,
+                                              norm_reg=norm_reg, beam_size=beam_size,
+                                              **regparams)
+
+            # Stokes I regularizers
+            elif regname in REGULARIZERS:
+
+                # here we regularize images at each frequency
+                if regname in REGULARIZERS_ALLFREQS_I:
+
+                    # TODO move this to checks?
+                    if (not isinstance(mf_flux, list)) or len(mf_flux) != len(obslist):
+                        raise Exception(f"when using regularizer '{regname}', "
+                                        + "mf_flux must be a list of same length as obslist!")
+
+                    regname_base = '_'.join(regname.split('_')[:-1])  # remove the '_mf' tag
+                    for i in range(len(obslist)):  # sum up regularizer values at each frequency
+
+                        logfreqratio = logfreqratio_list[i]
+                        flux_nu = mf_flux[i]
+
+                        imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
+                        prior_nu = mfutils.image_at_freq(xprior, logfreqratio)
+
+                        regi = imutils.regularizer(imcur_nu, prior_nu, embed_mask,
+                                                   flux_nu, xdim, ydim, psize,
+                                                   regname_base,
+                                                   norm_reg=norm_reg, beam_size=beam_size,
+                                                   **regparams)
+
+                        if i == 0:
+                            reg = regi
+                        else:
+                            reg += regi
+
+                # here we only regularize the reference frequency image
+                else:
+                    reg = imutils.regularizer(imcur[0], xprior[0], embed_mask,
+                                              flux, xdim, ydim, psize,
+                                              regname,
+                                              norm_reg=norm_reg, beam_size=beam_size,
+                                              **regparams)
+
+            # Spectral regularizers
+            elif regname in REGULARIZERS_SPECTRAL:
+
+                if regname in REGULARIZERS_SPECIND:
+                    idx = 4 if len(imcur) == 10 else 1
+                elif regname in REGULARIZERS_CURV:
+                    idx = 5 if len(imcur) == 10 else 2
+                elif regname in REGULARIZERS_SPECIND_P:
+                    idx = 6
+                elif regname in REGULARIZERS_CURV_P:
+                    idx = 7
+                elif regname in REGULARIZERS_RM:
+                    idx = 8
+                elif regname in REGULARIZERS_CM:
+                    idx = 9
+
+                reg = mfutils.regularizer_mf(imcur[idx], xprior[idx], embed_mask,
+                                             xdim, ydim, psize,
+                                             regname,
+                                             norm_reg=norm_reg, beam_size=beam_size,
+                                             **regparams)
+            else:
+                raise Exception(f"regularizer term {regname} not recognized!")
+
+        # Single-frequency polarimetric regularizer
+        elif regname in REGULARIZERS_POL:
+            reg = polutils.polregularizer(imcur, xprior, embed_mask,
+                                          flux, pflux, vflux,
+                                          xdim, ydim, psize,
+                                          regname,
+                                          norm_reg=norm_reg, beam_size=beam_size,
+                                          **regparams)
+
+        # Single-frequency, single-polarization regularizer
+        elif regname in REGULARIZERS:
+            if pol in POLARIZATION_MODES:
+                imcur0 = imcur[0]
+                prior0 = xprior[0]
+            else:
+                imcur0 = imcur
+                prior0 = xprior
+
+            reg = imutils.regularizer(imcur0, prior0, embed_mask,
+                                      flux, xdim, ydim, psize,
+                                      regname,
+                                      norm_reg=norm_reg, beam_size=beam_size,
+                                      **regparams)
+        else:
+            raise Exception(f"regularizer term {regname} not recognized!")
+
+        # put regularizer terms in the dictionary
+        reg_dict[regname] = reg
+
+    return reg_dict

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -748,3 +748,187 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
         reg_dict[regname] = reg
 
     return reg_dict
+
+
+def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
+                         flux, pflux, vflux, xdim, ydim, psize,
+                         norm_reg, beam_size, regparams,
+                         mf, mf_flux, obslist, logfreqratio_list, pol,
+                         which_solve, nimage):
+    """Compute regularizer gradient for each regularizer term.
+
+    Parameters
+    ----------
+    imcur : np.ndarray
+        Current image array transformed to bounded values.
+    reg_term_keys : list of str
+        Regularizer term names to evaluate, already sorted.
+    xprior : np.ndarray
+        Prior image array (same shape as imcur).
+    embed_mask : np.ndarray of bool
+        Pixel embedding mask.
+    flux, pflux, vflux : float
+        Total, polarized, and Stokes V fluxes for normalization.
+    xdim, ydim : int
+        Image shape (pixels).
+    psize : float
+        Pixel size (radians).
+    norm_reg : bool
+        Whether to apply per-regularizer normalization.
+    beam_size : float
+        Beam size for compact regularizers.
+    regparams : dict
+        Extra regularizer parameters forwarded as kwargs.
+    mf : bool
+        Whether multifrequency imaging is enabled.
+    mf_flux : list or None
+        Per-frequency total fluxes for REGULARIZERS_ALLFREQS_I.
+        Required as a list of length len(obslist) when any allfreq-I
+        regularizer is active.
+    obslist : list
+        List of Obsdata objects (one per frequency/epoch).
+    logfreqratio_list : list of float
+        Log frequency ratios log(nu_i/reffreq); one per obs.
+    pol : str
+        Polarization mode string.
+    which_solve : np.ndarray of bool
+        Per-Stokes solve mask (used by polregularizergrad).
+    nimage : int
+        Number of solved-for pixels (rows of the gradient array).
+
+    Returns
+    -------
+    reggrad_dict : dict
+        Mapping from regname to gradient array of shape (nimage,)
+        for single-pol, (4, nimage) for pol-bundled, or
+        (len(imcur), nimage) for multifrequency.
+    """
+    reggrad_dict = {}
+
+    for regname in reg_term_keys:
+
+        # Multifrequency regularizers
+        if mf:
+
+            # Polarimetric regularizers
+            if regname in REGULARIZERS_POL:
+                # we only regularize reference frequency image
+                imcur_pol = imcur[0:4]
+                prior_pol = xprior[0:4]
+                pol_solve = which_solve[0:4]
+                regp = polutils.polregularizergrad(imcur_pol, prior_pol, embed_mask,
+                                                   flux, pflux, vflux,
+                                                   xdim, ydim, psize,
+                                                   regname,
+                                                   norm_reg=norm_reg, beam_size=beam_size,
+                                                   pol_solve=pol_solve,
+                                                   **regparams)
+                reggrad = np.zeros((len(imcur), nimage))
+                reggrad[0:4] = regp
+
+            # Stokes I regularizers
+            elif regname in REGULARIZERS:
+
+                # here we regularize images at each frequency
+                if regname in REGULARIZERS_ALLFREQS_I:
+
+                    # TODO move this to checks?
+                    if (not isinstance(mf_flux, list)) or len(mf_flux) != len(obslist):
+                        raise Exception(f"when using regularizer '{regname}', "
+                                        + "mf_flux must be a list of same length as obslist!")
+
+                    regname_base = '_'.join(regname.split('_')[:-1])  # remove the '_mf' tag
+                    for i in range(len(obslist)):  # sum up regularizer gradients at each frequency
+
+                        logfreqratio = logfreqratio_list[i]
+                        flux_nu = mf_flux[i]
+
+                        imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
+                        prior_nu = mfutils.image_at_freq(xprior, logfreqratio)
+
+                        regi = imutils.regularizergrad(imcur_nu, prior_nu, embed_mask,
+                                                       flux_nu, xdim, ydim, psize,
+                                                       regname_base,
+                                                       norm_reg=norm_reg, beam_size=beam_size,
+                                                       **regparams)
+                        reggrad_i = mfutils.mf_all_grads_chain(regi, imcur_nu, imcur, logfreqratio)
+                        if i == 0:
+                            reggrad = reggrad_i
+                        else:
+                            reggrad += reggrad_i
+
+                # here we only regularize the reference frequency image
+                else:
+                    regi = imutils.regularizergrad(imcur[0], xprior[0],
+                                                   embed_mask, flux,
+                                                   xdim, ydim, psize,
+                                                   regname,
+                                                   norm_reg=norm_reg, beam_size=beam_size,
+                                                   **regparams)
+                    reggrad = np.zeros((len(imcur), nimage))
+                    reggrad[0] = regi
+
+            elif regname in REGULARIZERS_SPECTRAL:
+                if regname in REGULARIZERS_SPECIND:
+                    idx = 4 if len(imcur) == 10 else 1
+                elif regname in REGULARIZERS_CURV:
+                    idx = 5 if len(imcur) == 10 else 2
+                elif regname in REGULARIZERS_SPECIND_P:
+                    idx = 6
+                elif regname in REGULARIZERS_CURV_P:
+                    idx = 7
+                elif regname in REGULARIZERS_RM:
+                    idx = 8
+                elif regname in REGULARIZERS_CM:
+                    idx = 9
+
+                regmf = mfutils.regularizergrad_mf(imcur[idx], xprior[idx], embed_mask,
+                                                   xdim, ydim, psize,
+                                                   regname,
+                                                   norm_reg=norm_reg, beam_size=beam_size,
+                                                   **regparams)
+
+                reggrad = np.zeros((len(imcur), nimage))
+                reggrad[idx] = regmf
+            else:
+                raise Exception(f"regularizer term {regname} not recognized!")
+
+        else:
+            # Single-frequency polarimetric regularizer
+            if regname in REGULARIZERS_POL:
+                reggrad = polutils.polregularizergrad(imcur, xprior, embed_mask,
+                                                      flux, pflux, vflux,
+                                                      xdim, ydim, psize,
+                                                      regname,
+                                                      norm_reg=norm_reg, beam_size=beam_size,
+                                                      pol_solve=which_solve,
+                                                      **regparams)
+
+            # Single-frequency, single polarization regularizer
+            elif regname in REGULARIZERS:
+                if pol in POLARIZATION_MODES:
+                    imcur0 = imcur[0]
+                    prior0 = xprior[0]
+                else:
+                    imcur0 = imcur
+                    prior0 = xprior
+                reggrad = imutils.regularizergrad(imcur0, prior0, embed_mask, flux,
+                                                  xdim, ydim, psize,
+                                                  regname,
+                                                  norm_reg=norm_reg, beam_size=beam_size,
+                                                  **regparams)
+
+                # If imaging Stokes I with polarization simultaneously, bundle the gradient
+                if pol in POLARIZATION_MODES:
+                    reggrad = np.array((reggrad,
+                                        np.zeros(nimage),
+                                        np.zeros(nimage),
+                                        np.zeros(nimage)))
+
+            else:
+                raise Exception(f"regularizer term {regname} not recognized!")
+
+        # put regularizer terms in the dictionary
+        reggrad_dict[regname] = reggrad
+
+    return reggrad_dict

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -257,6 +257,11 @@ def transform_gradients(gradarr, imarr, transforms, which_solve):
         if pol_which_solve[0]==1 and ('log' in transforms):  # full polarization, including stokes I imaging
             outarr[0] = np.exp(imarr[0]) * gradarr[0]
 
+        # Polarimetric chain rule. mcv (m-only) and vcv (V-only) are legacy
+        # single-axis parametrizations of the polarization sphere; polcv
+        # parametrizes (rho, psi) jointly and is the preferred form for full
+        # multi-Stokes imaging going forward. See polutils.{polcv,mcv,vcv}_grad
+        # docstrings for the per-transform Jacobian.
         # Each *_grad returns shape (3, ...) so outarr[0] (the log term above) survives.
         if (pol_which_solve[1]==1 and pol_which_solve[3]==1 and ('polcv' in transforms)):
             outarr[1:4] = polutils.polcv_grad(imarr[0:4], gradarr[0:4])

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -2653,7 +2653,7 @@ def chisqdata_vis(Obsdata, Prior, mask, pol='I', **kwargs):
     # unpack keyword args
     systematic_noise = kwargs.get('systematic_noise', 0.)
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
     weighting = kwargs.get('weighting', 'natural')
 
     # unpack data
@@ -2680,7 +2680,7 @@ def chisqdata_amp(Obsdata, Prior, mask, pol='I', **kwargs):
     # unpack keyword args
     systematic_noise = kwargs.get('systematic_noise', 0.)
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
     weighting = kwargs.get('weighting', 'natural')
 
     # unpack data
@@ -2881,7 +2881,7 @@ def chisqdata_camp(Obsdata, Prior, mask, pol='I', **kwargs):
         count = 'min'
 
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
     weighting = kwargs.get('weighting', 'natural')
 
     # unpack data & mask low snr points
@@ -2930,7 +2930,7 @@ def chisqdata_logcamp(Obsdata, Prior, mask, pol='I', **kwargs):
         count = 'min'
 
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
     weighting = kwargs.get('weighting', 'natural')
 
     # unpack data & mask low snr points
@@ -2979,7 +2979,7 @@ def chisqdata_logcamp_diag(Obsdata, Prior, mask, pol='I', **kwargs):
         count = 'min'
 
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
 
     # unpack data & mask low snr points
     vtype = ehc.vis_poldict[pol]
@@ -3041,7 +3041,7 @@ def chisqdata_vis_fft(Obsdata, Prior, pol='I', **kwargs):
     # unpack keyword args
     systematic_noise = kwargs.get('systematic_noise', 0.)
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
     weighting = kwargs.get('weighting', 'natural')
     fft_pad_factor = kwargs.get('fft_pad_factor', ehc.FFT_PAD_DEFAULT)
     conv_func = kwargs.get('conv_func', ehc.GRIDDER_CONV_FUNC_DEFAULT)
@@ -3079,7 +3079,7 @@ def chisqdata_amp_fft(Obsdata, Prior, pol='I', **kwargs):
     # unpack keyword args
     systematic_noise = kwargs.get('systematic_noise', 0.)
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
     weighting = kwargs.get('weighting', 'natural')
     fft_pad_factor = kwargs.get('fft_pad_factor', ehc.FFT_PAD_DEFAULT)
     conv_func = kwargs.get('conv_func', ehc.GRIDDER_CONV_FUNC_DEFAULT)
@@ -3336,7 +3336,7 @@ def chisqdata_camp_fft(Obsdata, Prior, pol='I', **kwargs):
         count = 'min'
 
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
     weighting = kwargs.get('weighting', 'natural')
     fft_pad_factor = kwargs.get('fft_pad_factor', ehc.FFT_PAD_DEFAULT)
     conv_func = kwargs.get('conv_func', ehc.GRIDDER_CONV_FUNC_DEFAULT)
@@ -3398,7 +3398,7 @@ def chisqdata_logcamp_fft(Obsdata, Prior, pol='I', **kwargs):
         count = 'min'
 
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
     weighting = kwargs.get('weighting', 'natural')
     fft_pad_factor = kwargs.get('fft_pad_factor', ehc.FFT_PAD_DEFAULT)
     conv_func = kwargs.get('conv_func', ehc.GRIDDER_CONV_FUNC_DEFAULT)
@@ -3460,7 +3460,7 @@ def chisqdata_logcamp_diag_fft(Obsdata, Prior, pol='I', **kwargs):
         count = 'min'
 
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
     fft_pad_factor = kwargs.get('fft_pad_factor', ehc.FFT_PAD_DEFAULT)
     conv_func = kwargs.get('conv_func', ehc.GRIDDER_CONV_FUNC_DEFAULT)
     p_rad = kwargs.get('p_rad', ehc.GRIDDER_P_RAD_DEFAULT)
@@ -3553,7 +3553,7 @@ def chisqdata_vis_nfft(Obsdata, Prior, pol='I', **kwargs):
     # unpack keyword args
     systematic_noise = kwargs.get('systematic_noise', 0.)
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
     weighting = kwargs.get('weighting', 'natural')
     fft_pad_factor = kwargs.get('fft_pad_factor', ehc.FFT_PAD_DEFAULT)
     p_rad = kwargs.get('p_rad', ehc.GRIDDER_P_RAD_DEFAULT)
@@ -3586,7 +3586,7 @@ def chisqdata_amp_nfft(Obsdata, Prior, pol='I', **kwargs):
     # unpack keyword args
     systematic_noise = kwargs.get('systematic_noise', 0.)
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
     weighting = kwargs.get('weighting', 'natural')
     fft_pad_factor = kwargs.get('fft_pad_factor', ehc.FFT_PAD_DEFAULT)
     p_rad = kwargs.get('p_rad', ehc.GRIDDER_P_RAD_DEFAULT)
@@ -3819,7 +3819,7 @@ def chisqdata_camp_nfft(Obsdata, Prior, pol='I', **kwargs):
         count = 'min'
 
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
     weighting = kwargs.get('weighting', 'natural')
     fft_pad_factor = kwargs.get('fft_pad_factor', ehc.FFT_PAD_DEFAULT)
     p_rad = kwargs.get('p_rad', ehc.GRIDDER_P_RAD_DEFAULT)
@@ -3874,7 +3874,7 @@ def chisqdata_logcamp_nfft(Obsdata, Prior, pol='I', **kwargs):
         count = 'min'
 
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
     weighting = kwargs.get('weighting', 'natural')
     fft_pad_factor = kwargs.get('fft_pad_factor', ehc.FFT_PAD_DEFAULT)
     p_rad = kwargs.get('p_rad', ehc.GRIDDER_P_RAD_DEFAULT)
@@ -3929,7 +3929,7 @@ def chisqdata_logcamp_diag_nfft(Obsdata, Prior, pol='I', **kwargs):
         count = 'min'
 
     snrcut = kwargs.get('snrcut', 0.)
-    debias = kwargs.get('debias', True)
+    debias = kwargs.get('debias', False)
     fft_pad_factor = kwargs.get('fft_pad_factor', ehc.FFT_PAD_DEFAULT)
     p_rad = kwargs.get('p_rad', ehc.GRIDDER_P_RAD_DEFAULT)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,22 +176,23 @@ def initialize_imager():
     array ready to pass into make_chisq_dict / compute_chisq_dict. Accepts
     either a single obs or a list of obs.
     """
-    def _factory(obs, im, data_term, pol="I", ttype="direct",
-                 mf=False, mf_order=0, debias=True, snrcut=0.0,
+    def _factory(obs, im, data_term, reg_term=None, pol="I", ttype="direct",
+                 mf=False, mf_order=0, mf_flux=None, debias=True, snrcut=0.0,
                  transform=None):
         imgr_kw = dict(
             data_term=data_term, ttype=ttype, pol=pol,
             debias=debias, snrcut=snrcut,
+            mf=mf, mf_order=mf_order,
         )
+        if reg_term is not None:
+            imgr_kw["reg_term"] = reg_term
+        if mf_flux is not None:
+            imgr_kw["mf_flux"] = mf_flux
         if transform is not None:
             imgr_kw["transform"] = transform
         imgr = eh.imager.Imager(
             obs, im, prior_im=im, flux=im.total_flux(), **imgr_kw,
         )
-
-        # Mirror the early steps of make_image() so init_imager has the right state.
-        imgr.mf_next = mf
-        imgr.mf_order = mf_order
         if pol in POLARIZATION_MODES:
             imgr.prior_next = imgr.prior_next.switch_polrep(polrep_out="stokes", pol_prim_out="I")
             imgr.init_next = imgr.init_next.switch_polrep(polrep_out="stokes", pol_prim_out="I")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,7 +177,7 @@ def initialize_imager():
     either a single obs or a list of obs.
     """
     def _factory(obs, im, data_term, reg_term=None, pol="I", ttype="direct",
-                 mf=False, mf_order=0, mf_flux=None, debias=True, snrcut=0.0,
+                 mf=False, mf_order=0, mf_flux=None, debias=False, snrcut=0.0,
                  transform=None):
         imgr_kw = dict(
             data_term=data_term, ttype=ttype, pol=pol,

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -13,6 +13,7 @@ from ehtim.imaging.imager_backend import (
     compute_chisqgrad_dict,
     compute_embed,
     compute_reg_dict,
+    compute_reggrad_dict,
 )
 
 # Parametrize over square, tall, and wide images
@@ -164,6 +165,19 @@ def _call_backend_reg_dict(imgr, imcur, mf_flux=None):
         imgr.norm_reg, imgr.beam_size, imgr.regparams,
         imgr.mf_next, imgr.mf_flux if mf_flux is None else mf_flux,
         imgr.obslist_next, imgr._logfreqratio_list, imgr.pol_next,
+    )
+
+
+def _call_backend_reggrad_dict(imgr, imcur, mf_flux=None):
+    """Call compute_reggrad_dict with args pulled from an initialized Imager."""
+    return compute_reggrad_dict(
+        imcur, sorted(imgr.reg_term_next.keys()), imgr._xprior, imgr._embed_mask,
+        imgr.flux_next, imgr.pflux_next, imgr.vflux_next,
+        imgr.prior_next.xdim, imgr.prior_next.ydim, imgr.prior_next.psize,
+        imgr.norm_reg, imgr.beam_size, imgr.regparams,
+        imgr.mf_next, imgr.mf_flux if mf_flux is None else mf_flux,
+        imgr.obslist_next, imgr._logfreqratio_list, imgr.pol_next,
+        imgr._which_solve, imgr._nimage,
     )
 
 
@@ -605,4 +619,145 @@ class TestComputeRegDict:
         assert method_result.keys() == backend_result.keys()
         for key in method_result:
             np.testing.assert_array_equal(method_result[key], backend_result[key])
+
+
+class TestComputeReggradDict:
+    """Tests for compute_reggrad_dict (extracted from Imager.make_reggrad_dict)."""
+
+    def test_matches_imager_stokes_i(self, gauss_im, observe, initialize_imager):
+        """Single-freq, pol='I' — gradient shape (nimage,), bit-identical to method."""
+        obs = observe(gauss_im)
+        imgr, imcur = initialize_imager(
+            obs, gauss_im, {"vis": 100},
+            reg_term={"simple": 1, "tv": 10, "l1": 5},
+        )
+        method_result = imgr.make_reggrad_dict(imcur)
+        backend_result = _call_backend_reggrad_dict(imgr, imcur)
+
+        assert method_result.keys() == backend_result.keys() == {"simple", "tv", "l1"}
+        for key in method_result:
+            np.testing.assert_array_equal(method_result[key], backend_result[key])
+            assert method_result[key].shape == (imgr._nimage,)
+
+    def test_matches_imager_polarimetric(self, gauss_im_pol, observe, initialize_imager):
+        """pol='IP' with REGULARIZERS_POL — exercises polregularizergrad branch."""
+        obs = observe(gauss_im_pol)
+        imgr, imcur = initialize_imager(
+            obs, gauss_im_pol, {"pvis": 100},
+            reg_term={"hw": 1, "ptv": 1},
+            pol="IP", transform=["log", "mcv"],
+        )
+        method_result = imgr.make_reggrad_dict(imcur)
+        backend_result = _call_backend_reggrad_dict(imgr, imcur)
+
+        assert method_result.keys() == backend_result.keys() == {"hw", "ptv"}
+        for key in method_result:
+            np.testing.assert_array_equal(method_result[key], backend_result[key])
+
+    def test_matches_imager_stokes_i_pol_bundled(self, gauss_im_pol, observe,
+                                                  initialize_imager):
+        """pol='IP' with REGULARIZERS — exercises the (4, nimage) bundling branch."""
+        obs = observe(gauss_im_pol)
+        imgr, imcur = initialize_imager(
+            obs, gauss_im_pol, {"vis": 100, "pvis": 100},
+            reg_term={"simple": 1, "hw": 1},
+            pol="IP", transform=["log", "mcv"],
+        )
+        method_result = imgr.make_reggrad_dict(imcur)
+        backend_result = _call_backend_reggrad_dict(imgr, imcur)
+
+        assert method_result.keys() == backend_result.keys() == {"simple", "hw"}
+        for key in method_result:
+            np.testing.assert_array_equal(method_result[key], backend_result[key])
+        # Stokes I regularizer 'simple' is bundled to (4, nimage) for pol imaging.
+        assert backend_result["simple"].shape == (4, imgr._nimage)
+
+    def test_matches_imager_multifrequency(self, gauss_im, observe, initialize_imager):
+        """Multifrequency: hits mf+REGULARIZERS, mf+REGULARIZERS_ALLFREQS_I, mf+REGULARIZERS_SPECTRAL.
+
+        TODO: REGULARIZERS_POLSPECTRAL gradient paths (l2_alphap, l2_betap, l2_rm,
+        l2_cm) require length-10 imcur (mf + full pol). Add coverage once a
+        polarimetric multifreq fixture exists.
+        """
+        im_lo = gauss_im.copy()
+        im_lo.rf = REFFREQ_HZ
+        im_hi = gauss_im.copy()
+        im_hi.rf = MF_ALT_FREQ_HZ
+        obs_lo = observe(im_lo)
+        obs_hi = observe(im_hi)
+
+        imgr, imcur = initialize_imager(
+            [obs_lo, obs_hi], im_lo, {"vis": 100},
+            reg_term={"simple": 1, "flux_mf": 1, "l2_alpha": 1},
+            mf=True, mf_order=1,
+            mf_flux=[im_lo.total_flux(), im_hi.total_flux()],
+        )
+
+        method_result = imgr.make_reggrad_dict(imcur)
+        backend_result = _call_backend_reggrad_dict(imgr, imcur)
+
+        assert method_result.keys() == backend_result.keys() == {"simple", "flux_mf", "l2_alpha"}
+        for key in method_result:
+            np.testing.assert_array_equal(method_result[key], backend_result[key])
+
+    def test_unknown_regname_raises(self, gauss_im, observe, initialize_imager):
+        """Unknown regularizer name — backend raises with the documented message."""
+        obs = observe(gauss_im)
+        imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100})
+        with pytest.raises(Exception, match="not recognized"):
+            compute_reggrad_dict(
+                imcur, ["not_a_regularizer"], imgr._xprior, imgr._embed_mask,
+                imgr.flux_next, imgr.pflux_next, imgr.vflux_next,
+                imgr.prior_next.xdim, imgr.prior_next.ydim, imgr.prior_next.psize,
+                imgr.norm_reg, imgr.beam_size, imgr.regparams,
+                imgr.mf_next, imgr.mf_flux, imgr.obslist_next,
+                imgr._logfreqratio_list, imgr.pol_next,
+                imgr._which_solve, imgr._nimage,
+            )
+
+    def test_mf_flux_validation(self, gauss_im, observe, initialize_imager):
+        """mf=True + flux_mf regularizer + scalar mf_flux → raises."""
+        im_lo = gauss_im.copy()
+        im_lo.rf = REFFREQ_HZ
+        im_hi = gauss_im.copy()
+        im_hi.rf = MF_ALT_FREQ_HZ
+        obs_lo = observe(im_lo)
+        obs_hi = observe(im_hi)
+
+        imgr, imcur = initialize_imager(
+            [obs_lo, obs_hi], im_lo, {"vis": 100},
+            reg_term={"flux_mf": 1},
+            mf=True, mf_order=1,
+        )
+        with pytest.raises(Exception, match="mf_flux must be a list"):
+            _call_backend_reggrad_dict(imgr, imcur, mf_flux=2.0)
+
+    @pytest.mark.parametrize("xdim,ydim", IMAGE_SHAPES)
+    def test_rect_images(self, make_rect_image, observe, initialize_imager,
+                          xdim, ydim):
+        """Backend handles rectangular (xdim != ydim) images."""
+        im = make_rect_image(xdim, ydim)
+        obs = observe(im)
+        imgr, imcur = initialize_imager(
+            obs, im, {"vis": 100},
+            reg_term={"simple": 1, "tv": 10},
+        )
+        method_result = imgr.make_reggrad_dict(imcur)
+        backend_result = _call_backend_reggrad_dict(imgr, imcur)
+
+        assert method_result.keys() == backend_result.keys()
+        for key in method_result:
+            np.testing.assert_array_equal(method_result[key], backend_result[key])
+
+
+def test_reg_and_reggrad_share_keys(gauss_im, observe, initialize_imager):
+    """Cross-cutting invariant: reg and reggrad dicts share the same key set."""
+    obs = observe(gauss_im)
+    imgr, imcur = initialize_imager(
+        obs, gauss_im, {"vis": 100},
+        reg_term={"simple": 1, "tv": 10, "l1": 5},
+    )
+    reg = _call_backend_reg_dict(imgr, imcur)
+    reggrad = _call_backend_reggrad_dict(imgr, imcur)
+    assert set(reg.keys()) == set(reggrad.keys())
 

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -772,9 +772,13 @@ def test_reg_and_reggrad_share_keys(gauss_im, observe, initialize_imager):
 # ---------------------------------------------------------------------------
 
 def _fd_grad_of_transform(imarr, transforms, which_solve, scalar_obj):
-    """Centered FD gradient of (scalar_obj o transform_imarr) w.r.t. solver vars.
+    """Centered finite-difference gradient of (scalar_obj o transform_imarr).
 
-    Used to verify transform_gradients applies the chain rule correctly.
+    Returns d/dimarr [scalar_obj(transform_imarr(imarr))] — the gradient of
+    the composed function in solver-space. Computed numerically to second order
+    via centered differences with eps=1e-6 (precision ~1e-10 in float64).
+    Independent of transform_gradients itself, so suitable as ground truth
+    for the chain rule it implements.
     """
     eps = 1e-6
     grad = np.zeros_like(imarr)
@@ -791,17 +795,51 @@ def _fd_grad_of_transform(imarr, transforms, which_solve, scalar_obj):
 
 
 class TestTransformGradientsChainRule:
-    """transform_gradients chain rule agrees with FD of transform_imarr."""
+    """Verify transform_gradients implements the J^T-times-grad chain rule.
+
+    `transform_gradients(grad_phys, imarr, transforms, which_solve)` converts
+    a gradient w.r.t. PHYSICAL space (df/dphys, where phys = transform_imarr(imarr))
+    into a gradient w.r.t. SOLVER space (df/dimarr), via the chain rule
+    df/dimarr = J^T @ df/dphys, where J is the Jacobian of transform_imarr.
+
+    Strategy: pick any smooth scalar f(phys), compute df/dimarr two ways —
+    (1) the chain rule under test, and (2) centered finite differences applied
+    to (f o transform_imarr). They must agree to FD precision (~1e-6).
+
+    Coverage spans:
+      - Real-usage operating points where ehtim pins one slot to enforce the
+        diagonal-Jacobian regime (mcv ⇒ vfrac=0 for pol='IP'; vcv ⇒ mfrac=0
+        for pol='IV'; polcv has a diagonal Jacobian everywhere).
+      - General regimes where Jacobians have non-zero off-diagonal entries.
+        These exercise the cross-derivative terms (drho/dmprime ↔ phys[3] for
+        mcv, drho/dvprime ↔ phys[1] for vcv).
+      - Pure transforms in isolation (no `log` composition).
+      - Shape-dispatch branches: nimage==1 (single Stokes I 1D), nimage==3
+        (multifreq Stokes I), nimage==4 (single-freq pol), nimage==10 (mf+pol).
+    """
 
     @staticmethod
     def _scalar_obj(phys):
-        """Arbitrary smooth scalar objective: weighted sum of physical components."""
+        """Arbitrary smooth scalar f(phys) = sum(weights * phys**2).
+
+        Choice is deliberately generic — any C^2 scalar would work for the FD
+        check. This form gives a closed-form analytic gradient (df/dphys =
+        2*weights*phys) so the test can compute the chain-rule input directly
+        without numerical noise.
+        """
         weights = np.array([0.7, 1.3, -0.5, 0.9])[:, None]
         return float(np.sum(weights * phys**2))
 
     @staticmethod
     def _solver_imarr(seed=0, n=8, v_pre=None, m_pre=None, chi_pre=None):
-        """Build a (4, n) solver-variable array; pass a scalar to pin a row."""
+        """Build a (4, n) solver-space image array.
+
+        Rows are (imarr[0..3]) = (log_I, mprime, chi, vfrac_or_vprime); the
+        meaning of slots 1 and 3 depends on which transforms are active.
+        Passing a scalar for any of v_pre/m_pre/chi_pre pins that whole row
+        — used to construct the diagonal-Jacobian operating points (mcv with
+        vfrac=0, vcv with mfrac=0).
+        """
         rng = np.random.default_rng(seed)
         log_I = rng.uniform(-1.0, 1.0, size=n)
         m_arr = rng.uniform(-2.0, 2.0, size=n) if m_pre is None else np.full(n, m_pre)
@@ -840,7 +878,23 @@ class TestTransformGradientsChainRule:
     )
     def test_chain_rule_matches_finite_difference(self, transforms, which_solve,
                                                     imarr_kwargs, check_rows):
-        """Chain rule output must match centered FD of (obj o transform)."""
+        """transform_gradients(grad_phys, ...) ≈ FD of (f o transform_imarr).
+
+        For each parametrized scenario:
+          1. Build a solver-space imarr in the requested operating point.
+          2. Compute phys = transform_imarr(imarr) and the analytic
+             grad_phys = df/dphys = 2*weights*phys (the gradient of
+             `_scalar_obj` w.r.t. its physical argument).
+          3. Apply the chain rule under test:
+                grad_solver = transform_gradients(grad_phys, imarr, ...)
+          4. Compute the same df/dimarr numerically:
+                grad_fd = centered FD of (f o transform_imarr)
+          5. Assert grad_solver[k] ≈ grad_fd[k] for each solved-for row k.
+
+        check_rows lists the rows to compare; non-solved rows have their
+        gradient discarded by pack_imarr in real usage, so the value is
+        irrelevant and not asserted.
+        """
         imarr = self._solver_imarr(seed=0, **imarr_kwargs)
 
         phys = transform_imarr(imarr, transforms, which_solve)
@@ -860,7 +914,13 @@ class TestTransformGradientsChainRule:
             )
 
     def test_log_chain_preserved_under_mcv(self):
-        """outarr[0] from log+mcv must equal exp(imarr[0]) * gradarr[0]."""
+        """Direct check on the I-segment chain rule under log+mcv.
+
+        With gradarr = ones, transform_gradients should produce
+            outarr[0] = exp(imarr[0]) * gradarr[0] = exp(imarr[0])
+        because the `log` block multiplies by exp(imarr[0]) and the mcv
+        chain rule (which writes to slots 1:3) must not touch slot 0.
+        """
         imarr = self._solver_imarr(seed=1, v_pre=0.0)
         gradarr = np.ones_like(imarr)
         which_solve = np.array([1, 1, 0, 0])
@@ -869,7 +929,11 @@ class TestTransformGradientsChainRule:
         np.testing.assert_allclose(out[0], np.exp(imarr[0]), rtol=1e-12)
 
     def test_single_pol_log_chain_1d(self):
-        """nimage==1 branch: 1D imarr, outarr = exp(imarr) * gradarr."""
+        """nimage==1 dispatch: 1D imarr (single-freq Stokes I, no pol).
+
+        With `log`: outarr = exp(imarr) * gradarr (element-wise).
+        Without `log`: outarr = gradarr (identity).
+        """
         rng = np.random.default_rng(42)
         imarr = rng.uniform(-1.0, 1.0, size=8)
         gradarr = rng.uniform(-1.0, 1.0, size=8)
@@ -882,7 +946,12 @@ class TestTransformGradientsChainRule:
         np.testing.assert_allclose(out_no_log, gradarr, rtol=1e-12)
 
     def test_multifreq_stokes_i_log_chain(self):
-        """nimage==3 branch: log applies to row 0 only; spectral coeffs pass through."""
+        """nimage==3 dispatch: (3, N) imarr (multifreq Stokes I, no pol).
+
+        Layout is (log_I, alpha, beta) at the reference frequency. The `log`
+        transform applies only to row 0 (Stokes I); the spectral coefficients
+        in rows 1, 2 pass through unchanged.
+        """
         rng = np.random.default_rng(7)
         imarr = rng.uniform(-1.0, 1.0, size=(3, 6))
         gradarr = rng.uniform(-1.0, 1.0, size=(3, 6))
@@ -894,7 +963,13 @@ class TestTransformGradientsChainRule:
         np.testing.assert_array_equal(out[2], gradarr[2])
 
     def test_mf_pol_shape_smoke(self):
-        """nimage==10 branch (mf+pol): shape preserved, log applied to row 0, rows 4-9 pass through."""
+        """nimage==10 dispatch: (10, N) imarr (multifreq + full polarization).
+
+        Layout is (I, mprime, chi, vfrac, alpha, beta, alphap, betap, rm, cm).
+        Verifies the dispatcher (a) preserves shape, (b) applies `log` to slot
+        0, and (c) leaves slots 4-9 (spectral / Faraday / conversion-measure
+        coefficients) unchanged.
+        """
         rng = np.random.default_rng(13)
         n = 6
         imarr = np.empty((10, n))

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -154,19 +154,31 @@ def _call_backend_chisqgrad_dict(imgr, imcur):
     )
 
 
-def _call_backend_reg_dict(imgr, imcur, mf_flux=None):
-    """Call compute_reg_dict with args pulled from an initialized Imager.
+def _build_regparams(imgr, mf_flux=None):
+    """Bundle all regularizer params from an Imager into a single dict.
 
     `mf_flux` overrides imgr.mf_flux for tests that exercise the
     REGULARIZERS_ALLFREQS_I validation path.
     """
+    return {
+        'flux': imgr.flux_next,
+        'pflux': imgr.pflux_next,
+        'vflux': imgr.vflux_next,
+        'xdim': imgr.prior_next.xdim,
+        'ydim': imgr.prior_next.ydim,
+        'psize': imgr.prior_next.psize,
+        'beam_size': imgr.beam_size,
+        'mf_flux': imgr.mf_flux if mf_flux is None else mf_flux,
+        **imgr.regparams,
+    }
+
+
+def _call_backend_reg_dict(imgr, imcur, mf_flux=None):
+    """Call compute_reg_dict with args pulled from an initialized Imager."""
     return compute_reg_dict(
         imcur, sorted(imgr.reg_term_next.keys()), imgr._xprior, imgr._embed_mask,
-        imgr.flux_next, imgr.pflux_next, imgr.vflux_next,
-        imgr.prior_next.xdim, imgr.prior_next.ydim, imgr.prior_next.psize,
-        imgr.norm_reg, imgr.beam_size, imgr.regparams,
-        imgr.mf_next, imgr.mf_flux if mf_flux is None else mf_flux,
-        imgr.obslist_next, imgr._logfreqratio_list, imgr.pol_next,
+        imgr.mf_next, imgr.obslist_next, imgr._logfreqratio_list, imgr.pol_next,
+        imgr.norm_reg, _build_regparams(imgr, mf_flux=mf_flux),
     )
 
 
@@ -174,11 +186,8 @@ def _call_backend_reggrad_dict(imgr, imcur, mf_flux=None):
     """Call compute_reggrad_dict with args pulled from an initialized Imager."""
     return compute_reggrad_dict(
         imcur, sorted(imgr.reg_term_next.keys()), imgr._xprior, imgr._embed_mask,
-        imgr.flux_next, imgr.pflux_next, imgr.vflux_next,
-        imgr.prior_next.xdim, imgr.prior_next.ydim, imgr.prior_next.psize,
-        imgr.norm_reg, imgr.beam_size, imgr.regparams,
-        imgr.mf_next, imgr.mf_flux if mf_flux is None else mf_flux,
-        imgr.obslist_next, imgr._logfreqratio_list, imgr.pol_next,
+        imgr.mf_next, imgr.obslist_next, imgr._logfreqratio_list, imgr.pol_next,
+        imgr.norm_reg, _build_regparams(imgr, mf_flux=mf_flux),
         imgr._which_solve, imgr._nimage,
     )
 
@@ -580,11 +589,8 @@ class TestComputeRegDict:
         with pytest.raises(Exception, match="not recognized"):
             compute_reg_dict(
                 imcur, ["not_a_regularizer"], imgr._xprior, imgr._embed_mask,
-                imgr.flux_next, imgr.pflux_next, imgr.vflux_next,
-                imgr.prior_next.xdim, imgr.prior_next.ydim, imgr.prior_next.psize,
-                imgr.norm_reg, imgr.beam_size, imgr.regparams,
-                imgr.mf_next, imgr.mf_flux, imgr.obslist_next,
-                imgr._logfreqratio_list, imgr.pol_next,
+                imgr.mf_next, imgr.obslist_next, imgr._logfreqratio_list, imgr.pol_next,
+                imgr.norm_reg, _build_regparams(imgr),
             )
 
     def test_mf_flux_validation(self, gauss_im, observe, initialize_imager):
@@ -709,11 +715,8 @@ class TestComputeReggradDict:
         with pytest.raises(Exception, match="not recognized"):
             compute_reggrad_dict(
                 imcur, ["not_a_regularizer"], imgr._xprior, imgr._embed_mask,
-                imgr.flux_next, imgr.pflux_next, imgr.vflux_next,
-                imgr.prior_next.xdim, imgr.prior_next.ydim, imgr.prior_next.psize,
-                imgr.norm_reg, imgr.beam_size, imgr.regparams,
-                imgr.mf_next, imgr.mf_flux, imgr.obslist_next,
-                imgr._logfreqratio_list, imgr.pol_next,
+                imgr.mf_next, imgr.obslist_next, imgr._logfreqratio_list, imgr.pol_next,
+                imgr.norm_reg, _build_regparams(imgr),
                 imgr._which_solve, imgr._nimage,
             )
 

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -12,6 +12,7 @@ from ehtim.imaging.imager_backend import (
     compute_chisq_dict,
     compute_chisqgrad_dict,
     compute_embed,
+    compute_reg_dict,
 )
 
 # Parametrize over square, tall, and wide images
@@ -147,6 +148,22 @@ def _call_backend_chisqgrad_dict(imgr, imcur):
         imgr.obslist_next, imgr._logfreqratio_list, imgr.mf_next,
         imgr.pol_next, imgr._ttype, imgr._embed_mask,
         imgr._which_solve, imgr._nimage,
+    )
+
+
+def _call_backend_reg_dict(imgr, imcur, mf_flux=None):
+    """Call compute_reg_dict with args pulled from an initialized Imager.
+
+    `mf_flux` overrides imgr.mf_flux for tests that exercise the
+    REGULARIZERS_ALLFREQS_I validation path.
+    """
+    return compute_reg_dict(
+        imcur, sorted(imgr.reg_term_next.keys()), imgr._xprior, imgr._embed_mask,
+        imgr.flux_next, imgr.pflux_next, imgr.vflux_next,
+        imgr.prior_next.xdim, imgr.prior_next.ydim, imgr.prior_next.psize,
+        imgr.norm_reg, imgr.beam_size, imgr.regparams,
+        imgr.mf_next, imgr.mf_flux if mf_flux is None else mf_flux,
+        imgr.obslist_next, imgr._logfreqratio_list, imgr.pol_next,
     )
 
 
@@ -461,4 +478,131 @@ def test_chisq_and_chisqgrad_share_keys(gauss_im, observe, initialize_imager):
     chisq = _call_backend_chisq_dict(imgr, imcur)
     chisqgrad = _call_backend_chisqgrad_dict(imgr, imcur)
     assert set(chisq.keys()) == set(chisqgrad.keys())
+
+
+class TestComputeRegDict:
+    """Tests for compute_reg_dict (extracted from Imager.make_reg_dict)."""
+
+    def test_matches_imager_stokes_i(self, gauss_im, observe, initialize_imager):
+        """Single-freq, pol='I', multi-key reg_term — exercises sort + REGULARIZERS branch."""
+        obs = observe(gauss_im)
+        imgr, imcur = initialize_imager(
+            obs, gauss_im, {"vis": 100},
+            reg_term={"simple": 1, "tv": 10, "l1": 5},
+        )
+        method_result = imgr.make_reg_dict(imcur)
+        backend_result = _call_backend_reg_dict(imgr, imcur)
+
+        assert method_result.keys() == backend_result.keys() == {"simple", "tv", "l1"}
+        for key in method_result:
+            np.testing.assert_array_equal(method_result[key], backend_result[key])
+
+    def test_matches_imager_polarimetric(self, gauss_im_pol, observe, initialize_imager):
+        """Single-freq, pol='IP' with REGULARIZERS_POL — exercises polregularizer branch."""
+        obs = observe(gauss_im_pol)
+        imgr, imcur = initialize_imager(
+            obs, gauss_im_pol, {"pvis": 100},
+            reg_term={"hw": 1, "ptv": 1},
+            pol="IP", transform=["log", "mcv"],
+        )
+        method_result = imgr.make_reg_dict(imcur)
+        backend_result = _call_backend_reg_dict(imgr, imcur)
+
+        assert method_result.keys() == backend_result.keys() == {"hw", "ptv"}
+        for key in method_result:
+            np.testing.assert_array_equal(method_result[key], backend_result[key])
+
+    def test_matches_imager_stokes_i_pol_bundled(self, gauss_im_pol, observe,
+                                                  initialize_imager):
+        """pol='IP' with REGULARIZERS — exercises the imcur[0] slice branch."""
+        obs = observe(gauss_im_pol)
+        imgr, imcur = initialize_imager(
+            obs, gauss_im_pol, {"vis": 100, "pvis": 100},
+            reg_term={"simple": 1, "hw": 1},
+            pol="IP", transform=["log", "mcv"],
+        )
+        method_result = imgr.make_reg_dict(imcur)
+        backend_result = _call_backend_reg_dict(imgr, imcur)
+
+        assert method_result.keys() == backend_result.keys() == {"simple", "hw"}
+        for key in method_result:
+            np.testing.assert_array_equal(method_result[key], backend_result[key])
+
+    def test_matches_imager_multifrequency(self, gauss_im, observe, initialize_imager):
+        """Multifrequency: hits mf+REGULARIZERS, mf+REGULARIZERS_ALLFREQS_I, mf+REGULARIZERS_SPECTRAL.
+
+        TODO: REGULARIZERS_POLSPECTRAL (l2_alphap, l2_betap, l2_rm, l2_cm, etc.)
+        require a length-10 imcur (mf + full pol). Add coverage once a polarimetric
+        multifreq fixture exists.
+        """
+        im_lo = gauss_im.copy()
+        im_lo.rf = REFFREQ_HZ
+        im_hi = gauss_im.copy()
+        im_hi.rf = MF_ALT_FREQ_HZ
+        obs_lo = observe(im_lo)
+        obs_hi = observe(im_hi)
+
+        imgr, imcur = initialize_imager(
+            [obs_lo, obs_hi], im_lo, {"vis": 100},
+            reg_term={"simple": 1, "flux_mf": 1, "l2_alpha": 1},
+            mf=True, mf_order=1,
+            mf_flux=[im_lo.total_flux(), im_hi.total_flux()],
+        )
+
+        method_result = imgr.make_reg_dict(imcur)
+        backend_result = _call_backend_reg_dict(imgr, imcur)
+
+        assert method_result.keys() == backend_result.keys() == {"simple", "flux_mf", "l2_alpha"}
+        for key in method_result:
+            np.testing.assert_array_equal(method_result[key], backend_result[key])
+
+    def test_unknown_regname_raises(self, gauss_im, observe, initialize_imager):
+        """Unknown regularizer name — backend raises with the documented message."""
+        obs = observe(gauss_im)
+        imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100})
+        # Bypass Imager.check_params by passing reg_term_keys directly.
+        with pytest.raises(Exception, match="not recognized"):
+            compute_reg_dict(
+                imcur, ["not_a_regularizer"], imgr._xprior, imgr._embed_mask,
+                imgr.flux_next, imgr.pflux_next, imgr.vflux_next,
+                imgr.prior_next.xdim, imgr.prior_next.ydim, imgr.prior_next.psize,
+                imgr.norm_reg, imgr.beam_size, imgr.regparams,
+                imgr.mf_next, imgr.mf_flux, imgr.obslist_next,
+                imgr._logfreqratio_list, imgr.pol_next,
+            )
+
+    def test_mf_flux_validation(self, gauss_im, observe, initialize_imager):
+        """mf=True + flux_mf regularizer + scalar mf_flux → raises."""
+        im_lo = gauss_im.copy()
+        im_lo.rf = REFFREQ_HZ
+        im_hi = gauss_im.copy()
+        im_hi.rf = MF_ALT_FREQ_HZ
+        obs_lo = observe(im_lo)
+        obs_hi = observe(im_hi)
+
+        imgr, imcur = initialize_imager(
+            [obs_lo, obs_hi], im_lo, {"vis": 100},
+            reg_term={"flux_mf": 1},
+            mf=True, mf_order=1,
+        )
+        # Pass a scalar (not a list) as mf_flux — must raise.
+        with pytest.raises(Exception, match="mf_flux must be a list"):
+            _call_backend_reg_dict(imgr, imcur, mf_flux=2.0)
+
+    @pytest.mark.parametrize("xdim,ydim", IMAGE_SHAPES)
+    def test_rect_images(self, make_rect_image, observe, initialize_imager,
+                          xdim, ydim):
+        """Backend handles rectangular (xdim != ydim) images."""
+        im = make_rect_image(xdim, ydim)
+        obs = observe(im)
+        imgr, imcur = initialize_imager(
+            obs, im, {"vis": 100},
+            reg_term={"simple": 1, "tv": 10},
+        )
+        method_result = imgr.make_reg_dict(imcur)
+        backend_result = _call_backend_reg_dict(imgr, imcur)
+
+        assert method_result.keys() == backend_result.keys()
+        for key in method_result:
+            np.testing.assert_array_equal(method_result[key], backend_result[key])
 

--- a/tests/test_imager_history.py
+++ b/tests/test_imager_history.py
@@ -9,7 +9,6 @@ import pytest
 import ehtim as eh
 from ehtim.imager import Imager, ImagerRunState
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_imager_history.py
+++ b/tests/test_imager_history.py
@@ -118,6 +118,10 @@ class TestBeforeAnyRun:
     def test_debias_last_no_runs(self, imager, capsys):
         self._check_prints_no_runs_and_returns_none(Imager.debias_last, imager, capsys)
 
+    def test_debias_next_default_is_false(self, imager):
+        """debias defaults to False (flipped from True per task 2.15)."""
+        assert imager.debias_next is False
+
     def test_snrcut_last_no_runs(self, imager, capsys):
         self._check_prints_no_runs_and_returns_none(Imager.snrcut_last, imager, capsys)
 


### PR DESCRIPTION
Implements roadmap tasks 1A.4 + 1A.5 + 2.15, plus the regparams + docs follow-ups requested in review:

- **`f7e98c9` — Extract `make_reg_dict` into `compute_reg_dict` (task 1A.4).**
  Move method body to a pure backend function; relocate 11 `REGULARIZERS_*` constants to `imager_backend.py` (re-exported from `imager.py` for back-compat).

- **`386fe5b` — Extract `make_reggrad_dict` into `compute_reggrad_dict` (task 1A.5).**
  Same pattern; 144 LOC → 12-line wrapper. Drop now-unused `mfutils` import and 7 `REGULARIZERS_*` sub-list imports from `imager.py` — verified by grep that no external consumer was importing them.

- **`2fc67bb` — Flip `debias=True` → `False` default (task 2.15).**
  17 sites: 1 in `Imager.__init__`, 15 in `chisqdata_*` family in `imager_utils.py`, 1 in `initialize_imager` test fixture. Static audit found no test relied on the True default; full suite passes with zero modifications. New `test_debias_next_default_is_false` locks in the new default.

- **`f6568e6` — Pre-existing ruff I001 fix in `tests/test_imager_history.py`** (surfaced by CI lint after I touched the file).

- **`62c17c4` — Merge `dev-backend`** to pick up #228.

- **`1628570` — Pack regularizer args into `regparams` dict** (Andrew review).
  Bundled `flux`, `pflux`, `vflux`, `xdim`, `ydim`, `psize`, `beam_size`, `mf_flux` into `regparams` (alongside `major`/`minor`/`PA`/`alpha_A`/`epsilon_tv`); wrapper builds via new `_full_regparams()` helper. Dispatchers unchanged — `**regparams` spread handles binding. `compute_reg_dict` arg count dropped 18 → 10; `imager_backend.py` net –100 LOC.

- **`60a51b8` — Expand `TestTransformGradientsChainRule` docstrings** (#228 review follow-up).
  Added class-level docstring describing the J^T·grad strategy, the FD-as-ground-truth rationale, and the three coverage axes (real-usage / general / shape-dispatch); per-test docstrings explain what each case verifies.

- **`5c68567` — Document mcv/vcv as legacy in `transform_gradients`** (#228 review follow-up).
  Short pointer comment noting mcv/vcv are legacy single-axis parametrizations and polcv is preferred for full multi-Stokes; cross-references `polutils.{polcv,mcv,vcv}_grad` docstrings for the per-transform Jacobian.

## Test plan

- 303/303 tests pass (266 baseline + 11 `TestComputeRegDict` + 12 `TestComputeReggradDict` + 1 reg/reggrad parity test + 13 `TestTransformGradientsChainRule` from #228)
- All 5 dispatch branches covered (single-pol, polarimetric, pol-bundled, three multifreq paths)
- Rectangular images covered via parametrize
- Backend output bit-identical to method via `np.testing.assert_array_equal`
- Ruff clean on changed files
- CI green: lint, test (3.10), test (3.12), codecov/patch, codecov/project

## Notes for review

- No functional changes inside the dispatch bodies. Pre-existing patterns (sparse buffer allocation, duplicated `if pol in POLARIZATION_MODES`, three return shapes) were copied verbatim and flagged for a Phase-2 cleanup pass.
- The extended `initialize_imager` fixture now passes `mf` and `mf_order` to the Imager constructor (was previously mutated post-construction). This unblocked testing of mf-only regularizers (`flux_mf`, `l2_alpha`) which were rejected by the constructor's `check_params` under the old fixture.
- `debias=True` is still available via the explicit kwarg; legacy scripts that relied on the default need to add it explicitly (or accept the new behavior).

Closes the 1A.4 / 1A.5 / 2.15 boxes in #212.
