### PR TITLE
Merge chisq + polchisq dispatchers into unified term-level family

### DIFF
--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -45,12 +45,12 @@ from ehtim.imaging.imager_backend import (
     compute_objective_grad,
     compute_reg_dict,
     compute_reggrad_dict,
-    embed_imarr,
     transform_imarr,
     unpack_imarr,
     validate_limits,
     validate_params,
 )
+from ehtim.imaging.imager_utils import embed_imarr
 
 MAXIT = 200  # number of iterations
 NHIST = 50   # number of steps to store for hessian approx

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -855,9 +855,9 @@ def compute_chisqdata_term(obs, prior, mask, dtype, ttype='direct', pol='I', **k
             raise Exception(f"cannot use dterm {dtype} with pol={pol}")
         pol = 'I'
 
-    # Standard direct + all pol leaves take mask positionally.
-    # Standard fast/nfft leaves omit it (they index uv coords from obs directly).
-    if is_pol or ttype == 'direct':
+    # Only `direct` leaves take mask positionally; fast/nfft leaves index uv
+    # coords from obs directly and ignore the embed mask.
+    if ttype == 'direct':
         return helper(obs, prior, mask, pol=pol, **kwargs)
     return helper(obs, prior, pol=pol, **kwargs)
 

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -894,18 +894,13 @@ def _lookup_chisq_entry(dtype, ttype):
 def compute_chisq_term(imcur, dtype, A, data, sigma, ttype='direct', mask=None):
     """Single chi^2 dispatcher unifying chisq + polchisq.
 
-    Pol dtypes consume the full multi-row imcur ((4, npix) single-frequency
-    or (10, npix) multi-frequency). Standard dtypes consume the Stokes-I
-    row: `imcur[0]` if imcur is 2D (pol-mode imager solving for several
-    Stokes), or imcur itself if 1D (non-pol mode, single Stokes-I solver).
-    Mask embedding and FFT pre-computation match the legacy chisq /
-    polchisq bodies exactly.
-
     Parameters
     ----------
     imcur : np.ndarray
-        Solver-space image. 1D (npix,) in non-pol mode, 2D (nsolve, npix)
-        in pol / mf-pol mode.
+        Solver-space image. Pol dtypes consume the full multi-row array
+        (1D for non-pol mode, 2D (nsolve, npix) for pol/mf-pol with
+        nsolve in {3, 4, 10}). Standard dtypes consume the Stokes-I row:
+        `imcur[0]` when 2D, `imcur` itself when 1D.
     dtype : str
         One of the keys of _CHISQ_DISPATCH (12 dtypes).
     A, data, sigma

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -704,6 +704,100 @@ class ImagerInitState(NamedTuple):
     reffreq: float               # may be re-bound to init.rf when mf=True
 
 
+# Dispatch table for compute_chisqdata_term.
+# Maps (dtype, ttype) to the leaf helper that produces (data, sigma, A).
+# Standard dtypes route to imutils helpers; polarimetric dtypes (pvis/m/vvis)
+# route to polutils helpers. `logamp` aliases `amp` (same data product).
+# Pol dtypes have no `fast` ttype -- polchisqdata does not support FFT.
+_CHISQDATA_DISPATCH = {
+    'vis':          {'direct': imutils.chisqdata_vis,
+                     'fast':   imutils.chisqdata_vis_fft,
+                     'nfft':   imutils.chisqdata_vis_nfft},
+    'amp':          {'direct': imutils.chisqdata_amp,
+                     'fast':   imutils.chisqdata_amp_fft,
+                     'nfft':   imutils.chisqdata_amp_nfft},
+    'logamp':       {'direct': imutils.chisqdata_amp,
+                     'fast':   imutils.chisqdata_amp_fft,
+                     'nfft':   imutils.chisqdata_amp_nfft},
+    'bs':           {'direct': imutils.chisqdata_bs,
+                     'fast':   imutils.chisqdata_bs_fft,
+                     'nfft':   imutils.chisqdata_bs_nfft},
+    'cphase':       {'direct': imutils.chisqdata_cphase,
+                     'fast':   imutils.chisqdata_cphase_fft,
+                     'nfft':   imutils.chisqdata_cphase_nfft},
+    'cphase_diag':  {'direct': imutils.chisqdata_cphase_diag,
+                     'fast':   imutils.chisqdata_cphase_diag_fft,
+                     'nfft':   imutils.chisqdata_cphase_diag_nfft},
+    'camp':         {'direct': imutils.chisqdata_camp,
+                     'fast':   imutils.chisqdata_camp_fft,
+                     'nfft':   imutils.chisqdata_camp_nfft},
+    'logcamp':      {'direct': imutils.chisqdata_logcamp,
+                     'fast':   imutils.chisqdata_logcamp_fft,
+                     'nfft':   imutils.chisqdata_logcamp_nfft},
+    'logcamp_diag': {'direct': imutils.chisqdata_logcamp_diag,
+                     'fast':   imutils.chisqdata_logcamp_diag_fft,
+                     'nfft':   imutils.chisqdata_logcamp_diag_nfft},
+    'pvis':         {'direct': polutils.chisqdata_pvis,
+                     'nfft':   polutils.chisqdata_pvis_nfft},
+    'm':            {'direct': polutils.chisqdata_m,
+                     'nfft':   polutils.chisqdata_m_nfft},
+    'vvis':         {'direct': polutils.chisqdata_vvis,
+                     'nfft':   polutils.chisqdata_vvis_nfft},
+}
+
+
+def compute_chisqdata_term(obs, prior, mask, dtype, ttype='direct', pol='I', **kwargs):
+    """Single chisqdata dispatcher unifying chisqdata + polchisqdata.
+
+    Standard dtypes route to imutils.chisqdata_*; pol dtypes route to
+    polutils.chisqdata_*. Mask handling is asymmetric across the legacy
+    leaves (standard `fast`/`nfft` do not accept a mask param); this
+    function hides that.
+
+    Parameters
+    ----------
+    obs : ehtim.obsdata.Obsdata
+    prior : ehtim.image.Image
+    mask : np.ndarray of bool
+        Embedding mask. Passed positionally to direct + pol-nfft helpers;
+        ignored for standard fast/nfft (those helpers do not take mask).
+    dtype : str
+        Must be a key of _CHISQDATA_DISPATCH (12 dtypes).
+    ttype : {'direct', 'fast', 'nfft'}
+        'fast' is not supported for polarimetric dtypes.
+    pol : str
+        Polarization mode. Standard dtypes use this to unpack the right
+        Stokes (I/Q/U/V) data; pol dtypes absorb it via **kwargs (inert).
+    **kwargs
+        Per-dtype tuning knobs forwarded to the leaf helper. See
+        imager_utils.chisqdata for the standard kwarg list and
+        pol_imager_utils.chisqdata_pvis_nfft for the FFT-related kwargs.
+
+    Returns
+    -------
+    (data, sigma, A) tuple, same shape as the legacy chisqdata dispatchers.
+    """
+    if ttype not in ('direct', 'fast', 'nfft'):
+        raise Exception("Possible ttype values are 'fast', 'direct', 'nfft'!")
+
+    try:
+        by_ttype = _CHISQDATA_DISPATCH[dtype]
+    except KeyError:
+        raise Exception(f"data term {dtype} not recognized!")
+
+    if ttype not in by_ttype:
+        raise Exception(f"ttype={ttype!r} not supported for dtype={dtype!r}")
+
+    helper = by_ttype[ttype]
+    is_pol = dtype in DATATERMS_POL
+
+    # Standard direct + all pol leaves take mask positionally.
+    # Standard fast/nfft leaves omit it (they index uv coords from obs directly).
+    if is_pol or ttype == 'direct':
+        return helper(obs, prior, mask, pol=pol, **kwargs)
+    return helper(obs, prior, pol=pol, **kwargs)
+
+
 def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,
                         ttype, data_weighting_params, fft_params):
     """Pre-compute (data, sigma, A) tuples for every (data-term, observation) pair.

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -57,6 +57,12 @@ REGULARIZERS_SPECTRAL = REGULARIZERS_ISPECTRAL + REGULARIZERS_POLSPECTRAL
 MEANPOL_INIT = 0.2     # mean polarization fraction
 SIGMAPOL_INIT = 1.e-2  # perturbation scale
 
+# Whether mask-embedding under fast/nfft fills non-mask pixels with random
+# noise (vs a constant clipfloor). Set True historically to break TV-regularizer
+# gradient singularities; the newer `epsilon_tv` mechanism likely makes this
+# unnecessary -- revisit once epsilon_tv coverage is broader.
+EMBED_RANDOMFLOOR = True
+
 
 def pack_imarr(imarr, which_solve):
     """pack image array imarr into 1D array vec for minimizaiton
@@ -920,13 +926,12 @@ def compute_chisq_term(imcur, dtype, A, data, sigma, ttype='direct', mask=None):
 
     imvec = imcur if (is_pol or imcur.ndim == 1) else imcur[0]
 
-    # randomfloor=True breaks TV-regularizer gradient singularities.
     if (ttype != 'direct' and mask is not None
             and len(mask) > 0 and np.any(np.invert(mask))):
         if is_pol:
-            imvec = imutils.embed_imarr(imvec, mask, randomfloor=True)
+            imvec = imutils.embed_imarr(imvec, mask, randomfloor=EMBED_RANDOMFLOOR)
         else:
-            imvec = imutils.embed(imvec, mask, randomfloor=True)
+            imvec = imutils.embed(imvec, mask, randomfloor=EMBED_RANDOMFLOOR)
 
     if ttype == 'fast' and dtype not in _DIAG_DTYPES:
         imvec = obsh.fft_imvec(imvec, A[0])
@@ -953,9 +958,9 @@ def compute_chisqgrad_term(imcur, dtype, A, data, sigma, ttype='direct',
 
     if ttype != 'direct' and has_partial_mask:
         if is_pol:
-            imvec = imutils.embed_imarr(imvec, mask, randomfloor=True)
+            imvec = imutils.embed_imarr(imvec, mask, randomfloor=EMBED_RANDOMFLOOR)
         else:
-            imvec = imutils.embed(imvec, mask, randomfloor=True)
+            imvec = imutils.embed(imvec, mask, randomfloor=EMBED_RANDOMFLOOR)
 
     if ttype == 'fast' and dtype not in _DIAG_DTYPES:
         imvec = obsh.fft_imvec(imvec, A[0])

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -868,6 +868,24 @@ _CHISQ_DISPATCH = {
 }
 
 
+def _pol_solve_block(which_solve, pol):
+    """Slice the polarimetric (Stokes) block from which_solve.
+
+    Multi-frequency polarimetric `which_solve` has layout
+    [I, rho, phi, psi, alpha, beta, alpha_p, beta_p, RM, CM] (10 slots);
+    pol chi^2 gradient kernels only consume the first four (the Stokes
+    block). Single-frequency polarimetric which_solve is already 4-wide,
+    so this is a no-op there.
+
+    TODO(Phase 6): replace with a `WhichSolve(stokes, spectral)` NamedTuple
+    so arbitrary spectral layouts do not need this hardcoded slice. Flagged
+    by Andrew in #227.
+    """
+    if pol in POLARIZATION_MODES and len(which_solve) > 4:
+        return which_solve[:4]
+    return which_solve
+
+
 def _lookup_chisq_entry(dtype, ttype):
     """Look up (chisq_fn, chisqgrad_fn, is_pol) for (dtype, ttype). Raises on miss."""
     if ttype not in ('direct', 'fast', 'nfft'):

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -8,6 +8,7 @@ import numpy as np
 import ehtim.imaging.imager_utils as imutils
 import ehtim.imaging.multifreq_imager_utils as mfutils
 import ehtim.imaging.pol_imager_utils as polutils
+import ehtim.observing.obs_helpers as obsh
 
 # -----------------------------------------------------------------------------
 # Naming convention for image arguments throughout this module
@@ -805,6 +806,168 @@ def compute_chisqdata_term(obs, prior, mask, dtype, ttype='direct', pol='I', **k
     if is_pol or ttype == 'direct':
         return helper(obs, prior, mask, pol=pol, **kwargs)
     return helper(obs, prior, pol=pol, **kwargs)
+
+
+# Dtypes whose `fast` leaf is not preceded by an FFT pre-compute step. The diag
+# variants index the gridded image directly per-baseline, so the orchestrator
+# passes imvec (not the pre-FFT'd vis_arr). Mirrors imager_utils.chisq lines 81 / 95.
+_DIAG_DTYPES = frozenset({'cphase_diag', 'logcamp_diag'})
+
+
+# Dispatch table for compute_chisq_term + compute_chisqgrad_term. Maps
+# (dtype, ttype) to a (chisq_fn, chisqgrad_fn) pair, plus an `is_pol` flag.
+# Standard dtypes (`vis`, `amp`, ...) route to imutils leaves; polarimetric
+# (`pvis`, `m`, `vvis`) route to polutils leaves. Pol dtypes have no `fast`.
+# Phase 5 swaps entries in place to register JAX backends.
+_CHISQ_DISPATCH = {
+    'vis':          {'is_pol': False,
+                     'direct': (imutils.chisq_vis,          imutils.chisqgrad_vis),
+                     'fast':   (imutils.chisq_vis_fft,      imutils.chisqgrad_vis_fft),
+                     'nfft':   (imutils.chisq_vis_nfft,     imutils.chisqgrad_vis_nfft)},
+    'amp':          {'is_pol': False,
+                     'direct': (imutils.chisq_amp,          imutils.chisqgrad_amp),
+                     'fast':   (imutils.chisq_amp_fft,      imutils.chisqgrad_amp_fft),
+                     'nfft':   (imutils.chisq_amp_nfft,     imutils.chisqgrad_amp_nfft)},
+    'logamp':       {'is_pol': False,
+                     'direct': (imutils.chisq_logamp,       imutils.chisqgrad_logamp),
+                     'fast':   (imutils.chisq_logamp_fft,   imutils.chisqgrad_logamp_fft),
+                     'nfft':   (imutils.chisq_logamp_nfft,  imutils.chisqgrad_logamp_nfft)},
+    'bs':           {'is_pol': False,
+                     'direct': (imutils.chisq_bs,           imutils.chisqgrad_bs),
+                     'fast':   (imutils.chisq_bs_fft,       imutils.chisqgrad_bs_fft),
+                     'nfft':   (imutils.chisq_bs_nfft,      imutils.chisqgrad_bs_nfft)},
+    'cphase':       {'is_pol': False,
+                     'direct': (imutils.chisq_cphase,       imutils.chisqgrad_cphase),
+                     'fast':   (imutils.chisq_cphase_fft,   imutils.chisqgrad_cphase_fft),
+                     'nfft':   (imutils.chisq_cphase_nfft,  imutils.chisqgrad_cphase_nfft)},
+    'cphase_diag':  {'is_pol': False,
+                     'direct': (imutils.chisq_cphase_diag,      imutils.chisqgrad_cphase_diag),
+                     'fast':   (imutils.chisq_cphase_diag_fft,  imutils.chisqgrad_cphase_diag_fft),
+                     'nfft':   (imutils.chisq_cphase_diag_nfft, imutils.chisqgrad_cphase_diag_nfft)},
+    'camp':         {'is_pol': False,
+                     'direct': (imutils.chisq_camp,         imutils.chisqgrad_camp),
+                     'fast':   (imutils.chisq_camp_fft,     imutils.chisqgrad_camp_fft),
+                     'nfft':   (imutils.chisq_camp_nfft,    imutils.chisqgrad_camp_nfft)},
+    'logcamp':      {'is_pol': False,
+                     'direct': (imutils.chisq_logcamp,      imutils.chisqgrad_logcamp),
+                     'fast':   (imutils.chisq_logcamp_fft,  imutils.chisqgrad_logcamp_fft),
+                     'nfft':   (imutils.chisq_logcamp_nfft, imutils.chisqgrad_logcamp_nfft)},
+    'logcamp_diag': {'is_pol': False,
+                     'direct': (imutils.chisq_logcamp_diag,      imutils.chisqgrad_logcamp_diag),
+                     'fast':   (imutils.chisq_logcamp_diag_fft,  imutils.chisqgrad_logcamp_diag_fft),
+                     'nfft':   (imutils.chisq_logcamp_diag_nfft, imutils.chisqgrad_logcamp_diag_nfft)},
+    'pvis':         {'is_pol': True,
+                     'direct': (polutils.chisq_p,           polutils.chisqgrad_p),
+                     'nfft':   (polutils.chisq_p_nfft,      polutils.chisqgrad_p_nfft)},
+    'm':            {'is_pol': True,
+                     'direct': (polutils.chisq_m,           polutils.chisqgrad_m),
+                     'nfft':   (polutils.chisq_m_nfft,      polutils.chisqgrad_m_nfft)},
+    'vvis':         {'is_pol': True,
+                     'direct': (polutils.chisq_vvis,        polutils.chisqgrad_vvis),
+                     'nfft':   (polutils.chisq_vvis_nfft,   polutils.chisqgrad_vvis_nfft)},
+}
+
+
+def _lookup_chisq_entry(dtype, ttype):
+    """Look up (chisq_fn, chisqgrad_fn, is_pol) for (dtype, ttype). Raises on miss."""
+    if ttype not in ('direct', 'fast', 'nfft'):
+        raise Exception("Possible ttype values are 'fast', 'direct', 'nfft'!")
+    try:
+        entry = _CHISQ_DISPATCH[dtype]
+    except KeyError:
+        raise Exception(f"data term {dtype} not recognized!")
+    if ttype not in entry:
+        raise Exception(f"ttype={ttype!r} not supported for dtype={dtype!r}")
+    chisq_fn, chisqgrad_fn = entry[ttype]
+    return chisq_fn, chisqgrad_fn, entry['is_pol']
+
+
+def compute_chisq_term(imcur, dtype, A, data, sigma, ttype='direct', mask=None):
+    """Single chi^2 dispatcher unifying chisq + polchisq.
+
+    Pol dtypes consume the full (4, npix) imcur (or its (10, npix) multi-freq
+    extension); standard dtypes consume imcur[0]. Mask embedding and FFT
+    pre-computation match the legacy chisq / polchisq bodies exactly.
+
+    Parameters
+    ----------
+    imcur : np.ndarray
+        Multi-row image array. Pol dtypes read all rows; standard dtypes
+        read row 0 (Stokes I) only.
+    dtype : str
+        One of the keys of _CHISQ_DISPATCH (12 dtypes).
+    A, data, sigma
+        Per-dtype Fourier matrix or matrix-tuple, observed values, and
+        sigma values. Same shapes as the legacy leaf-helper signatures.
+    ttype : {'direct', 'fast', 'nfft'}
+        'fast' is not supported for pol dtypes.
+    mask : np.ndarray of bool, optional
+        Embedding mask used by fast / nfft leaves to expand the solver
+        image back onto the full grid. None or empty => no embedding.
+
+    Returns
+    -------
+    float
+    """
+    chisq_fn, _, is_pol = _lookup_chisq_entry(dtype, ttype)
+
+    imvec = imcur if is_pol else imcur[0]
+
+    # Embed onto full grid for fast / nfft if a partial mask was supplied.
+    # Legacy chisq / polchisq both use randomfloor=True to break TV singularities.
+    if (ttype != 'direct' and mask is not None
+            and len(mask) > 0 and np.any(np.invert(mask))):
+        if is_pol:
+            imvec = imutils.embed_imarr(imvec, mask, randomfloor=True)
+        else:
+            imvec = imutils.embed(imvec, mask, randomfloor=True)
+
+    # FFT pre-compute for the standard `fast` path (except _diag dtypes, whose
+    # leaves index the gridded image directly). Pol has no `fast` branch.
+    if ttype == 'fast' and dtype not in _DIAG_DTYPES:
+        imvec = obsh.fft_imvec(imvec, A[0])
+
+    return chisq_fn(imvec, A, data, sigma)
+
+
+def compute_chisqgrad_term(imcur, dtype, A, data, sigma, ttype='direct',
+                           mask=None, pol_solve=None):
+    """Single chi^2-gradient dispatcher. See compute_chisq_term.
+
+    Pol grad helpers take an extra `pol_solve` arg (Stokes block of which_solve);
+    standard grad helpers do not. Returned gradient is sliced back through `mask`
+    for fast / nfft to match the legacy chisqgrad / polchisqgrad return shapes:
+    pol grads are (4, n_masked); standard grads are (n_masked,).
+    """
+    _, chisqgrad_fn, is_pol = _lookup_chisq_entry(dtype, ttype)
+
+    imvec = imcur if is_pol else imcur[0]
+    has_partial_mask = (mask is not None and len(mask) > 0
+                        and np.any(np.invert(mask)))
+
+    if ttype != 'direct' and has_partial_mask:
+        if is_pol:
+            imvec = imutils.embed_imarr(imvec, mask, randomfloor=True)
+        else:
+            imvec = imutils.embed(imvec, mask, randomfloor=True)
+
+    if ttype == 'fast' and dtype not in _DIAG_DTYPES:
+        imvec = obsh.fft_imvec(imvec, A[0])
+
+    if is_pol:
+        # pol_solve is positional in the pol grad leaves; default to all-ones
+        # over the Stokes block if not supplied (matches polchisqgrad's default).
+        if pol_solve is None:
+            pol_solve = np.ones(4, dtype=int)
+        grad = chisqgrad_fn(imvec, A, data, sigma, pol_solve)
+    else:
+        grad = chisqgrad_fn(imvec, A, data, sigma)
+
+    # Mask-back gradient onto the solver subspace for fast / nfft.
+    if ttype != 'direct' and has_partial_mask:
+        grad = grad[:, mask] if is_pol else grad[mask]
+
+    return grad
 
 
 def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -57,35 +57,6 @@ MEANPOL_INIT = 0.2     # mean polarization fraction
 SIGMAPOL_INIT = 1.e-2  # perturbation scale
 
 
-def embed_imarr(imarr, mask, clipfloor=0., randomfloor=False):
-    """Embeds a multidimensional image array into the size of boolean embed mask
-    """
-
-    imarrdim = len(imarr.shape)
-    if imarrdim==2:
-        nsolve = imarr.shape[0]
-        nimage = imarr.shape[1]
-    elif imarrdim==1:
-        nsolve = 1
-        nimage = imarr.shape[0]
-        imarr = imarr.reshape((nsolve,nimage))
-    else:
-        raise Exception("in embed_imarr, imarr should have one or two dimensions!")
-
-    if nimage!=np.sum(mask):
-        raise Exception("in embed_imarr, number of masked pixels is not consistent with imarr shape!")
-
-    nimage_out = len(mask)
-    outarr = np.empty((nsolve,nimage_out))
-    # TODO does this require the for loop?
-    for kk in range(nsolve):
-        outarr[kk] = imutils.embed(imarr[kk], mask, clipfloor=clipfloor, randomfloor=randomfloor)
-
-    if imarrdim==1:
-        outarr = outarr[0]
-
-    return outarr
-
 def pack_imarr(imarr, which_solve):
     """pack image array imarr into 1D array vec for minimizaiton
        ignore quantities not solved for

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -903,15 +903,18 @@ def _lookup_chisq_entry(dtype, ttype):
 def compute_chisq_term(imcur, dtype, A, data, sigma, ttype='direct', mask=None):
     """Single chi^2 dispatcher unifying chisq + polchisq.
 
-    Pol dtypes consume the full (4, npix) imcur (or its (10, npix) multi-freq
-    extension); standard dtypes consume imcur[0]. Mask embedding and FFT
-    pre-computation match the legacy chisq / polchisq bodies exactly.
+    Pol dtypes consume the full multi-row imcur ((4, npix) single-frequency
+    or (10, npix) multi-frequency). Standard dtypes consume the Stokes-I
+    row: `imcur[0]` if imcur is 2D (pol-mode imager solving for several
+    Stokes), or imcur itself if 1D (non-pol mode, single Stokes-I solver).
+    Mask embedding and FFT pre-computation match the legacy chisq /
+    polchisq bodies exactly.
 
     Parameters
     ----------
     imcur : np.ndarray
-        Multi-row image array. Pol dtypes read all rows; standard dtypes
-        read row 0 (Stokes I) only.
+        Solver-space image. 1D (npix,) in non-pol mode, 2D (nsolve, npix)
+        in pol / mf-pol mode.
     dtype : str
         One of the keys of _CHISQ_DISPATCH (12 dtypes).
     A, data, sigma
@@ -929,7 +932,7 @@ def compute_chisq_term(imcur, dtype, A, data, sigma, ttype='direct', mask=None):
     """
     chisq_fn, _, is_pol = _lookup_chisq_entry(dtype, ttype)
 
-    imvec = imcur if is_pol else imcur[0]
+    imvec = imcur if (is_pol or imcur.ndim == 1) else imcur[0]
 
     # Embed onto full grid for fast / nfft if a partial mask was supplied.
     # Legacy chisq / polchisq both use randomfloor=True to break TV singularities.
@@ -959,7 +962,7 @@ def compute_chisqgrad_term(imcur, dtype, A, data, sigma, ttype='direct',
     """
     _, chisqgrad_fn, is_pol = _lookup_chisq_entry(dtype, ttype)
 
-    imvec = imcur if is_pol else imcur[0]
+    imvec = imcur if (is_pol or imcur.ndim == 1) else imcur[0]
     has_partial_mask = (mask is not None and len(mask) > 0
                         and np.any(np.invert(mask)))
 
@@ -1262,41 +1265,17 @@ def compute_chisq_dict(imcur, dat_term_keys,
     """
     chi2_dict = {}
     for dname in dat_term_keys:
-        # Loop over all observations
         for i in range(n_obs):
-            if n_obs == 1:
-                dname_key = dname
-            else:
-                dname_key = dname + (f'_{i}')
-
-            # get data products
-            (data, sigma, A) = data_tuples[dname_key]
-
-            # get current multifrequency image
-            if mf:
-                logfreqratio = logfreqratio_list[i]
-                imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
-            else:
-                imcur_nu = imcur
-
-            # Polarization chi^2 terms
-            if dname in DATATERMS_POL:
-                chi2 = polutils.polchisq(imcur_nu, A, data, sigma, dname,
-                                         ttype=ttype, mask=embed_mask)
-
-            # Single Polarization chi^2 terms
-            elif dname in DATATERMS:
-                if pol in POLARIZATION_MODES:
-                    imcur_nu_I = imcur_nu[0]
-                else:
-                    imcur_nu_I = imcur_nu
-                chi2 = imutils.chisq(imcur_nu_I, A, data, sigma, dname,
-                                     ttype=ttype, mask=embed_mask)
-
-            else:
-                raise Exception(f"data term {dname} not recognized!")
-
-            chi2_dict[dname_key] = chi2
+            dname_key = dname if n_obs == 1 else f"{dname}_{i}"
+            data, sigma, A = data_tuples[dname_key]
+            imcur_nu = (
+                mfutils.image_at_freq(imcur, logfreqratio_list[i])
+                if mf else imcur
+            )
+            chi2_dict[dname_key] = compute_chisq_term(
+                imcur_nu, dname, A, data, sigma,
+                ttype=ttype, mask=embed_mask,
+            )
 
     return chi2_dict
 
@@ -1341,59 +1320,36 @@ def compute_chisqgrad_dict(imcur, dat_term_keys,
         Mapping from dname (or dname_i for multi-obs) to chi^2 gradient array.
     """
     chi2grad_dict = {}
-    # Zero row reused in the polarization-bundled Stokes-I gradient; safe to share
-    # because np.array((...)) below copies into a new (4, nimage) array each time.
+    pol_solve = _pol_solve_block(which_solve, pol)
+    # Zero rows for bundling standard-dtype Stokes-I gradient into a (4, nimage)
+    # pol block when imaging is polarimetric. np.array((...)) below copies, so
+    # sharing zero_row across iterations is safe.
     zero_row = np.zeros(nimage)
+    is_pol_mode = pol in POLARIZATION_MODES
     for dname in dat_term_keys:
-        # Loop over all observations
         for i in range(n_obs):
-            if n_obs == 1:
-                dname_key = dname
-            else:
-                dname_key = dname + (f'_{i}')
+            dname_key = dname if n_obs == 1 else f"{dname}_{i}"
+            data, sigma, A = data_tuples[dname_key]
+            imcur_nu = (
+                mfutils.image_at_freq(imcur, logfreqratio_list[i])
+                if mf else imcur
+            )
 
-            # get data products
-            (data, sigma, A) = data_tuples[dname_key]
+            chi2grad = compute_chisqgrad_term(
+                imcur_nu, dname, A, data, sigma,
+                ttype=ttype, mask=embed_mask, pol_solve=pol_solve,
+            )
 
-            # get current multifrequency image
+            # Standard dtypes return (nimage,); wrap into (4, nimage) when the
+            # imager is in polarimetric mode so the regularizer + mf chains
+            # see a uniform Stokes block layout.
+            if dname in DATATERMS and is_pol_mode:
+                chi2grad = np.array((chi2grad, zero_row, zero_row, zero_row))
+
             if mf:
-                logfreqratio = logfreqratio_list[i]
-                imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
-            else:
-                imcur_nu = imcur
-
-            # Polarimetric chi^2 gradients
-            if dname in DATATERMS_POL:
-                if mf:
-                    pol_solve = which_solve[0:4]
-                else:
-                    pol_solve = which_solve
-                chi2grad = polutils.polchisqgrad(imcur_nu, A, data, sigma, dname,
-                                                 ttype=ttype, mask=embed_mask,
-                                                 pol_solve=pol_solve)
-
-            # Single polarization chi^2 gradients
-            elif dname in DATATERMS:
-                if pol in POLARIZATION_MODES:  # polarization
-                    imcur_nu_I = imcur_nu[0]
-                else:
-                    imcur_nu_I = imcur_nu
-
-                chi2grad = imutils.chisqgrad(imcur_nu_I, A, data, sigma, dname,
-                                             ttype=ttype, mask=embed_mask)
-
-                # If imaging Stokes I with polarization simultaneously, bundle the gradient
-                if pol in POLARIZATION_MODES:
-                    chi2grad = np.array((chi2grad, zero_row, zero_row, zero_row))
-
-            else:
-                raise Exception(f"data term {dname} not recognized!")
-
-            # If multifrequency imaging,
-            # transform the image gradients for all the solved quantities
-            if mf:
-                logfreqratio = logfreqratio_list[i]
-                chi2grad = mfutils.mf_all_grads_chain(chi2grad, imcur_nu, imcur, logfreqratio)
+                chi2grad = mfutils.mf_all_grads_chain(
+                    chi2grad, imcur_nu, imcur, logfreqratio_list[i],
+                )
 
             chi2grad_dict[dname_key] = np.array(chi2grad)
 

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -791,6 +791,15 @@ def compute_chisqdata_term(obs, prior, mask, dtype, ttype='direct', pol='I', **k
     helper = by_ttype[ttype]
     is_pol = dtype in DATATERMS_POL
 
+    # Standard data terms consume a single Stokes letter ('I'/'Q'/'U'/'V'). When
+    # the imager is in a multi-Stokes mode (e.g. 'IP', 'IQUV'), the leaf needs
+    # pol='I' to unpack Stokes-I visibilities; pol modes without 'I' (e.g. 'P')
+    # are incompatible with standard data terms.
+    if not is_pol and pol in POLARIZATION_MODES:
+        if 'I' not in pol:
+            raise Exception(f"cannot use dterm {dtype} with pol={pol}")
+        pol = 'I'
+
     # Standard direct + all pol leaves take mask positionally.
     # Standard fast/nfft leaves omit it (they index uv coords from obs directly).
     if is_pol or ttype == 'direct':
@@ -836,45 +845,21 @@ def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,
     for dname in dat_term_keys:
         for i, obs in enumerate(obslist):
             dname_key = dname if n_obs == 1 else f"{dname}_{i}"
-
-            if dname in DATATERMS_POL:
-                tup = polutils.polchisqdata(
-                    obs, prior, embed_mask, dname,
-                    ttype=ttype,
-                    fft_pad_factor=fft_params['fft_pad_factor'],
-                    conv_func=fft_params['fft_conv_func'],
-                    p_rad=fft_params['fft_gridder_prad'],
-                )
-
-            elif dname in DATATERMS:
-                if pol in POLARIZATION_MODES:
-                    if 'I' not in pol:
-                        raise Exception(
-                            f"cannot use dterm {dname} with pol={pol}")
-                    dterm_pol = 'I'
-                else:
-                    dterm_pol = pol
-
-                tup = imutils.chisqdata(
-                    obs, prior, embed_mask, dname,
-                    pol=dterm_pol,
-                    maxset=data_weighting_params['maxset'],
-                    debias=data_weighting_params['debias'],
-                    snrcut=data_weighting_params['snrcut'][dname],
-                    weighting=data_weighting_params['weighting'],
-                    systematic_noise=data_weighting_params['systematic_noise'],
-                    systematic_cphase_noise=data_weighting_params['systematic_cphase_noise'],
-                    cp_uv_min=data_weighting_params['cp_uv_min'],
-                    ttype=ttype,
-                    order=fft_params['fft_interp_order'],
-                    fft_pad_factor=fft_params['fft_pad_factor'],
-                    conv_func=fft_params['fft_conv_func'],
-                    p_rad=fft_params['fft_gridder_prad'],
-                )
-            else:
-                raise Exception(f"data term {dname} not recognized!")
-
-            data_tuples[dname_key] = tup
+            data_tuples[dname_key] = compute_chisqdata_term(
+                obs, prior, embed_mask, dname,
+                ttype=ttype, pol=pol,
+                maxset=data_weighting_params['maxset'],
+                debias=data_weighting_params['debias'],
+                snrcut=data_weighting_params['snrcut'][dname],
+                weighting=data_weighting_params['weighting'],
+                systematic_noise=data_weighting_params['systematic_noise'],
+                systematic_cphase_noise=data_weighting_params['systematic_cphase_noise'],
+                cp_uv_min=data_weighting_params['cp_uv_min'],
+                order=fft_params['fft_interp_order'],
+                fft_pad_factor=fft_params['fft_pad_factor'],
+                conv_func=fft_params['fft_conv_func'],
+                p_rad=fft_params['fft_gridder_prad'],
+            )
 
     return data_tuples
 

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -705,11 +705,7 @@ class ImagerInitState(NamedTuple):
     reffreq: float               # may be re-bound to init.rf when mf=True
 
 
-# Dispatch table for compute_chisqdata_term.
-# Maps (dtype, ttype) to the leaf helper that produces (data, sigma, A).
-# Standard dtypes route to imutils helpers; polarimetric dtypes (pvis/m/vvis)
-# route to polutils helpers. `logamp` aliases `amp` (same data product).
-# Pol dtypes have no `fast` ttype -- polchisqdata does not support FFT.
+# `logamp` aliases `amp` (same data product). Pol dtypes have no `fast`.
 _CHISQDATA_DISPATCH = {
     'vis':          {'direct': imutils.chisqdata_vis,
                      'fast':   imutils.chisqdata_vis_fft,
@@ -808,17 +804,12 @@ def compute_chisqdata_term(obs, prior, mask, dtype, ttype='direct', pol='I', **k
     return helper(obs, prior, pol=pol, **kwargs)
 
 
-# Dtypes whose `fast` leaf is not preceded by an FFT pre-compute step. The diag
-# variants index the gridded image directly per-baseline, so the orchestrator
-# passes imvec (not the pre-FFT'd vis_arr). Mirrors imager_utils.chisq lines 81 / 95.
+# _diag leaves index the gridded image directly per-baseline; their `fast`
+# variants take imvec rather than the pre-FFT'd vis_arr.
 _DIAG_DTYPES = frozenset({'cphase_diag', 'logcamp_diag'})
 
 
-# Dispatch table for compute_chisq_term + compute_chisqgrad_term. Maps
-# (dtype, ttype) to a (chisq_fn, chisqgrad_fn) pair, plus an `is_pol` flag.
-# Standard dtypes (`vis`, `amp`, ...) route to imutils leaves; polarimetric
-# (`pvis`, `m`, `vvis`) route to polutils leaves. Pol dtypes have no `fast`.
-# Phase 5 swaps entries in place to register JAX backends.
+# Pol dtypes have no `fast`; entries are (chisq_fn, chisqgrad_fn).
 _CHISQ_DISPATCH = {
     'vis':          {'is_pol': False,
                      'direct': (imutils.chisq_vis,          imutils.chisqgrad_vis),
@@ -934,8 +925,7 @@ def compute_chisq_term(imcur, dtype, A, data, sigma, ttype='direct', mask=None):
 
     imvec = imcur if (is_pol or imcur.ndim == 1) else imcur[0]
 
-    # Embed onto full grid for fast / nfft if a partial mask was supplied.
-    # Legacy chisq / polchisq both use randomfloor=True to break TV singularities.
+    # randomfloor=True breaks TV-regularizer gradient singularities.
     if (ttype != 'direct' and mask is not None
             and len(mask) > 0 and np.any(np.invert(mask))):
         if is_pol:
@@ -943,8 +933,6 @@ def compute_chisq_term(imcur, dtype, A, data, sigma, ttype='direct', mask=None):
         else:
             imvec = imutils.embed(imvec, mask, randomfloor=True)
 
-    # FFT pre-compute for the standard `fast` path (except _diag dtypes, whose
-    # leaves index the gridded image directly). Pol has no `fast` branch.
     if ttype == 'fast' and dtype not in _DIAG_DTYPES:
         imvec = obsh.fft_imvec(imvec, A[0])
 
@@ -955,9 +943,11 @@ def compute_chisqgrad_term(imcur, dtype, A, data, sigma, ttype='direct',
                            mask=None, pol_solve=None):
     """Single chi^2-gradient dispatcher. See compute_chisq_term.
 
-    Pol grad helpers take an extra `pol_solve` arg (Stokes block of which_solve);
-    standard grad helpers do not. Returned gradient is sliced back through `mask`
-    for fast / nfft to match the legacy chisqgrad / polchisqgrad return shapes:
+    For pol dtypes, `pol_solve` (the Stokes block of which_solve) must be
+    supplied explicitly -- there is no principled default since the right
+    value depends on the imager's pol mode. Standard grad helpers ignore
+    `pol_solve`. Returned gradient is sliced back through `mask` for
+    fast / nfft to match the legacy chisqgrad / polchisqgrad return shapes:
     pol grads are (4, n_masked); standard grads are (n_masked,).
     """
     _, chisqgrad_fn, is_pol = _lookup_chisq_entry(dtype, ttype)
@@ -976,15 +966,15 @@ def compute_chisqgrad_term(imcur, dtype, A, data, sigma, ttype='direct',
         imvec = obsh.fft_imvec(imvec, A[0])
 
     if is_pol:
-        # pol_solve is positional in the pol grad leaves; default to all-ones
-        # over the Stokes block if not supplied (matches polchisqgrad's default).
         if pol_solve is None:
-            pol_solve = np.ones(4, dtype=int)
+            raise Exception(
+                f"compute_chisqgrad_term requires explicit pol_solve for "
+                f"polarimetric dtype {dtype!r}"
+            )
         grad = chisqgrad_fn(imvec, A, data, sigma, pol_solve)
     else:
         grad = chisqgrad_fn(imvec, A, data, sigma)
 
-    # Mask-back gradient onto the solver subspace for fast / nfft.
     if ttype != 'direct' and has_partial_mask:
         grad = grad[:, mask] if is_pol else grad[mask]
 
@@ -1321,9 +1311,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys,
     """
     chi2grad_dict = {}
     pol_solve = _pol_solve_block(which_solve, pol)
-    # Zero rows for bundling standard-dtype Stokes-I gradient into a (4, nimage)
-    # pol block when imaging is polarimetric. np.array((...)) below copies, so
-    # sharing zero_row across iterations is safe.
+    # np.array((...)) below copies, so sharing zero_row across iterations is safe.
     zero_row = np.zeros(nimage)
     is_pol_mode = pol in POLARIZATION_MODES
     for dname in dat_term_keys:
@@ -1340,9 +1328,8 @@ def compute_chisqgrad_dict(imcur, dat_term_keys,
                 ttype=ttype, mask=embed_mask, pol_solve=pol_solve,
             )
 
-            # Standard dtypes return (nimage,); wrap into (4, nimage) when the
-            # imager is in polarimetric mode so the regularizer + mf chains
-            # see a uniform Stokes block layout.
+            # Pad standard (nimage,) grad to (4, nimage) Stokes block so the
+            # regularizer + mf chains see a uniform layout.
             if dname in DATATERMS and is_pol_mode:
                 chi2grad = np.array((chi2grad, zero_row, zero_row, zero_row))
 

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -63,6 +63,114 @@ SIGMAPOL_INIT = 1.e-2  # perturbation scale
 # unnecessary -- revisit once epsilon_tv coverage is broader.
 EMBED_RANDOMFLOOR = True
 
+# `logamp` aliases `amp` (same data product). Pol dtypes have no `fast`.
+_CHISQDATA_DISPATCH = {
+    'vis':          {'direct': imutils.chisqdata_vis,
+                     'fast':   imutils.chisqdata_vis_fft,
+                     'nfft':   imutils.chisqdata_vis_nfft},
+    'amp':          {'direct': imutils.chisqdata_amp,
+                     'fast':   imutils.chisqdata_amp_fft,
+                     'nfft':   imutils.chisqdata_amp_nfft},
+    'logamp':       {'direct': imutils.chisqdata_amp,
+                     'fast':   imutils.chisqdata_amp_fft,
+                     'nfft':   imutils.chisqdata_amp_nfft},
+    'bs':           {'direct': imutils.chisqdata_bs,
+                     'fast':   imutils.chisqdata_bs_fft,
+                     'nfft':   imutils.chisqdata_bs_nfft},
+    'cphase':       {'direct': imutils.chisqdata_cphase,
+                     'fast':   imutils.chisqdata_cphase_fft,
+                     'nfft':   imutils.chisqdata_cphase_nfft},
+    'cphase_diag':  {'direct': imutils.chisqdata_cphase_diag,
+                     'fast':   imutils.chisqdata_cphase_diag_fft,
+                     'nfft':   imutils.chisqdata_cphase_diag_nfft},
+    'camp':         {'direct': imutils.chisqdata_camp,
+                     'fast':   imutils.chisqdata_camp_fft,
+                     'nfft':   imutils.chisqdata_camp_nfft},
+    'logcamp':      {'direct': imutils.chisqdata_logcamp,
+                     'fast':   imutils.chisqdata_logcamp_fft,
+                     'nfft':   imutils.chisqdata_logcamp_nfft},
+    'logcamp_diag': {'direct': imutils.chisqdata_logcamp_diag,
+                     'fast':   imutils.chisqdata_logcamp_diag_fft,
+                     'nfft':   imutils.chisqdata_logcamp_diag_nfft},
+    'pvis':         {'direct': polutils.chisqdata_pvis,
+                     'nfft':   polutils.chisqdata_pvis_nfft},
+    'm':            {'direct': polutils.chisqdata_m,
+                     'nfft':   polutils.chisqdata_m_nfft},
+    'vvis':         {'direct': polutils.chisqdata_vvis,
+                     'nfft':   polutils.chisqdata_vvis_nfft},
+}
+
+# _diag leaves index the gridded image directly per-baseline; their `fast`
+# variants take imvec rather than the pre-FFT'd vis_arr.
+_DIAG_DTYPES = frozenset({'cphase_diag', 'logcamp_diag'})
+
+# Pol dtypes have no `fast`; entries are (chisq_fn, chisqgrad_fn).
+_CHISQ_DISPATCH = {
+    'vis':          {'is_pol': False,
+                     'direct': (imutils.chisq_vis,          imutils.chisqgrad_vis),
+                     'fast':   (imutils.chisq_vis_fft,      imutils.chisqgrad_vis_fft),
+                     'nfft':   (imutils.chisq_vis_nfft,     imutils.chisqgrad_vis_nfft)},
+    'amp':          {'is_pol': False,
+                     'direct': (imutils.chisq_amp,          imutils.chisqgrad_amp),
+                     'fast':   (imutils.chisq_amp_fft,      imutils.chisqgrad_amp_fft),
+                     'nfft':   (imutils.chisq_amp_nfft,     imutils.chisqgrad_amp_nfft)},
+    'logamp':       {'is_pol': False,
+                     'direct': (imutils.chisq_logamp,       imutils.chisqgrad_logamp),
+                     'fast':   (imutils.chisq_logamp_fft,   imutils.chisqgrad_logamp_fft),
+                     'nfft':   (imutils.chisq_logamp_nfft,  imutils.chisqgrad_logamp_nfft)},
+    'bs':           {'is_pol': False,
+                     'direct': (imutils.chisq_bs,           imutils.chisqgrad_bs),
+                     'fast':   (imutils.chisq_bs_fft,       imutils.chisqgrad_bs_fft),
+                     'nfft':   (imutils.chisq_bs_nfft,      imutils.chisqgrad_bs_nfft)},
+    'cphase':       {'is_pol': False,
+                     'direct': (imutils.chisq_cphase,       imutils.chisqgrad_cphase),
+                     'fast':   (imutils.chisq_cphase_fft,   imutils.chisqgrad_cphase_fft),
+                     'nfft':   (imutils.chisq_cphase_nfft,  imutils.chisqgrad_cphase_nfft)},
+    'cphase_diag':  {'is_pol': False,
+                     'direct': (imutils.chisq_cphase_diag,      imutils.chisqgrad_cphase_diag),
+                     'fast':   (imutils.chisq_cphase_diag_fft,  imutils.chisqgrad_cphase_diag_fft),
+                     'nfft':   (imutils.chisq_cphase_diag_nfft, imutils.chisqgrad_cphase_diag_nfft)},
+    'camp':         {'is_pol': False,
+                     'direct': (imutils.chisq_camp,         imutils.chisqgrad_camp),
+                     'fast':   (imutils.chisq_camp_fft,     imutils.chisqgrad_camp_fft),
+                     'nfft':   (imutils.chisq_camp_nfft,    imutils.chisqgrad_camp_nfft)},
+    'logcamp':      {'is_pol': False,
+                     'direct': (imutils.chisq_logcamp,      imutils.chisqgrad_logcamp),
+                     'fast':   (imutils.chisq_logcamp_fft,  imutils.chisqgrad_logcamp_fft),
+                     'nfft':   (imutils.chisq_logcamp_nfft, imutils.chisqgrad_logcamp_nfft)},
+    'logcamp_diag': {'is_pol': False,
+                     'direct': (imutils.chisq_logcamp_diag,      imutils.chisqgrad_logcamp_diag),
+                     'fast':   (imutils.chisq_logcamp_diag_fft,  imutils.chisqgrad_logcamp_diag_fft),
+                     'nfft':   (imutils.chisq_logcamp_diag_nfft, imutils.chisqgrad_logcamp_diag_nfft)},
+    'pvis':         {'is_pol': True,
+                     'direct': (polutils.chisq_p,           polutils.chisqgrad_p),
+                     'nfft':   (polutils.chisq_p_nfft,      polutils.chisqgrad_p_nfft)},
+    'm':            {'is_pol': True,
+                     'direct': (polutils.chisq_m,           polutils.chisqgrad_m),
+                     'nfft':   (polutils.chisq_m_nfft,      polutils.chisqgrad_m_nfft)},
+    'vvis':         {'is_pol': True,
+                     'direct': (polutils.chisq_vvis,        polutils.chisqgrad_vvis),
+                     'nfft':   (polutils.chisq_vvis_nfft,   polutils.chisqgrad_vvis_nfft)},
+}
+
+
+class ImagerInitState(NamedTuple):
+    """Solver-ready state produced by compute_init_state.
+
+    Each field corresponds to an Imager._* attribute consumed by
+    compute_objective / compute_objective_grad.
+    """
+    init_arr: np.ndarray         # multi-D, solver space
+    init_vec: np.ndarray         # 1D packed solver vector
+    prior_arr: np.ndarray        # multi-D, physical space
+    data_tuples: dict            # keyed by dname or f"{dname}_{i}"
+    embed_mask: np.ndarray       # boolean
+    coord_matrix: np.ndarray     # pixel-coord companion to embed_mask
+    logfreqratio_list: list      # log(nu_i / reffreq)
+    nimage: int                  # number of active pixels = sum(embed_mask)
+    which_solve: np.ndarray      # int 0/1 flags
+    reffreq: float               # may be re-bound to init.rf when mf=True
+
 
 def pack_imarr(imarr, which_solve):
     """pack image array imarr into 1D array vec for minimizaiton
@@ -693,62 +801,6 @@ def compute_which_solve(pol, mf,
     return np.array([1])
 
 
-class ImagerInitState(NamedTuple):
-    """Solver-ready state produced by compute_init_state.
-
-    Each field corresponds to an Imager._* attribute consumed by
-    compute_objective / compute_objective_grad.
-    """
-    init_arr: np.ndarray         # multi-D, solver space
-    init_vec: np.ndarray         # 1D packed solver vector
-    prior_arr: np.ndarray        # multi-D, physical space
-    data_tuples: dict            # keyed by dname or f"{dname}_{i}"
-    embed_mask: np.ndarray       # boolean
-    coord_matrix: np.ndarray     # pixel-coord companion to embed_mask
-    logfreqratio_list: list      # log(nu_i / reffreq)
-    nimage: int                  # number of active pixels = sum(embed_mask)
-    which_solve: np.ndarray      # int 0/1 flags
-    reffreq: float               # may be re-bound to init.rf when mf=True
-
-
-# `logamp` aliases `amp` (same data product). Pol dtypes have no `fast`.
-_CHISQDATA_DISPATCH = {
-    'vis':          {'direct': imutils.chisqdata_vis,
-                     'fast':   imutils.chisqdata_vis_fft,
-                     'nfft':   imutils.chisqdata_vis_nfft},
-    'amp':          {'direct': imutils.chisqdata_amp,
-                     'fast':   imutils.chisqdata_amp_fft,
-                     'nfft':   imutils.chisqdata_amp_nfft},
-    'logamp':       {'direct': imutils.chisqdata_amp,
-                     'fast':   imutils.chisqdata_amp_fft,
-                     'nfft':   imutils.chisqdata_amp_nfft},
-    'bs':           {'direct': imutils.chisqdata_bs,
-                     'fast':   imutils.chisqdata_bs_fft,
-                     'nfft':   imutils.chisqdata_bs_nfft},
-    'cphase':       {'direct': imutils.chisqdata_cphase,
-                     'fast':   imutils.chisqdata_cphase_fft,
-                     'nfft':   imutils.chisqdata_cphase_nfft},
-    'cphase_diag':  {'direct': imutils.chisqdata_cphase_diag,
-                     'fast':   imutils.chisqdata_cphase_diag_fft,
-                     'nfft':   imutils.chisqdata_cphase_diag_nfft},
-    'camp':         {'direct': imutils.chisqdata_camp,
-                     'fast':   imutils.chisqdata_camp_fft,
-                     'nfft':   imutils.chisqdata_camp_nfft},
-    'logcamp':      {'direct': imutils.chisqdata_logcamp,
-                     'fast':   imutils.chisqdata_logcamp_fft,
-                     'nfft':   imutils.chisqdata_logcamp_nfft},
-    'logcamp_diag': {'direct': imutils.chisqdata_logcamp_diag,
-                     'fast':   imutils.chisqdata_logcamp_diag_fft,
-                     'nfft':   imutils.chisqdata_logcamp_diag_nfft},
-    'pvis':         {'direct': polutils.chisqdata_pvis,
-                     'nfft':   polutils.chisqdata_pvis_nfft},
-    'm':            {'direct': polutils.chisqdata_m,
-                     'nfft':   polutils.chisqdata_m_nfft},
-    'vvis':         {'direct': polutils.chisqdata_vvis,
-                     'nfft':   polutils.chisqdata_vvis_nfft},
-}
-
-
 def compute_chisqdata_term(obs, prior, mask, dtype, ttype='direct', pol='I', **kwargs):
     """Single chisqdata dispatcher unifying chisqdata + polchisqdata.
 
@@ -808,61 +860,6 @@ def compute_chisqdata_term(obs, prior, mask, dtype, ttype='direct', pol='I', **k
     if is_pol or ttype == 'direct':
         return helper(obs, prior, mask, pol=pol, **kwargs)
     return helper(obs, prior, pol=pol, **kwargs)
-
-
-# _diag leaves index the gridded image directly per-baseline; their `fast`
-# variants take imvec rather than the pre-FFT'd vis_arr.
-_DIAG_DTYPES = frozenset({'cphase_diag', 'logcamp_diag'})
-
-
-# Pol dtypes have no `fast`; entries are (chisq_fn, chisqgrad_fn).
-_CHISQ_DISPATCH = {
-    'vis':          {'is_pol': False,
-                     'direct': (imutils.chisq_vis,          imutils.chisqgrad_vis),
-                     'fast':   (imutils.chisq_vis_fft,      imutils.chisqgrad_vis_fft),
-                     'nfft':   (imutils.chisq_vis_nfft,     imutils.chisqgrad_vis_nfft)},
-    'amp':          {'is_pol': False,
-                     'direct': (imutils.chisq_amp,          imutils.chisqgrad_amp),
-                     'fast':   (imutils.chisq_amp_fft,      imutils.chisqgrad_amp_fft),
-                     'nfft':   (imutils.chisq_amp_nfft,     imutils.chisqgrad_amp_nfft)},
-    'logamp':       {'is_pol': False,
-                     'direct': (imutils.chisq_logamp,       imutils.chisqgrad_logamp),
-                     'fast':   (imutils.chisq_logamp_fft,   imutils.chisqgrad_logamp_fft),
-                     'nfft':   (imutils.chisq_logamp_nfft,  imutils.chisqgrad_logamp_nfft)},
-    'bs':           {'is_pol': False,
-                     'direct': (imutils.chisq_bs,           imutils.chisqgrad_bs),
-                     'fast':   (imutils.chisq_bs_fft,       imutils.chisqgrad_bs_fft),
-                     'nfft':   (imutils.chisq_bs_nfft,      imutils.chisqgrad_bs_nfft)},
-    'cphase':       {'is_pol': False,
-                     'direct': (imutils.chisq_cphase,       imutils.chisqgrad_cphase),
-                     'fast':   (imutils.chisq_cphase_fft,   imutils.chisqgrad_cphase_fft),
-                     'nfft':   (imutils.chisq_cphase_nfft,  imutils.chisqgrad_cphase_nfft)},
-    'cphase_diag':  {'is_pol': False,
-                     'direct': (imutils.chisq_cphase_diag,      imutils.chisqgrad_cphase_diag),
-                     'fast':   (imutils.chisq_cphase_diag_fft,  imutils.chisqgrad_cphase_diag_fft),
-                     'nfft':   (imutils.chisq_cphase_diag_nfft, imutils.chisqgrad_cphase_diag_nfft)},
-    'camp':         {'is_pol': False,
-                     'direct': (imutils.chisq_camp,         imutils.chisqgrad_camp),
-                     'fast':   (imutils.chisq_camp_fft,     imutils.chisqgrad_camp_fft),
-                     'nfft':   (imutils.chisq_camp_nfft,    imutils.chisqgrad_camp_nfft)},
-    'logcamp':      {'is_pol': False,
-                     'direct': (imutils.chisq_logcamp,      imutils.chisqgrad_logcamp),
-                     'fast':   (imutils.chisq_logcamp_fft,  imutils.chisqgrad_logcamp_fft),
-                     'nfft':   (imutils.chisq_logcamp_nfft, imutils.chisqgrad_logcamp_nfft)},
-    'logcamp_diag': {'is_pol': False,
-                     'direct': (imutils.chisq_logcamp_diag,      imutils.chisqgrad_logcamp_diag),
-                     'fast':   (imutils.chisq_logcamp_diag_fft,  imutils.chisqgrad_logcamp_diag_fft),
-                     'nfft':   (imutils.chisq_logcamp_diag_nfft, imutils.chisqgrad_logcamp_diag_nfft)},
-    'pvis':         {'is_pol': True,
-                     'direct': (polutils.chisq_p,           polutils.chisqgrad_p),
-                     'nfft':   (polutils.chisq_p_nfft,      polutils.chisqgrad_p_nfft)},
-    'm':            {'is_pol': True,
-                     'direct': (polutils.chisq_m,           polutils.chisqgrad_m),
-                     'nfft':   (polutils.chisq_m_nfft,      polutils.chisqgrad_m_nfft)},
-    'vvis':         {'is_pol': True,
-                     'direct': (polutils.chisq_vvis,        polutils.chisqgrad_vvis),
-                     'nfft':   (polutils.chisq_vvis_nfft,   polutils.chisqgrad_vvis_nfft)},
-}
 
 
 def _pol_solve_block(which_solve, pol):

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -4076,6 +4076,79 @@ def embed(imvec, mask, clipfloor=0., randomfloor=False):
     return out
 
 
+def embed_imarr(imarr, mask, clipfloor=0., randomfloor=False):
+    """Embed a packed image array back onto the full image grid.
+
+    Multi-row generalization of `embed`: each row of `imarr` is independently
+    embedded back into a full-grid representation using `mask`. Pixels outside
+    the mask are filled with `clipfloor` (constant) or `clipfloor * |N(0, 1)|`
+    when `randomfloor=True`.
+
+    Lives in imager_utils alongside `embed` rather than in imager_backend.py
+    to avoid a module-load cycle (pol_imager_utils -> imager_backend imports).
+
+    Parameters
+    ----------
+    imarr : np.ndarray
+        Either 1D of length `sum(mask)` (Stokes-I only), or 2D of shape
+        (nsolve, sum(mask)) where nsolve is the number of Stokes / spectral
+        slots being solved for (1 for Stokes-I only, 4 for full polarization,
+        3 or 10 for the multifrequency variants).
+    mask : np.ndarray of bool
+        Embed mask of length npix_total. Number of True entries must equal
+        the second axis of `imarr` (or its length, for 1D input).
+    clipfloor : float, optional
+        Value placed at non-mask pixels when `randomfloor=False`. Default 0.0.
+    randomfloor : bool, optional
+        If True, non-mask pixels get `clipfloor * |N(0, 1)|` instead of a
+        constant. Used to break gradient singularities in total-variation
+        regularizers. Default False.
+
+    Returns
+    -------
+    out : np.ndarray
+        Same dimensionality as `imarr` (1D or 2D), but the second axis
+        (or only axis) is extended to len(mask).
+
+    Raises
+    ------
+    Exception
+        If `imarr` is not 1D or 2D, or if its mask-axis length does not
+        equal `sum(mask)`.
+    """
+    imarrdim = len(imarr.shape)
+    if imarrdim == 2:
+        nsolve = imarr.shape[0]
+        nimage = imarr.shape[1]
+    elif imarrdim == 1:
+        nsolve = 1
+        nimage = imarr.shape[0]
+        imarr = imarr.reshape((nsolve, nimage))
+    else:
+        raise Exception("in embed_imarr, imarr should have one or two dimensions!")
+
+    if nimage != np.sum(mask):
+        raise Exception("in embed_imarr, number of masked pixels is not consistent with imarr shape!")
+
+    nimage_out = len(mask)
+    outarr = np.empty((nsolve, nimage_out))
+    # Vectorized over the nsolve axis: scatter imarr into the masked columns
+    # of outarr, then fill non-mask columns with clipfloor (or random).
+    not_mask = ~mask.astype(bool)
+    outarr[:, mask.astype(bool)] = imarr
+    if randomfloor:
+        outarr[:, not_mask] = clipfloor * np.abs(
+            np.random.normal(size=(nsolve, int(not_mask.sum())))
+        )
+    else:
+        outarr[:, not_mask] = clipfloor
+
+    if imarrdim == 1:
+        outarr = outarr[0]
+
+    return outarr
+
+
 
 
 

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -3858,6 +3858,8 @@ def plot_i(im, Prior, nit, chi2_dict, **kwargs):
 
 
 
+# TODO(achael): consolidate `embed` (1D, this function) and `embed_imarr`
+# (1D or 2D, below) into a single implementation -- their bodies overlap.
 def embed(imvec, mask, clipfloor=0., randomfloor=False):
     """Embeds a 1d image vector into the size of boolean embed mask
     """

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -42,179 +42,33 @@ nit = 0  # global variable to track the iteration number in the plotting callbac
 
 
 def chisq(imvec, A, data, sigma, dtype, ttype='direct', mask=None):
-    """return the chi^2 for the appropriate dtype
+    """Return chi^2 for a standard data term.
+
+    Thin shim around imager_backend.compute_chisq_term retained for backward
+    compatibility. New code should call compute_chisq_term directly. Returns
+    1 (legacy silent fallback) if `dtype` is not a standard data term.
     """
-
-    if mask is None:
-        mask = []
-    chisq = 1
+    # Imported here to avoid a module-load cycle with pol_imager_utils.
+    from ehtim.imaging.imager_backend import compute_chisq_term
     if dtype not in DATATERMS:
-        return chisq
-
-    if ttype not in ['fast', 'direct', 'nfft']:
-        raise Exception("Possible ttype values are 'fast', 'direct'!, 'nfft!'")
-
-    if ttype == 'direct':
-        if dtype == 'vis':
-            chisq = chisq_vis(imvec, A, data, sigma)
-        elif dtype == 'amp':
-            chisq = chisq_amp(imvec, A, data, sigma)
-        elif dtype == 'logamp':
-            chisq = chisq_logamp(imvec, A, data, sigma)
-        elif dtype == 'bs':
-            chisq = chisq_bs(imvec, A, data, sigma)
-        elif dtype == 'cphase':
-            chisq = chisq_cphase(imvec, A, data, sigma)
-        elif dtype == 'cphase_diag':
-            chisq = chisq_cphase_diag(imvec, A, data, sigma)
-        elif dtype == 'camp':
-            chisq = chisq_camp(imvec, A, data, sigma)
-        elif dtype == 'logcamp':
-            chisq = chisq_logcamp(imvec, A, data, sigma)
-        elif dtype == 'logcamp_diag':
-            chisq = chisq_logcamp_diag(imvec, A, data, sigma)
-
-    elif ttype == 'fast':
-        if len(mask) > 0 and np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-
-        if dtype not in ['cphase_diag', 'logcamp_diag']:
-            vis_arr = obsh.fft_imvec(imvec, A[0])
-
-        if dtype == 'vis':
-            chisq = chisq_vis_fft(vis_arr, A, data, sigma)
-        elif dtype == 'amp':
-            chisq = chisq_amp_fft(vis_arr, A, data, sigma)
-        elif dtype == 'logamp':
-            chisq = chisq_logamp_fft(vis_arr, A, data, sigma)
-        elif dtype == 'bs':
-            chisq = chisq_bs_fft(vis_arr, A, data, sigma)
-        elif dtype == 'cphase':
-            chisq = chisq_cphase_fft(vis_arr, A, data, sigma)
-        elif dtype == 'cphase_diag':
-            chisq = chisq_cphase_diag_fft(imvec, A, data, sigma)
-        elif dtype == 'camp':
-            chisq = chisq_camp_fft(vis_arr, A, data, sigma)
-        elif dtype == 'logcamp':
-            chisq = chisq_logcamp_fft(vis_arr, A, data, sigma)
-        elif dtype == 'logcamp_diag':
-            chisq = chisq_logcamp_diag_fft(imvec, A, data, sigma)
-
-    elif ttype == 'nfft':
-        if len(mask) > 0 and np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-
-        if dtype == 'vis':
-            chisq = chisq_vis_nfft(imvec, A, data, sigma)
-        elif dtype == 'amp':
-            chisq = chisq_amp_nfft(imvec, A, data, sigma)
-        elif dtype == 'logamp':
-            chisq = chisq_logamp_nfft(imvec, A, data, sigma)
-        elif dtype == 'bs':
-            chisq = chisq_bs_nfft(imvec, A, data, sigma)
-        elif dtype == 'cphase':
-            chisq = chisq_cphase_nfft(imvec, A, data, sigma)
-        elif dtype == 'cphase_diag':
-            chisq = chisq_cphase_diag_nfft(imvec, A, data, sigma)
-        elif dtype == 'camp':
-            chisq = chisq_camp_nfft(imvec, A, data, sigma)
-        elif dtype == 'logcamp':
-            chisq = chisq_logcamp_nfft(imvec, A, data, sigma)
-        elif dtype == 'logcamp_diag':
-            chisq = chisq_logcamp_diag_nfft(imvec, A, data, sigma)
-
-    return chisq
+        return 1
+    return compute_chisq_term(imvec, dtype, A, data, sigma,
+                              ttype=ttype, mask=mask)
 
 
 def chisqgrad(imvec, A, data, sigma, dtype, ttype='direct', mask=None):
-    """return the chi^2 gradient for the appropriate dtype
+    """Return chi^2 gradient for a standard data term.
+
+    Thin shim around imager_backend.compute_chisqgrad_term retained for
+    backward compatibility. New code should call compute_chisqgrad_term
+    directly. Returns zeros (legacy silent fallback) if `dtype` is not a
+    standard data term.
     """
-
-    if mask is None:
-        mask = []
-    chisqgrad = np.zeros(len(imvec))
+    from ehtim.imaging.imager_backend import compute_chisqgrad_term
     if dtype not in DATATERMS:
-        return chisqgrad
-
-    if ttype not in ['fast', 'direct', 'nfft']:
-        raise Exception("Possible ttype values are 'fast', 'direct', 'nfft'!")
-
-    if ttype == 'direct':
-        if dtype == 'vis':
-            chisqgrad = chisqgrad_vis(imvec, A, data, sigma)
-        elif dtype == 'amp':
-            chisqgrad = chisqgrad_amp(imvec, A, data, sigma)
-        elif dtype == 'logamp':
-            chisqgrad = chisqgrad_logamp(imvec, A, data, sigma)
-        elif dtype == 'bs':
-            chisqgrad = chisqgrad_bs(imvec, A, data, sigma)
-        elif dtype == 'cphase':
-            chisqgrad = chisqgrad_cphase(imvec, A, data, sigma)
-        elif dtype == 'cphase_diag':
-            chisqgrad = chisqgrad_cphase_diag(imvec, A, data, sigma)
-        elif dtype == 'camp':
-            chisqgrad = chisqgrad_camp(imvec, A, data, sigma)
-        elif dtype == 'logcamp':
-            chisqgrad = chisqgrad_logcamp(imvec, A, data, sigma)
-        elif dtype == 'logcamp_diag':
-            chisqgrad = chisqgrad_logcamp_diag(imvec, A, data, sigma)
-
-    elif ttype == 'fast':
-        if len(mask) > 0 and np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-
-        if dtype not in ['cphase_diag', 'logcamp_diag']:
-            vis_arr = obsh.fft_imvec(imvec, A[0])
-
-        if dtype == 'vis':
-            chisqgrad = chisqgrad_vis_fft(vis_arr, A, data, sigma)
-        elif dtype == 'amp':
-            chisqgrad = chisqgrad_amp_fft(vis_arr, A, data, sigma)
-        elif dtype == 'logamp':
-            chisqgrad = chisqgrad_logamp_fft(vis_arr, A, data, sigma)
-        elif dtype == 'bs':
-            chisqgrad = chisqgrad_bs_fft(vis_arr, A, data, sigma)
-        elif dtype == 'cphase':
-            chisqgrad = chisqgrad_cphase_fft(vis_arr, A, data, sigma)
-        elif dtype == 'cphase_diag':
-            chisqgrad = chisqgrad_cphase_diag_fft(imvec, A, data, sigma)
-        elif dtype == 'camp':
-            chisqgrad = chisqgrad_camp_fft(vis_arr, A, data, sigma)
-        elif dtype == 'logcamp':
-            chisqgrad = chisqgrad_logcamp_fft(vis_arr, A, data, sigma)
-        elif dtype == 'logcamp_diag':
-            chisqgrad = chisqgrad_logcamp_diag_fft(imvec, A, data, sigma)
-
-        if len(mask) > 0 and np.any(np.invert(mask)):
-            chisqgrad = chisqgrad[mask]
-
-    elif ttype == 'nfft':
-        if len(mask) > 0 and np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-
-        if dtype == 'vis':
-            chisqgrad = chisqgrad_vis_nfft(imvec, A, data, sigma)
-        elif dtype == 'amp':
-            chisqgrad = chisqgrad_amp_nfft(imvec, A, data, sigma)
-        elif dtype == 'logamp':
-            chisqgrad = chisqgrad_logamp_nfft(imvec, A, data, sigma)
-        elif dtype == 'bs':
-            chisqgrad = chisqgrad_bs_nfft(imvec, A, data, sigma)
-        elif dtype == 'cphase':
-            chisqgrad = chisqgrad_cphase_nfft(imvec, A, data, sigma)
-        elif dtype == 'cphase_diag':
-            chisqgrad = chisqgrad_cphase_diag_nfft(imvec, A, data, sigma)
-        elif dtype == 'camp':
-            chisqgrad = chisqgrad_camp_nfft(imvec, A, data, sigma)
-        elif dtype == 'logcamp':
-            chisqgrad = chisqgrad_logcamp_nfft(imvec, A, data, sigma)
-        elif dtype == 'logcamp_diag':
-            chisqgrad = chisqgrad_logcamp_diag_nfft(imvec, A, data, sigma)
-
-        if len(mask) > 0 and np.any(np.invert(mask)):
-            chisqgrad = chisqgrad[mask]
-
-    return chisqgrad
+        return np.zeros(len(imvec))
+    return compute_chisqgrad_term(imvec, dtype, A, data, sigma,
+                                  ttype=ttype, mask=mask)
 
 
 def regularizer(imvec, nprior, mask, flux, xdim, ydim, psize, stype, **kwargs):
@@ -368,69 +222,19 @@ def regularizergrad(imvec, nprior, mask, flux, xdim, ydim, psize, stype, **kwarg
 
 
 def chisqdata(Obsdata, Prior, mask, dtype, pol='I', **kwargs):
-    """Return the data, sigma, and matrices for the appropriate dtype
+    """Return (data, sigma, A) for a standard data term.
+
+    Thin shim around imager_backend.compute_chisqdata_term retained for
+    backward compatibility. New code should call compute_chisqdata_term
+    directly. Returns (False, False, False) (legacy silent fallback) if
+    `dtype` is not a standard data term.
     """
-
-    ttype = kwargs.get('ttype', 'direct')
-    (data, sigma, A) = (False, False, False)
-    if ttype not in ['fast', 'direct', 'nfft']:
-        raise Exception("Possible ttype values are 'fast', 'direct', 'nfft'!")
-
-    if ttype == 'direct':
-        if dtype == 'vis':
-            (data, sigma, A) = chisqdata_vis(Obsdata, Prior, mask, pol=pol, **kwargs)
-        elif dtype == 'amp' or dtype == 'logamp':
-            (data, sigma, A) = chisqdata_amp(Obsdata, Prior, mask, pol=pol, **kwargs)
-        elif dtype == 'bs':
-            (data, sigma, A) = chisqdata_bs(Obsdata, Prior, mask, pol=pol, **kwargs)
-        elif dtype == 'cphase':
-            (data, sigma, A) = chisqdata_cphase(Obsdata, Prior, mask, pol=pol, **kwargs)
-        elif dtype == 'cphase_diag':
-            (data, sigma, A) = chisqdata_cphase_diag(Obsdata, Prior, mask, pol=pol, **kwargs)
-        elif dtype == 'camp':
-            (data, sigma, A) = chisqdata_camp(Obsdata, Prior, mask, pol=pol, **kwargs)
-        elif dtype == 'logcamp':
-            (data, sigma, A) = chisqdata_logcamp(Obsdata, Prior, mask, pol=pol, **kwargs)
-        elif dtype == 'logcamp_diag':
-            (data, sigma, A) = chisqdata_logcamp_diag(Obsdata, Prior, mask, pol=pol, **kwargs)
-
-    elif ttype == 'fast':
-        if dtype == 'vis':
-            (data, sigma, A) = chisqdata_vis_fft(Obsdata, Prior, pol=pol, **kwargs)
-        elif dtype == 'amp' or dtype == 'logamp':
-            (data, sigma, A) = chisqdata_amp_fft(Obsdata, Prior, pol=pol, **kwargs)
-        elif dtype == 'bs':
-            (data, sigma, A) = chisqdata_bs_fft(Obsdata, Prior, pol=pol, **kwargs)
-        elif dtype == 'cphase':
-            (data, sigma, A) = chisqdata_cphase_fft(Obsdata, Prior, pol=pol, **kwargs)
-        elif dtype == 'cphase_diag':
-            (data, sigma, A) = chisqdata_cphase_diag_fft(Obsdata, Prior, pol=pol, **kwargs)
-        elif dtype == 'camp':
-            (data, sigma, A) = chisqdata_camp_fft(Obsdata, Prior, pol=pol, **kwargs)
-        elif dtype == 'logcamp':
-            (data, sigma, A) = chisqdata_logcamp_fft(Obsdata, Prior, pol=pol, **kwargs)
-        elif dtype == 'logcamp_diag':
-            (data, sigma, A) = chisqdata_logcamp_diag_fft(Obsdata, Prior, pol=pol, **kwargs)
-
-    elif ttype == 'nfft':
-        if dtype == 'vis':
-            (data, sigma, A) = chisqdata_vis_nfft(Obsdata, Prior, pol=pol, **kwargs)
-        elif dtype == 'amp' or dtype == 'logamp':
-            (data, sigma, A) = chisqdata_amp_nfft(Obsdata, Prior, pol=pol, **kwargs)
-        elif dtype == 'bs':
-            (data, sigma, A) = chisqdata_bs_nfft(Obsdata, Prior, pol=pol, **kwargs)
-        elif dtype == 'cphase':
-            (data, sigma, A) = chisqdata_cphase_nfft(Obsdata, Prior, pol=pol, **kwargs)
-        elif dtype == 'cphase_diag':
-            (data, sigma, A) = chisqdata_cphase_diag_nfft(Obsdata, Prior, pol=pol, **kwargs)
-        elif dtype == 'camp':
-            (data, sigma, A) = chisqdata_camp_nfft(Obsdata, Prior, pol=pol, **kwargs)
-        elif dtype == 'logcamp':
-            (data, sigma, A) = chisqdata_logcamp_nfft(Obsdata, Prior, pol=pol, **kwargs)
-        elif dtype == 'logcamp_diag':
-            (data, sigma, A) = chisqdata_logcamp_diag_nfft(Obsdata, Prior, pol=pol, **kwargs)
-
-    return (data, sigma, A)
+    from ehtim.imaging.imager_backend import compute_chisqdata_term
+    ttype = kwargs.pop('ttype', 'direct')
+    if dtype not in DATATERMS:
+        return (False, False, False)
+    return compute_chisqdata_term(Obsdata, Prior, mask, dtype,
+                                  ttype=ttype, pol=pol, **kwargs)
 
 
 ##################################################################################################

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -45,13 +45,12 @@ def chisq(imvec, A, data, sigma, dtype, ttype='direct', mask=None):
     """Return chi^2 for a standard data term.
 
     Thin shim around imager_backend.compute_chisq_term retained for backward
-    compatibility. New code should call compute_chisq_term directly. Returns
-    1 (legacy silent fallback) if `dtype` is not a standard data term.
+    compatibility. New code should call compute_chisq_term directly.
     """
     # Imported here to avoid a module-load cycle with pol_imager_utils.
     from ehtim.imaging.imager_backend import compute_chisq_term
     if dtype not in DATATERMS:
-        return 1
+        raise Exception(f"data term {dtype!r} is not a standard data term")
     return compute_chisq_term(imvec, dtype, A, data, sigma,
                               ttype=ttype, mask=mask)
 
@@ -61,12 +60,11 @@ def chisqgrad(imvec, A, data, sigma, dtype, ttype='direct', mask=None):
 
     Thin shim around imager_backend.compute_chisqgrad_term retained for
     backward compatibility. New code should call compute_chisqgrad_term
-    directly. Returns zeros (legacy silent fallback) if `dtype` is not a
-    standard data term.
+    directly.
     """
     from ehtim.imaging.imager_backend import compute_chisqgrad_term
     if dtype not in DATATERMS:
-        return np.zeros(len(imvec))
+        raise Exception(f"data term {dtype!r} is not a standard data term")
     return compute_chisqgrad_term(imvec, dtype, A, data, sigma,
                                   ttype=ttype, mask=mask)
 
@@ -226,13 +224,12 @@ def chisqdata(Obsdata, Prior, mask, dtype, pol='I', **kwargs):
 
     Thin shim around imager_backend.compute_chisqdata_term retained for
     backward compatibility. New code should call compute_chisqdata_term
-    directly. Returns (False, False, False) (legacy silent fallback) if
-    `dtype` is not a standard data term.
+    directly.
     """
     from ehtim.imaging.imager_backend import compute_chisqdata_term
     ttype = kwargs.pop('ttype', 'direct')
     if dtype not in DATATERMS:
-        return (False, False, False)
+        raise Exception(f"data term {dtype!r} is not a standard data term")
     return compute_chisqdata_term(Obsdata, Prior, mask, dtype,
                                   ttype=ttype, pol=pol, **kwargs)
 

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -349,11 +349,10 @@ def polchisq(imarr, A, data, sigma, dtype, ttype='direct', mask=[]):
 
     Thin shim around imager_backend.compute_chisq_term retained for backward
     compatibility. New code should call compute_chisq_term directly.
-    Returns 1 (legacy silent fallback) if `dtype` is not a polarimetric term.
     """
     from ehtim.imaging.imager_backend import compute_chisq_term
     if dtype not in DATATERMS_POL:
-        return 1
+        raise Exception(f"data term {dtype!r} is not a polarimetric data term")
     return compute_chisq_term(imarr, dtype, A, data, sigma,
                               ttype=ttype, mask=mask)
 
@@ -364,12 +363,11 @@ def polchisqgrad(imarr, A, data, sigma, dtype, ttype='direct', mask=[],
 
     Thin shim around imager_backend.compute_chisqgrad_term retained for
     backward compatibility. New code should call compute_chisqgrad_term
-    directly. Returns zeros (legacy silent fallback) if `dtype` is not a
-    polarimetric term.
+    directly.
     """
     from ehtim.imaging.imager_backend import compute_chisqgrad_term
     if dtype not in DATATERMS_POL:
-        return np.zeros(imarr.shape)
+        raise Exception(f"data term {dtype!r} is not a polarimetric data term")
     return compute_chisqgrad_term(imarr, dtype, A, data, sigma,
                                   ttype=ttype, mask=mask, pol_solve=pol_solve)
 
@@ -471,13 +469,12 @@ def polchisqdata(Obsdata, Prior, mask, dtype, **kwargs):
 
     Thin shim around imager_backend.compute_chisqdata_term retained for
     backward compatibility. New code should call compute_chisqdata_term
-    directly. Returns (False, False, False) (legacy silent fallback) if
-    `dtype` is not a polarimetric term.
+    directly.
     """
     from ehtim.imaging.imager_backend import compute_chisqdata_term
     ttype = kwargs.pop('ttype', 'direct')
     if dtype not in DATATERMS_POL:
-        return (False, False, False)
+        raise Exception(f"data term {dtype!r} is not a polarimetric data term")
     return compute_chisqdata_term(Obsdata, Prior, mask, dtype,
                                   ttype=ttype, **kwargs)
 

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -1346,9 +1346,8 @@ def chisqdata_pvis(Obsdata, Prior, mask, **kwargs):
 
     return (vis, sigma, A)
 
-def chisqdata_pvis_nfft(Obsdata, Prior, mask, **kwargs):
-    """Return the visibilities, sigmas, and fourier matrix for an observation, prior, mask
-    """
+def chisqdata_pvis_nfft(Obsdata, Prior, **kwargs):
+    """Return the visibilities, sigmas, and fourier matrix for an observation."""
 
     # unpack keyword args
     fft_pad_factor = kwargs.get('fft_pad_factor',FFT_PAD_DEFAULT)
@@ -1383,9 +1382,8 @@ def chisqdata_m(Obsdata, Prior, mask, **kwargs):
 
     return (m, sigmam, A)
 
-def chisqdata_m_nfft(Obsdata, Prior, mask, **kwargs):
-    """Return the pol ratios, sigmas, and fourier matrix for an observation, prior, mask
-    """
+def chisqdata_m_nfft(Obsdata, Prior, **kwargs):
+    """Return the pol ratios, sigmas, and fourier matrix for an observation."""
 
     # unpack keyword args
     fft_pad_factor = kwargs.get('fft_pad_factor',FFT_PAD_DEFAULT)
@@ -1420,9 +1418,8 @@ def chisqdata_vvis(Obsdata, Prior, mask, **kwargs):
 
     return (vis, sigma, A)
 
-def chisqdata_vvis_nfft(Obsdata, Prior, mask, **kwargs):
-    """Return the visibilities, sigmas, and fourier matrix for an observation, prior, mask
-    """
+def chisqdata_vvis_nfft(Obsdata, Prior, **kwargs):
+    """Return the visibilities, sigmas, and fourier matrix for an observation."""
 
     # unpack keyword args
     fft_pad_factor = kwargs.get('fft_pad_factor',FFT_PAD_DEFAULT)

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -345,91 +345,33 @@ def vcv_grad(imarr, gradarr):
 ##################################################################################################
 
 def polchisq(imarr, A, data, sigma, dtype, ttype='direct', mask=[]):
-    """return the chi^2 for the appropriate dtype
+    """Return chi^2 for a polarimetric data term.
+
+    Thin shim around imager_backend.compute_chisq_term retained for backward
+    compatibility. New code should call compute_chisq_term directly.
+    Returns 1 (legacy silent fallback) if `dtype` is not a polarimetric term.
     """
-
-    chisq = 1
+    from ehtim.imaging.imager_backend import compute_chisq_term
     if dtype not in DATATERMS_POL:
-        return chisq
-    if ttype not in ['direct','nfft']:
-        raise Exception("Possible ttype values for polchisq are 'nfft' and 'direct'!")
+        return 1
+    return compute_chisq_term(imarr, dtype, A, data, sigma,
+                              ttype=ttype, mask=mask)
 
-    if ttype == 'direct':
-        # linear
-        if dtype == 'pvis':
-            chisq = chisq_p(imarr, A, data, sigma)
-        elif dtype == 'm':
-            chisq = chisq_m(imarr, A, data, sigma)
 
-        # circular
-        elif dtype == 'vvis':
-            chisq = chisq_vvis(imarr, A, data, sigma)
-
-    elif ttype== 'fast':
-        raise Exception("FFT not yet implemented in polchisq!")
-
-    elif ttype== 'nfft':
-        if len(mask)>0 and np.any(np.invert(mask)):
-            imarr = embed_imarr(imarr, mask, randomfloor=RANDOMFLOOR)
-
-        # linear
-        if dtype == 'pvis':
-            chisq = chisq_p_nfft(imarr, A, data, sigma)
-        elif dtype == 'm':
-            chisq = chisq_m_nfft(imarr, A, data, sigma)
-
-        # circular
-        elif dtype == 'vvis':
-            chisq = chisq_vvis_nfft(imarr, A, data, sigma)
-
-    return chisq
-
-def polchisqgrad(imarr, A, data, sigma, dtype, ttype='direct',mask=[],
+def polchisqgrad(imarr, A, data, sigma, dtype, ttype='direct', mask=[],
                  pol_solve=POL_SOLVE_DEFAULT):
+    """Return chi^2 gradient for a polarimetric data term.
 
-    """return the chi^2 gradient for the appropriate dtype
+    Thin shim around imager_backend.compute_chisqgrad_term retained for
+    backward compatibility. New code should call compute_chisqgrad_term
+    directly. Returns zeros (legacy silent fallback) if `dtype` is not a
+    polarimetric term.
     """
-
-    chisqgrad = np.zeros(imarr.shape)
+    from ehtim.imaging.imager_backend import compute_chisqgrad_term
     if dtype not in DATATERMS_POL:
-        return chisqgrad
-    if ttype not in ['direct','nfft']:
-        raise Exception("Possible ttype values for polchisqgrad are 'nfft' and 'direct'!")
-
-    if ttype == 'direct':
-        # linear
-        if dtype == 'pvis':
-            chisqgrad = chisqgrad_p(imarr, A, data, sigma, pol_solve)
-        elif dtype == 'm':
-            chisqgrad = chisqgrad_m(imarr, A, data, sigma, pol_solve)
-
-
-        # circular
-        elif dtype == 'vvis':
-            chisqgrad = chisqgrad_vvis(imarr, A, data, sigma, pol_solve)
-
-    elif ttype== 'fast':
-        raise Exception("FFT not yet implemented in polchisqgrad!")
-
-    elif ttype== 'nfft':
-        if len(mask)>0 and np.any(np.invert(mask)):
-            imarr = embed_imarr(imarr, mask, randomfloor=RANDOMFLOOR)
-
-        # linear
-        if dtype == 'pvis':
-            chisqgrad = chisqgrad_p_nfft(imarr, A, data, sigma, pol_solve)
-        elif dtype == 'm':
-            chisqgrad = chisqgrad_m_nfft(imarr, A, data, sigma, pol_solve)
-
-
-        # circular
-        elif dtype == 'vvis':
-            chisqgrad = chisqgrad_vvis_nfft(imarr, A, data, sigma, pol_solve)
-
-        if len(mask)>0 and np.any(np.invert(mask)):
-            chisqgrad = chisqgrad[:,mask]
-
-    return chisqgrad
+        return np.zeros(imarr.shape)
+    return compute_chisqgrad_term(imarr, dtype, A, data, sigma,
+                                  ttype=ttype, mask=mask, pol_solve=pol_solve)
 
 
 def polregularizer(imarr, priorarr, mask, flux, pflux, vflux, xdim, ydim, psize, stype, **kwargs):
@@ -525,36 +467,19 @@ def polregularizergrad(imarr, priorarr, mask, flux, pflux, vflux, xdim, ydim, ps
 
 
 def polchisqdata(Obsdata, Prior, mask, dtype, **kwargs):
+    """Return (data, sigma, A) for a polarimetric data term.
 
-    """Return the data, sigma, and matrices for the appropriate dtype
+    Thin shim around imager_backend.compute_chisqdata_term retained for
+    backward compatibility. New code should call compute_chisqdata_term
+    directly. Returns (False, False, False) (legacy silent fallback) if
+    `dtype` is not a polarimetric term.
     """
-
-    ttype = kwargs.get('ttype','direct')
-
-    (data, sigma, A) = (False, False, False)
-    if ttype not in ['direct','nfft']:
-        raise Exception("Possible ttype values for polchisqdata are 'nfft' and 'direct'!")
-
-    if ttype=='direct':
-        if dtype == 'pvis':
-            (data, sigma, A) = chisqdata_pvis(Obsdata, Prior, mask)
-        elif dtype == 'm':
-            (data, sigma, A) = chisqdata_m(Obsdata, Prior, mask)
-        elif dtype == 'vvis':
-            (data, sigma, A) = chisqdata_vvis(Obsdata, Prior, mask)
-
-    elif ttype=='fast':
-        raise Exception("FFT not yet implemented in polchisqdata!")
-
-    elif ttype=='nfft':
-        if dtype == 'pvis':
-            (data, sigma, A) = chisqdata_pvis_nfft(Obsdata, Prior, mask, **kwargs)
-        elif dtype == 'm':
-            (data, sigma, A) = chisqdata_m_nfft(Obsdata, Prior, mask, **kwargs)
-        elif dtype == 'vvis':
-            (data, sigma, A) = chisqdata_vvis_nfft(Obsdata, Prior, mask, **kwargs)
-
-    return (data, sigma, A)
+    from ehtim.imaging.imager_backend import compute_chisqdata_term
+    ttype = kwargs.pop('ttype', 'direct')
+    if dtype not in DATATERMS_POL:
+        return (False, False, False)
+    return compute_chisqdata_term(Obsdata, Prior, mask, dtype,
+                                  ttype=ttype, **kwargs)
 
 
 ##################################################################################################

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -27,7 +27,7 @@ except ImportError:
     _HAS_NFFT = False
 
 from ehtim.const_def import FFT_PAD_DEFAULT, GRIDDER_P_RAD_DEFAULT, RADPERAS
-from ehtim.imager import embed_imarr
+from ehtim.imaging.imager_utils import embed_imarr
 from ehtim.observing.obs_helpers import NFFTInfo, ftmatrix, ticks
 
 TANWIDTH_M = 0.5

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -1409,8 +1409,11 @@ def stv2_v_grad(imarr, vflux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT_V,
 ##################################################################################################
 # Chi^2 Data functions
 ##################################################################################################
-def chisqdata_pvis(Obsdata, Prior, mask):
-    """Return the visibilities, sigmas, and fourier matrix for an observation, prior, mask
+def chisqdata_pvis(Obsdata, Prior, mask, **kwargs):
+    """Return the visibilities, sigmas, and fourier matrix for an observation, prior, mask.
+
+    Accepts and ignores standard-chisqdata kwargs (pol, snrcut, debias, etc.) so the
+    unified compute_chisqdata_term dispatcher can pass them uniformly across all dtypes.
     """
 
     data_arr = Obsdata.unpack(['u','v','pvis','psigma'], conj=True)
@@ -1443,8 +1446,11 @@ def chisqdata_pvis_nfft(Obsdata, Prior, mask, **kwargs):
     return (vis, sigma, A)
 
 
-def chisqdata_m(Obsdata, Prior, mask):
-    """Return the pol  ratios, sigmas, and fourier matrix for and observation, prior, mask
+def chisqdata_m(Obsdata, Prior, mask, **kwargs):
+    """Return the pol ratios, sigmas, and fourier matrix for an observation, prior, mask.
+
+    Accepts and ignores standard-chisqdata kwargs (pol, snrcut, debias, etc.) so the
+    unified compute_chisqdata_term dispatcher can pass them uniformly across all dtypes.
     """
 
     mdata = Obsdata.unpack(['u','v','m','msigma'], conj=True)
@@ -1477,8 +1483,11 @@ def chisqdata_m_nfft(Obsdata, Prior, mask, **kwargs):
     return (m, sigmam, A)
 
 
-def chisqdata_vvis(Obsdata, Prior, mask):
-    """Return the visibilities, sigmas, and fourier matrix for an observation, prior, mask
+def chisqdata_vvis(Obsdata, Prior, mask, **kwargs):
+    """Return the visibilities, sigmas, and fourier matrix for an observation, prior, mask.
+
+    Accepts and ignores standard-chisqdata kwargs (pol, snrcut, debias, etc.) so the
+    unified compute_chisqdata_term dispatcher can pass them uniformly across all dtypes.
     """
 
     data_arr = Obsdata.unpack(['u','v','vvis','vsigma'], conj=False)

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -2597,3 +2597,80 @@ class TestValidateLimits:
         flux_warnings = [m for m in out if "> 120%" in m]
         assert len(flux_warnings) == 1  # only the second obs trips
 
+
+class TestPolChisqdataKwargs:
+    """Pol direct chisqdata leaves accept and ignore standard-chisqdata kwargs.
+
+    Prerequisite for the unified compute_chisqdata_term dispatcher: pol leaves
+    must tolerate the kwargs that standard leaves consume (pol, snrcut, debias,
+    weighting, maxset, systematic_noise, systematic_cphase_noise, cp_uv_min)
+    without choking. Pol data preparation does not use any of these knobs --
+    they are simply absorbed by **kwargs.
+    """
+
+    @staticmethod
+    def _full_mask(im):
+        return np.ones(im.imvec.size, dtype=bool)
+
+    @staticmethod
+    def _kitchen_sink_kwargs():
+        return dict(
+            pol='IP',
+            snrcut=3.0,
+            debias=True,
+            weighting='uniform',
+            maxset=True,
+            systematic_noise=0.05,
+            systematic_cphase_noise=0.02,
+            cp_uv_min=1e6,
+        )
+
+    def test_chisqdata_pvis_ignores_kwargs(self, gauss_im_pol, obs_direct):
+        from ehtim.imaging.pol_imager_utils import chisqdata_pvis
+        mask = self._full_mask(gauss_im_pol)
+        base = chisqdata_pvis(obs_direct, gauss_im_pol, mask)
+        ext = chisqdata_pvis(obs_direct, gauss_im_pol, mask, **self._kitchen_sink_kwargs())
+        np.testing.assert_array_equal(base[0], ext[0])
+        np.testing.assert_array_equal(base[1], ext[1])
+        np.testing.assert_array_equal(base[2], ext[2])
+
+    def test_chisqdata_m_ignores_kwargs(self, gauss_im_pol, obs_direct):
+        from ehtim.imaging.pol_imager_utils import chisqdata_m
+        mask = self._full_mask(gauss_im_pol)
+        base = chisqdata_m(obs_direct, gauss_im_pol, mask)
+        ext = chisqdata_m(obs_direct, gauss_im_pol, mask, **self._kitchen_sink_kwargs())
+        np.testing.assert_array_equal(base[0], ext[0])
+        np.testing.assert_array_equal(base[1], ext[1])
+        np.testing.assert_array_equal(base[2], ext[2])
+
+    def test_chisqdata_vvis_ignores_kwargs(self, gauss_im_pol, obs_direct):
+        from ehtim.imaging.pol_imager_utils import chisqdata_vvis
+        mask = self._full_mask(gauss_im_pol)
+        base = chisqdata_vvis(obs_direct, gauss_im_pol, mask)
+        ext = chisqdata_vvis(obs_direct, gauss_im_pol, mask, **self._kitchen_sink_kwargs())
+        np.testing.assert_array_equal(base[0], ext[0])
+        np.testing.assert_array_equal(base[1], ext[1])
+        np.testing.assert_array_equal(base[2], ext[2])
+
+    def test_chisqdata_pvis_nfft_still_accepts_fft_kwargs(self, gauss_im_pol, obs_nfft):
+        from ehtim.imaging.pol_imager_utils import chisqdata_pvis_nfft
+        mask = self._full_mask(gauss_im_pol)
+        # Standard kwargs are inert; FFT kwargs (fft_pad_factor, p_rad) still work.
+        out = chisqdata_pvis_nfft(obs_nfft, gauss_im_pol, mask,
+                                  pol='IP', snrcut=3.0, fft_pad_factor=2, p_rad=2)
+        assert len(out) == 3  # (vis, sigma, A) triple
+
+    def test_chisqdata_m_nfft_still_accepts_fft_kwargs(self, gauss_im_pol, obs_nfft):
+        from ehtim.imaging.pol_imager_utils import chisqdata_m_nfft
+        mask = self._full_mask(gauss_im_pol)
+        out = chisqdata_m_nfft(obs_nfft, gauss_im_pol, mask,
+                               debias=True, fft_pad_factor=2, p_rad=2)
+        assert len(out) == 3
+
+    def test_chisqdata_vvis_nfft_still_accepts_fft_kwargs(self, gauss_im_pol, obs_nfft):
+        from ehtim.imaging.pol_imager_utils import chisqdata_vvis_nfft
+        mask = self._full_mask(gauss_im_pol)
+        out = chisqdata_vvis_nfft(obs_nfft, gauss_im_pol, mask,
+                                  weighting='uniform', fft_pad_factor=2, p_rad=2)
+        assert len(out) == 3
+

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -25,7 +25,6 @@ from ehtim.imaging.imager_backend import (
     compute_reg_dict,
     compute_reggrad_dict,
     compute_which_solve,
-    embed_imarr,
     make_initarr,
     pack_imarr,
     transform_gradients,
@@ -35,6 +34,7 @@ from ehtim.imaging.imager_backend import (
     validate_limits,
     validate_params,
 )
+from ehtim.imaging.imager_utils import embed_imarr
 
 # Parametrize over square, tall, and wide images
 IMAGE_SHAPES = [

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -2981,6 +2981,18 @@ class TestComputeChisqTerm(_ChisqTermFixtures):
         with pytest.raises(Exception, match="Possible ttype values"):
             compute_chisq_term(imcur, 'vis', None, None, None, ttype='bogus')
 
+    def test_1d_imcur_standard_dtype(self, gauss_im, obs_direct):
+        """Non-pol mode passes a 1D imcur; standard dtype consumes it directly."""
+        from ehtim.imaging.imager_utils import chisq
+        mask = self._full_mask(gauss_im)
+        A, data, sigma = self._data_tuple(obs_direct, gauss_im, mask, 'vis',
+                                          'direct', 'I')
+        imcur_1d = gauss_im.imvec  # 1D, non-pol mode
+        legacy = chisq(imcur_1d, A, data, sigma, 'vis', ttype='direct', mask=mask)
+        new = compute_chisq_term(imcur_1d, 'vis', A, data, sigma,
+                                 ttype='direct', mask=mask)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
 
 class TestComputeChisqgradTerm(_ChisqTermFixtures):
     """Bit-identical parity vs imutils.chisqgrad / polutils.polchisqgrad."""

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -2744,8 +2744,6 @@ class TestComputeChisqdataTerm:
         cls._equal_recursive(a[0], b[0])
         cls._equal_recursive(a[1], b[1])
 
-    # ---- standard dtypes ----
-
     @pytest.mark.parametrize("dtype", STD_DTYPES)
     def test_parity_direct_standard(self, gauss_im, obs_direct, dtype):
         from ehtim.imaging.imager_utils import chisqdata
@@ -2779,8 +2777,6 @@ class TestComputeChisqdataTerm:
                                      ttype='nfft', pol='I', **kw)
         self._data_sigma_equal(legacy, new)
 
-    # ---- pol dtypes ----
-
     @pytest.mark.parametrize("dtype", POL_DTYPES)
     def test_parity_direct_pol(self, gauss_im_pol, obs_direct, dtype):
         from ehtim.imaging.pol_imager_utils import polchisqdata
@@ -2803,8 +2799,6 @@ class TestComputeChisqdataTerm:
                                      ttype='nfft', pol='IP', **kw_fft)
         self._data_sigma_equal(legacy, new)
 
-    # ---- exception cases ----
-
     def test_unknown_dtype_raises(self, gauss_im, obs_direct):
         mask = self._full_mask(gauss_im)
         with pytest.raises(Exception, match="data term .* not recognized"):
@@ -2822,8 +2816,6 @@ class TestComputeChisqdataTerm:
         with pytest.raises(Exception, match="Possible ttype values"):
             compute_chisqdata_term(obs_direct, gauss_im, mask, 'vis',
                                    ttype='bogus', pol='I')
-
-    # ---- pol-mode translation (override moved from compute_data_tuples) ----
 
     def test_standard_dtype_in_pol_mode_uses_stokes_I(self, gauss_im_pol, obs_direct):
         """In pol='IP' mode, a standard dtype ('vis') reads Stokes-I data.
@@ -2895,8 +2887,6 @@ class _ChisqTermFixtures:
 class TestComputeChisqTerm(_ChisqTermFixtures):
     """Bit-identical parity vs imutils.chisq / polutils.polchisq."""
 
-    # ---- standard dtypes ----
-
     @pytest.mark.parametrize("dtype", _ChisqTermFixtures.STD_DTYPES)
     def test_parity_direct_standard(self, gauss_im, obs_direct, dtype):
         from ehtim.imaging.imager_utils import chisq
@@ -2937,8 +2927,6 @@ class TestComputeChisqTerm(_ChisqTermFixtures):
                                  ttype='nfft', mask=mask)
         np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
 
-    # ---- pol dtypes ----
-
     @pytest.mark.parametrize("dtype", _ChisqTermFixtures.POL_DTYPES)
     def test_parity_direct_pol(self, gauss_im_pol, obs_direct, dtype):
         from ehtim.imaging.pol_imager_utils import polchisq
@@ -2963,8 +2951,6 @@ class TestComputeChisqTerm(_ChisqTermFixtures):
         new = compute_chisq_term(imcur, dtype, A, data, sigma,
                                  ttype='nfft', mask=mask)
         np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
-
-    # ---- exception cases ----
 
     def test_unknown_dtype_raises(self, gauss_im):
         imcur = np.array([gauss_im.imvec])
@@ -2996,8 +2982,6 @@ class TestComputeChisqTerm(_ChisqTermFixtures):
 
 class TestComputeChisqgradTerm(_ChisqTermFixtures):
     """Bit-identical parity vs imutils.chisqgrad / polutils.polchisqgrad."""
-
-    # ---- standard dtypes ----
 
     @pytest.mark.parametrize("dtype", _ChisqTermFixtures.STD_DTYPES)
     def test_parity_direct_standard(self, gauss_im, obs_direct, dtype):
@@ -3038,8 +3022,6 @@ class TestComputeChisqgradTerm(_ChisqTermFixtures):
                                      ttype='nfft', mask=mask)
         np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
 
-    # ---- pol dtypes ----
-
     @pytest.mark.parametrize("dtype", _ChisqTermFixtures.POL_DTYPES)
     def test_parity_direct_pol(self, gauss_im_pol, obs_direct, dtype):
         from ehtim.imaging.pol_imager_utils import polchisqgrad
@@ -3071,20 +3053,15 @@ class TestComputeChisqgradTerm(_ChisqTermFixtures):
                                      pol_solve=pol_solve)
         np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
 
-    # ---- pol_solve defaulting ----
-
-    def test_pol_grad_default_pol_solve(self, gauss_im_pol, obs_direct):
-        """Omitting pol_solve uses an all-ones default (full Stokes block)."""
-        from ehtim.imaging.pol_imager_utils import polchisqgrad
+    def test_pol_grad_missing_pol_solve_raises(self, gauss_im_pol, obs_direct):
+        """Pol grad requires explicit pol_solve; no hidden default."""
         mask = self._full_mask(gauss_im_pol)
         A, data, sigma = self._data_tuple(obs_direct, gauss_im_pol, mask, 'pvis',
                                           'direct', 'IP')
         imcur = self._imcur_pol(gauss_im_pol)
-        legacy = polchisqgrad(imcur, A, data, sigma, 'pvis', ttype='direct',
-                              mask=mask, pol_solve=np.ones(4, dtype=int))
-        new = compute_chisqgrad_term(imcur, 'pvis', A, data, sigma,
-                                     ttype='direct', mask=mask)
-        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+        with pytest.raises(Exception, match="requires explicit pol_solve"):
+            compute_chisqgrad_term(imcur, 'pvis', A, data, sigma,
+                                   ttype='direct', mask=mask)
 
 
 class TestPolSolveBlock:

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -10,6 +10,7 @@ import pytest
 import ehtim as eh
 from ehtim.imaging.imager_backend import (
     ImagerInitState,
+    _pol_solve_block,
     compute_chisq_dict,
     compute_chisq_term,
     compute_chisqdata_term,
@@ -3072,4 +3073,49 @@ class TestComputeChisqgradTerm(_ChisqTermFixtures):
         new = compute_chisqgrad_term(imcur, 'pvis', A, data, sigma,
                                      ttype='direct', mask=mask)
         np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+
+class TestPolSolveBlock:
+    """Tests for _pol_solve_block.
+
+    Slices a polarimetric Stokes block out of which_solve. The function is
+    a seam for the future WhichSolve(stokes, spectral) NamedTuple refactor;
+    today it's a static 4-wide slice for the multifrequency + pol case.
+    """
+
+    def test_singlefreq_stokes_i_passthrough(self):
+        """Single-freq Stokes-I: 1-wide which_solve, non-pol mode -> identity."""
+        ws = np.array([1])
+        out = _pol_solve_block(ws, pol='I')
+        np.testing.assert_array_equal(out, ws)
+
+    def test_singlefreq_pol_passthrough(self):
+        """Single-freq pol: 4-wide which_solve, pol mode -> identity (no slicing needed)."""
+        ws = np.array([1, 1, 1, 0])
+        out = _pol_solve_block(ws, pol='IP')
+        np.testing.assert_array_equal(out, ws)
+
+    def test_multifreq_stokes_i_passthrough(self):
+        """Multifreq Stokes-I: 3-wide which_solve, non-pol mode -> identity."""
+        ws = np.array([1, 1, 1])
+        out = _pol_solve_block(ws, pol='I')
+        np.testing.assert_array_equal(out, ws)
+
+    def test_multifreq_pol_sliced(self):
+        """Multifreq pol: 10-wide which_solve, pol mode -> first 4 entries."""
+        ws = np.array([1, 1, 0, 0, 1, 1, 0, 0, 0, 0])
+        out = _pol_solve_block(ws, pol='IP')
+        np.testing.assert_array_equal(out, ws[:4])
+
+    def test_multifreq_pol_non_pol_mode_passthrough(self):
+        """If pol mode is not in POLARIZATION_MODES, do not slice even if length > 4."""
+        ws = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 0])
+        out = _pol_solve_block(ws, pol='I')
+        np.testing.assert_array_equal(out, ws)
+
+    def test_pol_mode_short_which_solve_passthrough(self):
+        """Pol mode but 4-wide which_solve: no slicing (single-frequency case)."""
+        ws = np.array([1, 0, 0, 1])
+        out = _pol_solve_block(ws, pol='IV')
+        np.testing.assert_array_equal(out, ws)
 

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -2658,23 +2658,20 @@ class TestPolChisqdataKwargs:
 
     def test_chisqdata_pvis_nfft_still_accepts_fft_kwargs(self, gauss_im_pol, obs_nfft):
         from ehtim.imaging.pol_imager_utils import chisqdata_pvis_nfft
-        mask = self._full_mask(gauss_im_pol)
         # Standard kwargs are inert; FFT kwargs (fft_pad_factor, p_rad) still work.
-        out = chisqdata_pvis_nfft(obs_nfft, gauss_im_pol, mask,
+        out = chisqdata_pvis_nfft(obs_nfft, gauss_im_pol,
                                   pol='IP', snrcut=3.0, fft_pad_factor=2, p_rad=2)
         assert len(out) == 3  # (vis, sigma, A) triple
 
     def test_chisqdata_m_nfft_still_accepts_fft_kwargs(self, gauss_im_pol, obs_nfft):
         from ehtim.imaging.pol_imager_utils import chisqdata_m_nfft
-        mask = self._full_mask(gauss_im_pol)
-        out = chisqdata_m_nfft(obs_nfft, gauss_im_pol, mask,
+        out = chisqdata_m_nfft(obs_nfft, gauss_im_pol,
                                debias=True, fft_pad_factor=2, p_rad=2)
         assert len(out) == 3
 
     def test_chisqdata_vvis_nfft_still_accepts_fft_kwargs(self, gauss_im_pol, obs_nfft):
         from ehtim.imaging.pol_imager_utils import chisqdata_vvis_nfft
-        mask = self._full_mask(gauss_im_pol)
-        out = chisqdata_vvis_nfft(obs_nfft, gauss_im_pol, mask,
+        out = chisqdata_vvis_nfft(obs_nfft, gauss_im_pol,
                                   weighting='uniform', fft_pad_factor=2, p_rad=2)
         assert len(out) == 3
 

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -2820,3 +2820,27 @@ class TestComputeChisqdataTerm:
             compute_chisqdata_term(obs_direct, gauss_im, mask, 'vis',
                                    ttype='bogus', pol='I')
 
+    # ---- pol-mode translation (override moved from compute_data_tuples) ----
+
+    def test_standard_dtype_in_pol_mode_uses_stokes_I(self, gauss_im_pol, obs_direct):
+        """In pol='IP' mode, a standard dtype ('vis') reads Stokes-I data.
+
+        Equivalent to legacy chisqdata(..., pol='I') after the imager had
+        forced dterm_pol='I'. Compare with the new dispatcher passing pol='IP'.
+        """
+        from ehtim.imaging.imager_utils import chisqdata
+        mask = self._full_mask(gauss_im_pol)
+        kw = self._kwargs()
+        legacy_I = chisqdata(obs_direct, gauss_im_pol, mask, 'vis',
+                             pol='I', ttype='direct', **kw)
+        new_IP = compute_chisqdata_term(obs_direct, gauss_im_pol, mask, 'vis',
+                                        ttype='direct', pol='IP', **kw)
+        self._data_sigma_equal(legacy_I, new_IP)
+
+    def test_standard_dtype_with_no_stokes_I_pol_raises(self, gauss_im_pol, obs_direct):
+        """pol='P' (linear pol only, no Stokes-I) rejects standard data terms."""
+        mask = self._full_mask(gauss_im_pol)
+        with pytest.raises(Exception, match="cannot use dterm vis with pol=P"):
+            compute_chisqdata_term(obs_direct, gauss_im_pol, mask, 'vis',
+                                   ttype='direct', pol='P', **self._kwargs())
+

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -11,6 +11,7 @@ import ehtim as eh
 from ehtim.imaging.imager_backend import (
     ImagerInitState,
     compute_chisq_dict,
+    compute_chisqdata_term,
     compute_chisqgrad_dict,
     compute_data_tuples,
     compute_embed,
@@ -2673,4 +2674,149 @@ class TestPolChisqdataKwargs:
         out = chisqdata_vvis_nfft(obs_nfft, gauss_im_pol, mask,
                                   weighting='uniform', fft_pad_factor=2, p_rad=2)
         assert len(out) == 3
+
+
+class TestComputeChisqdataTerm:
+    """Bit-identical parity tests for compute_chisqdata_term vs legacy dispatchers.
+
+    The new dispatcher must produce exactly the same (data, sigma, A) triples
+    as imutils.chisqdata + polutils.polchisqdata so callers (compute_data_tuples)
+    can be rewired without behavior change.
+    """
+
+    STD_DTYPES = ['vis', 'amp', 'logamp', 'bs', 'cphase', 'cphase_diag',
+                  'camp', 'logcamp', 'logcamp_diag']
+    POL_DTYPES = ['pvis', 'm', 'vvis']
+
+    @staticmethod
+    def _kwargs():
+        """Kwargs matching compute_data_tuples' current call into chisqdata."""
+        return dict(
+            maxset=False, debias=False, snrcut=0., weighting='natural',
+            systematic_noise=0., systematic_cphase_noise=0., cp_uv_min=0.,
+            order=3, fft_pad_factor=2, conv_func='gaussian', p_rad=2,
+        )
+
+    @staticmethod
+    def _full_mask(im):
+        return np.ones(im.imvec.size, dtype=bool)
+
+    @classmethod
+    def _equal_recursive(cls, a, b, path=""):
+        """Recursive equality that handles dtype=object ragged arrays.
+
+        `_diag` chisqdata returns data + sigma as dtype=object arrays whose
+        elements are themselves variable-length numpy arrays (PR #233), and
+        a future leaf could nest object-arrays inside object-arrays.
+        assert_array_equal trips on element-wise comparison of object dtypes;
+        this walks the structure recursively. Both inputs are checked for
+        the object-dtype property to catch routing bugs that would change
+        the return shape.
+        """
+        a_is_obj = isinstance(a, np.ndarray) and a.dtype == object
+        b_is_obj = isinstance(b, np.ndarray) and b.dtype == object
+        assert a_is_obj == b_is_obj, (
+            f"at {path or '<root>'}: object-dtype mismatch "
+            f"(a object={a_is_obj}, b object={b_is_obj})"
+        )
+        if a_is_obj:
+            assert len(a) == len(b), (
+                f"at {path or '<root>'}: length mismatch ({len(a)} vs {len(b)})"
+            )
+            for i, (aa, bb) in enumerate(zip(a, b)):
+                cls._equal_recursive(aa, bb, path=f"{path}[{i}]")
+        else:
+            np.testing.assert_array_equal(a, b)
+
+    @classmethod
+    def _data_sigma_equal(cls, a, b):
+        """Compare data + sigma of the (data, sigma, A) triple.
+
+        A is intentionally not deep-compared: both new and legacy dispatchers
+        call the same leaf helper, so the returned A is identical by
+        construction. Deep-comparing A is fragile because some leaves return
+        dtype=object ragged arrays and NFFTInfo wrappers that don't satisfy
+        np.testing.assert_array_equal.
+        """
+        cls._equal_recursive(a[0], b[0])
+        cls._equal_recursive(a[1], b[1])
+
+    # ---- standard dtypes ----
+
+    @pytest.mark.parametrize("dtype", STD_DTYPES)
+    def test_parity_direct_standard(self, gauss_im, obs_direct, dtype):
+        from ehtim.imaging.imager_utils import chisqdata
+        mask = self._full_mask(gauss_im)
+        kw = self._kwargs()
+        legacy = chisqdata(obs_direct, gauss_im, mask, dtype, pol='I',
+                           ttype='direct', **kw)
+        new = compute_chisqdata_term(obs_direct, gauss_im, mask, dtype,
+                                     ttype='direct', pol='I', **kw)
+        self._data_sigma_equal(legacy, new)
+
+    @pytest.mark.parametrize("dtype", STD_DTYPES)
+    def test_parity_fast_standard(self, gauss_im, obs_fast, dtype):
+        from ehtim.imaging.imager_utils import chisqdata
+        mask = self._full_mask(gauss_im)
+        kw = self._kwargs()
+        legacy = chisqdata(obs_fast, gauss_im, mask, dtype, pol='I',
+                           ttype='fast', **kw)
+        new = compute_chisqdata_term(obs_fast, gauss_im, mask, dtype,
+                                     ttype='fast', pol='I', **kw)
+        self._data_sigma_equal(legacy, new)
+
+    @pytest.mark.parametrize("dtype", STD_DTYPES)
+    def test_parity_nfft_standard(self, gauss_im, obs_nfft, dtype):
+        from ehtim.imaging.imager_utils import chisqdata
+        mask = self._full_mask(gauss_im)
+        kw = self._kwargs()
+        legacy = chisqdata(obs_nfft, gauss_im, mask, dtype, pol='I',
+                           ttype='nfft', **kw)
+        new = compute_chisqdata_term(obs_nfft, gauss_im, mask, dtype,
+                                     ttype='nfft', pol='I', **kw)
+        self._data_sigma_equal(legacy, new)
+
+    # ---- pol dtypes ----
+
+    @pytest.mark.parametrize("dtype", POL_DTYPES)
+    def test_parity_direct_pol(self, gauss_im_pol, obs_direct, dtype):
+        from ehtim.imaging.pol_imager_utils import polchisqdata
+        mask = self._full_mask(gauss_im_pol)
+        kw_fft = dict(fft_pad_factor=2, conv_func='gaussian', p_rad=2)
+        legacy = polchisqdata(obs_direct, gauss_im_pol, mask, dtype,
+                              ttype='direct', **kw_fft)
+        new = compute_chisqdata_term(obs_direct, gauss_im_pol, mask, dtype,
+                                     ttype='direct', pol='IP', **kw_fft)
+        self._data_sigma_equal(legacy, new)
+
+    @pytest.mark.parametrize("dtype", POL_DTYPES)
+    def test_parity_nfft_pol(self, gauss_im_pol, obs_nfft, dtype):
+        from ehtim.imaging.pol_imager_utils import polchisqdata
+        mask = self._full_mask(gauss_im_pol)
+        kw_fft = dict(fft_pad_factor=2, conv_func='gaussian', p_rad=2)
+        legacy = polchisqdata(obs_nfft, gauss_im_pol, mask, dtype,
+                              ttype='nfft', **kw_fft)
+        new = compute_chisqdata_term(obs_nfft, gauss_im_pol, mask, dtype,
+                                     ttype='nfft', pol='IP', **kw_fft)
+        self._data_sigma_equal(legacy, new)
+
+    # ---- exception cases ----
+
+    def test_unknown_dtype_raises(self, gauss_im, obs_direct):
+        mask = self._full_mask(gauss_im)
+        with pytest.raises(Exception, match="data term .* not recognized"):
+            compute_chisqdata_term(obs_direct, gauss_im, mask, 'bogus',
+                                   ttype='direct', pol='I')
+
+    def test_pol_with_fast_raises(self, gauss_im_pol, obs_direct):
+        mask = self._full_mask(gauss_im_pol)
+        with pytest.raises(Exception, match="not supported for dtype"):
+            compute_chisqdata_term(obs_direct, gauss_im_pol, mask, 'pvis',
+                                   ttype='fast', pol='IP')
+
+    def test_invalid_ttype_raises(self, gauss_im, obs_direct):
+        mask = self._full_mask(gauss_im)
+        with pytest.raises(Exception, match="Possible ttype values"):
+            compute_chisqdata_term(obs_direct, gauss_im, mask, 'vis',
+                                   ttype='bogus', pol='I')
 

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -11,8 +11,10 @@ import ehtim as eh
 from ehtim.imaging.imager_backend import (
     ImagerInitState,
     compute_chisq_dict,
+    compute_chisq_term,
     compute_chisqdata_term,
     compute_chisqgrad_dict,
+    compute_chisqgrad_term,
     compute_data_tuples,
     compute_embed,
     compute_init_state,
@@ -2843,4 +2845,231 @@ class TestComputeChisqdataTerm:
         with pytest.raises(Exception, match="cannot use dterm vis with pol=P"):
             compute_chisqdata_term(obs_direct, gauss_im_pol, mask, 'vis',
                                    ttype='direct', pol='P', **self._kwargs())
+
+
+class _ChisqTermFixtures:
+    """Helpers shared by TestComputeChisqTerm + TestComputeChisqgradTerm."""
+
+    STD_DTYPES = TestComputeChisqdataTerm.STD_DTYPES
+    POL_DTYPES = TestComputeChisqdataTerm.POL_DTYPES
+
+    @staticmethod
+    def _full_mask(im):
+        return np.ones(im.imvec.size, dtype=bool)
+
+    @staticmethod
+    def _partial_mask(im, frac=0.7):
+        """Mask with the central `frac` of pixels True."""
+        n = im.imvec.size
+        m = np.zeros(n, dtype=bool)
+        # Mask the brightest fraction (Gaussian center) so the leaf gets
+        # nontrivial data on the masked subset.
+        cutoff = np.quantile(im.imvec, 1.0 - frac)
+        m[im.imvec >= cutoff] = True
+        return m
+
+    @staticmethod
+    def _imcur_pol(gauss_im_pol):
+        """Build a (4, npix) physical-space imcur from gauss_im_pol."""
+        I = gauss_im_pol.imvec
+        Q = 0.10 * I
+        U = 0.05 * I
+        V = 0.02 * I
+        # Convert to (I, rho, phi, psi) physical-space layout, matching
+        # what transform_imarr produces.
+        rho = np.sqrt(Q**2 + U**2 + V**2) / I
+        phi = np.arctan2(U, Q)
+        psi = np.arcsin(V / np.sqrt(Q**2 + U**2 + V**2 + 1e-30))
+        return np.array([I, rho, phi, psi])
+
+    @staticmethod
+    def _data_tuple(obs, prior, mask, dtype, ttype, pol):
+        """Get (A, data, sigma) for this (dtype, ttype) via the unified data-tuple dispatcher."""
+        data, sigma, A = compute_chisqdata_term(
+            obs, prior, mask, dtype, ttype=ttype, pol=pol,
+        )
+        return A, data, sigma
+
+
+class TestComputeChisqTerm(_ChisqTermFixtures):
+    """Bit-identical parity vs imutils.chisq / polutils.polchisq."""
+
+    # ---- standard dtypes ----
+
+    @pytest.mark.parametrize("dtype", _ChisqTermFixtures.STD_DTYPES)
+    def test_parity_direct_standard(self, gauss_im, obs_direct, dtype):
+        from ehtim.imaging.imager_utils import chisq
+        mask = self._full_mask(gauss_im)
+        A, data, sigma = self._data_tuple(obs_direct, gauss_im, mask, dtype,
+                                          'direct', 'I')
+        imcur = np.array([gauss_im.imvec])  # (1, npix) Stokes-I only
+        legacy = chisq(gauss_im.imvec, A, data, sigma, dtype, ttype='direct',
+                       mask=mask)
+        new = compute_chisq_term(imcur, dtype, A, data, sigma,
+                                 ttype='direct', mask=mask)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    @pytest.mark.parametrize("dtype", _ChisqTermFixtures.STD_DTYPES)
+    def test_parity_fast_standard(self, gauss_im, obs_fast, dtype):
+        from ehtim.imaging.imager_utils import chisq
+        mask = self._partial_mask(gauss_im)
+        A, data, sigma = self._data_tuple(obs_fast, gauss_im, mask, dtype,
+                                          'fast', 'I')
+        # Solver-space imcur: only the masked subset.
+        imvec = gauss_im.imvec[mask]
+        imcur = np.array([imvec])
+        legacy = chisq(imvec, A, data, sigma, dtype, ttype='fast', mask=mask)
+        new = compute_chisq_term(imcur, dtype, A, data, sigma,
+                                 ttype='fast', mask=mask)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    @pytest.mark.parametrize("dtype", _ChisqTermFixtures.STD_DTYPES)
+    def test_parity_nfft_standard(self, gauss_im, obs_nfft, dtype):
+        from ehtim.imaging.imager_utils import chisq
+        mask = self._partial_mask(gauss_im)
+        A, data, sigma = self._data_tuple(obs_nfft, gauss_im, mask, dtype,
+                                          'nfft', 'I')
+        imvec = gauss_im.imvec[mask]
+        imcur = np.array([imvec])
+        legacy = chisq(imvec, A, data, sigma, dtype, ttype='nfft', mask=mask)
+        new = compute_chisq_term(imcur, dtype, A, data, sigma,
+                                 ttype='nfft', mask=mask)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    # ---- pol dtypes ----
+
+    @pytest.mark.parametrize("dtype", _ChisqTermFixtures.POL_DTYPES)
+    def test_parity_direct_pol(self, gauss_im_pol, obs_direct, dtype):
+        from ehtim.imaging.pol_imager_utils import polchisq
+        mask = self._full_mask(gauss_im_pol)
+        A, data, sigma = self._data_tuple(obs_direct, gauss_im_pol, mask, dtype,
+                                          'direct', 'IP')
+        imcur = self._imcur_pol(gauss_im_pol)
+        legacy = polchisq(imcur, A, data, sigma, dtype, ttype='direct', mask=mask)
+        new = compute_chisq_term(imcur, dtype, A, data, sigma,
+                                 ttype='direct', mask=mask)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    @pytest.mark.parametrize("dtype", _ChisqTermFixtures.POL_DTYPES)
+    def test_parity_nfft_pol(self, gauss_im_pol, obs_nfft, dtype):
+        from ehtim.imaging.pol_imager_utils import polchisq
+        mask = self._partial_mask(gauss_im_pol)
+        A, data, sigma = self._data_tuple(obs_nfft, gauss_im_pol, mask, dtype,
+                                          'nfft', 'IP')
+        imcur_full = self._imcur_pol(gauss_im_pol)
+        imcur = imcur_full[:, mask]  # solver-space sub-array
+        legacy = polchisq(imcur, A, data, sigma, dtype, ttype='nfft', mask=mask)
+        new = compute_chisq_term(imcur, dtype, A, data, sigma,
+                                 ttype='nfft', mask=mask)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    # ---- exception cases ----
+
+    def test_unknown_dtype_raises(self, gauss_im):
+        imcur = np.array([gauss_im.imvec])
+        with pytest.raises(Exception, match="data term .* not recognized"):
+            compute_chisq_term(imcur, 'bogus', None, None, None, ttype='direct')
+
+    def test_pol_with_fast_raises(self, gauss_im_pol):
+        imcur = self._imcur_pol(gauss_im_pol)
+        with pytest.raises(Exception, match="not supported for dtype"):
+            compute_chisq_term(imcur, 'pvis', None, None, None, ttype='fast')
+
+    def test_invalid_ttype_raises(self, gauss_im):
+        imcur = np.array([gauss_im.imvec])
+        with pytest.raises(Exception, match="Possible ttype values"):
+            compute_chisq_term(imcur, 'vis', None, None, None, ttype='bogus')
+
+
+class TestComputeChisqgradTerm(_ChisqTermFixtures):
+    """Bit-identical parity vs imutils.chisqgrad / polutils.polchisqgrad."""
+
+    # ---- standard dtypes ----
+
+    @pytest.mark.parametrize("dtype", _ChisqTermFixtures.STD_DTYPES)
+    def test_parity_direct_standard(self, gauss_im, obs_direct, dtype):
+        from ehtim.imaging.imager_utils import chisqgrad
+        mask = self._full_mask(gauss_im)
+        A, data, sigma = self._data_tuple(obs_direct, gauss_im, mask, dtype,
+                                          'direct', 'I')
+        imcur = np.array([gauss_im.imvec])
+        legacy = chisqgrad(gauss_im.imvec, A, data, sigma, dtype,
+                           ttype='direct', mask=mask)
+        new = compute_chisqgrad_term(imcur, dtype, A, data, sigma,
+                                     ttype='direct', mask=mask)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    @pytest.mark.parametrize("dtype", _ChisqTermFixtures.STD_DTYPES)
+    def test_parity_fast_standard(self, gauss_im, obs_fast, dtype):
+        from ehtim.imaging.imager_utils import chisqgrad
+        mask = self._partial_mask(gauss_im)
+        A, data, sigma = self._data_tuple(obs_fast, gauss_im, mask, dtype,
+                                          'fast', 'I')
+        imvec = gauss_im.imvec[mask]
+        imcur = np.array([imvec])
+        legacy = chisqgrad(imvec, A, data, sigma, dtype, ttype='fast', mask=mask)
+        new = compute_chisqgrad_term(imcur, dtype, A, data, sigma,
+                                     ttype='fast', mask=mask)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    @pytest.mark.parametrize("dtype", _ChisqTermFixtures.STD_DTYPES)
+    def test_parity_nfft_standard(self, gauss_im, obs_nfft, dtype):
+        from ehtim.imaging.imager_utils import chisqgrad
+        mask = self._partial_mask(gauss_im)
+        A, data, sigma = self._data_tuple(obs_nfft, gauss_im, mask, dtype,
+                                          'nfft', 'I')
+        imvec = gauss_im.imvec[mask]
+        imcur = np.array([imvec])
+        legacy = chisqgrad(imvec, A, data, sigma, dtype, ttype='nfft', mask=mask)
+        new = compute_chisqgrad_term(imcur, dtype, A, data, sigma,
+                                     ttype='nfft', mask=mask)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    # ---- pol dtypes ----
+
+    @pytest.mark.parametrize("dtype", _ChisqTermFixtures.POL_DTYPES)
+    def test_parity_direct_pol(self, gauss_im_pol, obs_direct, dtype):
+        from ehtim.imaging.pol_imager_utils import polchisqgrad
+        mask = self._full_mask(gauss_im_pol)
+        A, data, sigma = self._data_tuple(obs_direct, gauss_im_pol, mask, dtype,
+                                          'direct', 'IP')
+        imcur = self._imcur_pol(gauss_im_pol)
+        pol_solve = np.ones(4, dtype=int)
+        legacy = polchisqgrad(imcur, A, data, sigma, dtype, ttype='direct',
+                              mask=mask, pol_solve=pol_solve)
+        new = compute_chisqgrad_term(imcur, dtype, A, data, sigma,
+                                     ttype='direct', mask=mask,
+                                     pol_solve=pol_solve)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    @pytest.mark.parametrize("dtype", _ChisqTermFixtures.POL_DTYPES)
+    def test_parity_nfft_pol(self, gauss_im_pol, obs_nfft, dtype):
+        from ehtim.imaging.pol_imager_utils import polchisqgrad
+        mask = self._partial_mask(gauss_im_pol)
+        A, data, sigma = self._data_tuple(obs_nfft, gauss_im_pol, mask, dtype,
+                                          'nfft', 'IP')
+        imcur_full = self._imcur_pol(gauss_im_pol)
+        imcur = imcur_full[:, mask]
+        pol_solve = np.ones(4, dtype=int)
+        legacy = polchisqgrad(imcur, A, data, sigma, dtype, ttype='nfft',
+                              mask=mask, pol_solve=pol_solve)
+        new = compute_chisqgrad_term(imcur, dtype, A, data, sigma,
+                                     ttype='nfft', mask=mask,
+                                     pol_solve=pol_solve)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    # ---- pol_solve defaulting ----
+
+    def test_pol_grad_default_pol_solve(self, gauss_im_pol, obs_direct):
+        """Omitting pol_solve uses an all-ones default (full Stokes block)."""
+        from ehtim.imaging.pol_imager_utils import polchisqgrad
+        mask = self._full_mask(gauss_im_pol)
+        A, data, sigma = self._data_tuple(obs_direct, gauss_im_pol, mask, 'pvis',
+                                          'direct', 'IP')
+        imcur = self._imcur_pol(gauss_im_pol)
+        legacy = polchisqgrad(imcur, A, data, sigma, 'pvis', ttype='direct',
+                              mask=mask, pol_solve=np.ones(4, dtype=int))
+        new = compute_chisqgrad_term(imcur, 'pvis', A, data, sigma,
+                                     ttype='direct', mask=mask)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
 


### PR DESCRIPTION
Closes task **2.11** in #212.

Merges the dual `chisq` + `polchisq` dispatchers into a single term-level family in `imager_backend.py`:

- **`compute_chisq_term`**, **`compute_chisqgrad_term`**, **`compute_chisqdata_term`** — dict-dispatched on `(dtype, ttype)`. 12 dtypes × valid ttypes, parity-tested bit-identically against the legacy paths.
- **`_pol_solve_block(which_solve, pol)`** helper encapsulates the `which_solve[0:4]` slicing pattern flagged as fragile in #227 (with a TODO for the Phase 6 `WhichSolve(stokes, spectral)` NamedTuple refactor).
- **Drops the `pol_next='I'` override** in `compute_data_tuples` flagged in #232 review; the validation moved into `compute_chisqdata_term`.
- **Legacy `chisq`/`chisqgrad`/`chisqdata` + `polchisq`/`polchisqgrad`/`polchisqdata`** become thin shims around the new term functions — back-compat preserved for `Obsdata.chisq`/`polchisq`, plotting, and calibration.
- **Cycle-break**: `embed_imarr` moved from `imager_backend.py` to `imager_utils.py` (next to `embed`) and vectorized over the `nsolve` axis. Bit-identical output to the previous per-row loop.

## JAX-readiness

`_CHISQ_DISPATCH` and `_CHISQDATA_DISPATCH` are the Phase 5 entry points: each entry can be swapped in place to register a JAX backend (e.g. `_CHISQ_DISPATCH['vis']['direct'] = (jax_chisq_vis, jax_chisqgrad_vis)`). `compute_chisq_term` is `jax.jit`-friendly under `static_argnames=('dtype', 'ttype')`.

## Design notes

- `compute_chisqgrad_term` requires explicit `pol_solve` for pol dtypes — no hidden default. The legacy shim still defaults to `POL_SOLVE_DEFAULT` and forwards it through, so external callers of `polchisqgrad(...)` without `pol_solve` are unchanged.
- Pol direct chisqdata leaves (`chisqdata_pvis`/`m`/`vvis`) now accept `**kwargs` so the unified dispatcher passes standard kwargs uniformly across all dtypes.
