### PR TITLE
Fix transform_gradients chain rule for polarimetric imaging

### DIFF
--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -238,12 +238,13 @@ def transform_gradients(gradarr, imarr, transforms, which_solve):
         if pol_which_solve[0]==1 and ('log' in transforms):  # full polarization, including stokes I imaging
             outarr[0] = np.exp(imarr[0]) * gradarr[0]
 
+        # Each *_grad returns shape (3, ...) so outarr[0] (the log term above) survives.
         if (pol_which_solve[1]==1 and pol_which_solve[3]==1 and ('polcv' in transforms)):
-            outarr[0:4] = polutils.polcv_chain(imarr[0:4]) * gradarr[0:4]
+            outarr[1:4] = polutils.polcv_grad(imarr[0:4], gradarr[0:4])
         elif (pol_which_solve[1]==1) and ('mcv' in transforms):
-            outarr[0:4] = polutils.mcv_chain(imarr[0:4]) * gradarr[0:4]
+            outarr[1:4] = polutils.mcv_grad(imarr[0:4], gradarr[0:4])
         elif (pol_which_solve[3]==1) and ('vcv' in transforms):
-            outarr[0:4] = polutils.vcv_chain(imarr[0:4]) * gradarr[0:4]
+            outarr[1:4] = polutils.vcv_grad(imarr[0:4], gradarr[0:4])
 
     return outarr
 

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -160,17 +160,32 @@ def polcv_r(imarr):
 
     return out
 
-def polcv_chain(imarr):
-    """chain rule term dm/dm' for mcv
-       input is solver values
+def polcv_grad(imarr, gradarr):
+    """Apply J^T @ gradarr for polcv (rho ← arctan(rho_pre/T_M); psi ← arctan(psi_pre/T_PSI)).
+
+    Diagonal Jacobian on slots 1 and 3; slot 2 (phi) passes through.
+
+    Parameters
+    ----------
+    imarr : np.ndarray, shape (4, ...)
+        Solver-space image array.
+    gradarr : np.ndarray, shape (4, ...)
+        Gradient w.r.t. physical components phys[0:4]. gradarr[0] is unused.
+
+    Returns
+    -------
+    out : np.ndarray, shape (3, ...)
+        Gradient w.r.t. solver slots (1, 2, 3).
     """
-    out = np.ones(imarr.shape)
+    rho_pre = imarr[1]
+    psi_pre = imarr[3]
+    drho_dpre = 1 / (TANWIDTH_M * np.pi * (1 + (rho_pre / TANWIDTH_M) ** 2))
+    dpsi_dpre = 1 / (TANWIDTH_PSI * (1 + (psi_pre / TANWIDTH_PSI) ** 2))
 
-    rho_prime = imarr[1]
-    out[1] = 1 / (TANWIDTH_M*np.pi*(1 + (rho_prime/TANWIDTH_M)**2))
-
-    psi_prime = imarr[3]
-    out[3] =  1 / (TANWIDTH_PSI*(1 + (psi_prime/TANWIDTH_PSI)**2))
+    out = np.empty((3,) + gradarr.shape[1:])
+    out[0] = drho_dpre * gradarr[1]
+    out[1] = gradarr[2]
+    out[2] = dpsi_dpre * gradarr[3]
     return out
 
 
@@ -209,36 +224,45 @@ def mcv_r(imarr):
     out = np.array((imarr[0], mfrac_prime, imarr[2], vfrac))
     return out
 
-# TODO WE ARE GOING TO HAVE TO CHECK ALL OF THESE NUMERICALLY
-def mcv_chain(imarr):
-    """chain rule terms drho/dm' and dpsi/dv' for mcv
-       input is solver values
+def mcv_grad(imarr, gradarr):
+    """Apply J^T @ gradarr for mcv (mprime → rho, psi; vfrac held constant).
+
+    phys[1]=rho and phys[3]=psi both depend on mprime via mfrac, so the
+    Jacobian has off-diagonal terms; both are included here. Slot 3 of
+    the result is zero because vfrac is held constant.
+
+    Parameters
+    ----------
+    imarr : np.ndarray, shape (4, ...)
+        Solver-space image array.
+    gradarr : np.ndarray, shape (4, ...)
+        Gradient w.r.t. physical components phys[0:4]. gradarr[0] is unused.
+
+    Returns
+    -------
+    out : np.ndarray, shape (3, ...)
+        Gradient w.r.t. solver slots (1, 2, 3).
     """
-    out = np.ones(imarr.shape)
+    vfrac = imarr[3]
+    mfrac_max = 1 - np.abs(vfrac)
+    if np.any(mfrac_max > 1):
+        raise Exception("mfrac_max>1 in mcv_grad!")
 
-    vfrac = imarr[3] # when using this transform, we interpret transformed imarr[3] as mfrac=\rho sin(\psi)
-    mfrac_max = 1-np.abs(vfrac)
-    if np.any(mfrac_max>1):
-        raise Exception("mfrac_max>1 in mcv!")
+    mprime = imarr[1]
+    mfrac = mfrac_max * (0.5 + np.arctan(mprime / TANWIDTH_M) / np.pi)
+    rho = np.sqrt(mfrac ** 2 + vfrac ** 2)
 
-    mfrac_prime =  imarr[1]
-    mfrac = mfrac_max*(0.5 + np.arctan(mfrac_prime/TANWIDTH_M)/np.pi)
+    dm_dmprime = mfrac_max / (TANWIDTH_M * np.pi * (1 + (mprime / TANWIDTH_M) ** 2))
 
-    rho = np.sqrt(mfrac**2 + vfrac**2)
-    psi = np.arcsin(vfrac/rho)
+    # Avoid 0/0 when total polarization is zero; in that limit both terms vanish.
+    safe_rho = np.where(rho > 0, rho, 1.0)
+    drho_dmprime = (mfrac / safe_rho) * dm_dmprime
+    dpsi_dmprime = -(vfrac * np.sign(mfrac)) / (safe_rho ** 2) * dm_dmprime
 
-    dm_dmprime = mfrac_max / (TANWIDTH_M*np.pi*(1 + (mfrac_prime/TANWIDTH_M)**2))
-
-    drho_dm = mfrac / rho                # drho/dm holding v constant
-    drho_dmprime = drho_dm * dm_dmprime
-    out[1] = drho_dmprime
-
-    # we only use mcv when holding v constant, so dF/imarr[3]=0
-    #dpsi_dm = -vfrac/ (rho*rho)         # dpsi/dm holding v constant # TODO CHECK
-    #dpsi_dmprime = dpsi_dm * dm_dmprime
-    #out[3] = dpsi_dmprime
-    out[3] = np.zeros(out[3].shape)
-
+    out = np.empty((3,) + gradarr.shape[1:])
+    out[0] = drho_dmprime * gradarr[1] + dpsi_dmprime * gradarr[3]
+    out[1] = gradarr[2]
+    out[2] = 0.0
     return out
 
 def vcv(imarr):
@@ -274,34 +298,45 @@ def vcv_r(imarr):
     out = np.array((imarr[0], mfrac, imarr[2], vfrac_prime))
     return out
 
-# TODO WE ARE GOING TO HAVE TO CHECK ALL OF THESE NUMERICALLY
-def vcv_chain(imarr):
-    """chain rule terms drho/dv' and dpsi/dv' for vcv
-       input is solver values
+def vcv_grad(imarr, gradarr):
+    """Apply J^T @ gradarr for vcv (vprime → rho, psi; mfrac held constant).
+
+    phys[1]=rho and phys[3]=psi both depend on vprime via vfrac, so the
+    Jacobian has off-diagonal terms. At mfrac=0 (pol='IV' regime) psi is
+    locally constant and the entire gradient flows through drho/dvprime.
+    Slot 1 of the result is zero because mfrac is held constant.
+
+    Parameters
+    ----------
+    imarr : np.ndarray, shape (4, ...)
+        Solver-space image array.
+    gradarr : np.ndarray, shape (4, ...)
+        Gradient w.r.t. physical components phys[0:4]. gradarr[0] is unused.
+
+    Returns
+    -------
+    out : np.ndarray, shape (3, ...)
+        Gradient w.r.t. solver slots (1, 2, 3).
     """
-    out = np.ones(imarr.shape)
+    mfrac = imarr[1]
+    vfrac_max = 1 - np.abs(mfrac)
+    if np.any(vfrac_max > 1):
+        raise Exception("vfrac_max>1 in vcv_grad!")
 
-    mfrac = imarr[1] # when using this transform, we interpret transformed imarr[1] as mfrac=\rho cos(\psi)
-    vfrac_max = 1-np.abs(mfrac)
-    if np.any(vfrac_max>1):
-        raise Exception("vfrac_max>1 in vcv_r!")
+    vprime = imarr[3]
+    vfrac = 2 * vfrac_max * np.arctan(vprime / TANWIDTH_V) / np.pi
+    rho = np.sqrt(mfrac ** 2 + vfrac ** 2)
 
-    vfrac_prime = imarr[3]
-    vfrac = 2*vfrac_max*np.arctan(vfrac_prime/TANWIDTH_V)/np.pi
-    rho = np.sqrt(mfrac**2 + vfrac**2)
-    psi = np.arcsin(vfrac/rho)
+    dv_dvprime = 2 * vfrac_max / (TANWIDTH_V * np.pi * (1 + (vprime / TANWIDTH_V) ** 2))
 
-    dv_dvprime = 2. * vfrac_max / (TANWIDTH_V*np.pi*(1 + (vfrac_prime/TANWIDTH_V)**2))
+    safe_rho = np.where(rho > 0, rho, 1.0)
+    drho_dvprime = (vfrac / safe_rho) * dv_dvprime
+    dpsi_dvprime = (np.abs(mfrac) / (safe_rho ** 2)) * dv_dvprime
 
-    # we only use mcv when holding v constant, so dF/imarr[1]=0
-    #drho_dv = rhofrac / v                # drho/dv holding m constant
-    #drho_dvprime = drho_dv * dv_dvprime
-    #out[1] = drho_dvprime
-    out[1] = np.zeros(out[3].shape)
-
-    dpsi_dv = mfrac / (rho*rho)          # dpsi/dv holding m constant # TODO CHECK
-    dpsi_dvprime = dpsi_dv * dv_dvprime
-    out[3] = dpsi_dvprime
+    out = np.empty((3,) + gradarr.shape[1:])
+    out[0] = 0.0
+    out[1] = gradarr[2]
+    out[2] = drho_dvprime * gradarr[1] + dpsi_dvprime * gradarr[3]
     return out
 
 

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -12,6 +12,8 @@ from ehtim.imaging.imager_backend import (
     compute_chisq_dict,
     compute_chisqgrad_dict,
     compute_embed,
+    transform_gradients,
+    transform_imarr,
 )
 
 # Parametrize over square, tall, and wide images
@@ -461,4 +463,150 @@ def test_chisq_and_chisqgrad_share_keys(gauss_im, observe, initialize_imager):
     chisq = _call_backend_chisq_dict(imgr, imcur)
     chisqgrad = _call_backend_chisqgrad_dict(imgr, imcur)
     assert set(chisq.keys()) == set(chisqgrad.keys())
+
+
+# ---------------------------------------------------------------------------
+# transform_gradients: chain rule correctness via finite differences
+# ---------------------------------------------------------------------------
+
+def _fd_grad_of_transform(imarr, transforms, which_solve, scalar_obj):
+    """Centered FD gradient of (scalar_obj o transform_imarr) w.r.t. solver vars.
+
+    Used to verify transform_gradients applies the chain rule correctly.
+    """
+    eps = 1e-6
+    grad = np.zeros_like(imarr)
+    for k in range(imarr.shape[0]):
+        for i in range(imarr.shape[1]):
+            ip = imarr.copy()
+            ip[k, i] += eps
+            im = imarr.copy()
+            im[k, i] -= eps
+            f_p = scalar_obj(transform_imarr(ip, transforms, which_solve))
+            f_m = scalar_obj(transform_imarr(im, transforms, which_solve))
+            grad[k, i] = (f_p - f_m) / (2 * eps)
+    return grad
+
+
+class TestTransformGradientsChainRule:
+    """transform_gradients chain rule agrees with FD of transform_imarr."""
+
+    @staticmethod
+    def _scalar_obj(phys):
+        """Arbitrary smooth scalar objective: weighted sum of physical components."""
+        weights = np.array([0.7, 1.3, -0.5, 0.9])[:, None]
+        return float(np.sum(weights * phys**2))
+
+    @staticmethod
+    def _solver_imarr(seed=0, n=8, v_pre=None, m_pre=None, chi_pre=None):
+        """Build a (4, n) solver-variable array; pass a scalar to pin a row."""
+        rng = np.random.default_rng(seed)
+        log_I = rng.uniform(-1.0, 1.0, size=n)
+        m_arr = rng.uniform(-2.0, 2.0, size=n) if m_pre is None else np.full(n, m_pre)
+        chi_arr = rng.uniform(-0.5, 0.5, size=n) if chi_pre is None else np.full(n, chi_pre)
+        v_arr = rng.uniform(-0.3, 0.3, size=n) if v_pre is None else np.full(n, v_pre)
+        return np.array([log_I, m_arr, chi_arr, v_arr])
+
+    @pytest.mark.parametrize(
+        "transforms,which_solve,imarr_kwargs,check_rows",
+        [
+            # ---- Real-usage operating points ----
+            # IP imaging: mcv with vfrac=0 (no V). Solve I, m_pre, chi.
+            (["log", "mcv"], np.array([1, 1, 1, 0]), {"v_pre": 0.0}, [0, 1, 2]),
+            # IV imaging: vcv with mfrac=0 (no Q/U). Solve I, v_pre.
+            (["log", "vcv"], np.array([1, 0, 0, 1]), {"m_pre": 0.0}, [0, 3]),
+            # IPV imaging: polcv with diagonal Jacobian. Solve I, rho_pre, psi_pre.
+            (["log", "polcv"], np.array([1, 1, 0, 1]), {}, [0, 1, 3]),
+            # ---- General regimes (cross-term coverage) ----
+            # mcv at vfrac != 0: dpsi/dmprime cross-term is nonzero.
+            (["log", "mcv"], np.array([1, 1, 0, 0]), {}, [0, 1]),
+            # vcv at mfrac != 0: dpsi/dvprime cross-term is nonzero.
+            (["log", "vcv"], np.array([1, 0, 0, 1]), {}, [0, 3]),
+            # ---- log only sanity ----
+            (["log"], np.array([1, 0, 0, 0]), {}, [0]),
+            # ---- pure pol cv (no log) sanity ----
+            (["mcv"], np.array([0, 1, 0, 0]), {"v_pre": 0.0}, [1]),
+            (["vcv"], np.array([0, 0, 0, 1]), {"m_pre": 0.0}, [3]),
+            (["polcv"], np.array([0, 1, 0, 1]), {}, [1, 3]),
+        ],
+        ids=[
+            "IP_vfrac0", "IV_mfrac0", "IPV",
+            "IP_general", "IV_general",
+            "log_only",
+            "mcv_only", "vcv_only", "polcv_only",
+        ],
+    )
+    def test_chain_rule_matches_finite_difference(self, transforms, which_solve,
+                                                    imarr_kwargs, check_rows):
+        """Chain rule output must match centered FD of (obj o transform)."""
+        imarr = self._solver_imarr(seed=0, **imarr_kwargs)
+
+        phys = transform_imarr(imarr, transforms, which_solve)
+        weights = np.array([0.7, 1.3, -0.5, 0.9])[:, None]
+        grad_phys = 2.0 * weights * phys
+
+        grad_solver = transform_gradients(grad_phys, imarr, transforms, which_solve)
+        grad_fd = _fd_grad_of_transform(
+            imarr, transforms, which_solve, self._scalar_obj,
+        )
+
+        for k in check_rows:
+            np.testing.assert_allclose(
+                grad_solver[k], grad_fd[k],
+                rtol=1e-5, atol=1e-8,
+                err_msg=f"chain rule mismatch on row {k} for transforms={transforms}",
+            )
+
+    def test_log_chain_preserved_under_mcv(self):
+        """outarr[0] from log+mcv must equal exp(imarr[0]) * gradarr[0]."""
+        imarr = self._solver_imarr(seed=1, v_pre=0.0)
+        gradarr = np.ones_like(imarr)
+        which_solve = np.array([1, 1, 0, 0])
+
+        out = transform_gradients(gradarr, imarr, ["log", "mcv"], which_solve)
+        np.testing.assert_allclose(out[0], np.exp(imarr[0]), rtol=1e-12)
+
+    def test_single_pol_log_chain_1d(self):
+        """nimage==1 branch: 1D imarr, outarr = exp(imarr) * gradarr."""
+        rng = np.random.default_rng(42)
+        imarr = rng.uniform(-1.0, 1.0, size=8)
+        gradarr = rng.uniform(-1.0, 1.0, size=8)
+        which_solve = np.array([1, 0, 0, 0])
+
+        out = transform_gradients(gradarr, imarr, ["log"], which_solve)
+        np.testing.assert_allclose(out, np.exp(imarr) * gradarr, rtol=1e-12)
+
+        out_no_log = transform_gradients(gradarr, imarr, [], which_solve)
+        np.testing.assert_allclose(out_no_log, gradarr, rtol=1e-12)
+
+    def test_multifreq_stokes_i_log_chain(self):
+        """nimage==3 branch: log applies to row 0 only; spectral coeffs pass through."""
+        rng = np.random.default_rng(7)
+        imarr = rng.uniform(-1.0, 1.0, size=(3, 6))
+        gradarr = rng.uniform(-1.0, 1.0, size=(3, 6))
+        which_solve = np.array([1, 1, 1, 0])
+
+        out = transform_gradients(gradarr, imarr, ["log"], which_solve)
+        np.testing.assert_allclose(out[0], np.exp(imarr[0]) * gradarr[0], rtol=1e-12)
+        np.testing.assert_array_equal(out[1], gradarr[1])
+        np.testing.assert_array_equal(out[2], gradarr[2])
+
+    def test_mf_pol_shape_smoke(self):
+        """nimage==10 branch (mf+pol): shape preserved, log applied to row 0, rows 4-9 pass through."""
+        rng = np.random.default_rng(13)
+        n = 6
+        imarr = np.empty((10, n))
+        imarr[0] = rng.uniform(-1.0, 1.0, size=n)
+        imarr[1] = rng.uniform(-2.0, 2.0, size=n)
+        imarr[2] = rng.uniform(-0.5, 0.5, size=n)
+        imarr[3] = 0.0  # vfrac pinned for pol='IP' regime
+        imarr[4:10] = rng.uniform(-0.3, 0.3, size=(6, n))
+        gradarr = rng.uniform(-1.0, 1.0, size=(10, n))
+        which_solve = np.array([1, 1, 0, 0, 1, 1, 0, 0, 0, 0])
+
+        out = transform_gradients(gradarr, imarr, ["log", "mcv"], which_solve)
+
+        assert out.shape == imarr.shape
+        np.testing.assert_allclose(out[0], np.exp(imarr[0]) * gradarr[0], rtol=1e-12)
+        np.testing.assert_array_equal(out[4:10], gradarr[4:10])
 


### PR DESCRIPTION
Replaces the element-wise `*_chain` chain rule API for the polcv / mcv / vcv image-space transforms with proper Jacobian-vector products (`*_grad`). The old element-wise scheme had three independent issues:

1. **I-segment clobbering** (the original task 2.14 ask): `outarr[0:4] = *_chain * gradarr[0:4]` overwrote `outarr[0] = exp(imarr[0]) * gradarr[0]` (set just above by the log block) because all `*_chain[0] = 1` from `np.ones` defaults. Stokes I gradient was off by a factor `exp(imarr[0])` whenever both `log` and any of `{mcv, vcv, polcv}` were active — i.e., all polarimetric Imager modes that solve for I.

2. **`mcv_chain` cross-terms dropped**: phys[1]=rho and phys[3]=psi both depend on mprime via mfrac. The element-wise scheme captured only the diagonal `drho/dmprime`, missing `dpsi/dmprime`. Vanishes at vfrac=0 (the real ehtim regime for pol="IP"), so subtle in production but visible off the V=0 axis.

3. **`vcv_chain` cross-terms dropped, completely broken at mfrac=0** (real pol="IV" regime): the only nonzero gradient contribution comes from the off-diagonal `drho/dvprime · grad_phys[1]`, which the element-wise scheme cannot route into `outarr[3]`. pol="IV" gradient descent was silently broken.

## Changes

- **`ehtim/imaging/pol_imager_utils.py`**: removed `polcv_chain` / `mcv_chain` / `vcv_chain`; added `polcv_grad(imarr, gradarr)` / `mcv_grad(imarr, gradarr)` / `vcv_grad(imarr, gradarr)`. Each returns shape `(3, ...)` for solver slots (1, 2, 3) and writes into `outarr[1:4]`. Math derived analytically (cross-terms verified by the FD tests below). `safe_rho = np.where(rho > 0, rho, 1.0)` handles the rho=0 limit cleanly.
- **`ehtim/imaging/imager_backend.py`**: 6-line edit to `transform_gradients` — the polarimetric branches now call `*_grad` and write to `outarr[1:4]`, leaving the log block's `outarr[0]` untouched.
- **`tests/test_imager_backend.py`**: new `TestTransformGradientsChainRule` class with 13 tests covering all dispatch branches.

## Test coverage

13 new tests, all passing:

| Test | Branch / scenario |
|---|---|
| `[IP_vfrac0]` | log+mcv at vfrac=0 (real pol="IP") |
| `[IV_mfrac0]` | log+vcv at mfrac=0 (real pol="IV") |
| `[IPV]` | log+polcv (real pol="IPV") |
| `[IP_general]` | log+mcv at vfrac≠0 (cross-term coverage) |
| `[IV_general]` | log+vcv at mfrac≠0 (cross-term coverage) |
| `[log_only]` | log standalone |
| `[mcv_only]` / `[vcv_only]` / `[polcv_only]` | each pol cv standalone (no log) |
| `test_log_chain_preserved_under_mcv` | direct I-segment regression |
| `test_single_pol_log_chain_1d` | nimage==1 branch backfill |
| `test_multifreq_stokes_i_log_chain` | nimage==3 branch backfill |
| `test_mf_pol_shape_smoke` | nimage==10 branch shape contract |

FD verification uses centered differences with eps=1e-6, tolerance rtol=1e-5. Verified by stash-and-rerun that the buggy version fails 4/9 parametrized cases plus the explicit regression test (the rest cover unaffected branches).

## Test plan

- [x] 279/279 tests pass (266 baseline + 13 new)
- [x] Ruff clean on changed files
- [x] FD math verified — pre-fix code fails the new tests
- [x] No external API breaks (the removed `*_chain` functions had only `transform_gradients` as a caller)

## Notes for review

- Simultaneous IP imaging: The fix unblocks correct gradient flow for pol="IP" and pol="IV" / "IPV".
- Branch is **independent of #227** (`feature/extract-reg-dicts`); `git merge-tree` confirms clean auto-merge whichever lands first.

Closes the 2.14 box in #212.