### PR TITLE
Regularizer dispatcher refactor + parametrized FD tests

### DIFF
--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -214,6 +214,12 @@ _REGULARIZER_DISPATCH = {
         lambda v, *, mask, **kw: -imutils.sflux(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
         lambda v, *, mask, **kw: -imutils.sfluxgrad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
         'stokes_i'),
+    # flux_mf shares the flux machinery; compute_reg_dict strips '_mf' and
+    # loops over frequencies, but direct callers should still resolve the name.
+    'flux_mf': (
+        lambda v, *, mask, **kw: -imutils.sflux(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: -imutils.sfluxgrad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        'stokes_i'),
     'simple': (
         lambda v, *, mask, **kw: -imutils.ssimple(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
         lambda v, *, mask, **kw: -imutils.ssimplegrad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
@@ -1669,6 +1675,27 @@ def compute_chisqgrad_dict(imcur, dat_term_keys,
     return chi2grad_dict
 
 
+def _spectral_slot(regname, n_slots):
+    """Return the imcur row index for a multifrequency spectral regularizer.
+
+    Slot layout: n_slots=3 (Stokes-I + alpha + beta) uses indices 1, 2.
+    n_slots=10 (full IPV + spectral expansion) uses 4-9.
+    """
+    if regname in REGULARIZERS_SPECIND:
+        return 4 if n_slots == 10 else 1
+    if regname in REGULARIZERS_CURV:
+        return 5 if n_slots == 10 else 2
+    if regname in REGULARIZERS_SPECIND_P:
+        return 6
+    if regname in REGULARIZERS_CURV_P:
+        return 7
+    if regname in REGULARIZERS_RM:
+        return 8
+    if regname in REGULARIZERS_CM:
+        return 9
+    raise Exception(f"regularizer term {regname!r} has no spectral slot mapping")
+
+
 def compute_reg_dict(imcur, reg_term_keys,
                      mf, pol,
                      logfreqratio_list, n_obs,
@@ -1715,85 +1742,52 @@ def compute_reg_dict(imcur, reg_term_keys,
 
     for regname in reg_term_keys:
 
-        # Multifrequency regularizers
         if mf:
-
-            # Polarimetric regularizers
             if regname in REGULARIZERS_POL:
-                imcur_pol = imcur[0:4]
-                prior_pol = priorvec[0:4]
-                reg = polutils.polregularizer(imcur_pol, prior_pol, embed_mask,
-                                              stype=regname, norm_reg=norm_reg,
-                                              **reg_kwargs)
+                reg = compute_regularizer_term(imcur[0:4], regname, embed_mask,
+                                               norm_reg=norm_reg, **reg_kwargs)
 
-            # Stokes I regularizers
             elif regname in REGULARIZERS:
-
                 if regname in REGULARIZERS_ALLFREQS_I:
-
-                    # TODO move this to checks?
                     if (not isinstance(mf_flux, list)) or len(mf_flux) != n_obs:
                         raise Exception(f"when using regularizer '{regname}', "
                                         + "mf_flux must be a list of same length as n_obs!")
 
-                    regname_base = '_'.join(regname.split('_')[:-1])  # remove the '_mf' tag
+                    regname_base = '_'.join(regname.split('_')[:-1])  # strip '_mf' tag
+                    reg = 0
                     for i in range(n_obs):
-
                         logfreqratio = logfreqratio_list[i]
                         imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
                         prior_nu = mfutils.image_at_freq(priorvec, logfreqratio)
-
-                        regi = imutils.regularizer(imcur_nu, prior_nu, embed_mask,
-                                                   stype=regname_base, norm_reg=norm_reg,
-                                                   **{**reg_kwargs, 'flux': mf_flux[i]})
-
-                        reg = regi if i == 0 else reg + regi
-
+                        reg = reg + compute_regularizer_term(
+                            imcur_nu, regname_base, embed_mask,
+                            nprior=prior_nu, norm_reg=norm_reg,
+                            **{**reg_kwargs, 'flux': mf_flux[i]})
                 else:
-                    reg = imutils.regularizer(imcur[0], priorvec[0], embed_mask,
-                                              stype=regname, norm_reg=norm_reg,
-                                              **reg_kwargs)
+                    reg = compute_regularizer_term(imcur[0], regname, embed_mask,
+                                                   nprior=priorvec[0],
+                                                   norm_reg=norm_reg, **reg_kwargs)
 
-            # Spectral regularizers
             elif regname in REGULARIZERS_SPECTRAL:
-
-                if regname in REGULARIZERS_SPECIND:
-                    idx = 4 if len(imcur) == 10 else 1
-                elif regname in REGULARIZERS_CURV:
-                    idx = 5 if len(imcur) == 10 else 2
-                elif regname in REGULARIZERS_SPECIND_P:
-                    idx = 6
-                elif regname in REGULARIZERS_CURV_P:
-                    idx = 7
-                elif regname in REGULARIZERS_RM:
-                    idx = 8
-                elif regname in REGULARIZERS_CM:
-                    idx = 9
-
-                reg = mfutils.regularizer_mf(imcur[idx], priorvec[idx], embed_mask,
-                                             stype=regname, norm_reg=norm_reg,
-                                             **reg_kwargs)
+                idx = _spectral_slot(regname, len(imcur))
+                reg = compute_regularizer_term(imcur[idx], regname, embed_mask,
+                                               nprior=priorvec[idx],
+                                               norm_reg=norm_reg, **reg_kwargs)
             else:
                 raise Exception(f"regularizer term {regname} not recognized!")
 
-        # Single-frequency polarimetric regularizer
         elif regname in REGULARIZERS_POL:
-            reg = polutils.polregularizer(imcur, priorvec, embed_mask,
-                                          stype=regname, norm_reg=norm_reg,
-                                          **reg_kwargs)
+            reg = compute_regularizer_term(imcur, regname, embed_mask,
+                                           norm_reg=norm_reg, **reg_kwargs)
 
-        # Single-frequency, single-polarization regularizer
         elif regname in REGULARIZERS:
             if pol in POLARIZATION_MODES:
-                imcur0 = imcur[0]
-                prior0 = priorvec[0]
+                imcur0, prior0 = imcur[0], priorvec[0]
             else:
-                imcur0 = imcur
-                prior0 = priorvec
-
-            reg = imutils.regularizer(imcur0, prior0, embed_mask,
-                                      stype=regname, norm_reg=norm_reg,
-                                      **reg_kwargs)
+                imcur0, prior0 = imcur, priorvec
+            reg = compute_regularizer_term(imcur0, regname, embed_mask,
+                                           nprior=prior0,
+                                           norm_reg=norm_reg, **reg_kwargs)
         else:
             raise Exception(f"regularizer term {regname} not recognized!")
 
@@ -1832,102 +1826,73 @@ def compute_reggrad_dict(imcur, reg_term_keys,
 
     for regname in reg_term_keys:
 
-        # Multifrequency regularizers
         if mf:
-
-            # Polarimetric regularizers
             if regname in REGULARIZERS_POL:
-                imcur_pol = imcur[0:4]
-                prior_pol = priorvec[0:4]
-                pol_solve = which_solve[0:4]
-                regp = polutils.polregularizergrad(imcur_pol, prior_pol, embed_mask,
-                                                   stype=regname, norm_reg=norm_reg,
-                                                   pol_solve=pol_solve,
-                                                   **reg_kwargs)
+                regp = compute_regularizergrad_term(
+                    imcur[0:4], regname, embed_mask,
+                    pol_solve=which_solve[0:4],
+                    norm_reg=norm_reg, **reg_kwargs)
                 reggrad = np.zeros((len(imcur), nimage))
                 reggrad[0:4] = regp
 
-            # Stokes I regularizers
             elif regname in REGULARIZERS:
-
                 if regname in REGULARIZERS_ALLFREQS_I:
-
-                    # TODO move this to checks?
                     if (not isinstance(mf_flux, list)) or len(mf_flux) != n_obs:
                         raise Exception(f"when using regularizer '{regname}', "
                                         + "mf_flux must be a list of same length as n_obs!")
 
-                    regname_base = '_'.join(regname.split('_')[:-1])  # remove the '_mf' tag
+                    regname_base = '_'.join(regname.split('_')[:-1])  # strip '_mf' tag
+                    reggrad = 0
                     for i in range(n_obs):
-
                         logfreqratio = logfreqratio_list[i]
                         imcur_nu = mfutils.image_at_freq(imcur, logfreqratio)
                         prior_nu = mfutils.image_at_freq(priorvec, logfreqratio)
-
-                        regi = imutils.regularizergrad(imcur_nu, prior_nu, embed_mask,
-                                                       stype=regname_base, norm_reg=norm_reg,
-                                                       **{**reg_kwargs, 'flux': mf_flux[i]})
-                        reggrad_i = mfutils.mf_all_grads_chain(regi, imcur_nu, imcur, logfreqratio)
-                        reggrad = reggrad_i if i == 0 else reggrad + reggrad_i
-
+                        regi = compute_regularizergrad_term(
+                            imcur_nu, regname_base, embed_mask,
+                            nprior=prior_nu, norm_reg=norm_reg,
+                            **{**reg_kwargs, 'flux': mf_flux[i]})
+                        reggrad = reggrad + mfutils.mf_all_grads_chain(
+                            regi, imcur_nu, imcur, logfreqratio)
                 else:
-                    regi = imutils.regularizergrad(imcur[0], priorvec[0], embed_mask,
-                                                   stype=regname, norm_reg=norm_reg,
-                                                   **reg_kwargs)
+                    regi = compute_regularizergrad_term(
+                        imcur[0], regname, embed_mask,
+                        nprior=priorvec[0], norm_reg=norm_reg, **reg_kwargs)
                     reggrad = np.zeros((len(imcur), nimage))
                     reggrad[0] = regi
 
             elif regname in REGULARIZERS_SPECTRAL:
-                if regname in REGULARIZERS_SPECIND:
-                    idx = 4 if len(imcur) == 10 else 1
-                elif regname in REGULARIZERS_CURV:
-                    idx = 5 if len(imcur) == 10 else 2
-                elif regname in REGULARIZERS_SPECIND_P:
-                    idx = 6
-                elif regname in REGULARIZERS_CURV_P:
-                    idx = 7
-                elif regname in REGULARIZERS_RM:
-                    idx = 8
-                elif regname in REGULARIZERS_CM:
-                    idx = 9
-
-                regmf = mfutils.regularizergrad_mf(imcur[idx], priorvec[idx], embed_mask,
-                                                   stype=regname, norm_reg=norm_reg,
-                                                   **reg_kwargs)
-
+                idx = _spectral_slot(regname, len(imcur))
+                regmf = compute_regularizergrad_term(
+                    imcur[idx], regname, embed_mask,
+                    nprior=priorvec[idx], norm_reg=norm_reg, **reg_kwargs)
                 reggrad = np.zeros((len(imcur), nimage))
                 reggrad[idx] = regmf
             else:
                 raise Exception(f"regularizer term {regname} not recognized!")
 
-        else:
-            # Single-frequency polarimetric regularizer
-            if regname in REGULARIZERS_POL:
-                reggrad = polutils.polregularizergrad(imcur, priorvec, embed_mask,
-                                                      stype=regname, norm_reg=norm_reg,
-                                                      pol_solve=which_solve,
-                                                      **reg_kwargs)
+        elif regname in REGULARIZERS_POL:
+            reggrad = compute_regularizergrad_term(
+                imcur, regname, embed_mask,
+                pol_solve=which_solve, norm_reg=norm_reg, **reg_kwargs)
 
-            # Single-frequency, single polarization regularizer
-            elif regname in REGULARIZERS:
-                if pol in POLARIZATION_MODES:
-                    imcur0 = imcur[0]
-                    prior0 = priorvec[0]
-                else:
-                    imcur0 = imcur
-                    prior0 = priorvec
-                reggrad = imutils.regularizergrad(imcur0, prior0, embed_mask,
-                                                  stype=regname, norm_reg=norm_reg,
-                                                  **reg_kwargs)
-
-                if pol in POLARIZATION_MODES:
-                    reggrad = np.array((reggrad,
-                                        np.zeros(nimage),
-                                        np.zeros(nimage),
-                                        np.zeros(nimage)))
-
+        elif regname in REGULARIZERS:
+            if pol in POLARIZATION_MODES:
+                imcur0, prior0 = imcur[0], priorvec[0]
             else:
-                raise Exception(f"regularizer term {regname} not recognized!")
+                imcur0, prior0 = imcur, priorvec
+            reggrad = compute_regularizergrad_term(
+                imcur0, regname, embed_mask,
+                nprior=prior0, norm_reg=norm_reg, **reg_kwargs)
+            # In polarization mode, pad the Stokes-I gradient into a (4, nimage)
+            # array with zeros for Q, U, V slots so it can be summed alongside
+            # polregularizergrad outputs.
+            if pol in POLARIZATION_MODES:
+                reggrad = np.array((reggrad,
+                                    np.zeros(nimage),
+                                    np.zeros(nimage),
+                                    np.zeros(nimage)))
+        else:
+            raise Exception(f"regularizer term {regname} not recognized!")
 
         reggrad_dict[regname] = reggrad
 

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -154,6 +154,251 @@ _CHISQ_DISPATCH = {
 }
 
 
+# Helpers for compound regularizers: tvlog / tv2log apply log to imvec before
+# calling stv / stv2 and adjust the gradient via the chain rule from log.
+def _tvlog_value(v, *, mask, **kw):
+    npix = kw['xdim'] * kw['ydim']
+    logflux = npix * np.abs(np.log(kw['flux'] / npix))
+    epsilon = kw.get('epsilon_tv', 0.)
+    if np.any(np.invert(mask)):
+        v = imutils.embed(v, mask, clipfloor=epsilon, randomfloor=True)
+    return -imutils.stv(np.log(v), kw['xdim'], kw['ydim'], kw['psize'], logflux,
+                        norm_reg=kw.get('norm_reg', True),
+                        beam_size=kw.get('beam_size'),
+                        epsilon=epsilon)
+
+
+def _tvlog_grad(v, *, mask, **kw):
+    npix = kw['xdim'] * kw['ydim']
+    logflux = npix * np.abs(np.log(kw['flux'] / npix))
+    epsilon = kw.get('epsilon_tv', 0.)
+    if np.any(np.invert(mask)):
+        v = imutils.embed(v, mask, clipfloor=epsilon, randomfloor=True)
+    g = -imutils.stvgrad(np.log(v), kw['xdim'], kw['ydim'], kw['psize'], logflux,
+                         norm_reg=kw.get('norm_reg', True),
+                         beam_size=kw.get('beam_size'),
+                         epsilon=epsilon)
+    return (g / v)[mask]
+
+
+def _tv2log_value(v, *, mask, **kw):
+    npix = kw['xdim'] * kw['ydim']
+    logflux = npix * np.abs(np.log(kw['flux'] / npix))
+    if np.any(np.invert(mask)):
+        v = imutils.embed(v, mask, randomfloor=True)
+    return -imutils.stv2(np.log(v), kw['xdim'], kw['ydim'], kw['psize'], logflux,
+                         norm_reg=kw.get('norm_reg', True),
+                         beam_size=kw.get('beam_size'))
+
+
+def _tv2log_grad(v, *, mask, **kw):
+    npix = kw['xdim'] * kw['ydim']
+    logflux = npix * np.abs(np.log(kw['flux'] / npix))
+    if np.any(np.invert(mask)):
+        v = imutils.embed(v, mask, randomfloor=True)
+    g = -imutils.stv2grad(np.log(v), kw['xdim'], kw['ydim'], kw['psize'], logflux,
+                          norm_reg=kw.get('norm_reg', True),
+                          beam_size=kw.get('beam_size'))
+    return (g / v)[mask]
+
+
+# Dispatch table: regname -> (value_fn, grad_fn, family).
+# value/grad signature: (imvec_or_imarr, *, mask, **kw) -> scalar / ndarray.
+# Each lambda is self-contained: handles its own embed pre-step and (for
+# spatial regs) [mask] post-slice. family is informational for compute_reg_dict
+# to decide how to slice the imcur input and how to bundle the gradient back
+# into a multi-Stokes shape when the imager runs in polarization mode.
+_REGULARIZER_DISPATCH = {
+    # Stokes-I regularizers (REGULARIZERS)
+    'flux': (
+        lambda v, *, mask, **kw: -imutils.sflux(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: -imutils.sfluxgrad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        'stokes_i'),
+    'simple': (
+        lambda v, *, mask, **kw: -imutils.ssimple(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: -imutils.ssimplegrad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        'stokes_i'),
+    'l1': (
+        lambda v, *, mask, **kw: -imutils.sl1(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: -imutils.sl1grad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        'stokes_i'),
+    'l1w': (
+        lambda v, *, mask, **kw: -imutils.sl1w(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: -imutils.sl1wgrad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        'stokes_i'),
+    'lA': (
+        lambda v, *, mask, **kw: -imutils.slA(v, kw['nprior'], kw['psize'], kw['flux'], kw.get('beam_size'), kw.get('alpha_A', 1.0), kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: -imutils.slAgrad(v, kw['nprior'], kw['psize'], kw['flux'], kw.get('beam_size'), kw.get('alpha_A', 1.0), kw.get('norm_reg', True)),
+        'stokes_i'),
+    'gs': (
+        lambda v, *, mask, **kw: -imutils.sgs(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: -imutils.sgsgrad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        'stokes_i'),
+    'patch': (
+        lambda v, *, mask, **kw: -imutils.spatch(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: -imutils.spatchgrad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        'stokes_i'),
+    'cm': (
+        lambda v, *, mask, **kw: -imutils.scm(v, kw['xdim'], kw['ydim'], kw['psize'], kw['flux'], mask, norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size')),
+        lambda v, *, mask, **kw: -imutils.scmgrad(v, kw['xdim'], kw['ydim'], kw['psize'], kw['flux'], mask, norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size')),
+        'stokes_i'),
+    'tv': (
+        lambda v, *, mask, **kw: -imutils.stv(
+            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
+            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size'), epsilon=kw.get('epsilon_tv', 0.)),
+        lambda v, *, mask, **kw: (-imutils.stvgrad(
+            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
+            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size'), epsilon=kw.get('epsilon_tv', 0.)))[mask],
+        'stokes_i'),
+    'tvlog': (_tvlog_value, _tvlog_grad, 'stokes_i'),
+    'tv2': (
+        lambda v, *, mask, **kw: -imutils.stv2(
+            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
+            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size')),
+        lambda v, *, mask, **kw: (-imutils.stv2grad(
+            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
+            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size')))[mask],
+        'stokes_i'),
+    'tv2log': (_tv2log_value, _tv2log_grad, 'stokes_i'),
+    'compact': (
+        lambda v, *, mask, **kw: -imutils.scompact(
+            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
+            norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: (-imutils.scompactgrad(
+            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
+            norm_reg=kw.get('norm_reg', True)))[mask],
+        'stokes_i'),
+    'compact2': (
+        lambda v, *, mask, **kw: -imutils.scompact2(
+            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
+            norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: (-imutils.scompact2grad(
+            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
+            norm_reg=kw.get('norm_reg', True)))[mask],
+        'stokes_i'),
+    'rgauss': (
+        lambda v, *, mask, **kw: -imutils.sgauss(
+            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+            kw['xdim'], kw['ydim'], kw['psize'],
+            major=kw.get('major', 1.0), minor=kw.get('minor', 1.0), PA=kw.get('PA', 1.0)),
+        lambda v, *, mask, **kw: (-imutils.sgauss_grad(
+            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+            kw['xdim'], kw['ydim'], kw['psize'],
+            kw.get('major', 1.0), kw.get('minor', 1.0), kw.get('PA', 1.0)))[mask],
+        'stokes_i'),
+    # Pol regularizers (REGULARIZERS_POL): operate on a (4, nimage) imarr;
+    # gradient leaves take pol_solve and return (4, nimage).
+    'msimple': (
+        lambda v, *, mask, **kw: -polutils.sm(v, kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: -polutils.smgrad(v, kw['flux'],
+            pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT),
+            norm_reg=kw.get('norm_reg', True)),
+        'pol'),
+    'hw': (
+        lambda v, *, mask, **kw: -polutils.shw(v, kw['flux'], norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: -polutils.shwgrad(v, kw['flux'],
+            pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT),
+            norm_reg=kw.get('norm_reg', True)),
+        'pol'),
+    'ptv': (
+        lambda v, *, mask, **kw: -polutils.stv_pol(
+            imutils.embed_imarr(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+            kw['flux'], kw['xdim'], kw['ydim'], kw['psize'],
+            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size', 1)),
+        lambda v, *, mask, **kw: _slice_pol_grad(
+            -polutils.stv_pol_grad(
+                imutils.embed_imarr(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+                kw['flux'], kw['xdim'], kw['ydim'], kw['psize'],
+                pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT),
+                norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size', 1)),
+            mask),
+        'pol'),
+    'vflux': (
+        lambda v, *, mask, **kw: -polutils.svflux(v, kw['vflux'], norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: -polutils.svfluxgrad(v, kw['vflux'],
+            pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT_V),
+            norm_reg=kw.get('norm_reg', True)),
+        'pol'),
+    'l1v': (
+        lambda v, *, mask, **kw: -polutils.sl1v(v, kw['vflux'], norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: -polutils.sl1vgrad(v, kw['vflux'],
+            pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT_V),
+            norm_reg=kw.get('norm_reg', True)),
+        'pol'),
+    'l2v': (
+        lambda v, *, mask, **kw: -polutils.sl2v(v, kw['vflux'], norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: -polutils.sl2vgrad(v, kw['vflux'],
+            pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT_V),
+            norm_reg=kw.get('norm_reg', True)),
+        'pol'),
+    'vtv': (
+        lambda v, *, mask, **kw: -polutils.stv_v(
+            imutils.embed_imarr(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+            kw['vflux'], kw['xdim'], kw['ydim'], kw['psize'],
+            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size', 1)),
+        lambda v, *, mask, **kw: _slice_pol_grad(
+            -polutils.stv_v_grad(
+                imutils.embed_imarr(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+                kw['vflux'], kw['xdim'], kw['ydim'], kw['psize'],
+                pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT_V),
+                norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size', 1)),
+            mask),
+        'pol'),
+    'vtv2': (
+        lambda v, *, mask, **kw: -polutils.stv2_v(
+            imutils.embed_imarr(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+            kw['vflux'], kw['xdim'], kw['ydim'], kw['psize'],
+            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size', 1)),
+        lambda v, *, mask, **kw: _slice_pol_grad(
+            -polutils.stv2_v_grad(
+                imutils.embed_imarr(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
+                kw['vflux'], kw['xdim'], kw['ydim'], kw['psize'],
+                pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT_V),
+                norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size', 1)),
+            mask),
+        'pol'),
+    # Multifrequency regularizers (REGULARIZERS_SPECTRAL):
+    # l2_* call l2_spec on a 1D spectral coefficient vector;
+    # tv_* call tv_spec with a different embed (no randomfloor).
+    **{name: (
+        lambda v, *, mask, **kw: -mfutils.l2_spec(v, kw['nprior'], norm_reg=kw.get('norm_reg', True)),
+        lambda v, *, mask, **kw: -mfutils.l2_spec_grad(v, kw['nprior'], norm_reg=kw.get('norm_reg', True)),
+        'mf')
+       for name in REGULARIZERS_SPECIND + REGULARIZERS_CURV + REGULARIZERS_SPECIND_P
+                   + REGULARIZERS_CURV_P + REGULARIZERS_RM + REGULARIZERS_CM
+       if name.startswith('l2_')},
+    **{name: (
+        lambda v, *, mask, **kw: -mfutils.tv_spec(
+            imutils.embed(v, mask, clipfloor=0, randomfloor=False) if np.any(np.invert(mask)) else v,
+            kw['xdim'], kw['ydim'], kw['psize'],
+            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size')),
+        lambda v, *, mask, **kw: (-mfutils.tv_spec_grad(
+            imutils.embed(v, mask, clipfloor=0, randomfloor=False) if np.any(np.invert(mask)) else v,
+            kw['xdim'], kw['ydim'], kw['psize'],
+            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size')))[mask],
+        'mf')
+       for name in REGULARIZERS_SPECIND + REGULARIZERS_CURV + REGULARIZERS_SPECIND_P
+                   + REGULARIZERS_CURV_P + REGULARIZERS_RM + REGULARIZERS_CM
+       if name.startswith('tv_')},
+}
+
+
+def _slice_pol_grad(grad, mask):
+    """Apply the [:, mask] post-slice to a (4, nimage_full) pol gradient when
+    the leaf operated on an embedded image array. No-op for already-masked input."""
+    if np.any(np.invert(mask)):
+        return grad[:, mask]
+    return grad
+
+
 class ImagerInitState(NamedTuple):
     """Solver-ready state produced by compute_init_state.
 
@@ -976,6 +1221,61 @@ def compute_chisqgrad_term(imcur, dtype, A, data, sigma, ttype='direct',
         grad = grad[:, mask] if is_pol else grad[mask]
 
     return grad
+
+
+def compute_regularizer_term(imvec_or_imarr, regname, mask, **kwargs):
+    """Single regularizer-value dispatcher.
+
+    Parameters
+    ----------
+    imvec_or_imarr : np.ndarray
+        1D image vector for Stokes-I and mf regularizers; (4, nimage) array for pol regularizers.
+    regname : str
+        Regularizer name. Must be a key of _REGULARIZER_DISPATCH.
+    mask : np.ndarray of bool
+        Pixel embedding mask. Spatial regularizers embed through this before computing.
+    **kwargs
+        Per-regularizer parameters (flux, xdim, ydim, psize, beam_size, alpha_A,
+        epsilon_tv, major, minor, PA, nprior, priorarr, vflux, pflux, pol_solve).
+        Each regularizer takes what it needs and ignores the rest.
+
+    Returns
+    -------
+    float
+        Regularizer value, negated so positive values indicate a penalty to minimize.
+    """
+    if regname not in _REGULARIZER_DISPATCH:
+        raise Exception(f"regularizer term {regname} not recognized!")
+    val_fn, _, _ = _REGULARIZER_DISPATCH[regname]
+    return val_fn(imvec_or_imarr, mask=mask, **kwargs)
+
+
+def compute_regularizergrad_term(imvec_or_imarr, regname, mask, **kwargs):
+    """Single regularizer-gradient dispatcher.
+
+    Parameters
+    ----------
+    imvec_or_imarr : np.ndarray
+        1D image vector for Stokes-I and mf regularizers; (4, nimage) array for pol regularizers.
+    regname : str
+        Regularizer name. Must be a key of _REGULARIZER_DISPATCH.
+    mask : np.ndarray of bool
+        Pixel embedding mask. Spatial regularizers embed through this before computing
+        and slice the gradient back through ``mask`` after.
+    **kwargs
+        Per-regularizer parameters; see compute_regularizer_term.
+
+    Returns
+    -------
+    np.ndarray
+        Gradient with shape (nimage,) for Stokes-I and mf regularizers, or
+        (4, nimage) for pol regularizers. Bundling a Stokes-I gradient into
+        the (4, nimage) shape for pol-mode imaging is the caller's responsibility.
+    """
+    if regname not in _REGULARIZER_DISPATCH:
+        raise Exception(f"regularizer term {regname} not recognized!")
+    _, grad_fn, _ = _REGULARIZER_DISPATCH[regname]
+    return grad_fn(imvec_or_imarr, mask=mask, **kwargs)
 
 
 class RegParams(NamedTuple):

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -154,255 +154,54 @@ _CHISQ_DISPATCH = {
 }
 
 
-# Helpers for compound regularizers: tvlog / tv2log apply log to imvec before
-# calling stv / stv2 and adjust the gradient via the chain rule from log.
-def _tvlog_value(v, *, mask, **kw):
-    npix = kw['xdim'] * kw['ydim']
-    logflux = npix * np.abs(np.log(kw['flux'] / npix))
-    epsilon = kw.get('epsilon_tv', 0.)
-    if np.any(np.invert(mask)):
-        v = imutils.embed(v, mask, clipfloor=epsilon, randomfloor=True)
-    return -imutils.stv(np.log(v), kw['xdim'], kw['ydim'], kw['psize'], logflux,
-                        norm_reg=kw.get('norm_reg', True),
-                        beam_size=kw.get('beam_size'),
-                        epsilon=epsilon)
-
-
-def _tvlog_grad(v, *, mask, **kw):
-    npix = kw['xdim'] * kw['ydim']
-    logflux = npix * np.abs(np.log(kw['flux'] / npix))
-    epsilon = kw.get('epsilon_tv', 0.)
-    if np.any(np.invert(mask)):
-        v = imutils.embed(v, mask, clipfloor=epsilon, randomfloor=True)
-    g = -imutils.stvgrad(np.log(v), kw['xdim'], kw['ydim'], kw['psize'], logflux,
-                         norm_reg=kw.get('norm_reg', True),
-                         beam_size=kw.get('beam_size'),
-                         epsilon=epsilon)
-    return (g / v)[mask]
-
-
-def _tv2log_value(v, *, mask, **kw):
-    npix = kw['xdim'] * kw['ydim']
-    logflux = npix * np.abs(np.log(kw['flux'] / npix))
-    if np.any(np.invert(mask)):
-        v = imutils.embed(v, mask, randomfloor=True)
-    return -imutils.stv2(np.log(v), kw['xdim'], kw['ydim'], kw['psize'], logflux,
-                         norm_reg=kw.get('norm_reg', True),
-                         beam_size=kw.get('beam_size'))
-
-
-def _tv2log_grad(v, *, mask, **kw):
-    npix = kw['xdim'] * kw['ydim']
-    logflux = npix * np.abs(np.log(kw['flux'] / npix))
-    if np.any(np.invert(mask)):
-        v = imutils.embed(v, mask, randomfloor=True)
-    g = -imutils.stv2grad(np.log(v), kw['xdim'], kw['ydim'], kw['psize'], logflux,
-                          norm_reg=kw.get('norm_reg', True),
-                          beam_size=kw.get('beam_size'))
-    return (g / v)[mask]
-
-
 # Dispatch table: regname -> (value_fn, grad_fn, family).
-# value/grad signature: (imvec_or_imarr, *, mask, **kw) -> scalar / ndarray.
-# Each lambda is self-contained: handles its own embed pre-step and (for
-# spatial regs) [mask] post-slice. family is informational for compute_reg_dict
+# Each entry points at a `reg_X` / `reggrad_X` wrapper in the regularizer's home
+# file (imager_utils / pol_imager_utils / multifreq_imager_utils). The wrappers
+# share a uniform (imvec_or_imarr, mask, **kwargs) signature and own their
+# embed-pre / mask-post-slice logic. family is informational for compute_reg_dict
 # to decide how to slice the imcur input and how to bundle the gradient back
 # into a multi-Stokes shape when the imager runs in polarization mode.
 _REGULARIZER_DISPATCH = {
-    # Stokes-I regularizers (REGULARIZERS)
-    'flux': (
-        lambda v, *, mask, **kw: -imutils.sflux(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: -imutils.sfluxgrad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        'stokes_i'),
+    # Stokes-I (REGULARIZERS)
+    'flux':     (imutils.reg_flux,     imutils.reggrad_flux,     'stokes_i'),
     # flux_mf shares the flux machinery; compute_reg_dict strips '_mf' and
-    # loops over frequencies, but direct callers should still resolve the name.
-    'flux_mf': (
-        lambda v, *, mask, **kw: -imutils.sflux(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: -imutils.sfluxgrad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        'stokes_i'),
-    'simple': (
-        lambda v, *, mask, **kw: -imutils.ssimple(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: -imutils.ssimplegrad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        'stokes_i'),
-    'l1': (
-        lambda v, *, mask, **kw: -imutils.sl1(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: -imutils.sl1grad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        'stokes_i'),
-    'l1w': (
-        lambda v, *, mask, **kw: -imutils.sl1w(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: -imutils.sl1wgrad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        'stokes_i'),
-    'lA': (
-        lambda v, *, mask, **kw: -imutils.slA(v, kw['nprior'], kw['psize'], kw['flux'], kw.get('beam_size'), kw.get('alpha_A', 1.0), kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: -imutils.slAgrad(v, kw['nprior'], kw['psize'], kw['flux'], kw.get('beam_size'), kw.get('alpha_A', 1.0), kw.get('norm_reg', True)),
-        'stokes_i'),
-    'gs': (
-        lambda v, *, mask, **kw: -imutils.sgs(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: -imutils.sgsgrad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        'stokes_i'),
-    'patch': (
-        lambda v, *, mask, **kw: -imutils.spatch(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: -imutils.spatchgrad(v, kw['nprior'], kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        'stokes_i'),
-    'cm': (
-        lambda v, *, mask, **kw: -imutils.scm(v, kw['xdim'], kw['ydim'], kw['psize'], kw['flux'], mask, norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size')),
-        lambda v, *, mask, **kw: -imutils.scmgrad(v, kw['xdim'], kw['ydim'], kw['psize'], kw['flux'], mask, norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size')),
-        'stokes_i'),
-    'tv': (
-        lambda v, *, mask, **kw: -imutils.stv(
-            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
-            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size'), epsilon=kw.get('epsilon_tv', 0.)),
-        lambda v, *, mask, **kw: (-imutils.stvgrad(
-            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
-            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size'), epsilon=kw.get('epsilon_tv', 0.)))[mask],
-        'stokes_i'),
-    'tvlog': (_tvlog_value, _tvlog_grad, 'stokes_i'),
-    'tv2': (
-        lambda v, *, mask, **kw: -imutils.stv2(
-            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
-            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size')),
-        lambda v, *, mask, **kw: (-imutils.stv2grad(
-            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
-            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size')))[mask],
-        'stokes_i'),
-    'tv2log': (_tv2log_value, _tv2log_grad, 'stokes_i'),
-    'compact': (
-        lambda v, *, mask, **kw: -imutils.scompact(
-            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
-            norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: (-imutils.scompactgrad(
-            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
-            norm_reg=kw.get('norm_reg', True)))[mask],
-        'stokes_i'),
-    'compact2': (
-        lambda v, *, mask, **kw: -imutils.scompact2(
-            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
-            norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: (-imutils.scompact2grad(
-            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-            kw['xdim'], kw['ydim'], kw['psize'], kw['flux'],
-            norm_reg=kw.get('norm_reg', True)))[mask],
-        'stokes_i'),
-    'rgauss': (
-        lambda v, *, mask, **kw: -imutils.sgauss(
-            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-            kw['xdim'], kw['ydim'], kw['psize'],
-            major=kw.get('major', 1.0), minor=kw.get('minor', 1.0), PA=kw.get('PA', 1.0)),
-        lambda v, *, mask, **kw: (-imutils.sgauss_grad(
-            imutils.embed(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-            kw['xdim'], kw['ydim'], kw['psize'],
-            kw.get('major', 1.0), kw.get('minor', 1.0), kw.get('PA', 1.0)))[mask],
-        'stokes_i'),
-    # Pol regularizers (REGULARIZERS_POL): operate on a (4, nimage) imarr;
-    # gradient leaves take pol_solve and return (4, nimage).
-    'msimple': (
-        lambda v, *, mask, **kw: -polutils.sm(v, kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: -polutils.smgrad(v, kw['flux'],
-            pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT),
-            norm_reg=kw.get('norm_reg', True)),
-        'pol'),
-    'hw': (
-        lambda v, *, mask, **kw: -polutils.shw(v, kw['flux'], norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: -polutils.shwgrad(v, kw['flux'],
-            pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT),
-            norm_reg=kw.get('norm_reg', True)),
-        'pol'),
-    'ptv': (
-        lambda v, *, mask, **kw: -polutils.stv_pol(
-            imutils.embed_imarr(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-            kw['flux'], kw['xdim'], kw['ydim'], kw['psize'],
-            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size', 1)),
-        lambda v, *, mask, **kw: _slice_pol_grad(
-            -polutils.stv_pol_grad(
-                imutils.embed_imarr(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-                kw['flux'], kw['xdim'], kw['ydim'], kw['psize'],
-                pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT),
-                norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size', 1)),
-            mask),
-        'pol'),
-    'vflux': (
-        lambda v, *, mask, **kw: -polutils.svflux(v, kw['vflux'], norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: -polutils.svfluxgrad(v, kw['vflux'],
-            pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT_V),
-            norm_reg=kw.get('norm_reg', True)),
-        'pol'),
-    'l1v': (
-        lambda v, *, mask, **kw: -polutils.sl1v(v, kw['vflux'], norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: -polutils.sl1vgrad(v, kw['vflux'],
-            pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT_V),
-            norm_reg=kw.get('norm_reg', True)),
-        'pol'),
-    'l2v': (
-        lambda v, *, mask, **kw: -polutils.sl2v(v, kw['vflux'], norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: -polutils.sl2vgrad(v, kw['vflux'],
-            pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT_V),
-            norm_reg=kw.get('norm_reg', True)),
-        'pol'),
-    'vtv': (
-        lambda v, *, mask, **kw: -polutils.stv_v(
-            imutils.embed_imarr(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-            kw['vflux'], kw['xdim'], kw['ydim'], kw['psize'],
-            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size', 1)),
-        lambda v, *, mask, **kw: _slice_pol_grad(
-            -polutils.stv_v_grad(
-                imutils.embed_imarr(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-                kw['vflux'], kw['xdim'], kw['ydim'], kw['psize'],
-                pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT_V),
-                norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size', 1)),
-            mask),
-        'pol'),
-    'vtv2': (
-        lambda v, *, mask, **kw: -polutils.stv2_v(
-            imutils.embed_imarr(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-            kw['vflux'], kw['xdim'], kw['ydim'], kw['psize'],
-            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size', 1)),
-        lambda v, *, mask, **kw: _slice_pol_grad(
-            -polutils.stv2_v_grad(
-                imutils.embed_imarr(v, mask, randomfloor=True) if np.any(np.invert(mask)) else v,
-                kw['vflux'], kw['xdim'], kw['ydim'], kw['psize'],
-                pol_solve=kw.get('pol_solve', polutils.POL_SOLVE_DEFAULT_V),
-                norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size', 1)),
-            mask),
-        'pol'),
-    # Multifrequency regularizers (REGULARIZERS_SPECTRAL):
-    # l2_* call l2_spec on a 1D spectral coefficient vector;
-    # tv_* call tv_spec with a different embed (no randomfloor).
-    **{name: (
-        lambda v, *, mask, **kw: -mfutils.l2_spec(v, kw['nprior'], norm_reg=kw.get('norm_reg', True)),
-        lambda v, *, mask, **kw: -mfutils.l2_spec_grad(v, kw['nprior'], norm_reg=kw.get('norm_reg', True)),
-        'mf')
+    # loops over frequencies, but direct callers still need to resolve the name.
+    'flux_mf':  (imutils.reg_flux,     imutils.reggrad_flux,     'stokes_i'),
+    'simple':   (imutils.reg_simple,   imutils.reggrad_simple,   'stokes_i'),
+    'l1':       (imutils.reg_l1,       imutils.reggrad_l1,       'stokes_i'),
+    'l1w':      (imutils.reg_l1w,      imutils.reggrad_l1w,      'stokes_i'),
+    'lA':       (imutils.reg_lA,       imutils.reggrad_lA,       'stokes_i'),
+    'gs':       (imutils.reg_gs,       imutils.reggrad_gs,       'stokes_i'),
+    'patch':    (imutils.reg_patch,    imutils.reggrad_patch,    'stokes_i'),
+    'cm':       (imutils.reg_cm,       imutils.reggrad_cm,       'stokes_i'),
+    'tv':       (imutils.reg_tv,       imutils.reggrad_tv,       'stokes_i'),
+    'tvlog':    (imutils.reg_tvlog,    imutils.reggrad_tvlog,    'stokes_i'),
+    'tv2':      (imutils.reg_tv2,      imutils.reggrad_tv2,      'stokes_i'),
+    'tv2log':   (imutils.reg_tv2log,   imutils.reggrad_tv2log,   'stokes_i'),
+    'compact':  (imutils.reg_compact,  imutils.reggrad_compact,  'stokes_i'),
+    'compact2': (imutils.reg_compact2, imutils.reggrad_compact2, 'stokes_i'),
+    'rgauss':   (imutils.reg_rgauss,   imutils.reggrad_rgauss,   'stokes_i'),
+    # Pol (REGULARIZERS_POL): operate on a (4, nimage) imarr.
+    'msimple':  (polutils.reg_msimple, polutils.reggrad_msimple, 'pol'),
+    'hw':       (polutils.reg_hw,      polutils.reggrad_hw,      'pol'),
+    'ptv':      (polutils.reg_ptv,     polutils.reggrad_ptv,     'pol'),
+    'vflux':    (polutils.reg_vflux,   polutils.reggrad_vflux,   'pol'),
+    'l1v':      (polutils.reg_l1v,     polutils.reggrad_l1v,     'pol'),
+    'l2v':      (polutils.reg_l2v,     polutils.reggrad_l2v,     'pol'),
+    'vtv':      (polutils.reg_vtv,     polutils.reggrad_vtv,     'pol'),
+    'vtv2':     (polutils.reg_vtv2,    polutils.reggrad_vtv2,    'pol'),
+    # Multifrequency (REGULARIZERS_SPECTRAL): all `l2_*` names share one wrapper,
+    # all `tv_*` names share another. compute_reg_dict pulls the right slot from
+    # imcur via mfutils.spectral_slot before passing the 1D vector through.
+    **{name: (mfutils.reg_l2_spec, mfutils.reggrad_l2_spec, 'mf')
        for name in REGULARIZERS_SPECIND + REGULARIZERS_CURV + REGULARIZERS_SPECIND_P
                    + REGULARIZERS_CURV_P + REGULARIZERS_RM + REGULARIZERS_CM
        if name.startswith('l2_')},
-    **{name: (
-        lambda v, *, mask, **kw: -mfutils.tv_spec(
-            imutils.embed(v, mask, clipfloor=0, randomfloor=False) if np.any(np.invert(mask)) else v,
-            kw['xdim'], kw['ydim'], kw['psize'],
-            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size')),
-        lambda v, *, mask, **kw: (-mfutils.tv_spec_grad(
-            imutils.embed(v, mask, clipfloor=0, randomfloor=False) if np.any(np.invert(mask)) else v,
-            kw['xdim'], kw['ydim'], kw['psize'],
-            norm_reg=kw.get('norm_reg', True), beam_size=kw.get('beam_size')))[mask],
-        'mf')
+    **{name: (mfutils.reg_tv_spec, mfutils.reggrad_tv_spec, 'mf')
        for name in REGULARIZERS_SPECIND + REGULARIZERS_CURV + REGULARIZERS_SPECIND_P
                    + REGULARIZERS_CURV_P + REGULARIZERS_RM + REGULARIZERS_CM
        if name.startswith('tv_')},
 }
-
-
-def _slice_pol_grad(grad, mask):
-    """Apply the [:, mask] post-slice to a (4, nimage_full) pol gradient when
-    the leaf operated on an embedded image array. No-op for already-masked input."""
-    if np.any(np.invert(mask)):
-        return grad[:, mask]
-    return grad
 
 
 class ImagerInitState(NamedTuple):
@@ -1675,27 +1474,6 @@ def compute_chisqgrad_dict(imcur, dat_term_keys,
     return chi2grad_dict
 
 
-def _spectral_slot(regname, n_slots):
-    """Return the imcur row index for a multifrequency spectral regularizer.
-
-    Slot layout: n_slots=3 (Stokes-I + alpha + beta) uses indices 1, 2.
-    n_slots=10 (full IPV + spectral expansion) uses 4-9.
-    """
-    if regname in REGULARIZERS_SPECIND:
-        return 4 if n_slots == 10 else 1
-    if regname in REGULARIZERS_CURV:
-        return 5 if n_slots == 10 else 2
-    if regname in REGULARIZERS_SPECIND_P:
-        return 6
-    if regname in REGULARIZERS_CURV_P:
-        return 7
-    if regname in REGULARIZERS_RM:
-        return 8
-    if regname in REGULARIZERS_CM:
-        return 9
-    raise Exception(f"regularizer term {regname!r} has no spectral slot mapping")
-
-
 def compute_reg_dict(imcur, reg_term_keys,
                      mf, pol,
                      logfreqratio_list, n_obs,
@@ -1769,7 +1547,7 @@ def compute_reg_dict(imcur, reg_term_keys,
                                                    norm_reg=norm_reg, **reg_kwargs)
 
             elif regname in REGULARIZERS_SPECTRAL:
-                idx = _spectral_slot(regname, len(imcur))
+                idx = mfutils.spectral_slot(regname, len(imcur))
                 reg = compute_regularizer_term(imcur[idx], regname, embed_mask,
                                                nprior=priorvec[idx],
                                                norm_reg=norm_reg, **reg_kwargs)
@@ -1861,7 +1639,7 @@ def compute_reggrad_dict(imcur, reg_term_keys,
                     reggrad[0] = regi
 
             elif regname in REGULARIZERS_SPECTRAL:
-                idx = _spectral_slot(regname, len(imcur))
+                idx = mfutils.spectral_slot(regname, len(imcur))
                 regmf = compute_regularizergrad_term(
                     imcur[idx], regname, embed_mask,
                     nprior=priorvec[idx], norm_reg=norm_reg, **reg_kwargs)

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -2050,6 +2050,51 @@ def stv2grad(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=No
     return out/norm
 
 
+def stvlog(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None, epsilon=0.):
+    """Total variation regularizer applied to log(imvec).
+
+    Forwards to stv with the log-transformed image and a transformed flux
+    `logflux = npix * |log(flux/npix)|` so the regularizer has a sensible
+    norm when norm_reg=True.
+    """
+    npix = nx * ny
+    logflux = npix * np.abs(np.log(flux / npix))
+    return stv(np.log(imvec), nx, ny, psize, logflux,
+               norm_reg=norm_reg, beam_size=beam_size, epsilon=epsilon)
+
+
+def stvloggrad(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None, epsilon=0.):
+    """Gradient of stvlog: applies stvgrad to log(imvec), then chain rule 1/imvec.
+    """
+    npix = nx * ny
+    logflux = npix * np.abs(np.log(flux / npix))
+    g = stvgrad(np.log(imvec), nx, ny, psize, logflux,
+                norm_reg=norm_reg, beam_size=beam_size, epsilon=epsilon)
+    return g / imvec
+
+
+def stv2log(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None):
+    """Squared total variation regularizer applied to log(imvec).
+
+    Forwards to stv2 with the log-transformed image and the transformed flux
+    used by stvlog.
+    """
+    npix = nx * ny
+    logflux = npix * np.abs(np.log(flux / npix))
+    return stv2(np.log(imvec), nx, ny, psize, logflux,
+                norm_reg=norm_reg, beam_size=beam_size)
+
+
+def stv2loggrad(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None):
+    """Gradient of stv2log: applies stv2grad to log(imvec), then chain rule 1/imvec.
+    """
+    npix = nx * ny
+    logflux = npix * np.abs(np.log(flux / npix))
+    g = stv2grad(np.log(imvec), nx, ny, psize, logflux,
+                 norm_reg=norm_reg, beam_size=beam_size)
+    return g / imvec
+
+
 def spatch(imvec, priorvec, flux, norm_reg=NORM_REGULARIZER):
     """Patch prior regularizer
     """
@@ -2272,6 +2317,230 @@ def sgauss_grad(imvec, xdim, ydim, psize, major, minor, PA):
     drgauss = drgauss/(major**2. * minor**2.)
 
     return -drgauss.reshape(-1)
+
+
+##################################################################################################
+# Imager-backend wrappers
+#
+# Each `reg_X` / `reggrad_X` adapts an `sX` / `sXgrad` regularizer above to the
+# uniform `(imvec, mask, **kwargs)` signature used by the `_REGULARIZER_DISPATCH`
+# table in `imager_backend.py`. The wrappers add the sign convention (the
+# imager minimizes `-regularizer`), unpack kwargs into the leaf's positional
+# args, and handle the embed-pre / mask-post-slice pattern for spatial regs.
+##################################################################################################
+
+
+def reg_flux(imvec, mask, **kwargs):
+    return -sflux(imvec, kwargs['nprior'], kwargs['flux'],
+                  norm_reg=kwargs.get('norm_reg', True))
+
+
+def reggrad_flux(imvec, mask, **kwargs):
+    return -sfluxgrad(imvec, kwargs['nprior'], kwargs['flux'],
+                      norm_reg=kwargs.get('norm_reg', True))
+
+
+def reg_simple(imvec, mask, **kwargs):
+    return -ssimple(imvec, kwargs['nprior'], kwargs['flux'],
+                    norm_reg=kwargs.get('norm_reg', True))
+
+
+def reggrad_simple(imvec, mask, **kwargs):
+    return -ssimplegrad(imvec, kwargs['nprior'], kwargs['flux'],
+                        norm_reg=kwargs.get('norm_reg', True))
+
+
+def reg_l1(imvec, mask, **kwargs):
+    return -sl1(imvec, kwargs['nprior'], kwargs['flux'],
+                norm_reg=kwargs.get('norm_reg', True))
+
+
+def reggrad_l1(imvec, mask, **kwargs):
+    return -sl1grad(imvec, kwargs['nprior'], kwargs['flux'],
+                    norm_reg=kwargs.get('norm_reg', True))
+
+
+def reg_l1w(imvec, mask, **kwargs):
+    return -sl1w(imvec, kwargs['nprior'], kwargs['flux'],
+                 norm_reg=kwargs.get('norm_reg', True))
+
+
+def reggrad_l1w(imvec, mask, **kwargs):
+    return -sl1wgrad(imvec, kwargs['nprior'], kwargs['flux'],
+                     norm_reg=kwargs.get('norm_reg', True))
+
+
+def reg_lA(imvec, mask, **kwargs):
+    return -slA(imvec, kwargs['nprior'], kwargs['psize'], kwargs['flux'],
+                kwargs.get('beam_size'), kwargs.get('alpha_A', 1.0),
+                kwargs.get('norm_reg', True))
+
+
+def reggrad_lA(imvec, mask, **kwargs):
+    return -slAgrad(imvec, kwargs['nprior'], kwargs['psize'], kwargs['flux'],
+                    kwargs.get('beam_size'), kwargs.get('alpha_A', 1.0),
+                    kwargs.get('norm_reg', True))
+
+
+def reg_gs(imvec, mask, **kwargs):
+    return -sgs(imvec, kwargs['nprior'], kwargs['flux'],
+                norm_reg=kwargs.get('norm_reg', True))
+
+
+def reggrad_gs(imvec, mask, **kwargs):
+    return -sgsgrad(imvec, kwargs['nprior'], kwargs['flux'],
+                    norm_reg=kwargs.get('norm_reg', True))
+
+
+def reg_patch(imvec, mask, **kwargs):
+    return -spatch(imvec, kwargs['nprior'], kwargs['flux'],
+                   norm_reg=kwargs.get('norm_reg', True))
+
+
+def reggrad_patch(imvec, mask, **kwargs):
+    return -spatchgrad(imvec, kwargs['nprior'], kwargs['flux'],
+                       norm_reg=kwargs.get('norm_reg', True))
+
+
+# scm / scmgrad take the embed mask as a positional and handle masking internally,
+# so these wrappers skip the embed-pre / mask-post pattern used by other spatial regs.
+def reg_cm(imvec, mask, **kwargs):
+    return -scm(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
+                kwargs['flux'], mask,
+                norm_reg=kwargs.get('norm_reg', True),
+                beam_size=kwargs.get('beam_size'))
+
+
+def reggrad_cm(imvec, mask, **kwargs):
+    return -scmgrad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
+                    kwargs['flux'], mask,
+                    norm_reg=kwargs.get('norm_reg', True),
+                    beam_size=kwargs.get('beam_size'))
+
+
+def reg_tv(imvec, mask, **kwargs):
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, randomfloor=True)
+    return -stv(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
+                norm_reg=kwargs.get('norm_reg', True),
+                beam_size=kwargs.get('beam_size'),
+                epsilon=kwargs.get('epsilon_tv', 0.))
+
+
+def reggrad_tv(imvec, mask, **kwargs):
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, randomfloor=True)
+    g = -stvgrad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
+                 norm_reg=kwargs.get('norm_reg', True),
+                 beam_size=kwargs.get('beam_size'),
+                 epsilon=kwargs.get('epsilon_tv', 0.))
+    return g[mask]
+
+
+# tvlog / tv2log use clipfloor=epsilon_tv (not the default 0) so the log
+# transform inside stvlog / stv2log stays defined where mask filled in values.
+def reg_tvlog(imvec, mask, **kwargs):
+    epsilon = kwargs.get('epsilon_tv', 0.)
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
+    return -stvlog(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
+                   norm_reg=kwargs.get('norm_reg', True),
+                   beam_size=kwargs.get('beam_size'),
+                   epsilon=epsilon)
+
+
+def reggrad_tvlog(imvec, mask, **kwargs):
+    epsilon = kwargs.get('epsilon_tv', 0.)
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
+    g = -stvloggrad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
+                    norm_reg=kwargs.get('norm_reg', True),
+                    beam_size=kwargs.get('beam_size'),
+                    epsilon=epsilon)
+    return g[mask]
+
+
+def reg_tv2(imvec, mask, **kwargs):
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, randomfloor=True)
+    return -stv2(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
+                 norm_reg=kwargs.get('norm_reg', True),
+                 beam_size=kwargs.get('beam_size'))
+
+
+def reggrad_tv2(imvec, mask, **kwargs):
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, randomfloor=True)
+    g = -stv2grad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
+                  norm_reg=kwargs.get('norm_reg', True),
+                  beam_size=kwargs.get('beam_size'))
+    return g[mask]
+
+
+def reg_tv2log(imvec, mask, **kwargs):
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, randomfloor=True)
+    return -stv2log(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
+                    norm_reg=kwargs.get('norm_reg', True),
+                    beam_size=kwargs.get('beam_size'))
+
+
+def reggrad_tv2log(imvec, mask, **kwargs):
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, randomfloor=True)
+    g = -stv2loggrad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
+                     norm_reg=kwargs.get('norm_reg', True),
+                     beam_size=kwargs.get('beam_size'))
+    return g[mask]
+
+
+def reg_compact(imvec, mask, **kwargs):
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, randomfloor=True)
+    return -scompact(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
+                     norm_reg=kwargs.get('norm_reg', True))
+
+
+def reggrad_compact(imvec, mask, **kwargs):
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, randomfloor=True)
+    g = -scompactgrad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
+                      norm_reg=kwargs.get('norm_reg', True))
+    return g[mask]
+
+
+def reg_compact2(imvec, mask, **kwargs):
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, randomfloor=True)
+    return -scompact2(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
+                      norm_reg=kwargs.get('norm_reg', True))
+
+
+def reggrad_compact2(imvec, mask, **kwargs):
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, randomfloor=True)
+    g = -scompact2grad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
+                       norm_reg=kwargs.get('norm_reg', True))
+    return g[mask]
+
+
+def reg_rgauss(imvec, mask, **kwargs):
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, randomfloor=True)
+    return -sgauss(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
+                   major=kwargs.get('major', 1.0),
+                   minor=kwargs.get('minor', 1.0),
+                   PA=kwargs.get('PA', 1.0))
+
+
+def reggrad_rgauss(imvec, mask, **kwargs):
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, randomfloor=True)
+    g = -sgauss_grad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
+                     kwargs.get('major', 1.0),
+                     kwargs.get('minor', 1.0),
+                     kwargs.get('PA', 1.0))
+    return g[mask]
 
 
 ##################################################################################################

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -70,153 +70,35 @@ def chisqgrad(imvec, A, data, sigma, dtype, ttype='direct', mask=None):
 
 
 def regularizer(imvec, nprior, mask, flux, xdim, ydim, psize, stype, **kwargs):
-    """return the regularizer value
+    """Return the regularizer value for a Stokes-I regularizer.
+
+    Thin shim around imager_backend.compute_regularizer_term retained for
+    backward compatibility. New code should call compute_regularizer_term
+    directly.
     """
-
-    norm_reg = kwargs.get('norm_reg', NORM_REGULARIZER)
-    beam_size = kwargs.get('beam_size', psize)
-    alpha_A = kwargs.get('alpha_A', 1.0)
-    epsilon = kwargs.get('epsilon_tv', 0.)
-
-    if stype == "flux":
-        s = -sflux(imvec, nprior, flux, norm_reg=norm_reg)
-    elif stype == "cm":
-        s = -scm(imvec, xdim, ydim, psize, flux, mask, norm_reg=norm_reg, beam_size=beam_size)
-    elif stype == "simple":
-        s = -ssimple(imvec, nprior, flux, norm_reg=norm_reg)
-    elif stype == "l1":
-        s = -sl1(imvec, nprior, flux, norm_reg=norm_reg)
-    elif stype == "l1w":
-        s = -sl1w(imvec, nprior, flux, norm_reg=norm_reg)
-    elif stype == "lA":
-        s = -slA(imvec, nprior, psize, flux, beam_size, alpha_A, norm_reg)
-    elif stype == "gs":
-        s = -sgs(imvec, nprior, flux, norm_reg=norm_reg)
-    elif stype == "patch":
-        s = -spatch(imvec, nprior, flux, norm_reg=norm_reg)
-    elif stype == "tv":
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-        s = -stv(imvec, xdim, ydim, psize, flux, norm_reg=norm_reg,beam_size=beam_size, epsilon=epsilon)
-    elif stype == "tvlog":
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
-        npix = xdim*ydim
-        logvec = np.log(imvec)
-        logflux = npix*np.abs(np.log(flux/npix))
-        s = -stv(logvec, xdim, ydim, psize, logflux, norm_reg=norm_reg,beam_size=beam_size, epsilon=epsilon)
-    elif stype == "tv2":
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-        s = -stv2(imvec, xdim, ydim, psize, flux, norm_reg=norm_reg, beam_size=beam_size)
-    elif stype == "tv2log":
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-        npix = xdim*ydim
-        logvec = np.log(imvec)
-        logflux = npix*np.abs(np.log(flux/npix))
-        s = -stv2(logvec, xdim, ydim, psize, logflux, norm_reg=norm_reg, beam_size=beam_size)
-    elif stype == "compact":
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-        s = -scompact(imvec, xdim, ydim, psize, flux, norm_reg=norm_reg)
-    elif stype == "compact2":
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-        s = -scompact2(imvec, xdim, ydim, psize, flux, norm_reg=norm_reg)
-    elif stype == "rgauss":
-        # additional key words for gaussian regularizer
-        major = kwargs.get('major', 1.0)
-        minor = kwargs.get('minor', 1.0)
-        PA = kwargs.get('PA', 1.0)
-
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-        s = -sgauss(imvec, xdim, ydim, psize, major=major, minor=minor, PA=PA)
-    else:
-        s = 0
-
-    return s
+    from ehtim.imaging.imager_backend import REGULARIZERS as _BACKEND_REGS
+    from ehtim.imaging.imager_backend import compute_regularizer_term
+    if stype not in _BACKEND_REGS:
+        raise Exception(f"regularizer term {stype!r} is not a Stokes-I regularizer")
+    return compute_regularizer_term(imvec, stype, mask,
+                                    nprior=nprior, flux=flux,
+                                    xdim=xdim, ydim=ydim, psize=psize, **kwargs)
 
 
 def regularizergrad(imvec, nprior, mask, flux, xdim, ydim, psize, stype, **kwargs):
-    """return the regularizer gradient
+    """Return the regularizer gradient for a Stokes-I regularizer.
+
+    Thin shim around imager_backend.compute_regularizergrad_term retained for
+    backward compatibility. New code should call compute_regularizergrad_term
+    directly.
     """
-
-    norm_reg = kwargs.get('norm_reg', NORM_REGULARIZER)
-    beam_size = kwargs.get('beam_size', psize)
-    alpha_A = kwargs.get('alpha_A', 1.0)
-    epsilon = kwargs.get('epsilon_tv', 0.)
-
-    if stype == "flux":
-        s = -sfluxgrad(imvec, nprior, flux, norm_reg=norm_reg)
-    elif stype == "cm":
-        s = -scmgrad(imvec, xdim, ydim, psize, flux, mask, norm_reg=norm_reg, beam_size=beam_size)
-    elif stype == "simple":
-        s = -ssimplegrad(imvec, nprior, flux, norm_reg=norm_reg)
-    elif stype == "l1":
-        s = -sl1grad(imvec, nprior, flux, norm_reg=norm_reg)
-    elif stype == "l1w":
-        s = -sl1wgrad(imvec, nprior, flux, norm_reg=norm_reg)
-    elif stype == "lA":
-        s = -slAgrad(imvec, nprior, psize, flux, beam_size, alpha_A, norm_reg)
-    elif stype == "gs":
-        s = -sgsgrad(imvec, nprior, flux, norm_reg=norm_reg)
-    elif stype == "patch":
-        s = -spatchgrad(imvec, nprior, flux, norm_reg=norm_reg)
-    elif stype == "tv":
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-        s = -stvgrad(imvec, xdim, ydim, psize, flux, norm_reg=norm_reg,
-                     beam_size=beam_size, epsilon=epsilon)
-        s = s[mask]
-    elif stype == "tvlog":
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
-        npix = xdim*ydim
-        logvec = np.log(imvec)
-        logflux = npix*np.abs(np.log(flux/npix))
-        s = -stvgrad(logvec, xdim, ydim, psize, logflux, norm_reg=norm_reg,beam_size=beam_size, epsilon=epsilon)
-        s = s / imvec
-        s = s[mask]
-    elif stype == "tv2":
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-        s = -stv2grad(imvec, xdim, ydim, psize, flux, norm_reg=norm_reg, beam_size=beam_size)
-        s = s[mask]
-    elif stype == "tv2log":
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-        npix = xdim*ydim
-        logvec = np.log(imvec)
-        logflux = npix*np.abs(np.log(flux/npix))
-        s = -stv2grad(logvec, xdim, ydim, psize, logflux, norm_reg=norm_reg, beam_size=beam_size)
-        s = s / imvec
-        s = s[mask]
-    elif stype == "compact":
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-        s = -scompactgrad(imvec, xdim, ydim, psize, flux, norm_reg=norm_reg)
-        s = s[mask]
-    elif stype == "compact2":
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-        s = -scompact2grad(imvec, xdim, ydim, psize, flux, norm_reg=norm_reg)
-        s = s[mask]
-    elif stype == "rgauss":
-        # additional key words for gaussian regularizer
-        major = kwargs.get('major', 1.0)
-        minor = kwargs.get('minor', 1.0)
-        PA = kwargs.get('PA', 1.0)
-
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, randomfloor=True)
-        s = -sgauss_grad(imvec, xdim, ydim, psize, major, minor, PA)
-        s = s[mask]
-    else:
-        s = np.zeros(len(imvec))
-
-    return s
+    from ehtim.imaging.imager_backend import REGULARIZERS as _BACKEND_REGS
+    from ehtim.imaging.imager_backend import compute_regularizergrad_term
+    if stype not in _BACKEND_REGS:
+        raise Exception(f"regularizer term {stype!r} is not a Stokes-I regularizer")
+    return compute_regularizergrad_term(imvec, stype, mask,
+                                        nprior=nprior, flux=flux,
+                                        xdim=xdim, ydim=ydim, psize=psize, **kwargs)
 
 
 def chisqdata(Obsdata, Prior, mask, dtype, pol='I', **kwargs):

--- a/ehtim/imaging/multifreq_imager_utils.py
+++ b/ehtim/imaging/multifreq_imager_utils.py
@@ -17,31 +17,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import range
-
-import string
-import time
 import numpy as np
-import scipy.optimize as opt
-import scipy.ndimage as nd
-import scipy.ndimage.filters as filt
-import matplotlib.pyplot as plt
-try:
-    from pynfft.nfft import NFFT
-except ImportError:
-    pass
-    #print("Warning: No NFFT installed! Cannot use nfft functions")
-
-import ehtim.image as image
-from . import linearize_energy as le
-
-from ehtim.const_def import *
-from ehtim.observing.obs_helpers import *
-#from ehtim.statistics.dataframes import *
-from ehtim.imaging.imager_utils import embed
 
 NORM_REGULARIZER = True
 EPSILON = 1.e-12
@@ -54,7 +30,7 @@ def image_at_freq(mfarr, log_freqratio):
         """Get the image or polarization image tuple from multifrequency data
         """
 
-        # Stokes I only 
+        # Stokes I only
         if len(mfarr)==3:
             imvec0 = mfarr[0] # reference frequency image
             alpha  = mfarr[1] # spectral index
@@ -64,15 +40,15 @@ def image_at_freq(mfarr, log_freqratio):
             imvec = np.exp(logimvec)
             out = imvec
 
-            
-        # Full Polarization    
+
+        # Full Polarization
         elif len(mfarr)==10:
             # reference frequency images
-            imvec0  = mfarr[0] 
+            imvec0  = mfarr[0]
             rhovec0 = mfarr[1]
             phivec0 = mfarr[2]
             psivec0 = mfarr[3]
-            
+
             alpha = mfarr[4] # spectral index
             beta = mfarr[5]  # spectral curvature
             alpha_pol = mfarr[6] # polarization fraction spectral index
@@ -82,41 +58,41 @@ def image_at_freq(mfarr, log_freqratio):
 
             logimvec = np.log(imvec0) + alpha*log_freqratio + beta*log_freqratio*log_freqratio
             imvec = np.exp(logimvec)
-            
+
             logrhovec_prime = np.log(rhovec0) + alpha_pol*log_freqratio + beta_pol*log_freqratio*log_freqratio
             rhovec_prime = np.exp(logrhovec_prime)
-            
+
             # transformation of rhovec to ensure it is always < 1 at any frequency
             # TODO: what to do about rhoprime=0?
             rhovec = (rhovec_prime**(-DD_RHOPOL) + 1)**(-1/DD_RHOPOL)
-            
-            # we use dimensionless rm scaled by lambda0^2 = c^2/nu0^2   
+
+            # we use dimensionless rm scaled by lambda0^2 = c^2/nu0^2
             phivec = phivec0 + rm*(np.exp(-2*log_freqratio)-1)
-            
+
             # TODO: we require psi be between -pi/2 and pi/2 for m=rho*cos(psi) to work
             # for now, we will just keep multifrequency V off
             # and dimensionless conversion measure scaled by lamba0^3 = c^3/nu0^3
             psivec = psivec0 #Plot + cm*(np.exp(-3*log_freqratio)-1)
-                        
+
             out = np.array((imvec, rhovec, phivec, psivec))
 
         else:
             raise Exception("in image_at_freq, len(mfarr) must be 3 or 10!")
-            
+
         return out
 
 def mf_all_grads_chain(funcgrad, image_cur, mfarr, log_freqratio):
         """Get the gradients of the reference image, spectral index, and curvature
-           w/r/t the gradient of a function funcgrad to the image 
+           w/r/t the gradient of a function funcgrad to the image
            at a given frequency freq = ref_freq*exp(log_freqratio)
         """
 
-        # Stokes I 
+        # Stokes I
         if len(mfarr)==3:
             # current image
-            imvec_cur = image_cur   
-            
-            # current reference image       
+            imvec_cur = image_cur
+
+            # current reference image
             I0 = mfarr[0]
 
             # apply chain rule
@@ -126,28 +102,28 @@ def mf_all_grads_chain(funcgrad, image_cur, mfarr, log_freqratio):
 
             out = np.array((dfunc_dI0, dfunc_dalpha, dfunc_dbeta))
 
-        # Full Polarization    
+        # Full Polarization
         elif len(mfarr)==10:
             # current image
             (imvec_cur, rhovec_cur, phivec_cur, psivec_cur) = image_cur
             rhovec_prime = (rhovec_cur**(-DD_RHOPOL) - 1)**(-1/DD_RHOPOL) # transform rho back to rho_prime
-                                              
+
             # current reference image
             I0  = mfarr[0]
             rho0 = mfarr[1]
 
             # gradients w/r/t polarization components
             (dfunc_dI, dfunc_drho, dfunc_dphi, dfunc_dpsi) = funcgrad
-            
-            # apply chain rule to gradients w/r/t I 
+
+            # apply chain rule to gradients w/r/t I
             dfunc_dI0    = dfunc_dI * imvec_cur / I0
             dfunc_dalpha = dfunc_dI * imvec_cur * log_freqratio
-            dfunc_dbeta  = dfunc_dI * imvec_cur * log_freqratio * log_freqratio    
+            dfunc_dbeta  = dfunc_dI * imvec_cur * log_freqratio * log_freqratio
 
             # apply chain rule for derivatives w/r/t rho
             # TODO: what to do about rho=0?
             drho_drhoprime = (rhovec_prime**(-1-DD_RHOPOL))*((1 + rhovec_prime**(-DD_RHOPOL))**(-1-1/DD_RHOPOL))
-        
+
             dfunc_drho0     = dfunc_drho * drho_drhoprime * rhovec_cur / rho0
             dfunc_dalphapol = dfunc_drho * drho_drhoprime * rhovec_cur * log_freqratio
             dfunc_dbetapol  = dfunc_drho * drho_drhoprime * rhovec_cur * log_freqratio * log_freqratio
@@ -162,69 +138,61 @@ def mf_all_grads_chain(funcgrad, image_cur, mfarr, log_freqratio):
             dfunc_dpsi0 = dfunc_dpsi
             dfunc_dcm   = np.zeros(dfunc_dpsi.shape)
             #dfunc_dcm   = dfunc_dpsi*(np.exp(-3*log_freqratio)-1)
-                        
-            out = np.array((dfunc_dI0, dfunc_drho0, dfunc_dphi0, dfunc_dpsi0, 
+
+            out = np.array((dfunc_dI0, dfunc_drho0, dfunc_dphi0, dfunc_dpsi0,
                             dfunc_dalpha, dfunc_dbeta,
                             dfunc_dalphapol, dfunc_dbetapol,
-                            dfunc_drm, dfunc_dcm))        
-                                
+                            dfunc_drm, dfunc_dcm))
+
         else:
-            raise Exception("in image_at_freq, len(mfarr) must be 3 or 10!")  
-                  
+            raise Exception("in image_at_freq, len(mfarr) must be 3 or 10!")
+
         return out
-        
-        
+
+
 ##################################################################################################
 # Mulitfrequency regularizers
 ##################################################################################################
 
 def regularizer_mf(imvec, nprior, mask, xdim, ydim, psize, stype, **kwargs):
-    """return the regularizer value on spectral index or curvature
+    """Return the regularizer value for a multifrequency regularizer.
+
+    Thin shim around imager_backend.compute_regularizer_term retained for
+    backward compatibility. New code should call compute_regularizer_term
+    directly.
     """
+    from ehtim.imaging.imager_backend import REGULARIZERS_SPECTRAL, compute_regularizer_term
+    if stype not in REGULARIZERS_SPECTRAL:
+        raise Exception(f"regularizer term {stype!r} is not a multifrequency regularizer")
+    return compute_regularizer_term(imvec, stype, mask,
+                                    nprior=nprior,
+                                    xdim=xdim, ydim=ydim, psize=psize, **kwargs)
 
-    norm_reg = kwargs.get('norm_reg', NORM_REGULARIZER)
-    beam_size = kwargs.get('beam_size', psize)
-
-    if "l2_" in stype:
-        s = -l2_spec(imvec, nprior, norm_reg=norm_reg)
-    elif "tv_" in stype:
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, clipfloor=0, randomfloor=False)
-        s = -tv_spec(imvec, xdim, ydim, psize, norm_reg=norm_reg, beam_size=beam_size)
-    else:
-        s = 0
-
-    return s
 
 def regularizergrad_mf(imvec, nprior, mask, xdim, ydim, psize, stype, **kwargs):
-    """return the regularizer gradient
+    """Return the regularizer gradient for a multifrequency regularizer.
+
+    Thin shim around imager_backend.compute_regularizergrad_term retained for
+    backward compatibility. New code should call compute_regularizergrad_term
+    directly.
     """
-
-    norm_reg = kwargs.get('norm_reg', NORM_REGULARIZER)
-    beam_size = kwargs.get('beam_size', psize)
-
-    if "l2_" in stype:
-        s = -l2_spec_grad(imvec, nprior, norm_reg=norm_reg)
-    elif "tv_" in stype:
-        if np.any(np.invert(mask)):
-            imvec = embed(imvec, mask, clipfloor=0, randomfloor=False)
-        s = -tv_spec_grad(imvec, xdim, ydim, psize, norm_reg=norm_reg, beam_size=beam_size)
-        s = s[mask]
-    else:
-        s = 0
-
-    return s
+    from ehtim.imaging.imager_backend import REGULARIZERS_SPECTRAL, compute_regularizergrad_term
+    if stype not in REGULARIZERS_SPECTRAL:
+        raise Exception(f"regularizer term {stype!r} is not a multifrequency regularizer")
+    return compute_regularizergrad_term(imvec, stype, mask,
+                                        nprior=nprior,
+                                        xdim=xdim, ydim=ydim, psize=psize, **kwargs)
 
 
 def l2_spec(imvec, priorvec, norm_reg=NORM_REGULARIZER):
     """L2 norm on spectral index w/r/t prior
     """
-    
+
     if norm_reg:
         norm = float(len(imvec))
     else:
         norm = 1
-        
+
     out = -(np.sum((imvec - priorvec)**2))
     return out/norm
 
@@ -245,10 +213,11 @@ def l2_spec_grad(imvec, priorvec, norm_reg=NORM_REGULARIZER):
 def tv_spec(imvec, nx, ny, psize, norm_reg=NORM_REGULARIZER, beam_size=None):
     """Total variation regularizer
     """
-    if beam_size is None: beam_size = psize
-    if norm_reg: 
+    if beam_size is None:
+        beam_size = psize
+    if norm_reg:
         norm = len(imvec)*psize / beam_size
-    else: 
+    else:
         norm = 1
 
     im = imvec.reshape(ny, nx)
@@ -262,10 +231,11 @@ def tv_spec(imvec, nx, ny, psize, norm_reg=NORM_REGULARIZER, beam_size=None):
 def tv_spec_grad(imvec, nx, ny, psize, norm_reg=NORM_REGULARIZER, beam_size=None):
     """Total variation gradient
     """
-    if beam_size is None: beam_size = psize
-    if norm_reg: 
+    if beam_size is None:
+        beam_size = psize
+    if norm_reg:
         norm = len(imvec)*psize / beam_size
-    else: 
+    else:
         norm = 1
 
     im = imvec.reshape(ny,nx)

--- a/ehtim/imaging/multifreq_imager_utils.py
+++ b/ehtim/imaging/multifreq_imager_utils.py
@@ -154,6 +154,35 @@ def mf_all_grads_chain(funcgrad, image_cur, mfarr, log_freqratio):
 # Mulitfrequency regularizers
 ##################################################################################################
 
+def spectral_slot(regname, n_slots):
+    """Return the imcur row index for a multifrequency spectral regularizer.
+
+    Slot layout: n_slots=3 (Stokes-I + alpha + beta) uses indices 1, 2.
+    n_slots=10 (full IPV + spectral expansion) uses 4-9.
+    """
+    from ehtim.imaging.imager_backend import (
+        REGULARIZERS_CM,
+        REGULARIZERS_CURV,
+        REGULARIZERS_CURV_P,
+        REGULARIZERS_RM,
+        REGULARIZERS_SPECIND,
+        REGULARIZERS_SPECIND_P,
+    )
+    if regname in REGULARIZERS_SPECIND:
+        return 4 if n_slots == 10 else 1
+    if regname in REGULARIZERS_CURV:
+        return 5 if n_slots == 10 else 2
+    if regname in REGULARIZERS_SPECIND_P:
+        return 6
+    if regname in REGULARIZERS_CURV_P:
+        return 7
+    if regname in REGULARIZERS_RM:
+        return 8
+    if regname in REGULARIZERS_CM:
+        return 9
+    raise Exception(f"regularizer term {regname!r} has no spectral slot mapping")
+
+
 def regularizer_mf(imvec, nprior, mask, xdim, ydim, psize, stype, **kwargs):
     """Return the regularizer value for a multifrequency regularizer.
 
@@ -265,6 +294,43 @@ def tv_spec_grad(imvec, nx, ny, psize, norm_reg=NORM_REGULARIZER, beam_size=None
     # add terms together and return
     out= -(g1 + g2 + g3).flatten()
     return out/norm
+
+
+##################################################################################################
+# Imager-backend wrappers
+#
+# Same pattern as `reg_X` / `reggrad_X` in `imager_utils.py`: each wrapper adapts
+# `l2_spec` / `tv_spec` to the uniform `(imvec, mask, **kwargs)` signature used by
+# `_REGULARIZER_DISPATCH`. tv_spec uses clipfloor=0 (not the default) and
+# randomfloor=False for embed since spectral-index images can be negative.
+##################################################################################################
+
+
+def reg_l2_spec(imvec, mask, **kwargs):
+    return -l2_spec(imvec, kwargs['nprior'], norm_reg=kwargs.get('norm_reg', True))
+
+
+def reggrad_l2_spec(imvec, mask, **kwargs):
+    return -l2_spec_grad(imvec, kwargs['nprior'], norm_reg=kwargs.get('norm_reg', True))
+
+
+def reg_tv_spec(imvec, mask, **kwargs):
+    from ehtim.imaging.imager_utils import embed
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, clipfloor=0, randomfloor=False)
+    return -tv_spec(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
+                    norm_reg=kwargs.get('norm_reg', True),
+                    beam_size=kwargs.get('beam_size'))
+
+
+def reggrad_tv_spec(imvec, mask, **kwargs):
+    from ehtim.imaging.imager_utils import embed
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, clipfloor=0, randomfloor=False)
+    g = -tv_spec_grad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
+                      norm_reg=kwargs.get('norm_reg', True),
+                      beam_size=kwargs.get('beam_size'))
+    return g[mask]
 
 
 

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -27,7 +27,6 @@ except ImportError:
     _HAS_NFFT = False
 
 from ehtim.const_def import FFT_PAD_DEFAULT, GRIDDER_P_RAD_DEFAULT, RADPERAS
-from ehtim.imaging.imager_utils import embed_imarr
 from ehtim.observing.obs_helpers import NFFTInfo, ftmatrix, ticks
 
 TANWIDTH_M = 0.5
@@ -373,95 +372,33 @@ def polchisqgrad(imarr, A, data, sigma, dtype, ttype='direct', mask=[],
 
 
 def polregularizer(imarr, priorarr, mask, flux, pflux, vflux, xdim, ydim, psize, stype, **kwargs):
-    # NOTE: priorarr is currently not used in any regularizer
+    """Return the regularizer value for a polarimetric regularizer.
 
-    norm_reg = kwargs.get('norm_reg', NORM_REGULARIZER)
-    beam_size = kwargs.get('beam_size',1)
-
-    reg = 0
+    Thin shim around imager_backend.compute_regularizer_term retained for
+    backward compatibility. New code should call compute_regularizer_term
+    directly. `priorarr` is currently not consumed by any pol regularizer.
+    """
+    from ehtim.imaging.imager_backend import compute_regularizer_term
     if stype not in REGULARIZERS_POL:
-        return reg
+        raise Exception(f"regularizer term {stype!r} is not a polarimetric regularizer")
+    return compute_regularizer_term(imarr, stype, mask,
+                                    flux=flux, pflux=pflux, vflux=vflux,
+                                    xdim=xdim, ydim=ydim, psize=psize, **kwargs)
 
-    # linear
-    if stype == "msimple":
-        reg = -sm(imarr, flux, norm_reg=norm_reg)
-    elif stype == "hw":
-        reg = -shw(imarr, flux, norm_reg=norm_reg)
-    elif stype == "ptv":
-        if np.any(np.invert(mask)):
-            imarr = embed_imarr(imarr, mask, randomfloor=RANDOMFLOOR)
-        reg = -stv_pol(imarr, flux, xdim, ydim, psize,
-                       norm_reg=norm_reg, beam_size=beam_size)
-    # circular
-    elif stype == 'vflux':
-        reg = -svflux(imarr, vflux, norm_reg=norm_reg)
-    elif stype == "l1v":
-        reg = -sl1v(imarr, vflux, norm_reg=norm_reg)
-    elif stype == "l2v":
-        reg = -sl2v(imarr, vflux, norm_reg=norm_reg)
-    elif stype == "vtv":
-        if np.any(np.invert(mask)):
-            imarr = embed_imarr(imarr, mask, randomfloor=RANDOMFLOOR)
-        reg = -stv_v(imarr, vflux, xdim, ydim, psize,
-                     norm_reg=norm_reg, beam_size=beam_size)
-    elif stype == "vtv2":
-        if np.any(np.invert(mask)):
-            imarr = embed_imarr(imarr, mask, randomfloor=RANDOMFLOOR)
-        reg = -stv2_v(imarr, vflux, xdim, ydim, psize,
-                      norm_reg=norm_reg, beam_size=beam_size)
-
-
-    return reg
 
 def polregularizergrad(imarr, priorarr, mask, flux, pflux, vflux, xdim, ydim, psize, stype, **kwargs):
-    # NOTE: priorarr is currently not used in any regularizer
+    """Return the regularizer gradient for a polarimetric regularizer.
 
-    norm_reg = kwargs.get('norm_reg', NORM_REGULARIZER)
-    beam_size = kwargs.get('beam_size',1)
-    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT)
-    reggrad = np.zeros(imarr.shape)
-
+    Thin shim around imager_backend.compute_regularizergrad_term retained for
+    backward compatibility. New code should call compute_regularizergrad_term
+    directly.
+    """
+    from ehtim.imaging.imager_backend import compute_regularizergrad_term
     if stype not in REGULARIZERS_POL:
-        return reggrad
-
-    # linear
-    if stype == "msimple":
-        reggrad = -smgrad(imarr, flux, pol_solve, norm_reg=norm_reg)
-    elif stype == "hw":
-        reggrad = -shwgrad(imarr, flux, pol_solve, norm_reg=norm_reg)
-    elif stype == "ptv":
-        if np.any(np.invert(mask)):
-            imarr = embed_imarr(imarr, mask, randomfloor=RANDOMFLOOR)
-        reggrad = -stv_pol_grad(imarr, flux, xdim, ydim, psize, pol_solve,
-                                norm_reg=norm_reg, beam_size=beam_size)
-        if np.any(np.invert(mask)):
-            reggrad = reggrad[:,mask]
-
-
-    # circular
-    elif stype == 'vflux':
-        reggrad = -svfluxgrad(imarr, vflux, pol_solve=pol_solve, norm_reg=norm_reg)
-    elif stype == "l1v":
-        reggrad = -sl1vgrad(imarr, vflux, pol_solve=pol_solve, norm_reg=norm_reg)
-    elif stype == "l2v":
-        reggrad = -sl2vgrad(imarr, vflux, pol_solve=pol_solve, norm_reg=norm_reg)
-    elif stype == "vtv":
-        if np.any(np.invert(mask)):
-            imarr = embed_imarr(imarr, mask, randomfloor=RANDOMFLOOR)
-        reggrad = -stv_v_grad(imarr, vflux, xdim, ydim, psize,
-                              pol_solve=pol_solve, norm_reg=norm_reg, beam_size=beam_size)
-        if np.any(np.invert(mask)):
-            reggrad = reggrad[:,mask]
-
-    elif stype == "vtv2":
-        if np.any(np.invert(mask)):
-            imarr = embed_imarr(imarr, mask, randomfloor=RANDOMFLOOR)
-        reggrad = -stv2_v_grad(imarr, vflux, xdim, ydim, psize,
-                               pol_solve=pol_solve, norm_reg=norm_reg, beam_size=beam_size)
-        if np.any(np.invert(mask)):
-            reggrad = reggrad[:,mask]
-
-    return reggrad
+        raise Exception(f"regularizer term {stype!r} is not a polarimetric regularizer")
+    return compute_regularizergrad_term(imarr, stype, mask,
+                                        flux=flux, pflux=pflux, vflux=vflux,
+                                        xdim=xdim, ydim=ydim, psize=psize, **kwargs)
 
 
 def polchisqdata(Obsdata, Prior, mask, dtype, **kwargs):

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -1268,6 +1268,128 @@ def stv2_v_grad(imarr, vflux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT_V,
 
     return gradout/norm
 
+
+##################################################################################################
+# Imager-backend wrappers
+#
+# Same pattern as `reg_X` / `reggrad_X` in `imager_utils.py`: each wrapper adapts
+# a pol regularizer above to the uniform `(imarr, mask, **kwargs)` signature used
+# by `_REGULARIZER_DISPATCH`. Pol spatial regularizers use `embed_imarr` (not
+# `embed`) for the pre-step and slice the gradient as `g[:, mask]` because the
+# pol gradient is shaped (4, nimage) — one row per Stokes component.
+##################################################################################################
+
+
+def reg_msimple(imarr, mask, **kwargs):
+    return -sm(imarr, kwargs['flux'], norm_reg=kwargs.get('norm_reg', True))
+
+
+def reggrad_msimple(imarr, mask, **kwargs):
+    return -smgrad(imarr, kwargs['flux'],
+                   pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT),
+                   norm_reg=kwargs.get('norm_reg', True))
+
+
+def reg_hw(imarr, mask, **kwargs):
+    return -shw(imarr, kwargs['flux'], norm_reg=kwargs.get('norm_reg', True))
+
+
+def reggrad_hw(imarr, mask, **kwargs):
+    return -shwgrad(imarr, kwargs['flux'],
+                    pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT),
+                    norm_reg=kwargs.get('norm_reg', True))
+
+
+def reg_ptv(imarr, mask, **kwargs):
+    from ehtim.imaging.imager_utils import embed_imarr
+    if np.any(np.invert(mask)):
+        imarr = embed_imarr(imarr, mask, randomfloor=True)
+    return -stv_pol(imarr, kwargs['flux'], kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
+                    norm_reg=kwargs.get('norm_reg', True),
+                    beam_size=kwargs.get('beam_size', 1))
+
+
+def reggrad_ptv(imarr, mask, **kwargs):
+    from ehtim.imaging.imager_utils import embed_imarr
+    if np.any(np.invert(mask)):
+        imarr = embed_imarr(imarr, mask, randomfloor=True)
+    g = -stv_pol_grad(imarr, kwargs['flux'], kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
+                      pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT),
+                      norm_reg=kwargs.get('norm_reg', True),
+                      beam_size=kwargs.get('beam_size', 1))
+    return g[:, mask] if np.any(np.invert(mask)) else g
+
+
+def reg_vflux(imarr, mask, **kwargs):
+    return -svflux(imarr, kwargs['vflux'], norm_reg=kwargs.get('norm_reg', True))
+
+
+def reggrad_vflux(imarr, mask, **kwargs):
+    return -svfluxgrad(imarr, kwargs['vflux'],
+                       pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V),
+                       norm_reg=kwargs.get('norm_reg', True))
+
+
+def reg_l1v(imarr, mask, **kwargs):
+    return -sl1v(imarr, kwargs['vflux'], norm_reg=kwargs.get('norm_reg', True))
+
+
+def reggrad_l1v(imarr, mask, **kwargs):
+    return -sl1vgrad(imarr, kwargs['vflux'],
+                     pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V),
+                     norm_reg=kwargs.get('norm_reg', True))
+
+
+def reg_l2v(imarr, mask, **kwargs):
+    return -sl2v(imarr, kwargs['vflux'], norm_reg=kwargs.get('norm_reg', True))
+
+
+def reggrad_l2v(imarr, mask, **kwargs):
+    return -sl2vgrad(imarr, kwargs['vflux'],
+                     pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V),
+                     norm_reg=kwargs.get('norm_reg', True))
+
+
+def reg_vtv(imarr, mask, **kwargs):
+    from ehtim.imaging.imager_utils import embed_imarr
+    if np.any(np.invert(mask)):
+        imarr = embed_imarr(imarr, mask, randomfloor=True)
+    return -stv_v(imarr, kwargs['vflux'], kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
+                  norm_reg=kwargs.get('norm_reg', True),
+                  beam_size=kwargs.get('beam_size', 1))
+
+
+def reggrad_vtv(imarr, mask, **kwargs):
+    from ehtim.imaging.imager_utils import embed_imarr
+    if np.any(np.invert(mask)):
+        imarr = embed_imarr(imarr, mask, randomfloor=True)
+    g = -stv_v_grad(imarr, kwargs['vflux'], kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
+                    pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V),
+                    norm_reg=kwargs.get('norm_reg', True),
+                    beam_size=kwargs.get('beam_size', 1))
+    return g[:, mask] if np.any(np.invert(mask)) else g
+
+
+def reg_vtv2(imarr, mask, **kwargs):
+    from ehtim.imaging.imager_utils import embed_imarr
+    if np.any(np.invert(mask)):
+        imarr = embed_imarr(imarr, mask, randomfloor=True)
+    return -stv2_v(imarr, kwargs['vflux'], kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
+                   norm_reg=kwargs.get('norm_reg', True),
+                   beam_size=kwargs.get('beam_size', 1))
+
+
+def reggrad_vtv2(imarr, mask, **kwargs):
+    from ehtim.imaging.imager_utils import embed_imarr
+    if np.any(np.invert(mask)):
+        imarr = embed_imarr(imarr, mask, randomfloor=True)
+    g = -stv2_v_grad(imarr, kwargs['vflux'], kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
+                     pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V),
+                     norm_reg=kwargs.get('norm_reg', True),
+                     beam_size=kwargs.get('beam_size', 1))
+    return g[:, mask] if np.any(np.invert(mask)) else g
+
+
 ##################################################################################################
 # Chi^2 Data functions
 ##################################################################################################

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -26,6 +26,8 @@ from ehtim.imaging.imager_backend import (
     compute_objective_grad,
     compute_reg_dict,
     compute_reggrad_dict,
+    compute_regularizer_term,
+    compute_regularizergrad_term,
     compute_which_solve,
     make_initarr,
     pack_imarr,
@@ -3207,4 +3209,143 @@ class TestPolSolveBlock:
         ws = np.array([1, 0, 0, 1])
         out = _pol_solve_block(ws, pol='IV')
         np.testing.assert_array_equal(out, ws)
+
+
+class TestComputeRegularizerTerm:
+    """Parity between compute_regularizer_term and the legacy outer dispatchers."""
+
+    @pytest.fixture(scope="class")
+    def stokes_setup(self, make_rect_image):
+        im = make_rect_image(32, 48)
+        mask = im.imvec > 0
+        imvec = im.imvec
+        nprior = np.ones_like(imvec) / len(imvec)
+        flux = im.total_flux()
+        return im, imvec, nprior, mask, flux
+
+    @pytest.fixture(scope="class")
+    def pol_setup(self, make_rect_image):
+        im = make_rect_image(32, 48)
+        mask = im.imvec > 0
+        nimage = int(np.sum(mask))
+        rng = np.random.default_rng(7)
+        I = im.imvec[mask]
+        rho = np.clip(0.3 + 0.05 * rng.standard_normal(nimage), 0.05, 0.95)
+        phi = 0.5 + 0.1 * rng.standard_normal(nimage)
+        psi = 0.2 + 0.05 * rng.standard_normal(nimage)
+        imarr = np.array([I, rho, phi, psi])
+        priorarr = np.zeros_like(imarr)
+        flux = im.total_flux()
+        return im, imarr, priorarr, mask, flux
+
+    @pytest.fixture(scope="class")
+    def mf_setup(self, make_rect_image):
+        im = make_rect_image(32, 48)
+        imvec = im.imvec
+        nprior = imvec * 0.5
+        mask = imvec > 0
+        return im, imvec, nprior, mask
+
+    @pytest.mark.parametrize("rtype", ['flux', 'simple', 'l1', 'l1w', 'lA', 'gs',
+                                       'patch', 'cm', 'tv', 'tvlog', 'tv2',
+                                       'tv2log', 'compact', 'compact2', 'rgauss'])
+    def test_parity_stokes_value(self, stokes_setup, rtype):
+        im, imvec, nprior, mask, flux = stokes_setup
+        kwargs = dict(nprior=nprior, flux=flux,
+                      xdim=im.xdim, ydim=im.ydim, psize=im.psize,
+                      beam_size=20 * eh.RADPERUAS,
+                      alpha_A=5000.0, epsilon_tv=0.0,
+                      major=50 * eh.RADPERUAS, minor=60 * eh.RADPERUAS,
+                      PA=np.pi / 3, norm_reg=True)
+        from ehtim.imaging.imager_utils import regularizer
+        legacy = regularizer(imvec, nprior, mask, flux,
+                             im.xdim, im.ydim, im.psize, rtype,
+                             beam_size=kwargs['beam_size'],
+                             alpha_A=kwargs['alpha_A'],
+                             epsilon_tv=kwargs['epsilon_tv'],
+                             major=kwargs['major'], minor=kwargs['minor'],
+                             PA=kwargs['PA'], norm_reg=True)
+        new = compute_regularizer_term(imvec, rtype, mask, **kwargs)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    @pytest.mark.parametrize("rtype", ['flux', 'simple', 'tv', 'rgauss'])
+    def test_parity_stokes_grad(self, stokes_setup, rtype):
+        im, imvec, nprior, mask, flux = stokes_setup
+        kwargs = dict(nprior=nprior, flux=flux,
+                      xdim=im.xdim, ydim=im.ydim, psize=im.psize,
+                      beam_size=20 * eh.RADPERUAS,
+                      alpha_A=5000.0, epsilon_tv=0.0,
+                      major=50 * eh.RADPERUAS, minor=60 * eh.RADPERUAS,
+                      PA=np.pi / 3, norm_reg=True)
+        from ehtim.imaging.imager_utils import regularizergrad
+        legacy = regularizergrad(imvec, nprior, mask, flux,
+                                 im.xdim, im.ydim, im.psize, rtype,
+                                 beam_size=kwargs['beam_size'],
+                                 alpha_A=kwargs['alpha_A'],
+                                 epsilon_tv=kwargs['epsilon_tv'],
+                                 major=kwargs['major'], minor=kwargs['minor'],
+                                 PA=kwargs['PA'], norm_reg=True)
+        new = compute_regularizergrad_term(imvec, rtype, mask, **kwargs)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    @pytest.mark.parametrize("rtype", ['msimple', 'hw', 'ptv', 'vflux',
+                                       'l1v', 'l2v', 'vtv', 'vtv2'])
+    def test_parity_pol_value(self, pol_setup, rtype):
+        im, imarr, priorarr, mask, flux = pol_setup
+        kwargs = dict(flux=flux, pflux=flux, vflux=flux,
+                      xdim=im.xdim, ydim=im.ydim, psize=im.psize,
+                      beam_size=20 * eh.RADPERUAS, norm_reg=True)
+        from ehtim.imaging.pol_imager_utils import polregularizer
+        legacy = polregularizer(imarr, priorarr, mask, flux, flux, flux,
+                                im.xdim, im.ydim, im.psize, rtype,
+                                beam_size=kwargs['beam_size'], norm_reg=True)
+        new = compute_regularizer_term(imarr, rtype, mask, **kwargs)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    @pytest.mark.parametrize("rtype", ['msimple', 'hw', 'ptv', 'vflux', 'vtv2'])
+    def test_parity_pol_grad(self, pol_setup, rtype):
+        from ehtim.imaging.pol_imager_utils import polregularizergrad
+        im, imarr, priorarr, mask, flux = pol_setup
+        # Pass pol_solve explicitly: in practice compute_reggrad_dict always
+        # forwards the imager's which_solve, so the leaf defaults are not
+        # exercised during normal imaging.
+        pol_solve = (1, 1, 1, 1)
+        kwargs = dict(flux=flux, pflux=flux, vflux=flux,
+                      xdim=im.xdim, ydim=im.ydim, psize=im.psize,
+                      beam_size=20 * eh.RADPERUAS, norm_reg=True,
+                      pol_solve=pol_solve)
+        legacy = polregularizergrad(imarr, priorarr, mask, flux, flux, flux,
+                                    im.xdim, im.ydim, im.psize, rtype,
+                                    beam_size=kwargs['beam_size'],
+                                    norm_reg=True, pol_solve=pol_solve)
+        new = compute_regularizergrad_term(imarr, rtype, mask, **kwargs)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    @pytest.mark.parametrize("rtype", ['l2_alpha', 'l2_beta', 'l2_rm', 'l2_cm',
+                                       'tv_alpha', 'tv_beta', 'tv_rm', 'tv_cm'])
+    def test_parity_mf_value(self, mf_setup, rtype):
+        im, imvec, nprior, mask = mf_setup
+        kwargs = dict(nprior=nprior, xdim=im.xdim, ydim=im.ydim, psize=im.psize,
+                      beam_size=20 * eh.RADPERUAS, norm_reg=True)
+        from ehtim.imaging.multifreq_imager_utils import regularizer_mf
+        legacy = regularizer_mf(imvec, nprior, mask, im.xdim, im.ydim, im.psize,
+                                rtype, beam_size=kwargs['beam_size'], norm_reg=True)
+        new = compute_regularizer_term(imvec, rtype, mask, **kwargs)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    @pytest.mark.parametrize("rtype", ['l2_alpha', 'tv_alpha', 'l2_rm', 'tv_cm'])
+    def test_parity_mf_grad(self, mf_setup, rtype):
+        from ehtim.imaging.multifreq_imager_utils import regularizergrad_mf
+        im, imvec, nprior, mask = mf_setup
+        kwargs = dict(nprior=nprior, xdim=im.xdim, ydim=im.ydim, psize=im.psize,
+                      beam_size=20 * eh.RADPERUAS, norm_reg=True)
+        legacy = regularizergrad_mf(imvec, nprior, mask, im.xdim, im.ydim, im.psize,
+                                    rtype, beam_size=kwargs['beam_size'], norm_reg=True)
+        new = compute_regularizergrad_term(imvec, rtype, mask, **kwargs)
+        np.testing.assert_allclose(new, legacy, rtol=1e-12, atol=1e-15)
+
+    def test_unknown_regname_raises(self, stokes_setup):
+        im, imvec, nprior, mask, flux = stokes_setup
+        with pytest.raises(Exception, match="not recognized"):
+            compute_regularizer_term(imvec, 'not_a_regularizer', mask)
 

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -10,6 +10,7 @@ import pytest
 
 import ehtim as eh
 import ehtim.imaging.imager_utils as iu
+import ehtim.imaging.pol_imager_utils as pu
 
 # Tolerances for gradient checks (calibrated on 32x48 synthetic Gaussian)
 MEDIAN_FRAC_TOL = 0.05
@@ -120,3 +121,148 @@ def _gradient_check(reg_setup, rtype):
     compare_floor = np.min(np.abs(grad_exact_sampled)) * 1e-20 + 1e-100
     frac_diff = np.abs((grad_numeric - grad_exact_sampled) / (np.abs(grad_exact_sampled) + compare_floor))
     return np.median(frac_diff), np.max(frac_diff)
+
+
+# polregularizer / polregularizergrad operate on a (4, nimage) imarr in
+# solver space: imarr[0]=I, imarr[1]=rho, imarr[2]=phi=2*chi, imarr[3]=psi.
+# Linear-pol regs solve slots (rho, phi); circular-pol regs solve psi only.
+POL_LIN_REGS = ('msimple', 'hw', 'ptv')
+POL_CIRC_REGS = ('vflux', 'l1v', 'l2v', 'vtv', 'vtv2')
+
+POL_MEDIAN_FRAC_TOL = 0.05
+POL_MAX_FRAC_TOL = 0.6
+# TV-style regs (ptv, vtv, vtv2) have a sqrt-of-squared-differences denominator
+# that goes to ~0 on smooth regions; a few FD samples near image edges land in
+# the small-denominator regime where the linear approximation breaks down.
+POL_MAX_FRAC_TOL_TV = 2.0
+
+
+def _pol_solve_for(rtype):
+    if rtype in POL_LIN_REGS:
+        return pu.POL_SOLVE_DEFAULT
+    return pu.POL_SOLVE_DEFAULT_V
+
+
+def _pol_tols(rtype):
+    if rtype in ('ptv', 'vtv', 'vtv2'):
+        return POL_MEDIAN_FRAC_TOL, POL_MAX_FRAC_TOL_TV
+    return POL_MEDIAN_FRAC_TOL, POL_MAX_FRAC_TOL
+
+
+@pytest.fixture(scope="module")
+def polreg_setup(make_rect_image):
+    """32x48 Gaussian Stokes I with jittered pol structure.
+
+    Per-pixel jitter on rho / phi / psi is required so TV-style regularizers
+    (ptv, vtv, vtv2) get a non-degenerate denominator in their gradient
+    (which is sqrt of squared spatial differences and goes to 0 on uniform
+    fields).
+    """
+    im = make_rect_image(32, 48)
+    im.pulse = eh.observing.pulses.deltaPulse2D
+
+    mask = im.imvec > 0
+    nimage = int(np.sum(mask))
+
+    rng = np.random.default_rng(7)
+    I = im.imvec[mask]
+    rho = np.clip(0.3 + 0.05 * rng.standard_normal(nimage), 0.05, 0.95)
+    phi = 0.5 + 0.1 * rng.standard_normal(nimage)
+    psi = 0.2 + 0.05 * rng.standard_normal(nimage)
+    imarr = np.array([I, rho, phi, psi])
+    priorarr = np.zeros_like(imarr)
+
+    flux = im.total_flux()
+    return im, imarr, priorarr, mask, flux, flux, flux
+
+
+def _polreg_kwargs(norm_reg=True):
+    return dict(beam_size=BEAM_SIZE, norm_reg=norm_reg)
+
+
+class TestPolRegularizerValues:
+    """Each REGULARIZERS_POL regularizer returns a finite, non-zero value."""
+
+    @pytest.mark.parametrize("rtype", pu.REGULARIZERS_POL)
+    @pytest.mark.parametrize("norm_reg", [True, False], ids=["normalized", "unnormalized"])
+    def test_returns_finite(self, polreg_setup, rtype, norm_reg):
+        im, imarr, priorarr, mask, flux, pflux, vflux = polreg_setup
+        val = pu.polregularizer(
+            imarr, priorarr, mask, flux, pflux, vflux,
+            im.xdim, im.ydim, im.psize, rtype,
+            **_polreg_kwargs(norm_reg=norm_reg),
+        )
+        assert np.isfinite(val), f"{rtype} (norm_reg={norm_reg}) returned {val}"
+
+    @pytest.mark.parametrize("rtype", pu.REGULARIZERS_POL)
+    def test_returns_nonzero(self, polreg_setup, rtype):
+        # Catches dispatch typos: a name listed in REGULARIZERS_POL whose
+        # body branch never matches will silently return 0.
+        im, imarr, priorarr, mask, flux, pflux, vflux = polreg_setup
+        val = pu.polregularizer(
+            imarr, priorarr, mask, flux, pflux, vflux,
+            im.xdim, im.ydim, im.psize, rtype,
+            **_polreg_kwargs(),
+        )
+        assert val != 0, f"{rtype} returned 0 - dispatch likely missed"
+
+
+class TestPolRegularizerGradients:
+    """Analytic gradients match numeric finite differences in pol_solve slots."""
+
+    @pytest.mark.parametrize("rtype", pu.REGULARIZERS_POL)
+    def test_median_frac_diff(self, polreg_setup, rtype):
+        median_tol, _ = _pol_tols(rtype)
+        median_frac, _ = _pol_gradient_check(polreg_setup, rtype)
+        assert median_frac < median_tol, (
+            f"{rtype} median fractional gradient diff = {median_frac:.6f} (tol={median_tol})"
+        )
+
+    @pytest.mark.parametrize("rtype", pu.REGULARIZERS_POL)
+    def test_max_frac_diff(self, polreg_setup, rtype):
+        _, max_tol = _pol_tols(rtype)
+        _, max_frac = _pol_gradient_check(polreg_setup, rtype)
+        assert max_frac < max_tol, (
+            f"{rtype} max fractional gradient diff = {max_frac:.6f} (tol={max_tol})"
+        )
+
+
+def _pol_gradient_check(polreg_setup, rtype):
+    """FD-vs-analytic check across N pixels in each pol_solve-active slot."""
+    im, imarr, priorarr, mask, flux, pflux, vflux = polreg_setup
+    kwargs = _polreg_kwargs()
+    pol_solve = _pol_solve_for(rtype)
+
+    y0 = pu.polregularizer(
+        imarr, priorarr, mask, flux, pflux, vflux,
+        im.xdim, im.ydim, im.psize, rtype, **kwargs,
+    )
+    grad_exact = pu.polregularizergrad(
+        imarr, priorarr, mask, flux, pflux, vflux,
+        im.xdim, im.ydim, im.psize, rtype,
+        pol_solve=pol_solve, **kwargs,
+    )
+
+    rng = np.random.default_rng(RNG_SEED)
+    nimage = imarr.shape[1]
+    sample_idx = rng.choice(nimage, size=N_GRAD_SAMPLES, replace=False)
+
+    frac_diffs = []
+    for slot in range(4):
+        if pol_solve[slot] == 0:
+            continue
+        for j in sample_idx:
+            dx = max(GRAD_DX_REL * abs(imarr[slot, j]), GRAD_DX_FLOOR)
+            imarr2 = imarr.copy()
+            imarr2[slot, j] += dx
+            y1 = pu.polregularizer(
+                imarr2, priorarr, mask, flux, pflux, vflux,
+                im.xdim, im.ydim, im.psize, rtype, **kwargs,
+            )
+            numeric = (y1 - y0) / dx
+            exact = grad_exact[slot, j]
+            compare_floor = max(abs(exact), 1e-100) * 1e-20 + 1e-100
+            frac_diffs.append(abs((numeric - exact) / (abs(exact) + compare_floor)))
+
+    frac_diffs = np.array(frac_diffs)
+    return float(np.median(frac_diffs)), float(np.max(frac_diffs))

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -9,7 +9,9 @@ import numpy as np
 import pytest
 
 import ehtim as eh
+import ehtim.imaging.imager_backend as ib
 import ehtim.imaging.imager_utils as iu
+import ehtim.imaging.multifreq_imager_utils as mfu
 import ehtim.imaging.pol_imager_utils as pu
 
 # Tolerances for gradient checks (calibrated on 32x48 synthetic Gaussian)
@@ -266,3 +268,95 @@ def _pol_gradient_check(polreg_setup, rtype):
 
     frac_diffs = np.array(frac_diffs)
     return float(np.median(frac_diffs)), float(np.max(frac_diffs))
+
+
+# regularizer_mf dispatches by string prefix: names starting with 'l2_'
+# compute an L2 distance from the prior; names starting with 'tv_' compute
+# spatial total variation. The 12 names in REGULARIZERS_SPECTRAL only differ
+# in which spectral coefficient slot (alpha / beta / rm / cm / _p variants)
+# the imager passes through; the computation itself is shared between them.
+
+
+@pytest.fixture(scope="module")
+def mfreg_setup(make_rect_image):
+    """32x48 spectral coefficient vector with a half-amplitude prior."""
+    im = make_rect_image(32, 48)
+    imvec = im.imvec
+    nprior = imvec * 0.5
+    mask = imvec > 0
+    return im, imvec, nprior, mask
+
+
+class TestMFRegularizerValues:
+    """REGULARIZERS_SPECTRAL regularizers return finite, non-zero values."""
+
+    @pytest.mark.parametrize("rtype", ib.REGULARIZERS_SPECTRAL)
+    @pytest.mark.parametrize("norm_reg", [True, False], ids=["normalized", "unnormalized"])
+    def test_returns_finite(self, mfreg_setup, rtype, norm_reg):
+        im, imvec, nprior, mask = mfreg_setup
+        val = mfu.regularizer_mf(
+            imvec, nprior, mask, im.xdim, im.ydim, im.psize, rtype,
+            beam_size=BEAM_SIZE, norm_reg=norm_reg,
+        )
+        assert np.isfinite(val), f"{rtype} (norm_reg={norm_reg}) returned {val}"
+
+    @pytest.mark.parametrize("rtype", ib.REGULARIZERS_SPECTRAL)
+    def test_returns_nonzero(self, mfreg_setup, rtype):
+        # A name that matches neither 'l2_' nor 'tv_' prefix silently returns 0.
+        # Guards against a future addition to REGULARIZERS_SPECTRAL that breaks
+        # the naming convention.
+        im, imvec, nprior, mask = mfreg_setup
+        val = mfu.regularizer_mf(
+            imvec, nprior, mask, im.xdim, im.ydim, im.psize, rtype,
+            beam_size=BEAM_SIZE,
+        )
+        assert val != 0, f"{rtype} returned 0 - dispatch likely missed"
+
+
+class TestMFRegularizerGradients:
+    """Analytic regularizergrad_mf matches numeric finite differences."""
+
+    @pytest.mark.parametrize("rtype", ib.REGULARIZERS_SPECTRAL)
+    def test_median_frac_diff(self, mfreg_setup, rtype):
+        median_frac, _ = _mfreg_gradient_check(mfreg_setup, rtype)
+        assert median_frac < MEDIAN_FRAC_TOL, (
+            f"{rtype} median fractional gradient diff = {median_frac:.6f}"
+        )
+
+    @pytest.mark.parametrize("rtype", ib.REGULARIZERS_SPECTRAL)
+    def test_max_frac_diff(self, mfreg_setup, rtype):
+        _, max_frac = _mfreg_gradient_check(mfreg_setup, rtype)
+        assert max_frac < MAX_FRAC_TOL, (
+            f"{rtype} max fractional gradient diff = {max_frac:.6f}"
+        )
+
+
+def _mfreg_gradient_check(mfreg_setup, rtype):
+    """Compare analytic and finite-difference gradients on N random pixels."""
+    im, imvec, nprior, mask = mfreg_setup
+    kwargs = dict(beam_size=BEAM_SIZE, norm_reg=True)
+
+    y0 = mfu.regularizer_mf(
+        imvec, nprior, mask, im.xdim, im.ydim, im.psize, rtype, **kwargs,
+    )
+    grad_exact = mfu.regularizergrad_mf(
+        imvec, nprior, mask, im.xdim, im.ydim, im.psize, rtype, **kwargs,
+    )
+
+    rng = np.random.default_rng(RNG_SEED)
+    sample_idx = rng.choice(len(imvec), size=N_GRAD_SAMPLES, replace=False)
+
+    grad_numeric = np.zeros(N_GRAD_SAMPLES)
+    for i, j in enumerate(sample_idx):
+        dx = max(GRAD_DX_REL * abs(imvec[j]), GRAD_DX_FLOOR)
+        imvec2 = imvec.copy()
+        imvec2[j] += dx
+        y1 = mfu.regularizer_mf(
+            imvec2, nprior, mask, im.xdim, im.ydim, im.psize, rtype, **kwargs,
+        )
+        grad_numeric[i] = (y1 - y0) / dx
+
+    grad_exact_sampled = grad_exact[sample_idx]
+    compare_floor = np.min(np.abs(grad_exact_sampled)) * 1e-20 + 1e-100
+    frac_diff = np.abs((grad_numeric - grad_exact_sampled) / (np.abs(grad_exact_sampled) + compare_floor))
+    return float(np.median(frac_diff)), float(np.max(frac_diff))


### PR DESCRIPTION
> ⚠️ **Split per @achael's request** ([comment](https://github.com/achael/eht-imaging/pull/238#issuecomment-3175862175)):
> the two bug-fix commits (`stv_pol_grad` factor-of-2 + neighbor-roll, and the `vtv2` typo in `REGULARIZERS_POL`) have been removed from this branch and ship separately in **#240** against `dev` for fast release.
> **This PR will have failing CI on `ptv` FD tests until #240 merges to `dev` and `dev` is merged into `dev-backend`.** Rebasing onto the synced `dev-backend` will turn CI green.

Closes roadmap tasks **2.3** (parametrized regularizer FD parity tests) + **2.5** (regularizer dispatcher refactor, mirroring PR #235's chisq pattern).

- **`_REGULARIZER_DISPATCH` + `compute_regularizer_term` / `compute_regularizergrad_term`** in `imager_backend.py`. 35 regularizer names (Stokes-I + pol + mf) routed through one dispatch table.
- **6 legacy outer dispatchers → thin shims** delegating to the term family. Now raise on unknown stype (silent-zero gone). Same pattern as PR #235's chisq shims.
- **`compute_reg_dict` / `compute_reggrad_dict` rewired** to call the term dispatcher directly. Body shrinks from ~110 to ~50 lines.
- **`tests/test_regularizers.py`** parametrized FD parity for all 35 regnames × value + gradient (was 15 Stokes-I only). These are the tests that caught the `stv_pol_grad` bug now in #240.

Legacy outer dispatchers silently returned 0 on unknown stype. Shims now raise. All in-tree callers use validated names; external user scripts that relied on silent-zero may need updates.

## Why CI will be red until #240 syncs

The parametrized pol FD test parametrizes over `REGULARIZERS_POL`, which includes `'ptv'`. With the bug fix removed from this branch, the analytic `stv_pol_grad` is still wrong on the underlying `dev-backend`, so the FD parity test for `'ptv'` will diverge. Once #240 merges to `dev` and `dev` is merged into `dev-backend`, this branch rebases onto the synced base and CI returns to green.