### PR TITLE
Extract objfunc/objgrad + remove chisq_transform legacy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [dev-backend]
   pull_request:
     branches: [dev-backend]
 
@@ -34,6 +36,8 @@ jobs:
         python-version: ["3.10", "3.12"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -194,9 +194,6 @@ class Imager:
         self.beam_size = self.obslist_next[0].res()
         self.regparams = {k: kwargs.get(k, REGPARAMS_DEFAULT[k]) for k in REGPARAMS_DEFAULT.keys()}
 
-        self.chisq_transform = False
-        self.chisq_offset_gradient = 0.0
-
         # FFT parameters
         self._ttype = kwargs.get('ttype', 'nfft')
         self._fft_gridder_prad = kwargs.get('fft_gridder_prad', GRIDDER_P_RAD_DEFAULT)
@@ -1132,7 +1129,6 @@ class Imager:
             self._data_tuples, self.obslist_next, self._logfreqratio_list,
             self.mf_next, self.pol_next, self._ttype, self._embed_mask,
             self._xprior, self.norm_reg, self._full_regparams(),
-            self.chisq_transform,
         )
 
     def objgrad(self, imvec):
@@ -1144,7 +1140,6 @@ class Imager:
             self.mf_next, self.pol_next, self._ttype, self._embed_mask,
             self._xprior, self.norm_reg, self._full_regparams(),
             self._nimage,
-            self.chisq_transform, self.chisq_offset_gradient,
         )
 
     def plotcur(self, imvec, **kwargs):

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -46,12 +46,12 @@ from ehtim.imaging.imager_backend import (
     compute_chisqgrad_dict,
     compute_embed,
     compute_objective,
+    compute_objective_grad,
     compute_reg_dict,
     compute_reggrad_dict,
     embed_imarr,
     make_initarr,
     pack_imarr,
-    transform_gradients,
     transform_imarr,
     transform_imarr_inverse,
     unpack_imarr,
@@ -1136,56 +1136,16 @@ class Imager:
         )
 
     def objgrad(self, imvec):
-        """Current objective function gradient.
-        """
-
-        # Unpack polarimetric/multifrequency vector into an array
-        imcur =  unpack_imarr(imvec, self._xarr, self._which_solve)
-
-        # apply image transform to bounded values
-        imcur_prime = imcur.copy()
-        imcur = transform_imarr(imcur, self.transform_next, self._which_solve)
-
-        # Data terms
-        datterm = 0.
-        chi2_term_dict = self.make_chisqgrad_dict(imcur)
-        if self.chisq_transform:
-            chi2_value_dict = self.make_chisq_dict(imcur)
-        for dname in sorted(self.dat_term_next.keys()):
-            hyperparameter = self.dat_term_next[dname]
-
-            for i, obs in enumerate(self.obslist_next):
-                if len(self.obslist_next)==1:
-                    dname_key = dname
-                else:
-                    dname_key = dname + (f'_{i}')
-
-                chi2_grad = chi2_term_dict[dname_key]
-
-                if self.chisq_transform:
-                    chi2_val = chi2_value_dict[dname]
-                    datterm += hyperparameter * chi2_grad * (1. - 1./(chi2_val**2))
-                else:
-                    datterm += hyperparameter * (chi2_grad + self.chisq_offset_gradient)
-
-        # Regularizer terms
-        regterm = 0
-        reg_term_dict = self.make_reggrad_dict(imcur)
-        for regname in sorted(self.reg_term_next.keys()):
-            hyperparameter = self.reg_term_next[regname]
-            regularizer_grad = reg_term_dict[regname]
-            regterm += hyperparameter * regularizer_grad
-
-        # Total gradient
-        grad = datterm + regterm
-
-        # Chain rule term for change of variables
-        grad = transform_gradients(grad, imcur_prime, self.transform_next, self._which_solve)
-
-        # repack gradient
-        grad = pack_imarr(grad, self._which_solve)
-
-        return grad
+        """Current objective function gradient."""
+        return compute_objective_grad(
+            imvec, self._xarr, self._which_solve, self.transform_next,
+            self.dat_term_next, self.reg_term_next,
+            self._data_tuples, self.obslist_next, self._logfreqratio_list,
+            self.mf_next, self.pol_next, self._ttype, self._embed_mask,
+            self._xprior, self.norm_reg, self._full_regparams(),
+            self._nimage,
+            self.chisq_transform, self.chisq_offset_gradient,
+        )
 
     def plotcur(self, imvec, **kwargs):
         """Plot current image.

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -484,7 +484,7 @@ class Imager:
         self._update_interval = kwargs.get('update_interval', 1)
 
         # Plot initial image
-        self.plotcur(self._xinit, **kwargs)
+        self.plotcur(self._init_vec, **kwargs)
 
         # Minimize
         print("Imaging . . .")
@@ -497,10 +497,10 @@ class Imager:
 
         tstart = time.time()
         if grads:
-            res = opt.minimize(self.objfunc, self._xinit, method='L-BFGS-B', jac=self.objgrad,
+            res = opt.minimize(self.objfunc, self._init_vec, method='L-BFGS-B', jac=self.objgrad,
                                options=optdict, callback=callback_func)
         else:
-            res = opt.minimize(self.objfunc, self._xinit, method='L-BFGS-B',
+            res = opt.minimize(self.objfunc, self._init_vec, method='L-BFGS-B',
                                options=optdict, callback=callback_func)
         tstop = time.time()
 
@@ -509,7 +509,7 @@ class Imager:
         self.tmpout = res.x
 
         # unpack output vector into outarr
-        outarr = unpack_imarr(out, self._xarr, self._which_solve)
+        outarr = unpack_imarr(out, self._init_arr, self._which_solve)
 
         # apply image transform to bounded values
         outarr = transform_imarr(outarr, self.transform_next, self._which_solve)
@@ -800,6 +800,20 @@ class Imager:
 
     def init_imager(self):
         """Set up Stokes I imager.
+
+        Naming convention for image arrays (used here and in imager_backend):
+            init_*   the *initial image* (used as the not-solved-for fallback
+                     in unpack_imarr; replaces solved-for slots with starting
+                     values for L-BFGS-B).
+            prior_*  the regularizer *prior image* (a reference for terms like
+                     'simple', 'l1', 'rgauss'; can differ from the initial image).
+            *_phys   array in physical (Stokes / pol-fraction) space.
+            *_solver array in transformed solver space (e.g. log, mcv, polcv).
+            *_arr    multi-D unwrapped array (one row per Stokes/freq term).
+            *_vec    1D packed solver vector (only the solved-for slots, ready
+                     for scipy.optimize).
+        Hence: self._prior_arr (physical), self._init_arr (solver),
+               self._init_vec (packed solver vector).
         """
         # Backends accept n_obs as a scalar; this assertion guards the
         # invariant they rely on (len(obslist) == len(freq_list) == len(logfreqratio_list)).
@@ -890,21 +904,21 @@ class Imager:
                 if ('P' in self.pol_next) or ('QU' in self.pol_next):
                     randompol_lin=True
 
-                initarr = make_initarr(self.init_next, self._embed_mask,
+                init_phys = make_initarr(self.init_next, self._embed_mask,
                                        norm_init=self.norm_init, flux=self.flux_next,
                                        mf=True, pol=True,
                                        randompol_lin=randompol_lin, randompol_circ=randompol_circ,
                                        meanpol=MEANPOL_INIT, sigmapol=SIGMAPOL_INIT)
-                priorarr = make_initarr(self.prior_next, self._embed_mask,
+                prior_phys = make_initarr(self.prior_next, self._embed_mask,
                                         norm_init=self.norm_init, flux=self.flux_next,
                                         mf=True, pol=True,
                                         randompol_lin=False, randompol_circ=False)
                 # prior
-                self._xprior = priorarr
+                self._prior_arr = prior_phys
 
-                # transform the initial image to solved for values and assign to self._xarr
-                initarr = transform_imarr_inverse(initarr, self.transform_next, self._which_solve)
-                self._xarr = initarr
+                # transform the initial image from physical to solver space
+                init_solver = transform_imarr_inverse(init_phys, self.transform_next, self._which_solve)
+                self._init_arr = init_solver
 
             # Stokes I multi-frequency
             else:
@@ -913,23 +927,23 @@ class Imager:
                 self._which_solve = np.array([1,do_a,do_b])
 
                 # make initial and prior images
-                initarr = make_initarr(self.init_next, self._embed_mask,
+                init_phys = make_initarr(self.init_next, self._embed_mask,
                                        norm_init=self.norm_init, flux=self.flux_next,
                                        mf=True, pol=False)
-                priorarr = make_initarr(self.prior_next, self._embed_mask,
+                prior_phys = make_initarr(self.prior_next, self._embed_mask,
                                        norm_init=self.norm_init, flux=self.flux_next,
                                        mf=True, pol=False)
 
                 # prior
-                self._xprior = priorarr
+                self._prior_arr = prior_phys
 
 
-                # transform the initial image to solved for values and assign to self._xarr
-                initarr = transform_imarr_inverse(initarr, self.transform_next, self._which_solve)
-                self._xarr = initarr
+                # transform the initial image from physical to solver space
+                init_solver = transform_imarr_inverse(init_phys, self.transform_next, self._which_solve)
+                self._init_arr = init_solver
 
             # Pack multi-frequency tuple into single vector
-            self._xinit = pack_imarr(self._xarr, self._which_solve)
+            self._init_vec = pack_imarr(self._init_arr, self._which_solve)
 
         # Set prior & initial image vectors for single-frequency imaging
         else:
@@ -965,24 +979,24 @@ class Imager:
                 if ('P' in self.pol_next) or ('QU' in self.pol_next):
                     randompol_lin=True
 
-                initarr = make_initarr(self.init_next, self._embed_mask,
+                init_phys = make_initarr(self.init_next, self._embed_mask,
                                        norm_init=self.norm_init, flux=self.flux_next,
                                        mf=False, pol=True,
                                        randompol_lin=randompol_lin, randompol_circ=randompol_circ,
                                        meanpol=MEANPOL_INIT, sigmapol=SIGMAPOL_INIT)
-                priorarr = make_initarr(self.prior_next, self._embed_mask,
+                prior_phys = make_initarr(self.prior_next, self._embed_mask,
                                        norm_init=self.norm_init, flux=self.flux_next,
                                        mf=False, pol=True,
                                        randompol_lin=False, randompol_circ=False)
                 # prior
-                self._xprior = priorarr
+                self._prior_arr = prior_phys
 
-                # transform the initial image to solved for values and assign to self._xarr
-                initarr = transform_imarr_inverse(initarr, self.transform_next, self._which_solve)
-                self._xarr = initarr
+                # transform the initial image from physical to solver space
+                init_solver = transform_imarr_inverse(init_phys, self.transform_next, self._which_solve)
+                self._init_arr = init_solver
 
                 # Pack into single vector
-                self._xinit = pack_imarr(self._xarr, self._which_solve)
+                self._init_vec = pack_imarr(self._init_arr, self._which_solve)
 
             # regular single-frequency single-stokes (or RR, LL) imaging
             else:
@@ -990,22 +1004,22 @@ class Imager:
                 self._which_solve = np.array([1])
 
                 # make initial and prior images
-                initarr = make_initarr(self.init_next, self._embed_mask,
+                init_phys = make_initarr(self.init_next, self._embed_mask,
                                        norm_init=self.norm_init, flux=self.flux_next,
                                        mf=False, pol=False)
-                priorarr = make_initarr(self.prior_next, self._embed_mask,
+                prior_phys = make_initarr(self.prior_next, self._embed_mask,
                                        norm_init=self.norm_init, flux=self.flux_next,
                                        mf=False, pol=False)
 
                 # Prior
-                self._xprior = priorarr
+                self._prior_arr = prior_phys
 
-                # transform the initial image to solved for values and assign to self._xarr
-                initarr = transform_imarr_inverse(initarr, self.transform_next, self._which_solve)
-                self._xarr = initarr
+                # transform the initial image from physical to solver space
+                init_solver = transform_imarr_inverse(init_phys, self.transform_next, self._which_solve)
+                self._init_arr = init_solver
 
                 # Pack into single vector
-                self._xinit = pack_imarr(self._xarr, self._which_solve)
+                self._init_vec = pack_imarr(self._init_arr, self._which_solve)
 
         # Make data term tuples
         if self._change_imgr_params:
@@ -1079,9 +1093,10 @@ class Imager:
            input is image array transformed to bounded values
         """
         return compute_chisq_dict(
-            imcur, sorted(self.dat_term_next.keys()), self._data_tuples,
-            len(self.obslist_next), self._logfreqratio_list, self.mf_next,
-            self.pol_next, self._ttype, self._embed_mask,
+            imcur, sorted(self.dat_term_next.keys()),
+            self.mf_next, self.pol_next,
+            self._data_tuples, self._logfreqratio_list, len(self.obslist_next),
+            self._ttype, self._embed_mask,
         )
 
     def make_chisqgrad_dict(self, imcur):
@@ -1089,9 +1104,10 @@ class Imager:
            input is image array transformed to bounded values
         """
         return compute_chisqgrad_dict(
-            imcur, sorted(self.dat_term_next.keys()), self._data_tuples,
-            len(self.obslist_next), self._logfreqratio_list, self.mf_next,
-            self.pol_next, self._ttype, self._embed_mask,
+            imcur, sorted(self.dat_term_next.keys()),
+            self.mf_next, self.pol_next,
+            self._data_tuples, self._logfreqratio_list, len(self.obslist_next),
+            self._ttype, self._embed_mask,
             self._which_solve, self._nimage,
         )
 
@@ -1114,9 +1130,11 @@ class Imager:
            input is image array transformed to bounded values
         """
         return compute_reg_dict(
-            imcur, sorted(self.reg_term_next.keys()), self._xprior, self._embed_mask,
-            self.mf_next, len(self.obslist_next), self._logfreqratio_list, self.pol_next,
-            self.norm_reg, self._full_regparams(),
+            imcur, sorted(self.reg_term_next.keys()),
+            self.mf_next, self.pol_next,
+            self._logfreqratio_list, len(self.obslist_next),
+            self._prior_arr, self.norm_reg, self._full_regparams(),
+            self._embed_mask,
         )
 
     def make_reggrad_dict(self, imcur):
@@ -1124,31 +1142,36 @@ class Imager:
            input is image array transformed to bounded values
         """
         return compute_reggrad_dict(
-            imcur, sorted(self.reg_term_next.keys()), self._xprior, self._embed_mask,
-            self.mf_next, len(self.obslist_next), self._logfreqratio_list, self.pol_next,
-            self.norm_reg, self._full_regparams(),
+            imcur, sorted(self.reg_term_next.keys()),
+            self.mf_next, self.pol_next,
+            self._logfreqratio_list, len(self.obslist_next),
+            self._prior_arr, self.norm_reg, self._full_regparams(),
+            self._embed_mask,
             self._which_solve, self._nimage,
         )
 
     def objfunc(self, imvec):
         """Current objective function."""
         return compute_objective(
-            imvec, self._xarr, self._which_solve, self.transform_next,
+            imvec, self._init_arr,
+            self.mf_next, self.pol_next,
+            self._which_solve, self._data_tuples,
+            self._logfreqratio_list, len(self.obslist_next),
             self.dat_term_next, self.reg_term_next,
-            self._data_tuples, len(self.obslist_next), self._logfreqratio_list,
-            self.mf_next, self.pol_next, self._ttype, self._embed_mask,
-            self._xprior, self.norm_reg, self._full_regparams(),
+            self._prior_arr, self.norm_reg, self._full_regparams(),
+            self.transform_next, self._embed_mask, self._ttype,
         )
 
     def objgrad(self, imvec):
         """Current objective function gradient."""
         return compute_objective_grad(
-            imvec, self._xarr, self._which_solve, self.transform_next,
+            imvec, self._init_arr,
+            self.mf_next, self.pol_next,
+            self._which_solve, self._data_tuples,
+            self._logfreqratio_list, len(self.obslist_next),
             self.dat_term_next, self.reg_term_next,
-            self._data_tuples, len(self.obslist_next), self._logfreqratio_list,
-            self.mf_next, self.pol_next, self._ttype, self._embed_mask,
-            self._xprior, self.norm_reg, self._full_regparams(),
-            self._nimage,
+            self._prior_arr, self.norm_reg, self._full_regparams(),
+            self.transform_next, self._embed_mask, self._ttype, self._nimage,
         )
 
     def plotcur(self, imvec, **kwargs):
@@ -1158,7 +1181,7 @@ class Imager:
         if self._show_updates:
             if self._nit % self._update_interval == 0:
                 # Unpack polarimetric/multifrequency vector into an array
-                imcur =  unpack_imarr(imvec, self._xarr, self._which_solve)
+                imcur =  unpack_imarr(imvec, self._init_arr, self._which_solve)
 
                 # apply image transform to bounded values
                 imcur_prime = imcur.copy()

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -801,6 +801,15 @@ class Imager:
     def init_imager(self):
         """Set up Stokes I imager.
         """
+        # Backends accept n_obs as a scalar; this assertion guards the
+        # invariant they rely on (len(obslist) == len(freq_list) == len(logfreqratio_list)).
+        n_obs = len(self.obslist_next)
+        if not (len(self.freq_list) == n_obs and len(self._logfreqratio_list) == n_obs):
+            raise Exception(
+                "Imager state inconsistent: len(obslist_next), len(freq_list), "
+                "len(_logfreqratio_list) must all match."
+            )
+
         # Set embedding mask
         self.set_embed()
         self._nimage = np.sum(self._embed_mask)
@@ -1071,7 +1080,7 @@ class Imager:
         """
         return compute_chisq_dict(
             imcur, sorted(self.dat_term_next.keys()), self._data_tuples,
-            self.obslist_next, self._logfreqratio_list, self.mf_next,
+            len(self.obslist_next), self._logfreqratio_list, self.mf_next,
             self.pol_next, self._ttype, self._embed_mask,
         )
 
@@ -1081,7 +1090,7 @@ class Imager:
         """
         return compute_chisqgrad_dict(
             imcur, sorted(self.dat_term_next.keys()), self._data_tuples,
-            self.obslist_next, self._logfreqratio_list, self.mf_next,
+            len(self.obslist_next), self._logfreqratio_list, self.mf_next,
             self.pol_next, self._ttype, self._embed_mask,
             self._which_solve, self._nimage,
         )
@@ -1106,7 +1115,7 @@ class Imager:
         """
         return compute_reg_dict(
             imcur, sorted(self.reg_term_next.keys()), self._xprior, self._embed_mask,
-            self.mf_next, self.obslist_next, self._logfreqratio_list, self.pol_next,
+            self.mf_next, len(self.obslist_next), self._logfreqratio_list, self.pol_next,
             self.norm_reg, self._full_regparams(),
         )
 
@@ -1116,7 +1125,7 @@ class Imager:
         """
         return compute_reggrad_dict(
             imcur, sorted(self.reg_term_next.keys()), self._xprior, self._embed_mask,
-            self.mf_next, self.obslist_next, self._logfreqratio_list, self.pol_next,
+            self.mf_next, len(self.obslist_next), self._logfreqratio_list, self.pol_next,
             self.norm_reg, self._full_regparams(),
             self._which_solve, self._nimage,
         )
@@ -1126,7 +1135,7 @@ class Imager:
         return compute_objective(
             imvec, self._xarr, self._which_solve, self.transform_next,
             self.dat_term_next, self.reg_term_next,
-            self._data_tuples, self.obslist_next, self._logfreqratio_list,
+            self._data_tuples, len(self.obslist_next), self._logfreqratio_list,
             self.mf_next, self.pol_next, self._ttype, self._embed_mask,
             self._xprior, self.norm_reg, self._full_regparams(),
         )
@@ -1136,7 +1145,7 @@ class Imager:
         return compute_objective_grad(
             imvec, self._xarr, self._which_solve, self.transform_next,
             self.dat_term_next, self.reg_term_next,
-            self._data_tuples, self.obslist_next, self._logfreqratio_list,
+            self._data_tuples, len(self.obslist_next), self._logfreqratio_list,
             self.mf_next, self.pol_next, self._ttype, self._embed_mask,
             self._xprior, self.norm_reg, self._full_regparams(),
             self._nimage,

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -45,6 +45,7 @@ from ehtim.imaging.imager_backend import (
     compute_chisq_dict,
     compute_chisqgrad_dict,
     compute_embed,
+    compute_objective,
     compute_reg_dict,
     compute_reggrad_dict,
     embed_imarr,
@@ -1124,46 +1125,15 @@ class Imager:
         )
 
     def objfunc(self, imvec):
-        """Current objective function.
-        """
-
-        # Unpack polarimetric/multifrequency vector into an array
-        imcur =  unpack_imarr(imvec, self._xarr, self._which_solve)
-
-        # apply image transform to bounded values
-        imcur = transform_imarr(imcur, self.transform_next, self._which_solve)
-
-        # Data terms
-        datterm = 0.
-        chi2_term_dict = self.make_chisq_dict(imcur)
-        for dname in sorted(self.dat_term_next.keys()):
-            hyperparameter = self.dat_term_next[dname]
-
-            for i, obs in enumerate(self.obslist_next):
-                if len(self.obslist_next)==1:
-                    dname_key = dname
-                else:
-                    dname_key = dname + (f'_{i}')
-
-                chi2 = chi2_term_dict[dname_key]
-
-                if self.chisq_transform:
-                    datterm += hyperparameter * (chi2 + 1./chi2 - 1.)
-                else:
-                    datterm += hyperparameter * (chi2 - 1.)
-
-        # Regularizer terms
-        regterm = 0
-        reg_term_dict = self.make_reg_dict(imcur)
-        for regname in sorted(self.reg_term_next.keys()):
-            hyperparameter = self.reg_term_next[regname]
-            regularizer = reg_term_dict[regname]
-            regterm += hyperparameter * regularizer
-
-        # Total cost
-        cost = datterm + regterm
-
-        return cost
+        """Current objective function."""
+        return compute_objective(
+            imvec, self._xarr, self._which_solve, self.transform_next,
+            self.dat_term_next, self.reg_term_next,
+            self._data_tuples, self.obslist_next, self._logfreqratio_list,
+            self.mf_next, self.pol_next, self._ttype, self._embed_mask,
+            self._xprior, self.norm_reg, self._full_regparams(),
+            self.chisq_transform,
+        )
 
     def objgrad(self, imvec):
         """Current objective function gradient.

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -858,8 +858,7 @@ def compute_objective(imvec, xarr, which_solve, transforms,
                       dat_term, reg_term,
                       data_tuples, obslist, logfreqratio_list,
                       mf, pol, ttype, embed_mask,
-                      xprior, norm_reg, regparams,
-                      chisq_transform=False):
+                      xprior, norm_reg, regparams):
     """Pure objective: data fidelity + regularization, summed with hyperparameter weights."""
 
     dat_term_keys = sorted(dat_term.keys())
@@ -884,11 +883,7 @@ def compute_objective(imvec, xarr, which_solve, transforms,
         weight = dat_term[dname]
         for i in range(n_obs):
             key = dname if n_obs == 1 else f"{dname}_{i}"
-            chi2 = chi2_dict[key]
-            if chisq_transform:
-                datterm = datterm + weight * (chi2 + 1.0 / chi2 - 1.0)
-            else:
-                datterm = datterm + weight * (chi2 - 1.0)
+            datterm = datterm + weight * (chi2_dict[key] - 1.0)
 
     regterm = 0.0
     for regname in reg_term_keys:
@@ -902,8 +897,7 @@ def compute_objective_grad(imvec, xarr, which_solve, transforms,
                            data_tuples, obslist, logfreqratio_list,
                            mf, pol, ttype, embed_mask,
                            xprior, norm_reg, regparams,
-                           nimage,
-                           chisq_transform=False, chisq_offset_gradient=0.0):
+                           nimage):
     """Pure objective gradient: data-fidelity grad + regularization grad,
     chain-ruled through the bounded-value transform, packed into solver space."""
 
@@ -920,12 +914,6 @@ def compute_objective_grad(imvec, xarr, which_solve, transforms,
         obslist, logfreqratio_list, mf, pol, ttype, embed_mask,
         which_solve, nimage,
     )
-    chi2val_dict = None
-    if chisq_transform:
-        chi2val_dict = compute_chisq_dict(
-            imcur, dat_term_keys, data_tuples,
-            obslist, logfreqratio_list, mf, pol, ttype, embed_mask,
-        )
 
     reggrad_dict = compute_reggrad_dict(
         imcur, reg_term_keys, xprior, embed_mask,
@@ -939,12 +927,7 @@ def compute_objective_grad(imvec, xarr, which_solve, transforms,
         weight = dat_term[dname]
         for i in range(n_obs):
             key = dname if n_obs == 1 else f"{dname}_{i}"
-            chi2_grad = chi2grad_dict[key]
-            if chisq_transform:
-                chi2_val = chi2val_dict[key]
-                datterm = datterm + weight * chi2_grad * (1.0 - 1.0 / (chi2_val ** 2))
-            else:
-                datterm = datterm + weight * (chi2_grad + chisq_offset_gradient)
+            datterm = datterm + weight * chi2grad_dict[key]
 
     regterm = 0.0
     for regname in reg_term_keys:

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -852,3 +852,46 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
         reggrad_dict[regname] = reggrad
 
     return reggrad_dict
+
+
+def compute_objective(imvec, xarr, which_solve, transforms,
+                      dat_term, reg_term,
+                      data_tuples, obslist, logfreqratio_list,
+                      mf, pol, ttype, embed_mask,
+                      xprior, norm_reg, regparams,
+                      chisq_transform=False):
+    """Pure objective: data fidelity + regularization, summed with hyperparameter weights."""
+
+    dat_term_keys = sorted(dat_term.keys())
+    reg_term_keys = sorted(reg_term.keys())
+
+    # Unpack solver vector into image array, then apply bounded-value transform
+    imcur = unpack_imarr(imvec, xarr, which_solve)
+    imcur = transform_imarr(imcur, transforms, which_solve)
+
+    chi2_dict = compute_chisq_dict(
+        imcur, dat_term_keys, data_tuples,
+        obslist, logfreqratio_list, mf, pol, ttype, embed_mask,
+    )
+    reg_dict = compute_reg_dict(
+        imcur, reg_term_keys, xprior, embed_mask,
+        mf, obslist, logfreqratio_list, pol, norm_reg, regparams,
+    )
+
+    n_obs = len(obslist)
+    datterm = 0.0
+    for dname in dat_term_keys:
+        weight = dat_term[dname]
+        for i in range(n_obs):
+            key = dname if n_obs == 1 else f"{dname}_{i}"
+            chi2 = chi2_dict[key]
+            if chisq_transform:
+                datterm = datterm + weight * (chi2 + 1.0 / chi2 - 1.0)
+            else:
+                datterm = datterm + weight * (chi2 - 1.0)
+
+    regterm = 0.0
+    for regname in reg_term_keys:
+        regterm = regterm + reg_term[regname] * reg_dict[regname]
+
+    return datterm + regterm

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -889,7 +889,58 @@ def compute_objective(imvec, initvec,
                       dat_term, reg_term,
                       priorvec, norm_reg, regparams,
                       transforms, embed_mask, ttype):
-    """Pure objective: data fidelity + regularization, summed with hyperparameter weights."""
+    """Compute the scalar imaging objective: data fidelity + regularization.
+
+    Pure-functional version of Imager.objfunc. Unpacks the 1D solver vector
+    `imvec` into a multi-D image array (filling not-solved-for slots from
+    `initvec`), applies the bounded-value transforms, evaluates each chi^2
+    and regularizer term via the dispatcher dicts, and returns the
+    hyperparameter-weighted sum.
+
+    Parameters
+    ----------
+    imvec : np.ndarray
+        1D solver vector (length sum(which_solve) * nimage), the optimization
+        variable for L-BFGS-B.
+    initvec : np.ndarray
+        Initial-image array (unwrapped, multi-D); used by `unpack_imarr` to
+        fill any not-solved-for slots. Distinct from `priorvec` (the
+        regularizer prior).
+    mf : bool
+        Multifrequency-imaging flag.
+    pol : str
+        Polarization mode (e.g. 'I', 'P', 'IP', 'V', 'IV', ...).
+    which_solve : np.ndarray of int
+        Per-Stokes / per-spectral-term solve mask.
+    data_tuples : dict
+        Pre-computed (data, sigma, A) tuples keyed by dname or dname_i.
+    logfreqratio_list : list of float
+        log(nu_i / reffreq) for each observation.
+    n_obs : int
+        Number of observations. Must equal len(logfreqratio_list); enforced
+        upstream by Imager.init_imager.
+    dat_term, reg_term : dict
+        Hyperparameter weights per data term and per regularizer term.
+    priorvec : np.ndarray
+        Prior-image array consumed by regularizers like 'simple', 'l1',
+        'rgauss'. Distinct from `initvec` (the optimization start point).
+    norm_reg : bool
+        Whether to apply per-regularizer normalization.
+    regparams : dict
+        Bundle of regularizer parameters. See compute_reg_dict.
+    transforms : list of str
+        Image transform list (e.g. ['log', 'mcv']) applied to imcur.
+    embed_mask : np.ndarray of bool
+        Pixel embedding mask.
+    ttype : str
+        Fourier-transform type ('direct', 'fast', 'nfft').
+
+    Returns
+    -------
+    cost : float
+        Scalar objective value, sum of weighted chi^2 deviations and
+        regularizer contributions.
+    """
 
     dat_term_keys = sorted(dat_term.keys())
     reg_term_keys = sorted(reg_term.keys())
@@ -934,8 +985,32 @@ def compute_objective_grad(imvec, initvec,
                            dat_term, reg_term,
                            priorvec, norm_reg, regparams,
                            transforms, embed_mask, ttype, nimage):
-    """Pure objective gradient: data-fidelity grad + regularization grad,
-    chain-ruled through the bounded-value transform, packed into solver space."""
+    """Compute the gradient of the imaging objective with respect to imvec.
+
+    Pure-functional version of Imager.objgrad. Computes the chi^2 and
+    regularizer gradients via the dispatcher dicts, sums them with the
+    hyperparameter weights, applies the chain rule through the bounded-value
+    transform, and packs the result back into solver space.
+
+    Designed so that `jax.grad(compute_objective)` is a drop-in replacement
+    once the underlying backends are JAXified (Phase 5D three-way check
+    against finite differences and analytic).
+
+    Parameters
+    ----------
+    imvec, initvec, mf, pol, which_solve, data_tuples, logfreqratio_list,
+    n_obs, dat_term, reg_term, priorvec, norm_reg, regparams, transforms,
+    embed_mask, ttype : see compute_objective.
+    nimage : int
+        Number of active pixels (sum of embed_mask). Used to size the
+        pre-pack gradient array.
+
+    Returns
+    -------
+    grad : np.ndarray
+        1D gradient vector (same length as imvec), suitable as the `jac`
+        argument to scipy.optimize.minimize.
+    """
 
     dat_term_keys = sorted(dat_term.keys())
     reg_term_keys = sorted(reg_term.keys())

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -941,10 +941,7 @@ def compute_objective_grad(imvec, xarr, which_solve, transforms,
             key = dname if n_obs == 1 else f"{dname}_{i}"
             chi2_grad = chi2grad_dict[key]
             if chisq_transform:
-                # chi2val_dict is keyed by dname (no per-obs suffix), unlike
-                # chi2grad_dict above. Asymmetry preserved verbatim from
-                # Imager.objgrad behaviour.
-                chi2_val = chi2val_dict[dname]
+                chi2_val = chi2val_dict[key]
                 datterm = datterm + weight * chi2_grad * (1.0 - 1.0 / (chi2_val ** 2))
             else:
                 datterm = datterm + weight * (chi2_grad + chisq_offset_gradient)

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -428,7 +428,7 @@ def compute_embed(imvec, xdim, ydim, psize, clipfloor):
     return embed_mask, coord_matrix
 
 
-def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist,
+def compute_chisq_dict(imcur, dat_term_keys, data_tuples, n_obs,
                        logfreqratio_list, mf, pol, ttype, embed_mask):
     """Compute chi^2 value for each data term across all observations.
 
@@ -441,8 +441,9 @@ def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist,
     data_tuples : dict
         Pre-computed data products keyed by dname or dname_i,
         each value is a (data, sigma, A) tuple.
-    obslist : list
-        List of Obsdata objects (one per frequency/epoch).
+    n_obs : int
+        Number of observations (frequencies/epochs). Must equal
+        len(logfreqratio_list); validated by Imager.init_imager.
     logfreqratio_list : list of float
         Log frequency ratios log(nu_i/reffreq); one per obs.
     mf : bool
@@ -461,9 +462,9 @@ def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist,
     """
     chi2_dict = {}
     for dname in dat_term_keys:
-        # Loop over all observations in the list
-        for i, obs in enumerate(obslist):
-            if len(obslist) == 1:
+        # Loop over all observations
+        for i in range(n_obs):
+            if n_obs == 1:
                 dname_key = dname
             else:
                 dname_key = dname + (f'_{i}')
@@ -500,7 +501,7 @@ def compute_chisq_dict(imcur, dat_term_keys, data_tuples, obslist,
     return chi2_dict
 
 
-def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist,
+def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, n_obs,
                            logfreqratio_list, mf, pol, ttype, embed_mask,
                            which_solve, nimage):
     """Compute chi^2 gradient for each data term across all observations.
@@ -514,8 +515,9 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist,
     data_tuples : dict
         Pre-computed data products keyed by dname or dname_i,
         each value is a (data, sigma, A) tuple.
-    obslist : list
-        List of Obsdata objects (one per frequency/epoch).
+    n_obs : int
+        Number of observations (frequencies/epochs). Must equal
+        len(logfreqratio_list); validated by Imager.init_imager.
     logfreqratio_list : list of float
         Log frequency ratios log(nu_i/reffreq); one per obs.
     mf : bool
@@ -541,9 +543,9 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist,
     # because np.array((...)) below copies into a new (4, nimage) array each time.
     zero_row = np.zeros(nimage)
     for dname in dat_term_keys:
-        # Loop over all observations in the list
-        for i, obs in enumerate(obslist):
-            if len(obslist) == 1:
+        # Loop over all observations
+        for i in range(n_obs):
+            if n_obs == 1:
                 dname_key = dname
             else:
                 dname_key = dname + (f'_{i}')
@@ -597,7 +599,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, obslist,
 
 
 def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
-                     mf, obslist, logfreqratio_list, pol,
+                     mf, n_obs, logfreqratio_list, pol,
                      norm_reg, regparams):
     """Compute regularizer value for each regularizer term.
 
@@ -613,8 +615,9 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
         Pixel embedding mask.
     mf : bool
         Whether multifrequency imaging is enabled.
-    obslist : list
-        List of Obsdata objects (one per frequency/epoch).
+    n_obs : int
+        Number of observations (frequencies/epochs). Must equal
+        len(logfreqratio_list); validated by Imager.init_imager.
     logfreqratio_list : list of float
         Log frequency ratios log(nu_i/reffreq); one per obs.
     pol : str
@@ -655,12 +658,12 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
                 if regname in REGULARIZERS_ALLFREQS_I:
 
                     # TODO move this to checks?
-                    if (not isinstance(mf_flux, list)) or len(mf_flux) != len(obslist):
+                    if (not isinstance(mf_flux, list)) or len(mf_flux) != n_obs:
                         raise Exception(f"when using regularizer '{regname}', "
-                                        + "mf_flux must be a list of same length as obslist!")
+                                        + "mf_flux must be a list of same length as n_obs!")
 
                     regname_base = '_'.join(regname.split('_')[:-1])  # remove the '_mf' tag
-                    for i in range(len(obslist)):
+                    for i in range(n_obs):
 
                         logfreqratio = logfreqratio_list[i]
                         imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
@@ -726,14 +729,14 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
 
 
 def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
-                         mf, obslist, logfreqratio_list, pol,
+                         mf, n_obs, logfreqratio_list, pol,
                          norm_reg, regparams,
                          which_solve, nimage):
     """Compute regularizer gradient for each regularizer term.
 
     Parameters
     ----------
-    imcur, reg_term_keys, xprior, embed_mask, mf, obslist, logfreqratio_list,
+    imcur, reg_term_keys, xprior, embed_mask, mf, n_obs, logfreqratio_list,
     pol, norm_reg, regparams : see compute_reg_dict.
     which_solve : np.ndarray of bool
         Per-Stokes solve mask (used by polregularizergrad).
@@ -773,12 +776,12 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
                 if regname in REGULARIZERS_ALLFREQS_I:
 
                     # TODO move this to checks?
-                    if (not isinstance(mf_flux, list)) or len(mf_flux) != len(obslist):
+                    if (not isinstance(mf_flux, list)) or len(mf_flux) != n_obs:
                         raise Exception(f"when using regularizer '{regname}', "
-                                        + "mf_flux must be a list of same length as obslist!")
+                                        + "mf_flux must be a list of same length as n_obs!")
 
                     regname_base = '_'.join(regname.split('_')[:-1])  # remove the '_mf' tag
-                    for i in range(len(obslist)):
+                    for i in range(n_obs):
 
                         logfreqratio = logfreqratio_list[i]
                         imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
@@ -856,7 +859,7 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
 
 def compute_objective(imvec, xarr, which_solve, transforms,
                       dat_term, reg_term,
-                      data_tuples, obslist, logfreqratio_list,
+                      data_tuples, n_obs, logfreqratio_list,
                       mf, pol, ttype, embed_mask,
                       xprior, norm_reg, regparams):
     """Pure objective: data fidelity + regularization, summed with hyperparameter weights."""
@@ -870,14 +873,13 @@ def compute_objective(imvec, xarr, which_solve, transforms,
 
     chi2_dict = compute_chisq_dict(
         imcur, dat_term_keys, data_tuples,
-        obslist, logfreqratio_list, mf, pol, ttype, embed_mask,
+        n_obs, logfreqratio_list, mf, pol, ttype, embed_mask,
     )
     reg_dict = compute_reg_dict(
         imcur, reg_term_keys, xprior, embed_mask,
-        mf, obslist, logfreqratio_list, pol, norm_reg, regparams,
+        mf, n_obs, logfreqratio_list, pol, norm_reg, regparams,
     )
 
-    n_obs = len(obslist)
     datterm = 0.0
     for dname in dat_term_keys:
         weight = dat_term[dname]
@@ -894,7 +896,7 @@ def compute_objective(imvec, xarr, which_solve, transforms,
 
 def compute_objective_grad(imvec, xarr, which_solve, transforms,
                            dat_term, reg_term,
-                           data_tuples, obslist, logfreqratio_list,
+                           data_tuples, n_obs, logfreqratio_list,
                            mf, pol, ttype, embed_mask,
                            xprior, norm_reg, regparams,
                            nimage):
@@ -911,17 +913,16 @@ def compute_objective_grad(imvec, xarr, which_solve, transforms,
 
     chi2grad_dict = compute_chisqgrad_dict(
         imcur, dat_term_keys, data_tuples,
-        obslist, logfreqratio_list, mf, pol, ttype, embed_mask,
+        n_obs, logfreqratio_list, mf, pol, ttype, embed_mask,
         which_solve, nimage,
     )
 
     reggrad_dict = compute_reggrad_dict(
         imcur, reg_term_keys, xprior, embed_mask,
-        mf, obslist, logfreqratio_list, pol, norm_reg, regparams,
+        mf, n_obs, logfreqratio_list, pol, norm_reg, regparams,
         which_solve, nimage,
     )
 
-    n_obs = len(obslist)
     datterm = 0.0
     for dname in dat_term_keys:
         weight = dat_term[dname]

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -23,6 +23,24 @@ import ehtim.imaging.imager_utils as imutils
 import ehtim.imaging.multifreq_imager_utils as mfutils
 import ehtim.imaging.pol_imager_utils as polutils
 
+# -----------------------------------------------------------------------------
+# Naming convention for image arguments throughout this module
+# -----------------------------------------------------------------------------
+# Functions here distinguish between the *initial* image and the *prior* image:
+#   initvec / init_arr : the initial-value image used to fill not-solved-for
+#                        slots in unpack_imarr (the L-BFGS-B start point).
+#   priorvec           : the regularizer prior image, referenced by terms like
+#                        'simple', 'l1', 'rgauss'. Can differ from the initial
+#                        image entirely.
+# Suffix conventions:
+#   *_arr / init_arr   : multi-D unwrapped array (one row per Stokes/freq term).
+#   *_vec / initvec    : same content as *_arr but conceptually a vector
+#                        in the function signature (kept for Imager-side
+#                        readability; shape is identical).
+#   imvec              : the 1D packed solver vector (just the solved-for slots).
+# Imager-side equivalents: self._init_arr, self._prior_arr, self._init_vec.
+# -----------------------------------------------------------------------------
+
 # Data term and polarization-mode names recognized by the chi^2 dispatchers.
 # Imported by ehtim.imager for backward compatibility.
 DATATERMS = ['vis', 'bs', 'amp', 'cphase', 'cphase_diag', 'camp', 'logcamp', 'logcamp_diag']
@@ -428,8 +446,10 @@ def compute_embed(imvec, xdim, ydim, psize, clipfloor):
     return embed_mask, coord_matrix
 
 
-def compute_chisq_dict(imcur, dat_term_keys, data_tuples, n_obs,
-                       logfreqratio_list, mf, pol, ttype, embed_mask):
+def compute_chisq_dict(imcur, dat_term_keys,
+                       mf, pol,
+                       data_tuples, logfreqratio_list, n_obs,
+                       ttype, embed_mask):
     """Compute chi^2 value for each data term across all observations.
 
     Parameters
@@ -438,18 +458,18 @@ def compute_chisq_dict(imcur, dat_term_keys, data_tuples, n_obs,
         Current image array transformed to bounded values.
     dat_term_keys : list of str
         Data term names to evaluate, already sorted.
-    data_tuples : dict
-        Pre-computed data products keyed by dname or dname_i,
-        each value is a (data, sigma, A) tuple.
-    n_obs : int
-        Number of observations (frequencies/epochs). Must equal
-        len(logfreqratio_list); validated by Imager.init_imager.
-    logfreqratio_list : list of float
-        Log frequency ratios log(nu_i/reffreq); one per obs.
     mf : bool
         Whether multifrequency imaging is enabled.
     pol : str
         Polarization mode string.
+    data_tuples : dict
+        Pre-computed data products keyed by dname or dname_i,
+        each value is a (data, sigma, A) tuple.
+    logfreqratio_list : list of float
+        Log frequency ratios log(nu_i/reffreq); one per obs.
+    n_obs : int
+        Number of observations (frequencies/epochs). Must equal
+        len(logfreqratio_list); validated by Imager.init_imager.
     ttype : str
         Transform type ('direct', 'fast', 'nfft').
     embed_mask : np.ndarray of bool
@@ -501,8 +521,10 @@ def compute_chisq_dict(imcur, dat_term_keys, data_tuples, n_obs,
     return chi2_dict
 
 
-def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, n_obs,
-                           logfreqratio_list, mf, pol, ttype, embed_mask,
+def compute_chisqgrad_dict(imcur, dat_term_keys,
+                           mf, pol,
+                           data_tuples, logfreqratio_list, n_obs,
+                           ttype, embed_mask,
                            which_solve, nimage):
     """Compute chi^2 gradient for each data term across all observations.
 
@@ -512,18 +534,18 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, n_obs,
         Current image array transformed to bounded values.
     dat_term_keys : list of str
         Data term names to evaluate, already sorted.
-    data_tuples : dict
-        Pre-computed data products keyed by dname or dname_i,
-        each value is a (data, sigma, A) tuple.
-    n_obs : int
-        Number of observations (frequencies/epochs). Must equal
-        len(logfreqratio_list); validated by Imager.init_imager.
-    logfreqratio_list : list of float
-        Log frequency ratios log(nu_i/reffreq); one per obs.
     mf : bool
         Whether multifrequency imaging is enabled.
     pol : str
         Polarization mode string.
+    data_tuples : dict
+        Pre-computed data products keyed by dname or dname_i,
+        each value is a (data, sigma, A) tuple.
+    logfreqratio_list : list of float
+        Log frequency ratios log(nu_i/reffreq); one per obs.
+    n_obs : int
+        Number of observations (frequencies/epochs). Must equal
+        len(logfreqratio_list); validated by Imager.init_imager.
     ttype : str
         Transform type ('direct', 'fast', 'nfft').
     embed_mask : np.ndarray of bool
@@ -598,9 +620,11 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, data_tuples, n_obs,
     return chi2grad_dict
 
 
-def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
-                     mf, n_obs, logfreqratio_list, pol,
-                     norm_reg, regparams):
+def compute_reg_dict(imcur, reg_term_keys,
+                     mf, pol,
+                     logfreqratio_list, n_obs,
+                     priorvec, norm_reg, regparams,
+                     embed_mask):
     """Compute regularizer value for each regularizer term.
 
     Parameters
@@ -609,19 +633,19 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
         Current image array transformed to bounded values.
     reg_term_keys : list of str
         Regularizer term names to evaluate, already sorted.
-    xprior : np.ndarray
-        Prior image array (same shape as imcur).
-    embed_mask : np.ndarray of bool
-        Pixel embedding mask.
     mf : bool
         Whether multifrequency imaging is enabled.
+    pol : str
+        Polarization mode string.
+    logfreqratio_list : list of float
+        Log frequency ratios log(nu_i/reffreq); one per obs.
     n_obs : int
         Number of observations (frequencies/epochs). Must equal
         len(logfreqratio_list); validated by Imager.init_imager.
-    logfreqratio_list : list of float
-        Log frequency ratios log(nu_i/reffreq); one per obs.
-    pol : str
-        Polarization mode string.
+    priorvec : np.ndarray
+        Prior image array (same shape as imcur). Used by regularizer terms
+        that depend on a reference image; distinct from `initvec` (the
+        initial image used for not-solved-for slots in `unpack_imarr`).
     norm_reg : bool
         Whether to apply per-regularizer normalization.
     regparams : dict
@@ -647,7 +671,7 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
             # Polarimetric regularizers
             if regname in REGULARIZERS_POL:
                 imcur_pol = imcur[0:4]
-                prior_pol = xprior[0:4]
+                prior_pol = priorvec[0:4]
                 reg = polutils.polregularizer(imcur_pol, prior_pol, embed_mask,
                                               stype=regname, norm_reg=norm_reg,
                                               **regparams)
@@ -667,7 +691,7 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
 
                         logfreqratio = logfreqratio_list[i]
                         imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
-                        prior_nu = mfutils.image_at_freq(xprior, logfreqratio)
+                        prior_nu = mfutils.image_at_freq(priorvec, logfreqratio)
 
                         regi = imutils.regularizer(imcur_nu, prior_nu, embed_mask,
                                                    stype=regname_base, norm_reg=norm_reg,
@@ -676,7 +700,7 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
                         reg = regi if i == 0 else reg + regi
 
                 else:
-                    reg = imutils.regularizer(imcur[0], xprior[0], embed_mask,
+                    reg = imutils.regularizer(imcur[0], priorvec[0], embed_mask,
                                               stype=regname, norm_reg=norm_reg,
                                               **regparams)
 
@@ -696,7 +720,7 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
                 elif regname in REGULARIZERS_CM:
                     idx = 9
 
-                reg = mfutils.regularizer_mf(imcur[idx], xprior[idx], embed_mask,
+                reg = mfutils.regularizer_mf(imcur[idx], priorvec[idx], embed_mask,
                                              stype=regname, norm_reg=norm_reg,
                                              **regparams)
             else:
@@ -704,7 +728,7 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
 
         # Single-frequency polarimetric regularizer
         elif regname in REGULARIZERS_POL:
-            reg = polutils.polregularizer(imcur, xprior, embed_mask,
+            reg = polutils.polregularizer(imcur, priorvec, embed_mask,
                                           stype=regname, norm_reg=norm_reg,
                                           **regparams)
 
@@ -712,10 +736,10 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
         elif regname in REGULARIZERS:
             if pol in POLARIZATION_MODES:
                 imcur0 = imcur[0]
-                prior0 = xprior[0]
+                prior0 = priorvec[0]
             else:
                 imcur0 = imcur
-                prior0 = xprior
+                prior0 = priorvec
 
             reg = imutils.regularizer(imcur0, prior0, embed_mask,
                                       stype=regname, norm_reg=norm_reg,
@@ -728,16 +752,18 @@ def compute_reg_dict(imcur, reg_term_keys, xprior, embed_mask,
     return reg_dict
 
 
-def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
-                         mf, n_obs, logfreqratio_list, pol,
-                         norm_reg, regparams,
+def compute_reggrad_dict(imcur, reg_term_keys,
+                         mf, pol,
+                         logfreqratio_list, n_obs,
+                         priorvec, norm_reg, regparams,
+                         embed_mask,
                          which_solve, nimage):
     """Compute regularizer gradient for each regularizer term.
 
     Parameters
     ----------
-    imcur, reg_term_keys, xprior, embed_mask, mf, n_obs, logfreqratio_list,
-    pol, norm_reg, regparams : see compute_reg_dict.
+    imcur, reg_term_keys, mf, pol, logfreqratio_list, n_obs,
+    priorvec, norm_reg, regparams, embed_mask : see compute_reg_dict.
     which_solve : np.ndarray of bool
         Per-Stokes solve mask (used by polregularizergrad).
     nimage : int
@@ -761,7 +787,7 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
             # Polarimetric regularizers
             if regname in REGULARIZERS_POL:
                 imcur_pol = imcur[0:4]
-                prior_pol = xprior[0:4]
+                prior_pol = priorvec[0:4]
                 pol_solve = which_solve[0:4]
                 regp = polutils.polregularizergrad(imcur_pol, prior_pol, embed_mask,
                                                    stype=regname, norm_reg=norm_reg,
@@ -785,7 +811,7 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
 
                         logfreqratio = logfreqratio_list[i]
                         imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
-                        prior_nu = mfutils.image_at_freq(xprior, logfreqratio)
+                        prior_nu = mfutils.image_at_freq(priorvec, logfreqratio)
 
                         regi = imutils.regularizergrad(imcur_nu, prior_nu, embed_mask,
                                                        stype=regname_base, norm_reg=norm_reg,
@@ -794,7 +820,7 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
                         reggrad = reggrad_i if i == 0 else reggrad + reggrad_i
 
                 else:
-                    regi = imutils.regularizergrad(imcur[0], xprior[0], embed_mask,
+                    regi = imutils.regularizergrad(imcur[0], priorvec[0], embed_mask,
                                                    stype=regname, norm_reg=norm_reg,
                                                    **regparams)
                     reggrad = np.zeros((len(imcur), nimage))
@@ -814,7 +840,7 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
                 elif regname in REGULARIZERS_CM:
                     idx = 9
 
-                regmf = mfutils.regularizergrad_mf(imcur[idx], xprior[idx], embed_mask,
+                regmf = mfutils.regularizergrad_mf(imcur[idx], priorvec[idx], embed_mask,
                                                    stype=regname, norm_reg=norm_reg,
                                                    **regparams)
 
@@ -826,7 +852,7 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
         else:
             # Single-frequency polarimetric regularizer
             if regname in REGULARIZERS_POL:
-                reggrad = polutils.polregularizergrad(imcur, xprior, embed_mask,
+                reggrad = polutils.polregularizergrad(imcur, priorvec, embed_mask,
                                                       stype=regname, norm_reg=norm_reg,
                                                       pol_solve=which_solve,
                                                       **regparams)
@@ -835,10 +861,10 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
             elif regname in REGULARIZERS:
                 if pol in POLARIZATION_MODES:
                     imcur0 = imcur[0]
-                    prior0 = xprior[0]
+                    prior0 = priorvec[0]
                 else:
                     imcur0 = imcur
-                    prior0 = xprior
+                    prior0 = priorvec
                 reggrad = imutils.regularizergrad(imcur0, prior0, embed_mask,
                                                   stype=regname, norm_reg=norm_reg,
                                                   **regparams)
@@ -857,27 +883,35 @@ def compute_reggrad_dict(imcur, reg_term_keys, xprior, embed_mask,
     return reggrad_dict
 
 
-def compute_objective(imvec, xarr, which_solve, transforms,
+def compute_objective(imvec, initvec,
+                      mf, pol,
+                      which_solve, data_tuples, logfreqratio_list, n_obs,
                       dat_term, reg_term,
-                      data_tuples, n_obs, logfreqratio_list,
-                      mf, pol, ttype, embed_mask,
-                      xprior, norm_reg, regparams):
+                      priorvec, norm_reg, regparams,
+                      transforms, embed_mask, ttype):
     """Pure objective: data fidelity + regularization, summed with hyperparameter weights."""
 
     dat_term_keys = sorted(dat_term.keys())
     reg_term_keys = sorted(reg_term.keys())
 
-    # Unpack solver vector into image array, then apply bounded-value transform
-    imcur = unpack_imarr(imvec, xarr, which_solve)
+    # Unpack solver vector into image array, then apply bounded-value transform.
+    # `initvec` provides the values used for any not-solved-for slots (it is
+    # the *initial* image, NOT the regularizer prior `priorvec`).
+    imcur = unpack_imarr(imvec, initvec, which_solve)
     imcur = transform_imarr(imcur, transforms, which_solve)
 
     chi2_dict = compute_chisq_dict(
-        imcur, dat_term_keys, data_tuples,
-        n_obs, logfreqratio_list, mf, pol, ttype, embed_mask,
+        imcur, dat_term_keys,
+        mf, pol,
+        data_tuples, logfreqratio_list, n_obs,
+        ttype, embed_mask,
     )
     reg_dict = compute_reg_dict(
-        imcur, reg_term_keys, xprior, embed_mask,
-        mf, n_obs, logfreqratio_list, pol, norm_reg, regparams,
+        imcur, reg_term_keys,
+        mf, pol,
+        logfreqratio_list, n_obs,
+        priorvec, norm_reg, regparams,
+        embed_mask,
     )
 
     datterm = 0.0
@@ -894,32 +928,39 @@ def compute_objective(imvec, xarr, which_solve, transforms,
     return datterm + regterm
 
 
-def compute_objective_grad(imvec, xarr, which_solve, transforms,
+def compute_objective_grad(imvec, initvec,
+                           mf, pol,
+                           which_solve, data_tuples, logfreqratio_list, n_obs,
                            dat_term, reg_term,
-                           data_tuples, n_obs, logfreqratio_list,
-                           mf, pol, ttype, embed_mask,
-                           xprior, norm_reg, regparams,
-                           nimage):
+                           priorvec, norm_reg, regparams,
+                           transforms, embed_mask, ttype, nimage):
     """Pure objective gradient: data-fidelity grad + regularization grad,
     chain-ruled through the bounded-value transform, packed into solver space."""
 
     dat_term_keys = sorted(dat_term.keys())
     reg_term_keys = sorted(reg_term.keys())
 
-    # Unpack solver vector; keep a pre-transform copy for the chain rule
-    imcur = unpack_imarr(imvec, xarr, which_solve)
+    # Unpack solver vector; keep a pre-transform copy for the chain rule.
+    # `initvec` is the initial image (for not-solved-for slots), distinct
+    # from `priorvec` which is the regularizer prior.
+    imcur = unpack_imarr(imvec, initvec, which_solve)
     imcur_prime = imcur.copy()
     imcur = transform_imarr(imcur, transforms, which_solve)
 
     chi2grad_dict = compute_chisqgrad_dict(
-        imcur, dat_term_keys, data_tuples,
-        n_obs, logfreqratio_list, mf, pol, ttype, embed_mask,
+        imcur, dat_term_keys,
+        mf, pol,
+        data_tuples, logfreqratio_list, n_obs,
+        ttype, embed_mask,
         which_solve, nimage,
     )
 
     reggrad_dict = compute_reggrad_dict(
-        imcur, reg_term_keys, xprior, embed_mask,
-        mf, n_obs, logfreqratio_list, pol, norm_reg, regparams,
+        imcur, reg_term_keys,
+        mf, pol,
+        logfreqratio_list, n_obs,
+        priorvec, norm_reg, regparams,
+        embed_mask,
         which_solve, nimage,
     )
 

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -895,3 +895,64 @@ def compute_objective(imvec, xarr, which_solve, transforms,
         regterm = regterm + reg_term[regname] * reg_dict[regname]
 
     return datterm + regterm
+
+
+def compute_objective_grad(imvec, xarr, which_solve, transforms,
+                           dat_term, reg_term,
+                           data_tuples, obslist, logfreqratio_list,
+                           mf, pol, ttype, embed_mask,
+                           xprior, norm_reg, regparams,
+                           nimage,
+                           chisq_transform=False, chisq_offset_gradient=0.0):
+    """Pure objective gradient: data-fidelity grad + regularization grad,
+    chain-ruled through the bounded-value transform, packed into solver space."""
+
+    dat_term_keys = sorted(dat_term.keys())
+    reg_term_keys = sorted(reg_term.keys())
+
+    # Unpack solver vector; keep a pre-transform copy for the chain rule
+    imcur = unpack_imarr(imvec, xarr, which_solve)
+    imcur_prime = imcur.copy()
+    imcur = transform_imarr(imcur, transforms, which_solve)
+
+    chi2grad_dict = compute_chisqgrad_dict(
+        imcur, dat_term_keys, data_tuples,
+        obslist, logfreqratio_list, mf, pol, ttype, embed_mask,
+        which_solve, nimage,
+    )
+    chi2val_dict = None
+    if chisq_transform:
+        chi2val_dict = compute_chisq_dict(
+            imcur, dat_term_keys, data_tuples,
+            obslist, logfreqratio_list, mf, pol, ttype, embed_mask,
+        )
+
+    reggrad_dict = compute_reggrad_dict(
+        imcur, reg_term_keys, xprior, embed_mask,
+        mf, obslist, logfreqratio_list, pol, norm_reg, regparams,
+        which_solve, nimage,
+    )
+
+    n_obs = len(obslist)
+    datterm = 0.0
+    for dname in dat_term_keys:
+        weight = dat_term[dname]
+        for i in range(n_obs):
+            key = dname if n_obs == 1 else f"{dname}_{i}"
+            chi2_grad = chi2grad_dict[key]
+            if chisq_transform:
+                # chi2val_dict is keyed by dname (no per-obs suffix), unlike
+                # chi2grad_dict above. Asymmetry preserved verbatim from
+                # Imager.objgrad behaviour.
+                chi2_val = chi2val_dict[dname]
+                datterm = datterm + weight * chi2_grad * (1.0 - 1.0 / (chi2_val ** 2))
+            else:
+                datterm = datterm + weight * (chi2_grad + chisq_offset_gradient)
+
+    regterm = 0.0
+    for regname in reg_term_keys:
+        regterm = regterm + reg_term[regname] * reggrad_dict[regname]
+
+    grad = datterm + regterm
+    grad = transform_gradients(grad, imcur_prime, transforms, which_solve)
+    return pack_imarr(grad, which_solve)

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -122,30 +122,34 @@ def pack_imarr(imarr, which_solve):
     return vec
 
 
-def unpack_imarr(vec, priorarr, which_solve):
-    """unpack minimized vector vec into array,
-       replace quantities not solved for with their initial values
+def unpack_imarr(vec, init_arr, which_solve):
+    """Unpack minimized 1D vector `vec` into a multi-D array.
+
+    For each Stokes / spectral slot k:
+      - if which_solve[k] == 1, take the next nimage values from `vec`;
+      - if which_solve[k] == 0, fall back to `init_arr[k]` (the *initial*
+        image, NOT a regularizer prior).
     """
 
-    imarrdim = len(priorarr.shape)
+    imarrdim = len(init_arr.shape)
     if imarrdim==2:
-        nsolve = priorarr.shape[0]
-        nimage = priorarr.shape[1]
+        nsolve = init_arr.shape[0]
+        nimage = init_arr.shape[1]
     elif imarrdim==1:
         nsolve = 1
-        nimage = priorarr.shape[0]
-        imarr = priorarr.reshape((nsolve,nimage))
+        nimage = init_arr.shape[0]
+        imarr = init_arr.reshape((nsolve,nimage))
     else:
-        raise Exception("in unpack_imarr, priorarr should have one or two dimensions !")
+        raise Exception("in unpack_imarr, init_arr should have one or two dimensions !")
 
     if nsolve != len(which_solve):
-        raise Exception("in unpack_imarr, priorarr has inconsistent shape with which_solve!")
+        raise Exception("in unpack_imarr, init_arr has inconsistent shape with which_solve!")
 
     imct = 0
     imarr = np.empty((nsolve, nimage))
     for kk in range(nsolve):
         if which_solve[kk]==0:
-            imarr[kk] = priorarr[kk]
+            imarr[kk] = init_arr[kk]
         else:
             imarr[kk] = vec[imct*nimage:(imct+1)*nimage]
             imct += 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,7 +200,7 @@ def initialize_imager():
         imgr.check_limits()
         imgr.init_imager()
 
-        imcur = unpack_imarr(imgr._xinit, imgr._xarr, imgr._which_solve)
+        imcur = unpack_imarr(imgr._init_vec, imgr._init_arr, imgr._which_solve)
         imcur = transform_imarr(imcur, imgr.transform_next, imgr._which_solve)
         return imgr, imcur
     return _factory

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -202,7 +202,6 @@ def _call_backend_objective(imgr, imvec):
         imgr._data_tuples, imgr.obslist_next, imgr._logfreqratio_list,
         imgr.mf_next, imgr.pol_next, imgr._ttype, imgr._embed_mask,
         imgr._xprior, imgr.norm_reg, _build_regparams(imgr),
-        imgr.chisq_transform,
     )
 
 
@@ -215,7 +214,6 @@ def _call_backend_objective_grad(imgr, imvec):
         imgr.mf_next, imgr.pol_next, imgr._ttype, imgr._embed_mask,
         imgr._xprior, imgr.norm_reg, _build_regparams(imgr),
         imgr._nimage,
-        imgr.chisq_transform, imgr.chisq_offset_gradient,
     )
 
 
@@ -856,19 +854,6 @@ class TestComputeObjective:
         method_value = imgr.objfunc(imvec)
         np.testing.assert_array_equal(backend_value, method_value)
 
-    def test_chisq_transform_branch(self, gauss_im, observe, initialize_imager):
-        """chisq_transform=True activates the (chi2 + 1/chi2 - 1) legacy branch."""
-        obs = observe(gauss_im)
-        imgr, _ = initialize_imager(
-            obs, gauss_im, {"vis": 100},
-            reg_term={"simple": 1},
-        )
-        imgr.chisq_transform = True
-        imvec = imgr._xinit
-        backend_value = _call_backend_objective(imgr, imvec)
-        method_value = imgr.objfunc(imvec)
-        np.testing.assert_array_equal(backend_value, method_value)
-
     @pytest.mark.parametrize("xdim,ydim", IMAGE_SHAPES)
     def test_rect_images(self, make_rect_image, observe, initialize_imager,
                           xdim, ydim):
@@ -966,46 +951,6 @@ class TestComputeObjectiveGrad:
         backend_grad = _call_backend_objective_grad(imgr, imvec)
         method_grad = imgr.objgrad(imvec)
         np.testing.assert_array_equal(backend_grad, method_grad)
-
-    def test_chisq_transform_branch(self, gauss_im, observe, initialize_imager):
-        """chisq_transform=True activates chi2_grad * (1 - 1/chi2^2) branch."""
-        obs = observe(gauss_im)
-        imgr, _ = initialize_imager(
-            obs, gauss_im, {"vis": 100},
-            reg_term={"simple": 1},
-        )
-        imgr.chisq_transform = True
-        imvec = imgr._xinit
-        backend_grad = _call_backend_objective_grad(imgr, imvec)
-        method_grad = imgr.objgrad(imvec)
-        np.testing.assert_array_equal(backend_grad, method_grad)
-
-    def test_chisq_transform_multi_obs(self, gauss_im, observe, initialize_imager):
-        """chisq_transform=True under multi-obs imaging.
-
-        Regression test for the per-obs key lookup: chi2val_dict is keyed by
-        f'{dname}_{i}' for multi-obs runs, so the chisq_transform branch must
-        index by the same key as the surrounding chi2grad_dict lookup. Pre-fix
-        this path raised KeyError before producing any gradient.
-        """
-        im_lo = gauss_im.copy()
-        im_lo.rf = REFFREQ_HZ
-        im_hi = gauss_im.copy()
-        im_hi.rf = MF_ALT_FREQ_HZ
-        obs_lo = observe(im_lo)
-        obs_hi = observe(im_hi)
-
-        imgr, _ = initialize_imager(
-            [obs_lo, obs_hi], im_lo, {"vis": 100},
-            reg_term={"simple": 1},
-            mf=True, mf_order=1,
-            mf_flux=[im_lo.total_flux(), im_hi.total_flux()],
-        )
-        imgr.chisq_transform = True
-        imvec = imgr._xinit
-        backend_grad = _call_backend_objective_grad(imgr, imvec)
-        assert np.all(np.isfinite(backend_grad))
-        assert backend_grad.shape == imvec.shape
 
     def test_fd_matches_analytic_stokes_i(self, gauss_im, observe, initialize_imager):
         """FD of compute_objective ≈ compute_objective_grad on solved-for indices.

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -140,18 +140,20 @@ class TestComputeEmbed:
 def _call_backend_chisq_dict(imgr, imcur):
     """Call compute_chisq_dict with args pulled from an initialized Imager."""
     return compute_chisq_dict(
-        imcur, sorted(imgr.dat_term_next.keys()), imgr._data_tuples,
-        len(imgr.obslist_next), imgr._logfreqratio_list, imgr.mf_next,
-        imgr.pol_next, imgr._ttype, imgr._embed_mask,
+        imcur, sorted(imgr.dat_term_next.keys()),
+        imgr.mf_next, imgr.pol_next,
+        imgr._data_tuples, imgr._logfreqratio_list, len(imgr.obslist_next),
+        imgr._ttype, imgr._embed_mask,
     )
 
 
 def _call_backend_chisqgrad_dict(imgr, imcur):
     """Call compute_chisqgrad_dict with args pulled from an initialized Imager."""
     return compute_chisqgrad_dict(
-        imcur, sorted(imgr.dat_term_next.keys()), imgr._data_tuples,
-        len(imgr.obslist_next), imgr._logfreqratio_list, imgr.mf_next,
-        imgr.pol_next, imgr._ttype, imgr._embed_mask,
+        imcur, sorted(imgr.dat_term_next.keys()),
+        imgr.mf_next, imgr.pol_next,
+        imgr._data_tuples, imgr._logfreqratio_list, len(imgr.obslist_next),
+        imgr._ttype, imgr._embed_mask,
         imgr._which_solve, imgr._nimage,
     )
 
@@ -178,18 +180,22 @@ def _build_regparams(imgr, mf_flux=None):
 def _call_backend_reg_dict(imgr, imcur, mf_flux=None):
     """Call compute_reg_dict with args pulled from an initialized Imager."""
     return compute_reg_dict(
-        imcur, sorted(imgr.reg_term_next.keys()), imgr._xprior, imgr._embed_mask,
-        imgr.mf_next, len(imgr.obslist_next), imgr._logfreqratio_list, imgr.pol_next,
-        imgr.norm_reg, _build_regparams(imgr, mf_flux=mf_flux),
+        imcur, sorted(imgr.reg_term_next.keys()),
+        imgr.mf_next, imgr.pol_next,
+        imgr._logfreqratio_list, len(imgr.obslist_next),
+        imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr, mf_flux=mf_flux),
+        imgr._embed_mask,
     )
 
 
 def _call_backend_reggrad_dict(imgr, imcur, mf_flux=None):
     """Call compute_reggrad_dict with args pulled from an initialized Imager."""
     return compute_reggrad_dict(
-        imcur, sorted(imgr.reg_term_next.keys()), imgr._xprior, imgr._embed_mask,
-        imgr.mf_next, len(imgr.obslist_next), imgr._logfreqratio_list, imgr.pol_next,
-        imgr.norm_reg, _build_regparams(imgr, mf_flux=mf_flux),
+        imcur, sorted(imgr.reg_term_next.keys()),
+        imgr.mf_next, imgr.pol_next,
+        imgr._logfreqratio_list, len(imgr.obslist_next),
+        imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr, mf_flux=mf_flux),
+        imgr._embed_mask,
         imgr._which_solve, imgr._nimage,
     )
 
@@ -197,23 +203,26 @@ def _call_backend_reggrad_dict(imgr, imcur, mf_flux=None):
 def _call_backend_objective(imgr, imvec):
     """Call compute_objective with args pulled from an initialized Imager."""
     return compute_objective(
-        imvec, imgr._xarr, imgr._which_solve, imgr.transform_next,
+        imvec, imgr._init_arr,
+        imgr.mf_next, imgr.pol_next,
+        imgr._which_solve, imgr._data_tuples,
+        imgr._logfreqratio_list, len(imgr.obslist_next),
         imgr.dat_term_next, imgr.reg_term_next,
-        imgr._data_tuples, len(imgr.obslist_next), imgr._logfreqratio_list,
-        imgr.mf_next, imgr.pol_next, imgr._ttype, imgr._embed_mask,
-        imgr._xprior, imgr.norm_reg, _build_regparams(imgr),
+        imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr),
+        imgr.transform_next, imgr._embed_mask, imgr._ttype,
     )
 
 
 def _call_backend_objective_grad(imgr, imvec):
     """Call compute_objective_grad with args pulled from an initialized Imager."""
     return compute_objective_grad(
-        imvec, imgr._xarr, imgr._which_solve, imgr.transform_next,
+        imvec, imgr._init_arr,
+        imgr.mf_next, imgr.pol_next,
+        imgr._which_solve, imgr._data_tuples,
+        imgr._logfreqratio_list, len(imgr.obslist_next),
         imgr.dat_term_next, imgr.reg_term_next,
-        imgr._data_tuples, len(imgr.obslist_next), imgr._logfreqratio_list,
-        imgr.mf_next, imgr.pol_next, imgr._ttype, imgr._embed_mask,
-        imgr._xprior, imgr.norm_reg, _build_regparams(imgr),
-        imgr._nimage,
+        imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr),
+        imgr.transform_next, imgr._embed_mask, imgr._ttype, imgr._nimage,
     )
 
 
@@ -613,9 +622,11 @@ class TestComputeRegDict:
         # Bypass Imager.check_params by passing reg_term_keys directly.
         with pytest.raises(Exception, match="not recognized"):
             compute_reg_dict(
-                imcur, ["not_a_regularizer"], imgr._xprior, imgr._embed_mask,
-                imgr.mf_next, len(imgr.obslist_next), imgr._logfreqratio_list, imgr.pol_next,
-                imgr.norm_reg, _build_regparams(imgr),
+                imcur, ["not_a_regularizer"],
+                imgr.mf_next, imgr.pol_next,
+                imgr._logfreqratio_list, len(imgr.obslist_next),
+                imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr),
+                imgr._embed_mask,
             )
 
     def test_mf_flux_validation(self, gauss_im, observe, initialize_imager):
@@ -739,9 +750,11 @@ class TestComputeReggradDict:
         imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100})
         with pytest.raises(Exception, match="not recognized"):
             compute_reggrad_dict(
-                imcur, ["not_a_regularizer"], imgr._xprior, imgr._embed_mask,
-                imgr.mf_next, len(imgr.obslist_next), imgr._logfreqratio_list, imgr.pol_next,
-                imgr.norm_reg, _build_regparams(imgr),
+                imcur, ["not_a_regularizer"],
+                imgr.mf_next, imgr.pol_next,
+                imgr._logfreqratio_list, len(imgr.obslist_next),
+                imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr),
+                imgr._embed_mask,
                 imgr._which_solve, imgr._nimage,
             )
 
@@ -802,7 +815,7 @@ class TestComputeObjective:
             obs, gauss_im, {"vis": 100, "amp": 10},
             reg_term={"simple": 1, "tv": 10},
         )
-        imvec = imgr._xinit
+        imvec = imgr._init_vec
         backend_value = _call_backend_objective(imgr, imvec)
         method_value = imgr.objfunc(imvec)
         np.testing.assert_array_equal(backend_value, method_value)
@@ -815,7 +828,7 @@ class TestComputeObjective:
             reg_term={"hw": 1, "ptv": 1},
             pol="IP", transform=["log", "mcv"],
         )
-        imvec = imgr._xinit
+        imvec = imgr._init_vec
         backend_value = _call_backend_objective(imgr, imvec)
         method_value = imgr.objfunc(imvec)
         np.testing.assert_array_equal(backend_value, method_value)
@@ -829,7 +842,7 @@ class TestComputeObjective:
             reg_term={"simple": 1, "hw": 1},
             pol="IP", transform=["log", "mcv"],
         )
-        imvec = imgr._xinit
+        imvec = imgr._init_vec
         backend_value = _call_backend_objective(imgr, imvec)
         method_value = imgr.objfunc(imvec)
         np.testing.assert_array_equal(backend_value, method_value)
@@ -849,7 +862,7 @@ class TestComputeObjective:
             mf=True, mf_order=1,
             mf_flux=[im_lo.total_flux(), im_hi.total_flux()],
         )
-        imvec = imgr._xinit
+        imvec = imgr._init_vec
         backend_value = _call_backend_objective(imgr, imvec)
         method_value = imgr.objfunc(imvec)
         np.testing.assert_array_equal(backend_value, method_value)
@@ -864,7 +877,7 @@ class TestComputeObjective:
             obs, im, {"vis": 100},
             reg_term={"simple": 1, "tv": 10},
         )
-        imvec = imgr._xinit
+        imvec = imgr._init_vec
         backend_value = _call_backend_objective(imgr, imvec)
         method_value = imgr.objfunc(imvec)
         np.testing.assert_array_equal(backend_value, method_value)
@@ -899,7 +912,7 @@ class TestComputeObjectiveGrad:
             obs, gauss_im, {"vis": 100, "amp": 10},
             reg_term={"simple": 1, "tv": 10},
         )
-        imvec = imgr._xinit
+        imvec = imgr._init_vec
         backend_grad = _call_backend_objective_grad(imgr, imvec)
         method_grad = imgr.objgrad(imvec)
         np.testing.assert_array_equal(backend_grad, method_grad)
@@ -913,7 +926,7 @@ class TestComputeObjectiveGrad:
             reg_term={"hw": 1, "ptv": 1},
             pol="IP", transform=["log", "mcv"],
         )
-        imvec = imgr._xinit
+        imvec = imgr._init_vec
         backend_grad = _call_backend_objective_grad(imgr, imvec)
         method_grad = imgr.objgrad(imvec)
         np.testing.assert_array_equal(backend_grad, method_grad)
@@ -927,7 +940,7 @@ class TestComputeObjectiveGrad:
             reg_term={"simple": 1, "hw": 1},
             pol="IP", transform=["log", "mcv"],
         )
-        imvec = imgr._xinit
+        imvec = imgr._init_vec
         backend_grad = _call_backend_objective_grad(imgr, imvec)
         method_grad = imgr.objgrad(imvec)
         np.testing.assert_array_equal(backend_grad, method_grad)
@@ -947,7 +960,7 @@ class TestComputeObjectiveGrad:
             mf=True, mf_order=1,
             mf_flux=[im_lo.total_flux(), im_hi.total_flux()],
         )
-        imvec = imgr._xinit
+        imvec = imgr._init_vec
         backend_grad = _call_backend_objective_grad(imgr, imvec)
         method_grad = imgr.objgrad(imvec)
         np.testing.assert_array_equal(backend_grad, method_grad)
@@ -963,7 +976,7 @@ class TestComputeObjectiveGrad:
             obs, gauss_im, {"vis": 100},
             reg_term={"simple": 1, "tv": 10},
         )
-        imvec = imgr._xinit
+        imvec = imgr._init_vec
 
         rng = np.random.default_rng(42)
         indices = rng.choice(len(imvec), size=20, replace=False)
@@ -991,7 +1004,7 @@ class TestComputeObjectiveGrad:
             reg_term={"simple": 1, "hw": 1},
             pol="IP", transform=["log", "mcv"],
         )
-        imvec = imgr._xinit
+        imvec = imgr._init_vec
 
         rng = np.random.default_rng(7)
         indices = rng.choice(len(imvec), size=20, replace=False)
@@ -1014,7 +1027,7 @@ class TestComputeObjectiveGrad:
             obs, im, {"vis": 100},
             reg_term={"simple": 1, "tv": 10},
         )
-        imvec = imgr._xinit
+        imvec = imgr._init_vec
         backend_grad = _call_backend_objective_grad(imgr, imvec)
         method_grad = imgr.objgrad(imvec)
         np.testing.assert_array_equal(backend_grad, method_grad)
@@ -1032,7 +1045,7 @@ def test_objective_and_objective_grad_share_consistency(gauss_im, observe,
         obs, gauss_im, {"vis": 100, "amp": 10},
         reg_term={"simple": 1},
     )
-    imvec = imgr._xinit
+    imvec = imgr._init_vec
     obj = _call_backend_objective(imgr, imvec)
     grad = _call_backend_objective_grad(imgr, imvec)
     assert np.isfinite(obj)

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -12,6 +12,7 @@ from ehtim.imaging.imager_backend import (
     compute_chisq_dict,
     compute_chisqgrad_dict,
     compute_embed,
+    compute_objective,
     compute_reg_dict,
     compute_reggrad_dict,
     transform_gradients,
@@ -189,6 +190,18 @@ def _call_backend_reggrad_dict(imgr, imcur, mf_flux=None):
         imgr.mf_next, imgr.obslist_next, imgr._logfreqratio_list, imgr.pol_next,
         imgr.norm_reg, _build_regparams(imgr, mf_flux=mf_flux),
         imgr._which_solve, imgr._nimage,
+    )
+
+
+def _call_backend_objective(imgr, imvec):
+    """Call compute_objective with args pulled from an initialized Imager."""
+    return compute_objective(
+        imvec, imgr._xarr, imgr._which_solve, imgr.transform_next,
+        imgr.dat_term_next, imgr.reg_term_next,
+        imgr._data_tuples, imgr.obslist_next, imgr._logfreqratio_list,
+        imgr.mf_next, imgr.pol_next, imgr._ttype, imgr._embed_mask,
+        imgr._xprior, imgr.norm_reg, _build_regparams(imgr),
+        imgr.chisq_transform,
     )
 
 
@@ -765,6 +778,97 @@ def test_reg_and_reggrad_share_keys(gauss_im, observe, initialize_imager):
     reg = _call_backend_reg_dict(imgr, imcur)
     reggrad = _call_backend_reggrad_dict(imgr, imcur)
     assert set(reg.keys()) == set(reggrad.keys())
+
+
+class TestComputeObjective:
+    """Tests for compute_objective (extracted from Imager.objfunc)."""
+
+    def test_matches_imager_stokes_i(self, gauss_im, observe, initialize_imager):
+        """Single-freq, pol='I', multi-key dat + reg — exercises sort + branch coverage."""
+        obs = observe(gauss_im)
+        imgr, _ = initialize_imager(
+            obs, gauss_im, {"vis": 100, "amp": 10},
+            reg_term={"simple": 1, "tv": 10},
+        )
+        imvec = imgr._xinit
+        backend_value = _call_backend_objective(imgr, imvec)
+        method_value = imgr.objfunc(imvec)
+        np.testing.assert_array_equal(backend_value, method_value)
+
+    def test_matches_imager_polarimetric(self, gauss_im_pol, observe, initialize_imager):
+        """pol='IP' with REGULARIZERS_POL — exercises polarimetric chisq + reg branches."""
+        obs = observe(gauss_im_pol)
+        imgr, _ = initialize_imager(
+            obs, gauss_im_pol, {"pvis": 100},
+            reg_term={"hw": 1, "ptv": 1},
+            pol="IP", transform=["log", "mcv"],
+        )
+        imvec = imgr._xinit
+        backend_value = _call_backend_objective(imgr, imvec)
+        method_value = imgr.objfunc(imvec)
+        np.testing.assert_array_equal(backend_value, method_value)
+
+    def test_matches_imager_stokes_i_pol_bundled(self, gauss_im_pol, observe,
+                                                   initialize_imager):
+        """pol='IP' with mixed Stokes-I + pol terms — both bundling branches active."""
+        obs = observe(gauss_im_pol)
+        imgr, _ = initialize_imager(
+            obs, gauss_im_pol, {"vis": 100, "pvis": 100},
+            reg_term={"simple": 1, "hw": 1},
+            pol="IP", transform=["log", "mcv"],
+        )
+        imvec = imgr._xinit
+        backend_value = _call_backend_objective(imgr, imvec)
+        method_value = imgr.objfunc(imvec)
+        np.testing.assert_array_equal(backend_value, method_value)
+
+    def test_matches_imager_multifrequency(self, gauss_im, observe, initialize_imager):
+        """Two obs at different rf — hits the f'{dname}_{i}' key suffix branch."""
+        im_lo = gauss_im.copy()
+        im_lo.rf = REFFREQ_HZ
+        im_hi = gauss_im.copy()
+        im_hi.rf = MF_ALT_FREQ_HZ
+        obs_lo = observe(im_lo)
+        obs_hi = observe(im_hi)
+
+        imgr, _ = initialize_imager(
+            [obs_lo, obs_hi], im_lo, {"vis": 100},
+            reg_term={"simple": 1, "flux_mf": 1, "l2_alpha": 1},
+            mf=True, mf_order=1,
+            mf_flux=[im_lo.total_flux(), im_hi.total_flux()],
+        )
+        imvec = imgr._xinit
+        backend_value = _call_backend_objective(imgr, imvec)
+        method_value = imgr.objfunc(imvec)
+        np.testing.assert_array_equal(backend_value, method_value)
+
+    def test_chisq_transform_branch(self, gauss_im, observe, initialize_imager):
+        """chisq_transform=True activates the (chi2 + 1/chi2 - 1) legacy branch."""
+        obs = observe(gauss_im)
+        imgr, _ = initialize_imager(
+            obs, gauss_im, {"vis": 100},
+            reg_term={"simple": 1},
+        )
+        imgr.chisq_transform = True
+        imvec = imgr._xinit
+        backend_value = _call_backend_objective(imgr, imvec)
+        method_value = imgr.objfunc(imvec)
+        np.testing.assert_array_equal(backend_value, method_value)
+
+    @pytest.mark.parametrize("xdim,ydim", IMAGE_SHAPES)
+    def test_rect_images(self, make_rect_image, observe, initialize_imager,
+                          xdim, ydim):
+        """Backend handles rectangular (xdim != ydim) images end-to-end."""
+        im = make_rect_image(xdim, ydim)
+        obs = observe(im)
+        imgr, _ = initialize_imager(
+            obs, im, {"vis": 100},
+            reg_term={"simple": 1, "tv": 10},
+        )
+        imvec = imgr._xinit
+        backend_value = _call_backend_objective(imgr, imvec)
+        method_value = imgr.objfunc(imvec)
+        np.testing.assert_array_equal(backend_value, method_value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -980,6 +980,33 @@ class TestComputeObjectiveGrad:
         method_grad = imgr.objgrad(imvec)
         np.testing.assert_array_equal(backend_grad, method_grad)
 
+    def test_chisq_transform_multi_obs(self, gauss_im, observe, initialize_imager):
+        """chisq_transform=True under multi-obs imaging.
+
+        Regression test for the per-obs key lookup: chi2val_dict is keyed by
+        f'{dname}_{i}' for multi-obs runs, so the chisq_transform branch must
+        index by the same key as the surrounding chi2grad_dict lookup. Pre-fix
+        this path raised KeyError before producing any gradient.
+        """
+        im_lo = gauss_im.copy()
+        im_lo.rf = REFFREQ_HZ
+        im_hi = gauss_im.copy()
+        im_hi.rf = MF_ALT_FREQ_HZ
+        obs_lo = observe(im_lo)
+        obs_hi = observe(im_hi)
+
+        imgr, _ = initialize_imager(
+            [obs_lo, obs_hi], im_lo, {"vis": 100},
+            reg_term={"simple": 1},
+            mf=True, mf_order=1,
+            mf_flux=[im_lo.total_flux(), im_hi.total_flux()],
+        )
+        imgr.chisq_transform = True
+        imvec = imgr._xinit
+        backend_grad = _call_backend_objective_grad(imgr, imvec)
+        assert np.all(np.isfinite(backend_grad))
+        assert backend_grad.shape == imvec.shape
+
     def test_fd_matches_analytic_stokes_i(self, gauss_im, observe, initialize_imager):
         """FD of compute_objective ≈ compute_objective_grad on solved-for indices.
 

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -141,7 +141,7 @@ def _call_backend_chisq_dict(imgr, imcur):
     """Call compute_chisq_dict with args pulled from an initialized Imager."""
     return compute_chisq_dict(
         imcur, sorted(imgr.dat_term_next.keys()), imgr._data_tuples,
-        imgr.obslist_next, imgr._logfreqratio_list, imgr.mf_next,
+        len(imgr.obslist_next), imgr._logfreqratio_list, imgr.mf_next,
         imgr.pol_next, imgr._ttype, imgr._embed_mask,
     )
 
@@ -150,7 +150,7 @@ def _call_backend_chisqgrad_dict(imgr, imcur):
     """Call compute_chisqgrad_dict with args pulled from an initialized Imager."""
     return compute_chisqgrad_dict(
         imcur, sorted(imgr.dat_term_next.keys()), imgr._data_tuples,
-        imgr.obslist_next, imgr._logfreqratio_list, imgr.mf_next,
+        len(imgr.obslist_next), imgr._logfreqratio_list, imgr.mf_next,
         imgr.pol_next, imgr._ttype, imgr._embed_mask,
         imgr._which_solve, imgr._nimage,
     )
@@ -179,7 +179,7 @@ def _call_backend_reg_dict(imgr, imcur, mf_flux=None):
     """Call compute_reg_dict with args pulled from an initialized Imager."""
     return compute_reg_dict(
         imcur, sorted(imgr.reg_term_next.keys()), imgr._xprior, imgr._embed_mask,
-        imgr.mf_next, imgr.obslist_next, imgr._logfreqratio_list, imgr.pol_next,
+        imgr.mf_next, len(imgr.obslist_next), imgr._logfreqratio_list, imgr.pol_next,
         imgr.norm_reg, _build_regparams(imgr, mf_flux=mf_flux),
     )
 
@@ -188,7 +188,7 @@ def _call_backend_reggrad_dict(imgr, imcur, mf_flux=None):
     """Call compute_reggrad_dict with args pulled from an initialized Imager."""
     return compute_reggrad_dict(
         imcur, sorted(imgr.reg_term_next.keys()), imgr._xprior, imgr._embed_mask,
-        imgr.mf_next, imgr.obslist_next, imgr._logfreqratio_list, imgr.pol_next,
+        imgr.mf_next, len(imgr.obslist_next), imgr._logfreqratio_list, imgr.pol_next,
         imgr.norm_reg, _build_regparams(imgr, mf_flux=mf_flux),
         imgr._which_solve, imgr._nimage,
     )
@@ -199,7 +199,7 @@ def _call_backend_objective(imgr, imvec):
     return compute_objective(
         imvec, imgr._xarr, imgr._which_solve, imgr.transform_next,
         imgr.dat_term_next, imgr.reg_term_next,
-        imgr._data_tuples, imgr.obslist_next, imgr._logfreqratio_list,
+        imgr._data_tuples, len(imgr.obslist_next), imgr._logfreqratio_list,
         imgr.mf_next, imgr.pol_next, imgr._ttype, imgr._embed_mask,
         imgr._xprior, imgr.norm_reg, _build_regparams(imgr),
     )
@@ -210,7 +210,7 @@ def _call_backend_objective_grad(imgr, imvec):
     return compute_objective_grad(
         imvec, imgr._xarr, imgr._which_solve, imgr.transform_next,
         imgr.dat_term_next, imgr.reg_term_next,
-        imgr._data_tuples, imgr.obslist_next, imgr._logfreqratio_list,
+        imgr._data_tuples, len(imgr.obslist_next), imgr._logfreqratio_list,
         imgr.mf_next, imgr.pol_next, imgr._ttype, imgr._embed_mask,
         imgr._xprior, imgr.norm_reg, _build_regparams(imgr),
         imgr._nimage,
@@ -614,7 +614,7 @@ class TestComputeRegDict:
         with pytest.raises(Exception, match="not recognized"):
             compute_reg_dict(
                 imcur, ["not_a_regularizer"], imgr._xprior, imgr._embed_mask,
-                imgr.mf_next, imgr.obslist_next, imgr._logfreqratio_list, imgr.pol_next,
+                imgr.mf_next, len(imgr.obslist_next), imgr._logfreqratio_list, imgr.pol_next,
                 imgr.norm_reg, _build_regparams(imgr),
             )
 
@@ -740,7 +740,7 @@ class TestComputeReggradDict:
         with pytest.raises(Exception, match="not recognized"):
             compute_reggrad_dict(
                 imcur, ["not_a_regularizer"], imgr._xprior, imgr._embed_mask,
-                imgr.mf_next, imgr.obslist_next, imgr._logfreqratio_list, imgr.pol_next,
+                imgr.mf_next, len(imgr.obslist_next), imgr._logfreqratio_list, imgr.pol_next,
                 imgr.norm_reg, _build_regparams(imgr),
                 imgr._which_solve, imgr._nimage,
             )

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -13,6 +13,7 @@ from ehtim.imaging.imager_backend import (
     compute_chisqgrad_dict,
     compute_embed,
     compute_objective,
+    compute_objective_grad,
     compute_reg_dict,
     compute_reggrad_dict,
     transform_gradients,
@@ -202,6 +203,19 @@ def _call_backend_objective(imgr, imvec):
         imgr.mf_next, imgr.pol_next, imgr._ttype, imgr._embed_mask,
         imgr._xprior, imgr.norm_reg, _build_regparams(imgr),
         imgr.chisq_transform,
+    )
+
+
+def _call_backend_objective_grad(imgr, imvec):
+    """Call compute_objective_grad with args pulled from an initialized Imager."""
+    return compute_objective_grad(
+        imvec, imgr._xarr, imgr._which_solve, imgr.transform_next,
+        imgr.dat_term_next, imgr.reg_term_next,
+        imgr._data_tuples, imgr.obslist_next, imgr._logfreqratio_list,
+        imgr.mf_next, imgr.pol_next, imgr._ttype, imgr._embed_mask,
+        imgr._xprior, imgr.norm_reg, _build_regparams(imgr),
+        imgr._nimage,
+        imgr.chisq_transform, imgr.chisq_offset_gradient,
     )
 
 
@@ -869,6 +883,192 @@ class TestComputeObjective:
         backend_value = _call_backend_objective(imgr, imvec)
         method_value = imgr.objfunc(imvec)
         np.testing.assert_array_equal(backend_value, method_value)
+
+
+def _fd_grad_of_objective(imgr, imvec, indices, eps=1e-6):
+    """Centered finite-difference gradient of compute_objective at given indices.
+
+    Returns a full-length grad array but only the entries at `indices` are
+    populated. Independent of compute_objective_grad — usable as ground truth
+    for the analytic gradient under test.
+    """
+    grad = np.zeros_like(imvec)
+    for i in indices:
+        v_p = imvec.copy()
+        v_p[i] += eps
+        v_m = imvec.copy()
+        v_m[i] -= eps
+        f_p = _call_backend_objective(imgr, v_p)
+        f_m = _call_backend_objective(imgr, v_m)
+        grad[i] = (f_p - f_m) / (2 * eps)
+    return grad
+
+
+class TestComputeObjectiveGrad:
+    """Tests for compute_objective_grad (extracted from Imager.objgrad)."""
+
+    def test_matches_imager_stokes_i(self, gauss_im, observe, initialize_imager):
+        """Single-freq, pol='I' — gradient bit-identical to method, 1D shape."""
+        obs = observe(gauss_im)
+        imgr, _ = initialize_imager(
+            obs, gauss_im, {"vis": 100, "amp": 10},
+            reg_term={"simple": 1, "tv": 10},
+        )
+        imvec = imgr._xinit
+        backend_grad = _call_backend_objective_grad(imgr, imvec)
+        method_grad = imgr.objgrad(imvec)
+        np.testing.assert_array_equal(backend_grad, method_grad)
+        assert backend_grad.shape == imvec.shape
+
+    def test_matches_imager_polarimetric(self, gauss_im_pol, observe, initialize_imager):
+        """pol='IP' with REGULARIZERS_POL — exercises polchisqgrad + polreggrad chain."""
+        obs = observe(gauss_im_pol)
+        imgr, _ = initialize_imager(
+            obs, gauss_im_pol, {"pvis": 100},
+            reg_term={"hw": 1, "ptv": 1},
+            pol="IP", transform=["log", "mcv"],
+        )
+        imvec = imgr._xinit
+        backend_grad = _call_backend_objective_grad(imgr, imvec)
+        method_grad = imgr.objgrad(imvec)
+        np.testing.assert_array_equal(backend_grad, method_grad)
+
+    def test_matches_imager_stokes_i_pol_bundled(self, gauss_im_pol, observe,
+                                                   initialize_imager):
+        """pol='IP' with mixed Stokes-I + pol terms — cross-Stokes chain rule path."""
+        obs = observe(gauss_im_pol)
+        imgr, _ = initialize_imager(
+            obs, gauss_im_pol, {"vis": 100, "pvis": 100},
+            reg_term={"simple": 1, "hw": 1},
+            pol="IP", transform=["log", "mcv"],
+        )
+        imvec = imgr._xinit
+        backend_grad = _call_backend_objective_grad(imgr, imvec)
+        method_grad = imgr.objgrad(imvec)
+        np.testing.assert_array_equal(backend_grad, method_grad)
+
+    def test_matches_imager_multifrequency(self, gauss_im, observe, initialize_imager):
+        """Two obs at different rf — multifreq grad bundling + key suffix branch."""
+        im_lo = gauss_im.copy()
+        im_lo.rf = REFFREQ_HZ
+        im_hi = gauss_im.copy()
+        im_hi.rf = MF_ALT_FREQ_HZ
+        obs_lo = observe(im_lo)
+        obs_hi = observe(im_hi)
+
+        imgr, _ = initialize_imager(
+            [obs_lo, obs_hi], im_lo, {"vis": 100},
+            reg_term={"simple": 1, "flux_mf": 1, "l2_alpha": 1},
+            mf=True, mf_order=1,
+            mf_flux=[im_lo.total_flux(), im_hi.total_flux()],
+        )
+        imvec = imgr._xinit
+        backend_grad = _call_backend_objective_grad(imgr, imvec)
+        method_grad = imgr.objgrad(imvec)
+        np.testing.assert_array_equal(backend_grad, method_grad)
+
+    def test_chisq_transform_branch(self, gauss_im, observe, initialize_imager):
+        """chisq_transform=True activates chi2_grad * (1 - 1/chi2^2) branch."""
+        obs = observe(gauss_im)
+        imgr, _ = initialize_imager(
+            obs, gauss_im, {"vis": 100},
+            reg_term={"simple": 1},
+        )
+        imgr.chisq_transform = True
+        imvec = imgr._xinit
+        backend_grad = _call_backend_objective_grad(imgr, imvec)
+        method_grad = imgr.objgrad(imvec)
+        np.testing.assert_array_equal(backend_grad, method_grad)
+
+    def test_fd_matches_analytic_stokes_i(self, gauss_im, observe, initialize_imager):
+        """FD of compute_objective ≈ compute_objective_grad on solved-for indices.
+
+        Independent verification of the analytic gradient via centered FD.
+        Samples 20 random indices to keep the test under a few seconds.
+        """
+        obs = observe(gauss_im)
+        imgr, _ = initialize_imager(
+            obs, gauss_im, {"vis": 100},
+            reg_term={"simple": 1, "tv": 10},
+        )
+        imvec = imgr._xinit
+
+        rng = np.random.default_rng(42)
+        indices = rng.choice(len(imvec), size=20, replace=False)
+
+        grad_analytic = _call_backend_objective_grad(imgr, imvec)
+        grad_fd = _fd_grad_of_objective(imgr, imvec, indices)
+
+        np.testing.assert_allclose(
+            grad_analytic[indices], grad_fd[indices],
+            rtol=1e-4, atol=1e-8,
+        )
+
+    def test_fd_matches_analytic_polarimetric(self, gauss_im_pol, observe,
+                                                initialize_imager):
+        """FD verification under pol='IP' with log+mcv transforms.
+
+        Exercises the chain rule applied through both the log (Stokes I) and
+        mcv (polarization) transform components, on top of the polarimetric
+        forward model. atol=1e-7 covers the FD noise floor: with chisq values
+        ~O(1e6) and eps=1e-6, FD precision floors near 1e-7 in absolute terms.
+        """
+        obs = observe(gauss_im_pol)
+        imgr, _ = initialize_imager(
+            obs, gauss_im_pol, {"vis": 100, "pvis": 100},
+            reg_term={"simple": 1, "hw": 1},
+            pol="IP", transform=["log", "mcv"],
+        )
+        imvec = imgr._xinit
+
+        rng = np.random.default_rng(7)
+        indices = rng.choice(len(imvec), size=20, replace=False)
+
+        grad_analytic = _call_backend_objective_grad(imgr, imvec)
+        grad_fd = _fd_grad_of_objective(imgr, imvec, indices)
+
+        np.testing.assert_allclose(
+            grad_analytic[indices], grad_fd[indices],
+            rtol=1e-4, atol=1e-7,
+        )
+
+    @pytest.mark.parametrize("xdim,ydim", IMAGE_SHAPES)
+    def test_rect_images(self, make_rect_image, observe, initialize_imager,
+                          xdim, ydim):
+        """Backend handles rectangular (xdim != ydim) images end-to-end."""
+        im = make_rect_image(xdim, ydim)
+        obs = observe(im)
+        imgr, _ = initialize_imager(
+            obs, im, {"vis": 100},
+            reg_term={"simple": 1, "tv": 10},
+        )
+        imvec = imgr._xinit
+        backend_grad = _call_backend_objective_grad(imgr, imvec)
+        method_grad = imgr.objgrad(imvec)
+        np.testing.assert_array_equal(backend_grad, method_grad)
+
+
+def test_objective_and_objective_grad_share_consistency(gauss_im, observe,
+                                                          initialize_imager):
+    """Cross-cutting invariant: gradient finite-norm and re-evaluation parity.
+
+    Uses 'simple' regularizer only; TV/L1 can produce NaN at zero-pixel
+    edges of the unblurred prior, which is unrelated to objective wiring.
+    """
+    obs = observe(gauss_im)
+    imgr, _ = initialize_imager(
+        obs, gauss_im, {"vis": 100, "amp": 10},
+        reg_term={"simple": 1},
+    )
+    imvec = imgr._xinit
+    obj = _call_backend_objective(imgr, imvec)
+    grad = _call_backend_objective_grad(imgr, imvec)
+    assert np.isfinite(obj)
+    assert np.all(np.isfinite(grad))
+    assert grad.shape == imvec.shape
+    # Re-evaluation parity through the method wrappers
+    np.testing.assert_array_equal(obj, imgr.objfunc(imvec))
+    np.testing.assert_array_equal(grad, imgr.objgrad(imvec))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Covers tasks 1B.1 / 1B.2 plus a thorough cleanup after the code review. After this lands, only `init_imager` (1C.1) and the integration test (1F.1) remain in Phase 1.

### Original extraction (commits 1–3)
- **`9c1f965`** — extract `Imager.objfunc` → pure `compute_objective` (1B.1)
- **`1777a90`** — extract `Imager.objgrad` → pure `compute_objective_grad` (1B.2)
- **`a10d040`** — fix `chisq_transform=True` multi-obs `KeyError` *(superseded by C1 below; the whole `chisq_transform` path is now removed)*

### Review response (commits 4–8, addressing comments)
- **`3f59865` (C1)** — drop the `chisq_transform` legacy path entirely. Removes the param and branches from `compute_objective` / `compute_objective_grad`, the `Imager.chisq_transform` / `chisq_offset_gradient` attrs
- **`91456fb` (C2)** — replace `obslist` argument with explicit `n_obs: int` in all six backend functions (`compute_chisq_dict`, `compute_chisqgrad_dict`, `compute_reg_dict`, `compute_reggrad_dict`, `compute_objective`, `compute_objective_grad`). Backends never used obslist for anything but `len(obslist)`. New consistency assertion in `Imager.init_imager` catches any future drift between `len(obslist_next)`, `len(freq_list)`, and `len(_logfreqratio_list)`.
- **`bdda3a6` (C3)** — reorder backend signatures (variable + initial-reference + mode flags first; data state in the middle; reg state and image-side machinery last). Rename function parameters: `xarr` → `initvec`, `xprior` → `priorvec`. Rename Imager attributes for consistency: `_xarr` → `_init_arr`, `_xprior` → `_prior_arr`, `_xinit` → `_init_vec`. Local vars in `init_imager` likewise: `initarr` → `init_phys` and `init_solver` (making the physical-vs-solver-space pipeline visible at the call site); `priorarr` → `prior_phys`. Naming convention is documented at the top of `imager_backend.py` and in `init_imager`'s docstring.
- **`0efecbe` (C4)** — full NumPy-style docstrings (Parameters / Returns) on `compute_objective` and `compute_objective_grad`. The other four backend functions already had them.
- **`df5c311` (C5)** —Rename `priorarr` parameter → `init_arr` in `unpack_imarr`. The function fills not-solved-for slots with the *initial* image, not the regularizer prior; the old name was historically misleading.

## n_obs design rationale
We went with explicit `n_obs: int` over relying on `len(logfreqratio_list)` because:
1. **JAX-friendly** — `n_obs` is a natural `static_argname` for `jax.jit`. Computing `len(traced_array)` inside a jitted function works but is less clean.
2. **Decouples** chi^2 / regularizer compute semantics from frequency-list semantics. A future Phase 6 refactor introducing per-channel frequency lists won't break the chi^2 path.
3. **Cleaner validation locus** — `Imager.init_imager` asserts the cross-list invariant upfront

## Test coverage
- `TestComputeObjective` — 10 tests: single-pol, polarimetric, IP-bundled, multifreq, rect-image parametrize.
- `TestComputeObjectiveGrad` — 11 tests: same on gradients + 2 finite-difference verifications (Stokes I + IP) against `compute_objective`.
- `test_objective_and_objective_grad_share_consistency` — parity invariant.

## JAX-readiness
The new pure functions are designed for `jax.jit` / `jax.grad` once the underlying backends are JAXified in Phase 5:
- Pure, no `self`, no `+=` on arrays, no Python branching on array values.
- Planned `static_argnames` (now flat in the namespace): `('mf', 'pol', 'transforms', 'ttype')` plus static dict-key structure on `dat_term` / `reg_term` / `regparams`.
- `compute_objective_grad` is structured so `jax.grad(compute_objective)` is a drop-in replacement during Phase 5D's three-way check (analytic vs numeric vs autodiff).