### PR TITLE
Convert _full_regparams() dict to RegParams NamedTuple

### DIFF
--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -37,6 +37,7 @@ from ehtim.imaging.imager_backend import (
     DATATERMS,
     DATATERMS_POL,
     POLARIZATION_MODES,
+    RegParams,
     compute_chisq_dict,
     compute_chisqgrad_dict,
     compute_init_state,
@@ -732,18 +733,22 @@ class Imager:
         )
 
     def _full_regparams(self):
-        """Bundle all regularizer params into a single dict for the backend."""
-        return {
-            'flux': self.flux_next,
-            'pflux': self.pflux_next,
-            'vflux': self.vflux_next,
-            'xdim': self.prior_next.xdim,
-            'ydim': self.prior_next.ydim,
-            'psize': self.prior_next.psize,
-            'beam_size': self.beam_size,
-            'mf_flux': self.mf_flux,
-            **self.regparams,
-        }
+        """Bundle all regularizer params into a RegParams NamedTuple for the backend."""
+        return RegParams(
+            flux=self.flux_next,
+            pflux=self.pflux_next,
+            vflux=self.vflux_next,
+            xdim=self.prior_next.xdim,
+            ydim=self.prior_next.ydim,
+            psize=self.prior_next.psize,
+            beam_size=self.beam_size,
+            mf_flux=self.mf_flux,
+            major=self.regparams['major'],
+            minor=self.regparams['minor'],
+            PA=self.regparams['PA'],
+            alpha_A=self.regparams['alpha_A'],
+            epsilon_tv=self.regparams['epsilon_tv'],
+        )
 
     def _full_data_weighting_params(self):
         """Bundle data-weighting params into a single dict for the backend."""

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -1,7 +1,7 @@
 # imager_backend.py
 # Pure functional backend for imager.py
 
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 import numpy as np
 
@@ -748,13 +748,13 @@ class RegParams(NamedTuple):
       Term-specific kwargs : major, minor, PA, alpha_A, epsilon_tv
     """
     flux: float
-    pflux: Optional[float]
-    vflux: Optional[float]
+    pflux: float | None
+    vflux: float | None
     xdim: int
     ydim: int
     psize: float
     beam_size: float
-    mf_flux: Optional[list]      # length n_obs when REGULARIZERS_ALLFREQS_I active
+    mf_flux: list | None         # length n_obs when REGULARIZERS_ALLFREQS_I active
     major: float
     minor: float
     PA: float

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -1,7 +1,7 @@
 # imager_backend.py
 # Pure functional backend for imager.py
 
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 import numpy as np
 
@@ -731,6 +731,35 @@ class ImagerInitState(NamedTuple):
     nimage: int                  # number of active pixels = sum(embed_mask)
     which_solve: np.ndarray      # int 0/1 flags
     reffreq: float               # may be re-bound to init.rf when mf=True
+
+
+class RegParams(NamedTuple):
+    """Bundle of regularizer parameters passed to compute_reg_dict / compute_reggrad_dict.
+
+    Built once per imager run by Imager._full_regparams() and forwarded into
+    each regularizer function via ``**reg_params._asdict()``. Regularizer
+    functions take what they need from this bundle; extra fields are ignored
+    via their trailing ``**kwargs``.
+
+    Field groups:
+      Image scale          : flux, pflux, vflux
+      Image geometry       : xdim, ydim, psize, beam_size
+      Multifrequency       : mf_flux
+      Term-specific kwargs : major, minor, PA, alpha_A, epsilon_tv
+    """
+    flux: float
+    pflux: Optional[float]
+    vflux: Optional[float]
+    xdim: int
+    ydim: int
+    psize: float
+    beam_size: float
+    mf_flux: Optional[list]      # length n_obs when REGULARIZERS_ALLFREQS_I active
+    major: float
+    minor: float
+    PA: float
+    alpha_A: float
+    epsilon_tv: float
 
 
 def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -1201,7 +1201,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys,
 def compute_reg_dict(imcur, reg_term_keys,
                      mf, pol,
                      logfreqratio_list, n_obs,
-                     priorvec, norm_reg, regparams,
+                     priorvec, norm_reg, reg_params,
                      embed_mask):
     """Compute regularizer value for each regularizer term.
 
@@ -1226,19 +1226,20 @@ def compute_reg_dict(imcur, reg_term_keys,
         initial image used for not-solved-for slots in `unpack_imarr`).
     norm_reg : bool
         Whether to apply per-regularizer normalization.
-    regparams : dict
-        Bundle of regularizer parameters: must contain `flux`, `pflux`, `vflux`,
-        `xdim`, `ydim`, `psize`, `beam_size`, and `mf_flux` (list of per-freq
-        fluxes, required when any REGULARIZERS_ALLFREQS_I term is active);
-        plus any term-specific kwargs (e.g. `major`, `minor`, `PA`, `alpha_A`,
-        `epsilon_tv`). Spread into the underlying dispatchers as **kwargs.
+    reg_params : RegParams
+        Bundle of regularizer parameters. See the RegParams docstring for the
+        field list. Forwarded into each regularizer call via
+        ``**reg_params._asdict()``.
+    embed_mask : np.ndarray of bool
+        Pixel embedding mask.
 
     Returns
     -------
     reg_dict : dict
         Mapping from regname to regularizer scalar.
     """
-    mf_flux = regparams.get('mf_flux')
+    mf_flux = reg_params.mf_flux
+    reg_kwargs = reg_params._asdict()
     reg_dict = {}
 
     for regname in reg_term_keys:
@@ -1252,7 +1253,7 @@ def compute_reg_dict(imcur, reg_term_keys,
                 prior_pol = priorvec[0:4]
                 reg = polutils.polregularizer(imcur_pol, prior_pol, embed_mask,
                                               stype=regname, norm_reg=norm_reg,
-                                              **regparams)
+                                              **reg_kwargs)
 
             # Stokes I regularizers
             elif regname in REGULARIZERS:
@@ -1273,14 +1274,14 @@ def compute_reg_dict(imcur, reg_term_keys,
 
                         regi = imutils.regularizer(imcur_nu, prior_nu, embed_mask,
                                                    stype=regname_base, norm_reg=norm_reg,
-                                                   **{**regparams, 'flux': mf_flux[i]})
+                                                   **{**reg_kwargs, 'flux': mf_flux[i]})
 
                         reg = regi if i == 0 else reg + regi
 
                 else:
                     reg = imutils.regularizer(imcur[0], priorvec[0], embed_mask,
                                               stype=regname, norm_reg=norm_reg,
-                                              **regparams)
+                                              **reg_kwargs)
 
             # Spectral regularizers
             elif regname in REGULARIZERS_SPECTRAL:
@@ -1300,7 +1301,7 @@ def compute_reg_dict(imcur, reg_term_keys,
 
                 reg = mfutils.regularizer_mf(imcur[idx], priorvec[idx], embed_mask,
                                              stype=regname, norm_reg=norm_reg,
-                                             **regparams)
+                                             **reg_kwargs)
             else:
                 raise Exception(f"regularizer term {regname} not recognized!")
 
@@ -1308,7 +1309,7 @@ def compute_reg_dict(imcur, reg_term_keys,
         elif regname in REGULARIZERS_POL:
             reg = polutils.polregularizer(imcur, priorvec, embed_mask,
                                           stype=regname, norm_reg=norm_reg,
-                                          **regparams)
+                                          **reg_kwargs)
 
         # Single-frequency, single-polarization regularizer
         elif regname in REGULARIZERS:
@@ -1321,7 +1322,7 @@ def compute_reg_dict(imcur, reg_term_keys,
 
             reg = imutils.regularizer(imcur0, prior0, embed_mask,
                                       stype=regname, norm_reg=norm_reg,
-                                      **regparams)
+                                      **reg_kwargs)
         else:
             raise Exception(f"regularizer term {regname} not recognized!")
 
@@ -1333,7 +1334,7 @@ def compute_reg_dict(imcur, reg_term_keys,
 def compute_reggrad_dict(imcur, reg_term_keys,
                          mf, pol,
                          logfreqratio_list, n_obs,
-                         priorvec, norm_reg, regparams,
+                         priorvec, norm_reg, reg_params,
                          embed_mask,
                          which_solve, nimage):
     """Compute regularizer gradient for each regularizer term.
@@ -1341,7 +1342,7 @@ def compute_reggrad_dict(imcur, reg_term_keys,
     Parameters
     ----------
     imcur, reg_term_keys, mf, pol, logfreqratio_list, n_obs,
-    priorvec, norm_reg, regparams, embed_mask : see compute_reg_dict.
+    priorvec, norm_reg, reg_params, embed_mask : see compute_reg_dict.
     which_solve : np.ndarray of bool
         Per-Stokes solve mask (used by polregularizergrad).
     nimage : int
@@ -1354,7 +1355,8 @@ def compute_reggrad_dict(imcur, reg_term_keys,
         for single-pol, (4, nimage) for pol-bundled, or
         (len(imcur), nimage) for multifrequency.
     """
-    mf_flux = regparams.get('mf_flux')
+    mf_flux = reg_params.mf_flux
+    reg_kwargs = reg_params._asdict()
     reggrad_dict = {}
 
     for regname in reg_term_keys:
@@ -1370,7 +1372,7 @@ def compute_reggrad_dict(imcur, reg_term_keys,
                 regp = polutils.polregularizergrad(imcur_pol, prior_pol, embed_mask,
                                                    stype=regname, norm_reg=norm_reg,
                                                    pol_solve=pol_solve,
-                                                   **regparams)
+                                                   **reg_kwargs)
                 reggrad = np.zeros((len(imcur), nimage))
                 reggrad[0:4] = regp
 
@@ -1393,14 +1395,14 @@ def compute_reggrad_dict(imcur, reg_term_keys,
 
                         regi = imutils.regularizergrad(imcur_nu, prior_nu, embed_mask,
                                                        stype=regname_base, norm_reg=norm_reg,
-                                                       **{**regparams, 'flux': mf_flux[i]})
+                                                       **{**reg_kwargs, 'flux': mf_flux[i]})
                         reggrad_i = mfutils.mf_all_grads_chain(regi, imcur_nu, imcur, logfreqratio)
                         reggrad = reggrad_i if i == 0 else reggrad + reggrad_i
 
                 else:
                     regi = imutils.regularizergrad(imcur[0], priorvec[0], embed_mask,
                                                    stype=regname, norm_reg=norm_reg,
-                                                   **regparams)
+                                                   **reg_kwargs)
                     reggrad = np.zeros((len(imcur), nimage))
                     reggrad[0] = regi
 
@@ -1420,7 +1422,7 @@ def compute_reggrad_dict(imcur, reg_term_keys,
 
                 regmf = mfutils.regularizergrad_mf(imcur[idx], priorvec[idx], embed_mask,
                                                    stype=regname, norm_reg=norm_reg,
-                                                   **regparams)
+                                                   **reg_kwargs)
 
                 reggrad = np.zeros((len(imcur), nimage))
                 reggrad[idx] = regmf
@@ -1433,7 +1435,7 @@ def compute_reggrad_dict(imcur, reg_term_keys,
                 reggrad = polutils.polregularizergrad(imcur, priorvec, embed_mask,
                                                       stype=regname, norm_reg=norm_reg,
                                                       pol_solve=which_solve,
-                                                      **regparams)
+                                                      **reg_kwargs)
 
             # Single-frequency, single polarization regularizer
             elif regname in REGULARIZERS:
@@ -1445,7 +1447,7 @@ def compute_reggrad_dict(imcur, reg_term_keys,
                     prior0 = priorvec
                 reggrad = imutils.regularizergrad(imcur0, prior0, embed_mask,
                                                   stype=regname, norm_reg=norm_reg,
-                                                  **regparams)
+                                                  **reg_kwargs)
 
                 if pol in POLARIZATION_MODES:
                     reggrad = np.array((reggrad,
@@ -1465,7 +1467,7 @@ def compute_objective(imvec, initvec,
                       mf, pol,
                       which_solve, data_tuples, logfreqratio_list, n_obs,
                       dat_term, reg_term,
-                      priorvec, norm_reg, regparams,
+                      priorvec, norm_reg, reg_params,
                       transforms, embed_mask, ttype):
     """Compute the scalar imaging objective: data fidelity + regularization.
 
@@ -1504,7 +1506,7 @@ def compute_objective(imvec, initvec,
         'rgauss'. Distinct from `initvec` (the optimization start point).
     norm_reg : bool
         Whether to apply per-regularizer normalization.
-    regparams : dict
+    reg_params : RegParams
         Bundle of regularizer parameters. See compute_reg_dict.
     transforms : list of str
         Image transform list (e.g. ['log', 'mcv']) applied to imcur.
@@ -1539,7 +1541,7 @@ def compute_objective(imvec, initvec,
         imcur, reg_term_keys,
         mf, pol,
         logfreqratio_list, n_obs,
-        priorvec, norm_reg, regparams,
+        priorvec, norm_reg, reg_params,
         embed_mask,
     )
 
@@ -1561,7 +1563,7 @@ def compute_objective_grad(imvec, initvec,
                            mf, pol,
                            which_solve, data_tuples, logfreqratio_list, n_obs,
                            dat_term, reg_term,
-                           priorvec, norm_reg, regparams,
+                           priorvec, norm_reg, reg_params,
                            transforms, embed_mask, ttype, nimage):
     """Compute the gradient of the imaging objective with respect to imvec.
 
@@ -1577,7 +1579,7 @@ def compute_objective_grad(imvec, initvec,
     Parameters
     ----------
     imvec, initvec, mf, pol, which_solve, data_tuples, logfreqratio_list,
-    n_obs, dat_term, reg_term, priorvec, norm_reg, regparams, transforms,
+    n_obs, dat_term, reg_term, priorvec, norm_reg, reg_params, transforms,
     embed_mask, ttype : see compute_objective.
     nimage : int
         Number of active pixels (sum of embed_mask). Used to size the
@@ -1612,7 +1614,7 @@ def compute_objective_grad(imvec, initvec,
         imcur, reg_term_keys,
         mf, pol,
         logfreqratio_list, n_obs,
-        priorvec, norm_reg, regparams,
+        priorvec, norm_reg, reg_params,
         embed_mask,
         which_solve, nimage,
     )

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -1276,7 +1276,9 @@ class TestRegParams:
             regp.flux = 2.0
 
     def test_regparams_kwarg_override(self, gauss_im, observe):
-        """Imager(..., major=..., epsilon_tv=...) propagates into RegParams."""
+        """Imager(..., major=..., epsilon_tv=...) propagates into RegParams,
+        and the other REGPARAMS_DEFAULT fields keep their defaults."""
+        from ehtim.imager import REGPARAMS_DEFAULT
         obs = observe(gauss_im)
         custom_major = 25 * ehc.RADPERUAS
         custom_eps = 0.123
@@ -1291,6 +1293,10 @@ class TestRegParams:
         regp = imgr._full_regparams()
         assert regp.major == custom_major
         assert regp.epsilon_tv == custom_eps
+        # Unspecified REGPARAMS_DEFAULT fields keep their defaults.
+        assert regp.minor == REGPARAMS_DEFAULT["minor"]
+        assert regp.PA == REGPARAMS_DEFAULT["PA"]
+        assert regp.alpha_A == REGPARAMS_DEFAULT["alpha_A"]
 
     def test_mf_flux_propagation(self, gauss_im, observe, initialize_imager):
         """Multifrequency mf_flux list propagates into RegParams.mf_flux."""

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -10,6 +10,7 @@ import pytest
 import ehtim as eh
 from ehtim.imaging.imager_backend import (
     ImagerInitState,
+    RegParams,
     compute_chisq_dict,
     compute_chisqgrad_dict,
     compute_data_tuples,
@@ -566,22 +567,26 @@ def _call_backend_chisqgrad_dict(imgr, imcur):
 
 
 def _build_regparams(imgr, mf_flux=None):
-    """Bundle all regularizer params from an Imager into a single dict.
+    """Bundle all regularizer params from an Imager into a RegParams NamedTuple.
 
     `mf_flux` overrides imgr.mf_flux for tests that exercise the
     REGULARIZERS_ALLFREQS_I validation path.
     """
-    return {
-        'flux': imgr.flux_next,
-        'pflux': imgr.pflux_next,
-        'vflux': imgr.vflux_next,
-        'xdim': imgr.prior_next.xdim,
-        'ydim': imgr.prior_next.ydim,
-        'psize': imgr.prior_next.psize,
-        'beam_size': imgr.beam_size,
-        'mf_flux': imgr.mf_flux if mf_flux is None else mf_flux,
-        **imgr.regparams,
-    }
+    return RegParams(
+        flux=imgr.flux_next,
+        pflux=imgr.pflux_next,
+        vflux=imgr.vflux_next,
+        xdim=imgr.prior_next.xdim,
+        ydim=imgr.prior_next.ydim,
+        psize=imgr.prior_next.psize,
+        beam_size=imgr.beam_size,
+        mf_flux=imgr.mf_flux if mf_flux is None else mf_flux,
+        major=imgr.regparams['major'],
+        minor=imgr.regparams['minor'],
+        PA=imgr.regparams['PA'],
+        alpha_A=imgr.regparams['alpha_A'],
+        epsilon_tv=imgr.regparams['epsilon_tv'],
+    )
 
 
 def _call_backend_reg_dict(imgr, imcur, mf_flux=None):

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import ehtim as eh
+import ehtim.const_def as ehc
 from ehtim.imaging.imager_backend import (
     ImagerInitState,
     RegParams,
@@ -1215,6 +1216,97 @@ def test_reg_and_reggrad_share_keys(gauss_im, observe, initialize_imager):
     reg = _call_backend_reg_dict(imgr, imcur)
     reggrad = _call_backend_reggrad_dict(imgr, imcur)
     assert set(reg.keys()) == set(reggrad.keys())
+
+
+class TestRegParams:
+    """Tests for the RegParams NamedTuple bundle and Imager._full_regparams()."""
+
+    EXPECTED_FIELDS = (
+        "flux", "pflux", "vflux",
+        "xdim", "ydim", "psize", "beam_size",
+        "mf_flux",
+        "major", "minor", "PA", "alpha_A", "epsilon_tv",
+    )
+
+    def test_full_regparams_returns_namedtuple(self, gauss_im, observe,
+                                                initialize_imager):
+        """Imager._full_regparams() returns a RegParams instance."""
+        obs = observe(gauss_im)
+        imgr, _ = initialize_imager(obs, gauss_im, {"vis": 100})
+        regp = imgr._full_regparams()
+        assert isinstance(regp, RegParams)
+
+    def test_field_access_matches_imager_attrs(self, gauss_im, observe,
+                                                 initialize_imager):
+        """Every RegParams field reads back the corresponding Imager attribute."""
+        obs = observe(gauss_im)
+        imgr, _ = initialize_imager(obs, gauss_im, {"vis": 100})
+        regp = imgr._full_regparams()
+
+        assert regp.flux == imgr.flux_next
+        assert regp.pflux == imgr.pflux_next
+        assert regp.vflux == imgr.vflux_next
+        assert regp.xdim == imgr.prior_next.xdim
+        assert regp.ydim == imgr.prior_next.ydim
+        assert regp.psize == imgr.prior_next.psize
+        assert regp.beam_size == imgr.beam_size
+        assert regp.mf_flux == imgr.mf_flux
+        assert regp.major == imgr.regparams["major"]
+        assert regp.minor == imgr.regparams["minor"]
+        assert regp.PA == imgr.regparams["PA"]
+        assert regp.alpha_A == imgr.regparams["alpha_A"]
+        assert regp.epsilon_tv == imgr.regparams["epsilon_tv"]
+
+    def test_asdict_has_expected_keys(self, gauss_im, observe,
+                                       initialize_imager):
+        """_asdict() exposes exactly the documented field set; pinned so future
+        2.18/2.19 promotions don't silently drop/add a key."""
+        obs = observe(gauss_im)
+        imgr, _ = initialize_imager(obs, gauss_im, {"vis": 100})
+        keys = imgr._full_regparams()._asdict().keys()
+        assert tuple(keys) == self.EXPECTED_FIELDS
+
+    def test_immutability(self, gauss_im, observe, initialize_imager):
+        """RegParams is immutable (NamedTuple). This pins JAX-pytree-friendly
+        semantics: any update must go through ._replace(...)."""
+        obs = observe(gauss_im)
+        imgr, _ = initialize_imager(obs, gauss_im, {"vis": 100})
+        regp = imgr._full_regparams()
+        with pytest.raises(AttributeError):
+            regp.flux = 2.0
+
+    def test_regparams_kwarg_override(self, gauss_im, observe):
+        """Imager(..., major=..., epsilon_tv=...) propagates into RegParams."""
+        obs = observe(gauss_im)
+        custom_major = 25 * ehc.RADPERUAS
+        custom_eps = 0.123
+        imgr = eh.imager.Imager(
+            obs, gauss_im, prior_im=gauss_im, flux=gauss_im.total_flux(),
+            data_term={"vis": 100}, ttype="direct", pol="I",
+            major=custom_major, epsilon_tv=custom_eps,
+        )
+        imgr.check_params()
+        imgr.check_limits()
+        imgr.init_imager()
+        regp = imgr._full_regparams()
+        assert regp.major == custom_major
+        assert regp.epsilon_tv == custom_eps
+
+    def test_mf_flux_propagation(self, gauss_im, observe, initialize_imager):
+        """Multifrequency mf_flux list propagates into RegParams.mf_flux."""
+        im_lo = gauss_im.copy()
+        im_lo.rf = REFFREQ_HZ
+        im_hi = gauss_im.copy()
+        im_hi.rf = MF_ALT_FREQ_HZ
+        obs_lo = observe(im_lo)
+        obs_hi = observe(im_hi)
+        imgr, _ = initialize_imager(
+            [obs_lo, obs_hi], im_lo, {"vis": 100},
+            mf=True, mf_order=1,
+            mf_flux=[1.0, 2.0],
+        )
+        regp = imgr._full_regparams()
+        assert regp.mf_flux == [1.0, 2.0]
 
 
 class TestComputeObjective:


### PR DESCRIPTION
Promotes `Imager._full_regparams()` from a flat dict to a typed `RegParams` NamedTuple, the third of three flat-dict helpers introduced in the #232 cleanup. Sets the pattern for 2.18 (DataWeighting), 2.19 (FFTParams), and 2.21 (ImagerConfig).

- New `class RegParams(NamedTuple)` in `imager_backend.py` next to `ImagerInitState` — 13 flat fields: image scale (flux/pflux/vflux), geometry (xdim/ydim/psize/beam_size), multifrequency (mf_flux), and the five regparams-default term kwargs (major/minor/PA/alpha_A/epsilon_tv).
- `compute_reg_dict` / `compute_reggrad_dict` / `compute_objective` / `compute_objective_grad` take `reg_params: RegParams`; leaf calls forward via `**reg_params._asdict()` so existing regularizer functions don't change.
- `Imager._full_regparams()` now returns `RegParams(...)`; test helper `_build_regparams()` updated to match.
- 6 new tests in `TestRegParams` cover construction, field access, `_asdict()` key set (pinned for future 2.18/2.19 promotions), immutability, kwarg-override propagation, and mf_flux propagation.