### PR TITLE
Promote config bundles to NamedTuples

### DIFF
--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -37,6 +37,7 @@ from ehtim.imaging.imager_backend import (
     DATATERMS,
     DATATERMS_POL,
     POLARIZATION_MODES,
+    DataWeighting,
     RegParams,
     compute_chisq_dict,
     compute_chisqgrad_dict,
@@ -751,16 +752,16 @@ class Imager:
         )
 
     def _full_data_weighting_params(self):
-        """Bundle data-weighting params into a single dict for the backend."""
-        return {
-            'maxset': self.maxset_next,
-            'debias': self.debias_next,
-            'snrcut': self.snrcut_next,
-            'weighting': self.weighting_next,
-            'systematic_noise': self.systematic_noise_next,
-            'systematic_cphase_noise': self.systematic_cphase_noise_next,
-            'cp_uv_min': self.cp_uv_min,
-        }
+        """Bundle data-weighting params into a DataWeighting NamedTuple for the backend."""
+        return DataWeighting(
+            maxset=self.maxset_next,
+            debias=self.debias_next,
+            snrcut=self.snrcut_next,
+            weighting=self.weighting_next,
+            systematic_noise=self.systematic_noise_next,
+            systematic_cphase_noise=self.systematic_cphase_noise_next,
+            cp_uv_min=self.cp_uv_min,
+        )
 
     def _full_fft_params(self):
         """Bundle FFT/NFFT params into a single dict for the backend."""

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -190,7 +190,7 @@ class Imager:
         self.beam_size = self.obslist_next[0].res()
         self.regparams = {k: kwargs.get(k, REGPARAMS_DEFAULT[k]) for k in REGPARAMS_DEFAULT.keys()}
 
-        # FFT / Fourier-grid parameters (consumed by the backend via self._full_fft_params())
+        # FFT / Fourier-grid parameters (consumed by the backend via self._fft_params())
         ttype = kwargs.get('ttype', 'nfft')
         self._fft_gridder_prad = kwargs.get('fft_gridder_prad', GRIDDER_P_RAD_DEFAULT)
         self._fft_conv_func = kwargs.get('fft_conv_func', GRIDDER_CONV_FUNC_DEFAULT)
@@ -699,7 +699,7 @@ class Imager:
             self.freq_list, self.reffreq, self._config,
             self.norm_init, self.flux_next, self.clipfloor_next,
             sorted(self.dat_term_next.keys()),
-            self._full_data_weighting_params(), self._full_fft_params(),
+            self._data_weighting_params(), self._fft_params(),
             compute_data=self._change_imgr_params,
             prior_data_tuples=getattr(self, "_data_tuples", None),
         )
@@ -739,7 +739,7 @@ class Imager:
             self._which_solve, self._nimage,
         )
 
-    def _full_regparams(self):
+    def _regparams(self):
         """Bundle all regularizer params into a RegParams NamedTuple for the backend."""
         return RegParams(
             flux=self.flux_next,
@@ -757,7 +757,7 @@ class Imager:
             epsilon_tv=self.regparams['epsilon_tv'],
         )
 
-    def _full_data_weighting_params(self):
+    def _data_weighting_params(self):
         """Bundle data-weighting params into a DataWeighting NamedTuple for the backend."""
         return DataWeighting(
             maxset=self.maxset_next,
@@ -769,7 +769,7 @@ class Imager:
             cp_uv_min=self.cp_uv_min,
         )
 
-    def _full_fft_params(self):
+    def _fft_params(self):
         """Bundle Fourier-grid params into a FourierGridParams NamedTuple for the backend."""
         return FourierGridParams(
             fft_pad_factor=self._fft_pad_factor,
@@ -785,7 +785,7 @@ class Imager:
         return compute_reg_dict(
             imcur, sorted(self.reg_term_next.keys()), self._config,
             self._logfreqratio_list, len(self.obslist_next),
-            self._prior_arr, self.norm_reg, self._full_regparams(),
+            self._prior_arr, self.norm_reg, self._regparams(),
             self._embed_mask,
         )
 
@@ -796,7 +796,7 @@ class Imager:
         return compute_reggrad_dict(
             imcur, sorted(self.reg_term_next.keys()), self._config,
             self._logfreqratio_list, len(self.obslist_next),
-            self._prior_arr, self.norm_reg, self._full_regparams(),
+            self._prior_arr, self.norm_reg, self._regparams(),
             self._embed_mask,
             self._which_solve, self._nimage,
         )
@@ -808,7 +808,7 @@ class Imager:
             self._which_solve, self._data_tuples,
             self._logfreqratio_list, len(self.obslist_next),
             self.dat_term_next, self.reg_term_next,
-            self._prior_arr, self.norm_reg, self._full_regparams(),
+            self._prior_arr, self.norm_reg, self._regparams(),
             self._embed_mask,
         )
 
@@ -819,7 +819,7 @@ class Imager:
             self._which_solve, self._data_tuples,
             self._logfreqratio_list, len(self.obslist_next),
             self.dat_term_next, self.reg_term_next,
-            self._prior_arr, self.norm_reg, self._full_regparams(),
+            self._prior_arr, self.norm_reg, self._regparams(),
             self._embed_mask, self._nimage,
         )
 

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -38,6 +38,7 @@ from ehtim.imaging.imager_backend import (
     DATATERMS_POL,
     POLARIZATION_MODES,
     DataWeighting,
+    FourierGridParams,
     RegParams,
     compute_chisq_dict,
     compute_chisqgrad_dict,
@@ -764,13 +765,13 @@ class Imager:
         )
 
     def _full_fft_params(self):
-        """Bundle FFT/NFFT params into a single dict for the backend."""
-        return {
-            'fft_pad_factor': self._fft_pad_factor,
-            'fft_conv_func': self._fft_conv_func,
-            'fft_gridder_prad': self._fft_gridder_prad,
-            'fft_interp_order': self._fft_interp_order,
-        }
+        """Bundle Fourier-grid params into a FourierGridParams NamedTuple for the backend."""
+        return FourierGridParams(
+            fft_pad_factor=self._fft_pad_factor,
+            fft_conv_func=self._fft_conv_func,
+            fft_gridder_prad=self._fft_gridder_prad,
+            fft_interp_order=self._fft_interp_order,
+        )
 
     def make_reg_dict(self, imcur):
         """Make a dictionary of current regularizer values

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -159,10 +159,9 @@ class Imager:
         self.pflux_next = kwargs.get('pflux', flux)
         self.vflux_next = kwargs.get('vflux', flux)
 
-        # Polarization and image transforms
-        self.pol_next = kwargs.get('pol', self.init_next.pol_prim)
-        self.transform_next = kwargs.get('transform', ['log','mcv'])
-        self.transform_next = np.array([self.transform_next]).flatten() #so we can handle multiple transforms
+        # Polarization and image transforms (consumed by the backend via self._config)
+        pol = kwargs.get('pol', self.init_next.pol_prim)
+        transforms = np.array([kwargs.get('transform', ['log', 'mcv'])]).flatten()
 
         # Weighting/debiasing/snr cut/systematic noise
         self.debias_next = kwargs.get('debias', False)
@@ -191,21 +190,16 @@ class Imager:
         self.beam_size = self.obslist_next[0].res()
         self.regparams = {k: kwargs.get(k, REGPARAMS_DEFAULT[k]) for k in REGPARAMS_DEFAULT.keys()}
 
-        # FFT parameters
-        self._ttype = kwargs.get('ttype', 'nfft')
+        # FFT / Fourier-grid parameters (consumed by the backend via self._full_fft_params())
+        ttype = kwargs.get('ttype', 'nfft')
         self._fft_gridder_prad = kwargs.get('fft_gridder_prad', GRIDDER_P_RAD_DEFAULT)
         self._fft_conv_func = kwargs.get('fft_conv_func', GRIDDER_CONV_FUNC_DEFAULT)
         self._fft_pad_factor = kwargs.get('fft_pad_factor', FFT_PAD_DEFAULT)
         self._fft_interp_order = kwargs.get('fft_interp_order', FFT_INTERP_DEFAULT)
 
         # multifrequency
-        self.mf_next = kwargs.get('mf',False)
-
-        self.mf_order = kwargs.get('mf_order',0)
-        self.mf_order_pol = kwargs.get('mf_order_pol',0)
-        self.mf_rm = kwargs.get('mf_rm',0)
-        self.mf_cm = kwargs.get('mf_cm',0)
-        self.mf_flux = kwargs.get('mf_flux',[self.flux_next]) # TODO: merge these
+        mf = kwargs.get('mf', False)
+        self.mf_flux = kwargs.get('mf_flux', [self.flux_next])  # TODO: merge these
 
         if kwargs.get('mf_which_solve') is not None:
             raise Exception("'mf_which_solve' argument for multifrequency imaging is deprecated -- use 'mf_order' instead!")
@@ -216,10 +210,17 @@ class Imager:
         self._change_imgr_params = True
         self.nruns = 0
 
-        # Bundled static config consumed by the backend. Must be (re)built any
-        # time make_image() mutates pol / mf / mf_order / mf_order_pol / mf_rm /
-        # mf_cm — see the _replace() call in make_image() below.
-        self._config = self._full_imager_config()
+        # Bundled static config consumed by the backend. Must be rebuilt via
+        # _replace() any time make_image() overrides pol / mf / mf_*.
+        self._config = ImagerConfig(
+            pol=pol, transforms=transforms, ttype=ttype, mf=mf,
+            mf_config=MfConfig(
+                mf_order=kwargs.get('mf_order', 0),
+                mf_order_pol=kwargs.get('mf_order_pol', 0),
+                mf_rm=kwargs.get('mf_rm', 0),
+                mf_cm=kwargs.get('mf_cm', 0),
+            ),
+        )
 
         # Set embedding matrices and prepare imager
         self.check_params()
@@ -775,21 +776,6 @@ class Imager:
             fft_conv_func=self._fft_conv_func,
             fft_gridder_prad=self._fft_gridder_prad,
             fft_interp_order=self._fft_interp_order,
-        )
-
-    def _full_imager_config(self):
-        """Bundle static imager config into an ImagerConfig NamedTuple for the backend."""
-        return ImagerConfig(
-            pol=self.pol_next,
-            transforms=self.transform_next,
-            ttype=self._ttype,
-            mf=self.mf_next,
-            mf_config=MfConfig(
-                mf_order=self.mf_order,
-                mf_order_pol=self.mf_order_pol,
-                mf_rm=self.mf_rm,
-                mf_cm=self.mf_cm,
-            ),
         )
 
     def make_reg_dict(self, imcur):

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -689,10 +689,9 @@ class Imager:
         state = compute_init_state(
             self.obslist_next, self.init_next, self.prior_next,
             self.freq_list, self.reffreq,
-            self.pol_next, self.mf_next, self.transform_next,
-            self.mf_order, self.mf_order_pol, self.mf_rm, self.mf_cm,
+            self._full_imager_config(),
             self.norm_init, self.flux_next, self.clipfloor_next,
-            sorted(self.dat_term_next.keys()), self._ttype,
+            sorted(self.dat_term_next.keys()),
             self._full_data_weighting_params(), self._full_fft_params(),
             compute_data=self._change_imgr_params,
             prior_data_tuples=getattr(self, "_data_tuples", None),

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -716,10 +716,9 @@ class Imager:
            input is image array transformed to bounded values
         """
         return compute_chisq_dict(
-            imcur, sorted(self.dat_term_next.keys()),
-            self.mf_next, self.pol_next,
+            imcur, sorted(self.dat_term_next.keys()), self._full_imager_config(),
             self._data_tuples, self._logfreqratio_list, len(self.obslist_next),
-            self._ttype, self._embed_mask,
+            self._embed_mask,
         )
 
     def make_chisqgrad_dict(self, imcur):
@@ -727,10 +726,9 @@ class Imager:
            input is image array transformed to bounded values
         """
         return compute_chisqgrad_dict(
-            imcur, sorted(self.dat_term_next.keys()),
-            self.mf_next, self.pol_next,
+            imcur, sorted(self.dat_term_next.keys()), self._full_imager_config(),
             self._data_tuples, self._logfreqratio_list, len(self.obslist_next),
-            self._ttype, self._embed_mask,
+            self._embed_mask,
             self._which_solve, self._nimage,
         )
 
@@ -793,8 +791,7 @@ class Imager:
            input is image array transformed to bounded values
         """
         return compute_reg_dict(
-            imcur, sorted(self.reg_term_next.keys()),
-            self.mf_next, self.pol_next,
+            imcur, sorted(self.reg_term_next.keys()), self._full_imager_config(),
             self._logfreqratio_list, len(self.obslist_next),
             self._prior_arr, self.norm_reg, self._full_regparams(),
             self._embed_mask,
@@ -805,8 +802,7 @@ class Imager:
            input is image array transformed to bounded values
         """
         return compute_reggrad_dict(
-            imcur, sorted(self.reg_term_next.keys()),
-            self.mf_next, self.pol_next,
+            imcur, sorted(self.reg_term_next.keys()), self._full_imager_config(),
             self._logfreqratio_list, len(self.obslist_next),
             self._prior_arr, self.norm_reg, self._full_regparams(),
             self._embed_mask,
@@ -816,25 +812,23 @@ class Imager:
     def objfunc(self, imvec):
         """Current objective function."""
         return compute_objective(
-            imvec, self._init_arr,
-            self.mf_next, self.pol_next,
+            imvec, self._init_arr, self._full_imager_config(),
             self._which_solve, self._data_tuples,
             self._logfreqratio_list, len(self.obslist_next),
             self.dat_term_next, self.reg_term_next,
             self._prior_arr, self.norm_reg, self._full_regparams(),
-            self.transform_next, self._embed_mask, self._ttype,
+            self._embed_mask,
         )
 
     def objgrad(self, imvec):
         """Current objective function gradient."""
         return compute_objective_grad(
-            imvec, self._init_arr,
-            self.mf_next, self.pol_next,
+            imvec, self._init_arr, self._full_imager_config(),
             self._which_solve, self._data_tuples,
             self._logfreqratio_list, len(self.obslist_next),
             self.dat_term_next, self.reg_term_next,
             self._prior_arr, self.norm_reg, self._full_regparams(),
-            self.transform_next, self._embed_mask, self._ttype, self._nimage,
+            self._embed_mask, self._nimage,
         )
 
     def plotcur(self, imvec, **kwargs):

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -216,6 +216,11 @@ class Imager:
         self._change_imgr_params = True
         self.nruns = 0
 
+        # Bundled static config consumed by the backend. Must be (re)built any
+        # time make_image() mutates pol / mf / mf_order / mf_order_pol / mf_rm /
+        # mf_cm — see the _replace() call in make_image() below.
+        self._config = self._full_imager_config()
+
         # Set embedding matrices and prepare imager
         self.check_params()
         self.check_limits()
@@ -446,11 +451,14 @@ class Imager:
         print(f"Imager run {int(self.nruns)+1} ")
 
         # multifrequency parameters
-        self.mf_next = mf
-        self.mf_order = kwargs.get('mf_order', self.mf_order)
-        self.mf_order_pol = kwargs.get('mf_order_pol', self.mf_order_pol)
-        self.mf_rm = kwargs.get('mf_rm', self.mf_rm)
-        self.mf_cm = kwargs.get('mf_cm', self.mf_cm)
+        mf_cfg = self._config.mf_config
+        new_mf_cfg = mf_cfg._replace(
+            mf_order=kwargs.get('mf_order', mf_cfg.mf_order),
+            mf_order_pol=kwargs.get('mf_order_pol', mf_cfg.mf_order_pol),
+            mf_rm=kwargs.get('mf_rm', mf_cfg.mf_rm),
+            mf_cm=kwargs.get('mf_cm', mf_cfg.mf_cm),
+        )
+        self._config = self._config._replace(mf=mf, mf_config=new_mf_cfg)
         if kwargs.get('mf_which_solve') is not None:
             raise Exception("'mf_which_solve' argument for multifrequency imaging is deprecated -- use 'mf_order' instead!")
         if kwargs.get('reg_all_freq_mf') is not None:
@@ -458,13 +466,13 @@ class Imager:
 
         # polarization parameters
         if pol is None:
-            pol_prim = self.pol_next
+            pol_prim = self._config.pol
         else:
-            self.pol_next = pol
+            self._config = self._config._replace(pol=pol)
             pol_prim = pol
 
         # For polarimetric imaging, we must switch polrep to Stokes
-        if self.pol_next in POLARIZATION_MODES:
+        if self._config.pol in POLARIZATION_MODES:
             print("Imaging Polarization: switching image polrep to Stokes!")
             self.prior_next = self.prior_next.switch_polrep(polrep_out='stokes', pol_prim_out='I')
             self.init_next = self.init_next.switch_polrep(polrep_out='stokes', pol_prim_out='I')
@@ -509,7 +517,7 @@ class Imager:
         outarr = unpack_imarr(out, self._init_arr, self._which_solve)
 
         # apply image transform to bounded values
-        outarr = transform_imarr(outarr, self.transform_next, self._which_solve)
+        outarr = transform_imarr(outarr, self._config.transforms, self._which_solve)
 
         # get and print final statistics
         outstr = ""
@@ -551,8 +559,7 @@ class Imager:
         """Check parameter consistency.
         """
         validate_params(
-            self.prior_next, self.init_next,
-            self._full_imager_config(),
+            self.prior_next, self.init_next, self._config,
             self.dat_term_next.keys(), self.reg_term_next.keys(),
             self.freq_list,
         )
@@ -561,7 +568,7 @@ class Imager:
         if self.nruns == 0:
             return
 
-        if self.pol_next != self.pol_last():
+        if self._config.pol != self.pol_last():
             print("changed polarization!")
             self._change_imgr_params = True
             return
@@ -628,23 +635,23 @@ class Imager:
             print("changed refrence frequency!")
             self._change_imgr_params = True
             return
-        if self.mf_next != self.mf_last():
+        if self._config.mf != self.mf_last():
             print("changed multifrequncy strategy!")
             self._change_imgr_params = True
             return
-        if self.mf_order != self.mf_order_last():
+        if self._config.mf_config.mf_order != self.mf_order_last():
             print("changed multifrequncy order!")
             self._change_imgr_params = True
             return
-        if self.mf_order_pol != self.mf_order_pol_last():
+        if self._config.mf_config.mf_order_pol != self.mf_order_pol_last():
             print("changed pol. multifrequncy order!")
             self._change_imgr_params = True
             return
-        if self.mf_rm != self.mf_rm_last():
+        if self._config.mf_config.mf_rm != self.mf_rm_last():
             print("changed pol. rm imaging order!")
             self._change_imgr_params = True
             return
-        if self.mf_cm != self.mf_cm_last():
+        if self._config.mf_config.mf_cm != self.mf_cm_last():
             print("changed pol. cm imaging order!")
             self._change_imgr_params = True
             return
@@ -655,7 +662,7 @@ class Imager:
         """Check image parameter consistency with observation.
         """
         for msg in validate_limits(
-            self.prior_next, self.obslist_next, self.pol_next,
+            self.prior_next, self.obslist_next, self._config.pol,
             self.flux_next, self.mf_flux,
         ):
             print(msg)
@@ -688,8 +695,7 @@ class Imager:
 
         state = compute_init_state(
             self.obslist_next, self.init_next, self.prior_next,
-            self.freq_list, self.reffreq,
-            self._full_imager_config(),
+            self.freq_list, self.reffreq, self._config,
             self.norm_init, self.flux_next, self.clipfloor_next,
             sorted(self.dat_term_next.keys()),
             self._full_data_weighting_params(), self._full_fft_params(),
@@ -716,7 +722,7 @@ class Imager:
            input is image array transformed to bounded values
         """
         return compute_chisq_dict(
-            imcur, sorted(self.dat_term_next.keys()), self._full_imager_config(),
+            imcur, sorted(self.dat_term_next.keys()), self._config,
             self._data_tuples, self._logfreqratio_list, len(self.obslist_next),
             self._embed_mask,
         )
@@ -726,7 +732,7 @@ class Imager:
            input is image array transformed to bounded values
         """
         return compute_chisqgrad_dict(
-            imcur, sorted(self.dat_term_next.keys()), self._full_imager_config(),
+            imcur, sorted(self.dat_term_next.keys()), self._config,
             self._data_tuples, self._logfreqratio_list, len(self.obslist_next),
             self._embed_mask,
             self._which_solve, self._nimage,
@@ -791,7 +797,7 @@ class Imager:
            input is image array transformed to bounded values
         """
         return compute_reg_dict(
-            imcur, sorted(self.reg_term_next.keys()), self._full_imager_config(),
+            imcur, sorted(self.reg_term_next.keys()), self._config,
             self._logfreqratio_list, len(self.obslist_next),
             self._prior_arr, self.norm_reg, self._full_regparams(),
             self._embed_mask,
@@ -802,7 +808,7 @@ class Imager:
            input is image array transformed to bounded values
         """
         return compute_reggrad_dict(
-            imcur, sorted(self.reg_term_next.keys()), self._full_imager_config(),
+            imcur, sorted(self.reg_term_next.keys()), self._config,
             self._logfreqratio_list, len(self.obslist_next),
             self._prior_arr, self.norm_reg, self._full_regparams(),
             self._embed_mask,
@@ -812,7 +818,7 @@ class Imager:
     def objfunc(self, imvec):
         """Current objective function."""
         return compute_objective(
-            imvec, self._init_arr, self._full_imager_config(),
+            imvec, self._init_arr, self._config,
             self._which_solve, self._data_tuples,
             self._logfreqratio_list, len(self.obslist_next),
             self.dat_term_next, self.reg_term_next,
@@ -823,7 +829,7 @@ class Imager:
     def objgrad(self, imvec):
         """Current objective function gradient."""
         return compute_objective_grad(
-            imvec, self._init_arr, self._full_imager_config(),
+            imvec, self._init_arr, self._config,
             self._which_solve, self._data_tuples,
             self._logfreqratio_list, len(self.obslist_next),
             self.dat_term_next, self.reg_term_next,
@@ -842,7 +848,7 @@ class Imager:
 
                 # apply image transform to bounded values
                 imcur_prime = imcur.copy()
-                imcur = transform_imarr(imcur, self.transform_next, self._which_solve)
+                imcur = transform_imarr(imcur, self._config.transforms, self._which_solve)
 
                 # Get chi^2 and regularizer
                 chi2_term_dict = self.make_chisq_dict(imcur)
@@ -875,18 +881,18 @@ class Imager:
                     outstr += f"{regname} : {rval:0.1f} "
 
                 # Embed and plot the image
-                if not self.mf_next: # TODO plot multi-frequency?
+                if not self._config.mf: # TODO plot multi-frequency?
                     if np.any(np.invert(self._embed_mask)):
                         implot = embed_imarr(imcur, self._embed_mask)
                     else:
                         implot = imcur
 
-                    if self.pol_next in POLARIZATION_MODES:
+                    if self._config.pol in POLARIZATION_MODES:
                         polutils.plot_m(implot, self.prior_next, self._nit, chi2_term_dict, **kwargs)
 
                     else:
                         imutils.plot_i(implot, self.prior_next, self._nit,
-                                       chi2_term_dict, pol=self.pol_next, **kwargs)
+                                       chi2_term_dict, pol=self._config.pol, **kwargs)
 
                 if self._nit == 0:
                     print()
@@ -902,9 +908,9 @@ class Imager:
         if np.any(np.invert(self._embed_mask)):
             outarr = embed_imarr(outarr, self._embed_mask)
 
-        if self.mf_next:
+        if self._config.mf:
             # multi-frequency polarization
-            if self.pol_next in POLARIZATION_MODES:
+            if self._config.pol in POLARIZATION_MODES:
                 iimage_out = outarr[0]
                 polarr_out = (outarr[0], outarr[1], outarr[2], outarr[3])
                 specind_out = outarr[4]
@@ -925,7 +931,7 @@ class Imager:
                 curv_out = outarr[2]
         else:
             # single frequency polarization
-            if self.pol_next in POLARIZATION_MODES:
+            if self._config.pol in POLARIZATION_MODES:
                 iimage_out = outarr[0]
                 polarr_out = (outarr[0], outarr[1], outarr[2], outarr[3])
 
@@ -951,11 +957,11 @@ class Imager:
                 continue
 
             # Did we solve for polarimeric image or are we copying over old polarization data?
-            if self.pol_next in POLARIZATION_MODES and pol2 == 'Q':
+            if self._config.pol in POLARIZATION_MODES and pol2 == 'Q':
                 polvec = qimage_out
-            elif self.pol_next in POLARIZATION_MODES and pol2 == 'U':
+            elif self._config.pol in POLARIZATION_MODES and pol2 == 'U':
                 polvec = uimage_out
-            elif self.pol_next in POLARIZATION_MODES and pol2 == 'V':
+            elif self._config.pol in POLARIZATION_MODES and pol2 == 'V':
                 polvec = vimage_out
             else:
                 polvec = self.init_next._imdict[pol2]
@@ -966,12 +972,12 @@ class Imager:
 
         # Copy over spectral information to the output image
         outim._mflist = copy.deepcopy(self.init_next._mflist)
-        if self.mf_next:
+        if self._config.mf:
             outim._mflist[0] = specind_out
             outim._mflist[1] = curv_out
 
             # polarization multi-frequency
-            if self.pol_next in POLARIZATION_MODES:
+            if self._config.pol in POLARIZATION_MODES:
                 outim._mflist[2] = specind_out_pol
                 outim._mflist[3] = curv_out_pol
                 outim._mflist[4] = rm_out
@@ -992,7 +998,7 @@ class Imager:
             dat_term=self.dat_term_next,
             maxit=self.maxit_next,
             stop=self.stop_next,
-            pol=self.pol_next,
+            pol=self._config.pol,
             flux=self.flux_next,
             pflux=self.pflux_next,
             vflux=self.vflux_next,
@@ -1001,16 +1007,16 @@ class Imager:
             debias=self.debias_next,
             systematic_noise=self.systematic_noise_next,
             systematic_cphase_noise=self.systematic_cphase_noise_next,
-            transform=self.transform_next,
+            transform=self._config.transforms,
             weighting=self.weighting_next,
             maxset=self.maxset_next,
             cp_uv_min=self.cp_uv_min,
             reffreq=self.reffreq,
-            mf=self.mf_next,
-            mf_order=self.mf_order,
-            mf_order_pol=self.mf_order_pol,
-            mf_rm=self.mf_rm,
-            mf_cm=self.mf_cm,
+            mf=self._config.mf,
+            mf_order=self._config.mf_config.mf_order,
+            mf_order_pol=self._config.mf_config.mf_order_pol,
+            mf_rm=self._config.mf_config.mf_rm,
+            mf_cm=self._config.mf_config.mf_cm,
         ))
 
 

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -39,6 +39,8 @@ from ehtim.imaging.imager_backend import (
     POLARIZATION_MODES,
     DataWeighting,
     FourierGridParams,
+    ImagerConfig,
+    MfConfig,
     RegParams,
     compute_chisq_dict,
     compute_chisqgrad_dict,
@@ -549,10 +551,9 @@ class Imager:
         """Check parameter consistency.
         """
         validate_params(
-            self.prior_next, self.init_next, self.pol_next,
-            self.transform_next,
+            self.prior_next, self.init_next,
+            self._full_imager_config(),
             self.dat_term_next.keys(), self.reg_term_next.keys(),
-            self._ttype, self.mf_next, self.mf_order, self.mf_order_pol,
             self.freq_list,
         )
 
@@ -771,6 +772,21 @@ class Imager:
             fft_conv_func=self._fft_conv_func,
             fft_gridder_prad=self._fft_gridder_prad,
             fft_interp_order=self._fft_interp_order,
+        )
+
+    def _full_imager_config(self):
+        """Bundle static imager config into an ImagerConfig NamedTuple for the backend."""
+        return ImagerConfig(
+            pol=self.pol_next,
+            transforms=self.transform_next,
+            ttype=self._ttype,
+            mf=self.mf_next,
+            mf_config=MfConfig(
+                mf_order=self.mf_order,
+                mf_order_pol=self.mf_order_pol,
+                mf_rm=self.mf_rm,
+                mf_cm=self.mf_cm,
+            ),
         )
 
     def make_reg_dict(self, imcur):

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -1,6 +1,7 @@
 # imager_backend.py
 # Pure functional backend for imager.py
 
+from collections.abc import Sequence
 from typing import NamedTuple
 
 import numpy as np
@@ -1169,12 +1170,19 @@ class ImagerConfig(NamedTuple):
       Polarization   : pol, transforms
       Transform type : ttype
       Multifrequency : mf, mf_config (nested MfConfig)
+
+    JAX note: this bundle is a *static* pytree, not a traced one. The string
+    leaves (pol, ttype, transform names) and the dict leaf in the sibling
+    DataWeighting bundle (snrcut) aren't valid JAX traceable values. When
+    jitting backend functions that take a config, pass it as a
+    ``static_argname='config'`` so the structure participates in cache keying
+    rather than tracing.
     """
-    pol: str             # imager polarization mode ('I', 'IP', 'IV', 'IPV', 'QU', ...)
-    transforms: list     # bounded-value transform stack applied to imcur (e.g. ['log', 'mcv'])
-    ttype: str           # Fourier transform type ('direct', 'fast', 'nfft')
-    mf: bool             # multifrequency-imaging master flag
-    mf_config: MfConfig  # nested multifrequency expansion config
+    pol: str                       # imager polarization mode ('I', 'IP', 'IV', 'IPV', 'QU', ...)
+    transforms: Sequence[str]      # bounded-value transform stack applied to imcur (e.g. ['log', 'mcv'])
+    ttype: str                     # Fourier transform type ('direct', 'fast', 'nfft')
+    mf: bool                       # multifrequency-imaging master flag
+    mf_config: MfConfig            # nested multifrequency expansion config
 
 
 def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, config,

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -524,8 +524,7 @@ def make_initarr(image, mask, norm_init=False, flux=1,
     return initarr
 
 
-def validate_params(prior, init, pol, transforms, dat_term_keys, reg_term_keys,
-                    ttype, mf, mf_order, mf_order_pol, freq_list):
+def validate_params(prior, init, config, dat_term_keys, reg_term_keys, freq_list):
     """Validate imager configuration. Raises Exception on bad config.
 
     Pure validator extracted from Imager.check_params. Exception messages
@@ -536,23 +535,23 @@ def validate_params(prior, init, pol, transforms, dat_term_keys, reg_term_keys,
     prior, init : ehtim.image.Image
         Prior (regularizer reference) and initial-value images. Must share
         psize / xdim / ydim / rf / polrep.
-    pol : str
-        Polarization mode. For polrep='stokes': one of 'I', 'Q', 'U', 'V',
-        'P', 'IP', 'IQU', 'IV', 'IQUV'. For polrep='circ': 'RR' or 'LL'.
-    transforms : iterable of str
-        Active solver transforms (subset of 'log', 'mcv', 'vcv', 'polcv').
+    config : ImagerConfig
+        Imager configuration bundle. See the ImagerConfig docstring for the
+        field list. Reads pol, transforms, ttype, mf, mf_config.mf_order,
+        mf_config.mf_order_pol.
     dat_term_keys, reg_term_keys : iterable of str
         Data term and regularizer term keys actually requested.
-    ttype : str
-        Fourier transform type: 'direct', 'fast', or 'nfft'.
-    mf : bool
-        Multifrequency mode flag.
-    mf_order, mf_order_pol : int
-        Multifrequency expansion orders (must be in [0, 1, 2]).
     freq_list : list of float
         Per-observation reference frequencies. For mf=True, must contain
         at least two distinct values.
     """
+    pol = config.pol
+    transforms = config.transforms
+    ttype = config.ttype
+    mf = config.mf
+    mf_order = config.mf_config.mf_order
+    mf_order_pol = config.mf_config.mf_order_pol
+
     if ((prior.psize != init.psize) or
         (prior.xdim != init.xdim) or
         (prior.ydim != init.ydim)):

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -754,9 +754,7 @@ def compute_logfreqratios(freq_list, reffreq):
     return [np.log(nu / reffreq) for nu in freq_list]
 
 
-def compute_which_solve(pol, mf,
-                        mf_order=0, mf_order_pol=0,
-                        mf_rm=False, mf_cm=False):
+def compute_which_solve(config):
     """Build the which-solve flag array indicating which Stokes / spectral
     parameter slots are optimized vs held fixed.
 
@@ -769,28 +767,20 @@ def compute_which_solve(pol, mf,
 
     Parameters
     ----------
-    pol : str
-        Polarization mode (e.g. 'I', 'IP', 'IV'). Polarimetric modes are those
-        listed in POLARIZATION_MODES.
-    mf : bool
-        Multi-frequency imaging flag.
-    mf_order : {0, 1, 2}, optional
-        Stokes-I spectral expansion order. 0 -> none, 1 -> alpha only,
-        2 -> alpha + beta. Only used when mf=True.
-    mf_order_pol : {0, 1, 2}, optional
-        Polarimetric spectral expansion order (alpha_p, beta_p). Only used
-        when mf=True and pol is polarimetric.
-    mf_rm : bool, optional
-        Solve for rotation measure (RM). Only used when mf=True and pol is
-        polarimetric.
-    mf_cm : bool, optional
-        Solve for conversion measure (CM). Only used when mf=True and pol is
-        polarimetric.
+    config : ImagerConfig
+        Bundled static imager config; reads pol, mf, and mf_config fields.
 
     Returns
     -------
     np.ndarray of int (0/1)
     """
+    pol = config.pol
+    mf = config.mf
+    mf_order = config.mf_config.mf_order
+    mf_order_pol = config.mf_config.mf_order_pol
+    mf_rm = config.mf_config.mf_rm
+    mf_cm = config.mf_config.mf_cm
+
     is_pol = pol in POLARIZATION_MODES
 
     if mf:
@@ -850,7 +840,7 @@ def compute_which_solve(pol, mf,
     return np.array([1])
 
 
-def compute_chisqdata_term(obs, prior, mask, dtype, ttype='direct', pol='I', **kwargs):
+def compute_chisqdata_term(obs, prior, mask, dtype, config, **kwargs):
     """Single chisqdata dispatcher unifying chisqdata + polchisqdata.
 
     Standard dtypes route to imutils.chisqdata_*; pol dtypes route to
@@ -867,11 +857,8 @@ def compute_chisqdata_term(obs, prior, mask, dtype, ttype='direct', pol='I', **k
         ignored for standard fast/nfft (those helpers do not take mask).
     dtype : str
         Must be a key of _CHISQDATA_DISPATCH (12 dtypes).
-    ttype : {'direct', 'fast', 'nfft'}
-        'fast' is not supported for polarimetric dtypes.
-    pol : str
-        Polarization mode. Standard dtypes use this to unpack the right
-        Stokes (I/Q/U/V) data; pol dtypes absorb it via **kwargs (inert).
+    config : ImagerConfig
+        Bundled imager config; reads ttype and pol fields.
     **kwargs
         Per-dtype tuning knobs forwarded to the leaf helper. See
         imager_utils.chisqdata for the standard kwarg list and
@@ -881,6 +868,9 @@ def compute_chisqdata_term(obs, prior, mask, dtype, ttype='direct', pol='I', **k
     -------
     (data, sigma, A) tuple, same shape as the legacy chisqdata dispatchers.
     """
+    ttype = config.ttype
+    pol = config.pol
+
     if ttype not in ('direct', 'fast', 'nfft'):
         raise Exception("Possible ttype values are 'fast', 'direct', 'nfft'!")
 
@@ -1187,8 +1177,8 @@ class ImagerConfig(NamedTuple):
     mf_config: MfConfig  # nested multifrequency expansion config
 
 
-def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,
-                        ttype, data_weighting, fourier_grid):
+def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, config,
+                        data_weighting, fourier_grid):
     """Pre-compute (data, sigma, A) tuples for every (data-term, observation) pair.
 
     Dispatches to polutils.polchisqdata for polarimetric terms (in
@@ -1201,9 +1191,8 @@ def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,
     embed_mask : np.ndarray of bool
     dat_term_keys : iterable of str
         Sorted dat_term names. Each must be in DATATERMS or DATATERMS_POL.
-    pol : str
-        Polarization mode of the imager (e.g. 'I', 'IP', 'IV').
-    ttype : {'direct', 'fast', 'nfft'}
+    config : ImagerConfig
+        Provides pol and ttype for dispatch.
     data_weighting : DataWeighting
         Per-data-term knobs forwarded to imutils.chisqdata. See the DataWeighting
         docstring for the field list.
@@ -1224,8 +1213,7 @@ def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,
         for i, obs in enumerate(obslist):
             dname_key = dname if n_obs == 1 else f"{dname}_{i}"
             data_tuples[dname_key] = compute_chisqdata_term(
-                obs, prior, embed_mask, dname,
-                ttype=ttype, pol=pol,
+                obs, prior, embed_mask, dname, config,
                 maxset=data_weighting.maxset,
                 debias=data_weighting.debias,
                 snrcut=data_weighting.snrcut[dname],
@@ -1317,10 +1305,7 @@ def compute_init_state(
     reffreq_eff = init_image.rf if mf else reffreq
     logfreqratio_list = compute_logfreqratios(freq_list, reffreq_eff)
 
-    which_solve = compute_which_solve(
-        pol, mf, mf_order=mf_cfg.mf_order, mf_order_pol=mf_cfg.mf_order_pol,
-        mf_rm=mf_cfg.mf_rm, mf_cm=mf_cfg.mf_cm,
-    )
+    which_solve = compute_which_solve(config)
 
     is_pol = pol in POLARIZATION_MODES
 
@@ -1359,8 +1344,8 @@ def compute_init_state(
 
     if compute_data:
         data_tuples = compute_data_tuples(
-            obslist, prior_image, embed_mask, dat_term_keys, pol,
-            ttype, data_weighting, fourier_grid,
+            obslist, prior_image, embed_mask, dat_term_keys, config,
+            data_weighting, fourier_grid,
         )
     else:
         data_tuples = prior_data_tuples
@@ -1426,10 +1411,9 @@ def compute_embed(imvec, xdim, ydim, psize, clipfloor):
     return embed_mask, coord_matrix
 
 
-def compute_chisq_dict(imcur, dat_term_keys,
-                       mf, pol,
+def compute_chisq_dict(imcur, dat_term_keys, config,
                        data_tuples, logfreqratio_list, n_obs,
-                       ttype, embed_mask):
+                       embed_mask):
     """Compute chi^2 value for each data term across all observations.
 
     Parameters
@@ -1438,10 +1422,8 @@ def compute_chisq_dict(imcur, dat_term_keys,
         Current image array transformed to bounded values.
     dat_term_keys : list of str
         Data term names to evaluate, already sorted.
-    mf : bool
-        Whether multifrequency imaging is enabled.
-    pol : str
-        Polarization mode string.
+    config : ImagerConfig
+        Bundled imager config; reads mf, pol, ttype fields.
     data_tuples : dict
         Pre-computed data products keyed by dname or dname_i,
         each value is a (data, sigma, A) tuple.
@@ -1450,8 +1432,6 @@ def compute_chisq_dict(imcur, dat_term_keys,
     n_obs : int
         Number of observations (frequencies/epochs). Must equal
         len(logfreqratio_list); validated by Imager.init_imager.
-    ttype : str
-        Transform type ('direct', 'fast', 'nfft').
     embed_mask : np.ndarray of bool
         Pixel embedding mask.
 
@@ -1460,6 +1440,9 @@ def compute_chisq_dict(imcur, dat_term_keys,
     chi2_dict : dict
         Mapping from dname (or dname_i for multi-obs) to chi^2 scalar.
     """
+    mf = config.mf
+    ttype = config.ttype
+
     chi2_dict = {}
     for dname in dat_term_keys:
         for i in range(n_obs):
@@ -1477,10 +1460,9 @@ def compute_chisq_dict(imcur, dat_term_keys,
     return chi2_dict
 
 
-def compute_chisqgrad_dict(imcur, dat_term_keys,
-                           mf, pol,
+def compute_chisqgrad_dict(imcur, dat_term_keys, config,
                            data_tuples, logfreqratio_list, n_obs,
-                           ttype, embed_mask,
+                           embed_mask,
                            which_solve, nimage):
     """Compute chi^2 gradient for each data term across all observations.
 
@@ -1490,10 +1472,8 @@ def compute_chisqgrad_dict(imcur, dat_term_keys,
         Current image array transformed to bounded values.
     dat_term_keys : list of str
         Data term names to evaluate, already sorted.
-    mf : bool
-        Whether multifrequency imaging is enabled.
-    pol : str
-        Polarization mode string.
+    config : ImagerConfig
+        Bundled imager config; reads mf, pol, ttype fields.
     data_tuples : dict
         Pre-computed data products keyed by dname or dname_i,
         each value is a (data, sigma, A) tuple.
@@ -1502,8 +1482,6 @@ def compute_chisqgrad_dict(imcur, dat_term_keys,
     n_obs : int
         Number of observations (frequencies/epochs). Must equal
         len(logfreqratio_list); validated by Imager.init_imager.
-    ttype : str
-        Transform type ('direct', 'fast', 'nfft').
     embed_mask : np.ndarray of bool
         Pixel embedding mask.
     which_solve : np.ndarray of int
@@ -1516,6 +1494,10 @@ def compute_chisqgrad_dict(imcur, dat_term_keys,
     chi2grad_dict : dict
         Mapping from dname (or dname_i for multi-obs) to chi^2 gradient array.
     """
+    mf = config.mf
+    pol = config.pol
+    ttype = config.ttype
+
     chi2grad_dict = {}
     pol_solve = _pol_solve_block(which_solve, pol)
     # np.array((...)) below copies, so sharing zero_row across iterations is safe.
@@ -1550,8 +1532,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys,
     return chi2grad_dict
 
 
-def compute_reg_dict(imcur, reg_term_keys,
-                     mf, pol,
+def compute_reg_dict(imcur, reg_term_keys, config,
                      logfreqratio_list, n_obs,
                      priorvec, norm_reg, reg_params,
                      embed_mask):
@@ -1563,10 +1544,8 @@ def compute_reg_dict(imcur, reg_term_keys,
         Current image array transformed to bounded values.
     reg_term_keys : list of str
         Regularizer term names to evaluate, already sorted.
-    mf : bool
-        Whether multifrequency imaging is enabled.
-    pol : str
-        Polarization mode string.
+    config : ImagerConfig
+        Bundled imager config; reads mf and pol fields.
     logfreqratio_list : list of float
         Log frequency ratios log(nu_i/reffreq); one per obs.
     n_obs : int
@@ -1590,6 +1569,9 @@ def compute_reg_dict(imcur, reg_term_keys,
     reg_dict : dict
         Mapping from regname to regularizer scalar.
     """
+    mf = config.mf
+    pol = config.pol
+
     mf_flux = reg_params.mf_flux
     reg_kwargs = reg_params._asdict()
     reg_dict = {}
@@ -1650,8 +1632,7 @@ def compute_reg_dict(imcur, reg_term_keys,
     return reg_dict
 
 
-def compute_reggrad_dict(imcur, reg_term_keys,
-                         mf, pol,
+def compute_reggrad_dict(imcur, reg_term_keys, config,
                          logfreqratio_list, n_obs,
                          priorvec, norm_reg, reg_params,
                          embed_mask,
@@ -1660,7 +1641,7 @@ def compute_reggrad_dict(imcur, reg_term_keys,
 
     Parameters
     ----------
-    imcur, reg_term_keys, mf, pol, logfreqratio_list, n_obs,
+    imcur, reg_term_keys, config, logfreqratio_list, n_obs,
     priorvec, norm_reg, reg_params, embed_mask : see compute_reg_dict.
     which_solve : np.ndarray of bool
         Per-Stokes solve mask (used by polregularizergrad).
@@ -1674,6 +1655,9 @@ def compute_reggrad_dict(imcur, reg_term_keys,
         for single-pol, (4, nimage) for pol-bundled, or
         (len(imcur), nimage) for multifrequency.
     """
+    mf = config.mf
+    pol = config.pol
+
     mf_flux = reg_params.mf_flux
     reg_kwargs = reg_params._asdict()
     reggrad_dict = {}
@@ -1753,12 +1737,11 @@ def compute_reggrad_dict(imcur, reg_term_keys,
     return reggrad_dict
 
 
-def compute_objective(imvec, initvec,
-                      mf, pol,
+def compute_objective(imvec, initvec, config,
                       which_solve, data_tuples, logfreqratio_list, n_obs,
                       dat_term, reg_term,
                       priorvec, norm_reg, reg_params,
-                      transforms, embed_mask, ttype):
+                      embed_mask):
     """Compute the scalar imaging objective: data fidelity + regularization.
 
     Pure-functional version of Imager.objfunc. Unpacks the 1D solver vector
@@ -1776,10 +1759,8 @@ def compute_objective(imvec, initvec,
         Initial-image array (unwrapped, multi-D); used by `unpack_imarr` to
         fill any not-solved-for slots. Distinct from `priorvec` (the
         regularizer prior).
-    mf : bool
-        Multifrequency-imaging flag.
-    pol : str
-        Polarization mode (e.g. 'I', 'P', 'IP', 'V', 'IV', ...).
+    config : ImagerConfig
+        Bundled imager config; reads pol, mf, transforms, ttype fields.
     which_solve : np.ndarray of int
         Per-Stokes / per-spectral-term solve mask.
     data_tuples : dict
@@ -1798,12 +1779,8 @@ def compute_objective(imvec, initvec,
         Whether to apply per-regularizer normalization.
     reg_params : RegParams
         Bundle of regularizer parameters. See compute_reg_dict.
-    transforms : list of str
-        Image transform list (e.g. ['log', 'mcv']) applied to imcur.
     embed_mask : np.ndarray of bool
         Pixel embedding mask.
-    ttype : str
-        Fourier-transform type ('direct', 'fast', 'nfft').
 
     Returns
     -------
@@ -1811,6 +1788,7 @@ def compute_objective(imvec, initvec,
         Scalar objective value, sum of weighted chi^2 deviations and
         regularizer contributions.
     """
+    transforms = config.transforms
 
     dat_term_keys = sorted(dat_term.keys())
     reg_term_keys = sorted(reg_term.keys())
@@ -1822,14 +1800,12 @@ def compute_objective(imvec, initvec,
     imcur = transform_imarr(imcur, transforms, which_solve)
 
     chi2_dict = compute_chisq_dict(
-        imcur, dat_term_keys,
-        mf, pol,
+        imcur, dat_term_keys, config,
         data_tuples, logfreqratio_list, n_obs,
-        ttype, embed_mask,
+        embed_mask,
     )
     reg_dict = compute_reg_dict(
-        imcur, reg_term_keys,
-        mf, pol,
+        imcur, reg_term_keys, config,
         logfreqratio_list, n_obs,
         priorvec, norm_reg, reg_params,
         embed_mask,
@@ -1849,12 +1825,11 @@ def compute_objective(imvec, initvec,
     return datterm + regterm
 
 
-def compute_objective_grad(imvec, initvec,
-                           mf, pol,
+def compute_objective_grad(imvec, initvec, config,
                            which_solve, data_tuples, logfreqratio_list, n_obs,
                            dat_term, reg_term,
                            priorvec, norm_reg, reg_params,
-                           transforms, embed_mask, ttype, nimage):
+                           embed_mask, nimage):
     """Compute the gradient of the imaging objective with respect to imvec.
 
     Pure-functional version of Imager.objgrad. Computes the chi^2 and
@@ -1868,9 +1843,9 @@ def compute_objective_grad(imvec, initvec,
 
     Parameters
     ----------
-    imvec, initvec, mf, pol, which_solve, data_tuples, logfreqratio_list,
-    n_obs, dat_term, reg_term, priorvec, norm_reg, reg_params, transforms,
-    embed_mask, ttype : see compute_objective.
+    imvec, initvec, config, which_solve, data_tuples, logfreqratio_list,
+    n_obs, dat_term, reg_term, priorvec, norm_reg, reg_params,
+    embed_mask : see compute_objective.
     nimage : int
         Number of active pixels (sum of embed_mask). Used to size the
         pre-pack gradient array.
@@ -1881,6 +1856,7 @@ def compute_objective_grad(imvec, initvec,
         1D gradient vector (same length as imvec), suitable as the `jac`
         argument to scipy.optimize.minimize.
     """
+    transforms = config.transforms
 
     dat_term_keys = sorted(dat_term.keys())
     reg_term_keys = sorted(reg_term.keys())
@@ -1893,16 +1869,14 @@ def compute_objective_grad(imvec, initvec,
     imcur = transform_imarr(imcur, transforms, which_solve)
 
     chi2grad_dict = compute_chisqgrad_dict(
-        imcur, dat_term_keys,
-        mf, pol,
+        imcur, dat_term_keys, config,
         data_tuples, logfreqratio_list, n_obs,
-        ttype, embed_mask,
+        embed_mask,
         which_solve, nimage,
     )
 
     reggrad_dict = compute_reggrad_dict(
-        imcur, reg_term_keys,
-        mf, pol,
+        imcur, reg_term_keys, config,
         logfreqratio_list, n_obs,
         priorvec, norm_reg, reg_params,
         embed_mask,

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -1245,10 +1245,9 @@ def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,
 def compute_init_state(
     obslist, init_image, prior_image,
     freq_list, reffreq,
-    pol, mf, transforms,
-    mf_order, mf_order_pol, mf_rm, mf_cm,
+    config,
     norm_init, flux, clipfloor,
-    dat_term_keys, ttype,
+    dat_term_keys,
     data_weighting, fourier_grid,
     *, compute_data=True, prior_data_tuples=None,
 ):
@@ -1259,9 +1258,8 @@ def compute_init_state(
     into the single state bundle consumed by compute_objective /
     compute_objective_grad.
 
-    JAX note: when jitted, expect static_argnames=('pol', 'mf', 'transforms',
-    'mf_order', 'mf_order_pol', 'mf_rm', 'mf_cm', 'ttype', 'dat_term_keys',
-    'compute_data').
+    JAX note: when jitted, expect static_argnames=('config', 'dat_term_keys',
+    'compute_data') with config as a frozen pytree.
 
     Parameters
     ----------
@@ -1272,17 +1270,14 @@ def compute_init_state(
         Reference frequencies (Hz) of each obs in obslist.
     reffreq : float
         Reference frequency (Hz) of the multi-frequency expansion. When
-        mf=True this is overridden by init_image.rf.
-    pol, mf, transforms : str, bool, list of str
-        Polarization mode, multi-frequency flag, transform stack
-        (e.g. ['log', 'mcv']).
-    mf_order, mf_order_pol, mf_rm, mf_cm :
-        Multi-frequency expansion orders + RM/CM solve flags.
+        config.mf=True this is overridden by init_image.rf.
+    config : ImagerConfig
+        Static imager configuration. Provides pol, transforms, ttype, mf,
+        and the nested mf_config bundle.
     norm_init : bool
     flux, clipfloor : float
     dat_term_keys : iterable of str
         Sorted dat_term names. Each must be in DATATERMS or DATATERMS_POL.
-    ttype : {'direct', 'fast', 'nfft'}
     data_weighting : DataWeighting
         Per-data-term knobs forwarded to compute_data_tuples.
     fourier_grid : FourierGridParams
@@ -1300,6 +1295,12 @@ def compute_init_state(
     -------
     ImagerInitState
     """
+    pol = config.pol
+    mf = config.mf
+    transforms = config.transforms
+    ttype = config.ttype
+    mf_cfg = config.mf_config
+
     n_obs = len(obslist)
     if len(freq_list) != n_obs:
         raise Exception(
@@ -1317,8 +1318,8 @@ def compute_init_state(
     logfreqratio_list = compute_logfreqratios(freq_list, reffreq_eff)
 
     which_solve = compute_which_solve(
-        pol, mf, mf_order=mf_order, mf_order_pol=mf_order_pol,
-        mf_rm=mf_rm, mf_cm=mf_cm,
+        pol, mf, mf_order=mf_cfg.mf_order, mf_order_pol=mf_cfg.mf_order_pol,
+        mf_rm=mf_cfg.mf_rm, mf_cm=mf_cfg.mf_cm,
     )
 
     is_pol = pol in POLARIZATION_MODES

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -223,6 +223,118 @@ class ImagerInitState(NamedTuple):
     reffreq: float               # may be re-bound to init.rf when mf=True
 
 
+class RegParams(NamedTuple):
+    """Bundle of regularizer parameters passed to compute_reg_dict / compute_reggrad_dict.
+
+    Built once per imager run by Imager._regparams() and forwarded into each
+    regularizer function via ``**reg_params._asdict()``. Regularizer functions
+    take what they need from this bundle; extra fields are ignored via their
+    trailing ``**kwargs``.
+
+    Field groups:
+      Image scale          : flux, pflux, vflux
+      Image geometry       : xdim, ydim, psize, beam_size
+      Multifrequency       : mf_flux
+      Term-specific kwargs : major, minor, PA, alpha_A, epsilon_tv
+    """
+    flux: float
+    pflux: float | None
+    vflux: float | None
+    xdim: int
+    ydim: int
+    psize: float
+    beam_size: float
+    mf_flux: list | None         # length n_obs when REGULARIZERS_ALLFREQS_I active
+    major: float
+    minor: float
+    PA: float
+    alpha_A: float
+    epsilon_tv: float
+
+
+class DataWeighting(NamedTuple):
+    """Bundle of data-weighting parameters passed to compute_data_tuples.
+
+    Built once per imager run by Imager._data_weighting_params() and forwarded
+    into compute_data_tuples, which reads its fields directly.
+
+    Field groups:
+      Closure-set selection   : maxset
+      Noise corrections       : debias, systematic_noise, systematic_cphase_noise
+      SNR filtering           : snrcut
+      Weighting scheme        : weighting
+      UV closure-phase filter : cp_uv_min
+    """
+    maxset: bool                    # use the maximal independent set of closure quantities
+    debias: bool                    # apply noise-bias correction to visibility amplitudes
+    snrcut: dict                    # per-data-term SNR threshold (dname -> float)
+    weighting: str                  # baseline weighting scheme ('natural', 'uniform')
+    systematic_noise: float         # fractional sys-noise added in quadrature to amplitudes
+    systematic_cphase_noise: float  # absolute sys-noise added in quadrature to closure phases (deg)
+    cp_uv_min: float | bool         # minimum UV-separation cut on closure phases (False = no cut)
+
+
+class FourierGridParams(NamedTuple):
+    """Bundle of Fourier-grid parameters used by ttype='fast' and ttype='nfft'.
+
+    These configure the gridding kernel + grid padding + interpolation order
+    shared between the FFT and NFFT transform paths. Built once per imager
+    run by Imager._fft_params() and passed into compute_data_tuples.
+
+    Field groups:
+      Grid           : fft_pad_factor
+      Gridding kernel: fft_conv_func, fft_gridder_prad
+      Interpolation  : fft_interp_order
+    """
+    fft_pad_factor: float    # zero-padding factor for the Fourier grid (typical: 2)
+    fft_conv_func: str       # gridding convolution kernel ('gaussian', 'pillbox', ...)
+    fft_gridder_prad: float  # gridding kernel half-support in pixels
+    fft_interp_order: int    # interpolation order for grid-sample lookups
+
+
+class MfConfig(NamedTuple):
+    """Multifrequency solver configuration bundled inside ImagerConfig.
+
+    Carries the spectral-expansion orders read by compute_which_solve and
+    related multifrequency dispatch code paths. Unused when ImagerConfig.mf
+    is False, but always populated with defaults.
+
+    Field groups:
+      Spectral expansion : mf_order, mf_order_pol
+      RM / CM solves     : mf_rm, mf_cm
+    """
+    mf_order: int      # spectral-index expansion order for Stokes I (0=off, 1=alpha, 2=alpha+beta)
+    mf_order_pol: int  # spectral-index expansion order for polarization (0 / 1 / 2)
+    mf_rm: int         # solve for Faraday rotation measure (0=off, 1=on)
+    mf_cm: int         # solve for Faraday conversion measure (0=off, 1=on)
+
+
+class ImagerConfig(NamedTuple):
+    """Static imaging configuration bundled at Imager construction.
+
+    Replaces the flat self.pol_next / self.transform_next / self._ttype /
+    self.mf_next / self.mf_* attrs on the Imager class. Crosses into every
+    backend function that previously took these as individual args.
+
+    Field groups:
+      Polarization   : pol, transforms
+      Transform type : ttype
+      Multifrequency : mf, mf_config (nested MfConfig)
+
+    JAX note: this bundle is a *static* pytree, not a traced one. The string
+    leaves (pol, ttype, transform names) and the dict leaf in the sibling
+    DataWeighting bundle (snrcut) aren't valid JAX traceable values. When
+    jitting backend functions that take a config, pass it as a
+    ``static_argname='config'`` so the structure participates in cache keying
+    rather than tracing.
+    """
+    pol: str                       # imager polarization mode ('I', 'IP', 'IV', 'IPV', 'QU', ...)
+    transforms: Sequence[str]      # bounded-value transform stack applied to imcur (e.g. ['log', 'mcv'])
+    ttype: str                     # Fourier transform type ('direct', 'fast', 'nfft')
+    mf: bool                       # multifrequency-imaging master flag
+    mf_config: MfConfig            # nested multifrequency expansion config
+
+
 def pack_imarr(imarr, which_solve):
     """pack image array imarr into 1D array vec for minimizaiton
        ignore quantities not solved for
@@ -1071,118 +1183,6 @@ def compute_regularizergrad_term(imvec_or_imarr, regname, mask, **kwargs):
         raise Exception(f"regularizer term {regname} not recognized!")
     _, grad_fn, _ = _REGULARIZER_DISPATCH[regname]
     return grad_fn(imvec_or_imarr, mask=mask, **kwargs)
-
-
-class RegParams(NamedTuple):
-    """Bundle of regularizer parameters passed to compute_reg_dict / compute_reggrad_dict.
-
-    Built once per imager run by Imager._full_regparams() and forwarded into
-    each regularizer function via ``**reg_params._asdict()``. Regularizer
-    functions take what they need from this bundle; extra fields are ignored
-    via their trailing ``**kwargs``.
-
-    Field groups:
-      Image scale          : flux, pflux, vflux
-      Image geometry       : xdim, ydim, psize, beam_size
-      Multifrequency       : mf_flux
-      Term-specific kwargs : major, minor, PA, alpha_A, epsilon_tv
-    """
-    flux: float
-    pflux: float | None
-    vflux: float | None
-    xdim: int
-    ydim: int
-    psize: float
-    beam_size: float
-    mf_flux: list | None         # length n_obs when REGULARIZERS_ALLFREQS_I active
-    major: float
-    minor: float
-    PA: float
-    alpha_A: float
-    epsilon_tv: float
-
-
-class DataWeighting(NamedTuple):
-    """Bundle of data-weighting parameters passed to compute_data_tuples.
-
-    Built once per imager run by Imager._full_data_weighting_params() and
-    forwarded into compute_data_tuples, which reads its fields directly.
-
-    Field groups:
-      Closure-set selection   : maxset
-      Noise corrections       : debias, systematic_noise, systematic_cphase_noise
-      SNR filtering           : snrcut
-      Weighting scheme        : weighting
-      UV closure-phase filter : cp_uv_min
-    """
-    maxset: bool                    # use the maximal independent set of closure quantities
-    debias: bool                    # apply noise-bias correction to visibility amplitudes
-    snrcut: dict                    # per-data-term SNR threshold (dname -> float)
-    weighting: str                  # baseline weighting scheme ('natural', 'uniform')
-    systematic_noise: float         # fractional sys-noise added in quadrature to amplitudes
-    systematic_cphase_noise: float  # absolute sys-noise added in quadrature to closure phases (deg)
-    cp_uv_min: float | bool         # minimum UV-separation cut on closure phases (False = no cut)
-
-
-class FourierGridParams(NamedTuple):
-    """Bundle of Fourier-grid parameters used by ttype='fast' and ttype='nfft'.
-
-    These configure the gridding kernel + grid padding + interpolation order
-    shared between the FFT and NFFT transform paths. Built once per imager
-    run by Imager._full_fft_params() and passed into compute_data_tuples.
-
-    Field groups:
-      Grid           : fft_pad_factor
-      Gridding kernel: fft_conv_func, fft_gridder_prad
-      Interpolation  : fft_interp_order
-    """
-    fft_pad_factor: float    # zero-padding factor for the Fourier grid (typical: 2)
-    fft_conv_func: str       # gridding convolution kernel ('gaussian', 'pillbox', ...)
-    fft_gridder_prad: float  # gridding kernel half-support in pixels
-    fft_interp_order: int    # interpolation order for grid-sample lookups
-
-
-class MfConfig(NamedTuple):
-    """Multifrequency solver configuration bundled inside ImagerConfig.
-
-    Carries the spectral-expansion orders read by compute_which_solve and
-    related multifrequency dispatch code paths. Unused when ImagerConfig.mf
-    is False, but always populated with defaults.
-
-    Field groups:
-      Spectral expansion : mf_order, mf_order_pol
-      RM / CM solves     : mf_rm, mf_cm
-    """
-    mf_order: int      # spectral-index expansion order for Stokes I (0=off, 1=alpha, 2=alpha+beta)
-    mf_order_pol: int  # spectral-index expansion order for polarization (0 / 1 / 2)
-    mf_rm: int         # solve for Faraday rotation measure (0=off, 1=on)
-    mf_cm: int         # solve for Faraday conversion measure (0=off, 1=on)
-
-
-class ImagerConfig(NamedTuple):
-    """Static imaging configuration bundled at Imager construction.
-
-    Replaces the flat self.pol_next / self.transform_next / self._ttype /
-    self.mf_next / self.mf_* attrs on the Imager class. Crosses into every
-    backend function that previously took these as individual args.
-
-    Field groups:
-      Polarization   : pol, transforms
-      Transform type : ttype
-      Multifrequency : mf, mf_config (nested MfConfig)
-
-    JAX note: this bundle is a *static* pytree, not a traced one. The string
-    leaves (pol, ttype, transform names) and the dict leaf in the sibling
-    DataWeighting bundle (snrcut) aren't valid JAX traceable values. When
-    jitting backend functions that take a config, pass it as a
-    ``static_argname='config'`` so the structure participates in cache keying
-    rather than tracing.
-    """
-    pol: str                       # imager polarization mode ('I', 'IP', 'IV', 'IPV', 'QU', ...)
-    transforms: Sequence[str]      # bounded-value transform stack applied to imcur (e.g. ['log', 'mcv'])
-    ttype: str                     # Fourier transform type ('direct', 'fast', 'nfft')
-    mf: bool                       # multifrequency-imaging master flag
-    mf_config: MfConfig            # nested multifrequency expansion config
 
 
 def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, config,

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -1112,6 +1112,82 @@ class RegParams(NamedTuple):
     epsilon_tv: float
 
 
+class DataWeighting(NamedTuple):
+    """Bundle of data-weighting parameters passed to compute_data_tuples.
+
+    Built once per imager run by Imager._full_data_weighting_params() and
+    forwarded into compute_data_tuples, which reads its fields directly.
+
+    Field groups:
+      Closure-set selection   : maxset
+      Noise corrections       : debias, systematic_noise, systematic_cphase_noise
+      SNR filtering           : snrcut
+      Weighting scheme        : weighting
+      UV closure-phase filter : cp_uv_min
+    """
+    maxset: bool                    # use the maximal independent set of closure quantities
+    debias: bool                    # apply noise-bias correction to visibility amplitudes
+    snrcut: dict                    # per-data-term SNR threshold (dname -> float)
+    weighting: str                  # baseline weighting scheme ('natural', 'uniform')
+    systematic_noise: float         # fractional sys-noise added in quadrature to amplitudes
+    systematic_cphase_noise: float  # absolute sys-noise added in quadrature to closure phases (deg)
+    cp_uv_min: float | bool         # minimum UV-separation cut on closure phases (False = no cut)
+
+
+class FourierGridParams(NamedTuple):
+    """Bundle of Fourier-grid parameters used by ttype='fast' and ttype='nfft'.
+
+    These configure the gridding kernel + grid padding + interpolation order
+    shared between the FFT and NFFT transform paths. Built once per imager
+    run by Imager._full_fft_params() and passed into compute_data_tuples.
+
+    Field groups:
+      Grid           : fft_pad_factor
+      Gridding kernel: fft_conv_func, fft_gridder_prad
+      Interpolation  : fft_interp_order
+    """
+    fft_pad_factor: float    # zero-padding factor for the Fourier grid (typical: 2)
+    fft_conv_func: str       # gridding convolution kernel ('gaussian', 'pillbox', ...)
+    fft_gridder_prad: float  # gridding kernel half-support in pixels
+    fft_interp_order: int    # interpolation order for grid-sample lookups
+
+
+class MfConfig(NamedTuple):
+    """Multifrequency solver configuration bundled inside ImagerConfig.
+
+    Carries the spectral-expansion orders read by compute_which_solve and
+    related multifrequency dispatch code paths. Unused when ImagerConfig.mf
+    is False, but always populated with defaults.
+
+    Field groups:
+      Spectral expansion : mf_order, mf_order_pol
+      RM / CM solves     : mf_rm, mf_cm
+    """
+    mf_order: int      # spectral-index expansion order for Stokes I (0=off, 1=alpha, 2=alpha+beta)
+    mf_order_pol: int  # spectral-index expansion order for polarization (0 / 1 / 2)
+    mf_rm: int         # solve for Faraday rotation measure (0=off, 1=on)
+    mf_cm: int         # solve for Faraday conversion measure (0=off, 1=on)
+
+
+class ImagerConfig(NamedTuple):
+    """Static imaging configuration bundled at Imager construction.
+
+    Replaces the flat self.pol_next / self.transform_next / self._ttype /
+    self.mf_next / self.mf_* attrs on the Imager class. Crosses into every
+    backend function that previously took these as individual args.
+
+    Field groups:
+      Polarization   : pol, transforms
+      Transform type : ttype
+      Multifrequency : mf, mf_config (nested MfConfig)
+    """
+    pol: str             # imager polarization mode ('I', 'IP', 'IV', 'IPV', 'QU', ...)
+    transforms: list     # bounded-value transform stack applied to imcur (e.g. ['log', 'mcv'])
+    ttype: str           # Fourier transform type ('direct', 'fast', 'nfft')
+    mf: bool             # multifrequency-imaging master flag
+    mf_config: MfConfig  # nested multifrequency expansion config
+
+
 def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,
                         ttype, data_weighting_params, fft_params):
     """Pre-compute (data, sigma, A) tuples for every (data-term, observation) pair.

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -1189,7 +1189,7 @@ class ImagerConfig(NamedTuple):
 
 
 def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,
-                        ttype, data_weighting_params, fft_params):
+                        ttype, data_weighting, fourier_grid):
     """Pre-compute (data, sigma, A) tuples for every (data-term, observation) pair.
 
     Dispatches to polutils.polchisqdata for polarimetric terms (in
@@ -1205,10 +1205,10 @@ def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,
     pol : str
         Polarization mode of the imager (e.g. 'I', 'IP', 'IV').
     ttype : {'direct', 'fast', 'nfft'}
-    data_weighting_params : DataWeighting
+    data_weighting : DataWeighting
         Per-data-term knobs forwarded to imutils.chisqdata. See the DataWeighting
         docstring for the field list.
-    fft_params : FourierGridParams
+    fourier_grid : FourierGridParams
         Gridding parameters for ttype='fast' / 'nfft'. See the FourierGridParams
         docstring for the field list.
 
@@ -1227,17 +1227,17 @@ def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,
             data_tuples[dname_key] = compute_chisqdata_term(
                 obs, prior, embed_mask, dname,
                 ttype=ttype, pol=pol,
-                maxset=data_weighting_params.maxset,
-                debias=data_weighting_params.debias,
-                snrcut=data_weighting_params.snrcut[dname],
-                weighting=data_weighting_params.weighting,
-                systematic_noise=data_weighting_params.systematic_noise,
-                systematic_cphase_noise=data_weighting_params.systematic_cphase_noise,
-                cp_uv_min=data_weighting_params.cp_uv_min,
-                order=fft_params.fft_interp_order,
-                fft_pad_factor=fft_params.fft_pad_factor,
-                conv_func=fft_params.fft_conv_func,
-                p_rad=fft_params.fft_gridder_prad,
+                maxset=data_weighting.maxset,
+                debias=data_weighting.debias,
+                snrcut=data_weighting.snrcut[dname],
+                weighting=data_weighting.weighting,
+                systematic_noise=data_weighting.systematic_noise,
+                systematic_cphase_noise=data_weighting.systematic_cphase_noise,
+                cp_uv_min=data_weighting.cp_uv_min,
+                order=fourier_grid.fft_interp_order,
+                fft_pad_factor=fourier_grid.fft_pad_factor,
+                conv_func=fourier_grid.fft_conv_func,
+                p_rad=fourier_grid.fft_gridder_prad,
             )
 
     return data_tuples
@@ -1250,7 +1250,7 @@ def compute_init_state(
     mf_order, mf_order_pol, mf_rm, mf_cm,
     norm_init, flux, clipfloor,
     dat_term_keys, ttype,
-    data_weighting_params, fft_params,
+    data_weighting, fourier_grid,
     *, compute_data=True, prior_data_tuples=None,
 ):
     """Build solver-ready imager state. Pure function.
@@ -1262,7 +1262,7 @@ def compute_init_state(
 
     JAX note: when jitted, expect static_argnames=('pol', 'mf', 'transforms',
     'mf_order', 'mf_order_pol', 'mf_rm', 'mf_cm', 'ttype', 'dat_term_keys',
-    'compute_data') plus static dict-key structure on data_weighting_params.
+    'compute_data').
 
     Parameters
     ----------
@@ -1284,8 +1284,10 @@ def compute_init_state(
     dat_term_keys : iterable of str
         Sorted dat_term names. Each must be in DATATERMS or DATATERMS_POL.
     ttype : {'direct', 'fast', 'nfft'}
-    data_weighting_params, fft_params : dict
-        Forwarded to compute_data_tuples; see its docstring for required keys.
+    data_weighting : DataWeighting
+        Per-data-term knobs forwarded to compute_data_tuples.
+    fourier_grid : FourierGridParams
+        Gridding parameters forwarded to compute_data_tuples.
 
     Other Parameters
     ----------------
@@ -1358,7 +1360,7 @@ def compute_init_state(
     if compute_data:
         data_tuples = compute_data_tuples(
             obslist, prior_image, embed_mask, dat_term_keys, pol,
-            ttype, data_weighting_params, fft_params,
+            ttype, data_weighting, fourier_grid,
         )
     else:
         data_tuples = prior_data_tuples

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -1205,10 +1205,9 @@ def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,
     pol : str
         Polarization mode of the imager (e.g. 'I', 'IP', 'IV').
     ttype : {'direct', 'fast', 'nfft'}
-    data_weighting_params : dict
-        Per-data-term knobs forwarded to imutils.chisqdata. Expected keys:
-        'maxset', 'debias', 'snrcut' (dict[dname -> float]), 'weighting',
-        'systematic_noise', 'systematic_cphase_noise', 'cp_uv_min'.
+    data_weighting_params : DataWeighting
+        Per-data-term knobs forwarded to imutils.chisqdata. See the DataWeighting
+        docstring for the field list.
     fft_params : dict
         FFT/NFFT-specific parameters. Expected keys:
         'fft_pad_factor', 'fft_conv_func', 'fft_gridder_prad',
@@ -1229,13 +1228,13 @@ def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,
             data_tuples[dname_key] = compute_chisqdata_term(
                 obs, prior, embed_mask, dname,
                 ttype=ttype, pol=pol,
-                maxset=data_weighting_params['maxset'],
-                debias=data_weighting_params['debias'],
-                snrcut=data_weighting_params['snrcut'][dname],
-                weighting=data_weighting_params['weighting'],
-                systematic_noise=data_weighting_params['systematic_noise'],
-                systematic_cphase_noise=data_weighting_params['systematic_cphase_noise'],
-                cp_uv_min=data_weighting_params['cp_uv_min'],
+                maxset=data_weighting_params.maxset,
+                debias=data_weighting_params.debias,
+                snrcut=data_weighting_params.snrcut[dname],
+                weighting=data_weighting_params.weighting,
+                systematic_noise=data_weighting_params.systematic_noise,
+                systematic_cphase_noise=data_weighting_params.systematic_cphase_noise,
+                cp_uv_min=data_weighting_params.cp_uv_min,
                 order=fft_params['fft_interp_order'],
                 fft_pad_factor=fft_params['fft_pad_factor'],
                 conv_func=fft_params['fft_conv_func'],

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -1208,10 +1208,9 @@ def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,
     data_weighting_params : DataWeighting
         Per-data-term knobs forwarded to imutils.chisqdata. See the DataWeighting
         docstring for the field list.
-    fft_params : dict
-        FFT/NFFT-specific parameters. Expected keys:
-        'fft_pad_factor', 'fft_conv_func', 'fft_gridder_prad',
-        'fft_interp_order'.
+    fft_params : FourierGridParams
+        Gridding parameters for ttype='fast' / 'nfft'. See the FourierGridParams
+        docstring for the field list.
 
     Returns
     -------
@@ -1235,10 +1234,10 @@ def compute_data_tuples(obslist, prior, embed_mask, dat_term_keys, pol,
                 systematic_noise=data_weighting_params.systematic_noise,
                 systematic_cphase_noise=data_weighting_params.systematic_cphase_noise,
                 cp_uv_min=data_weighting_params.cp_uv_min,
-                order=fft_params['fft_interp_order'],
-                fft_pad_factor=fft_params['fft_pad_factor'],
-                conv_func=fft_params['fft_conv_func'],
-                p_rad=fft_params['fft_gridder_prad'],
+                order=fft_params.fft_interp_order,
+                fft_pad_factor=fft_params.fft_pad_factor,
+                conv_func=fft_params.fft_conv_func,
+                p_rad=fft_params.fft_gridder_prad,
             )
 
     return data_tuples

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -108,12 +108,17 @@ def chisqdata(Obsdata, Prior, mask, dtype, pol='I', **kwargs):
     backward compatibility. New code should call compute_chisqdata_term
     directly.
     """
-    from ehtim.imaging.imager_backend import compute_chisqdata_term
+    from ehtim.imaging.imager_backend import (
+        compute_chisqdata_term, ImagerConfig, MfConfig,
+    )
     ttype = kwargs.pop('ttype', 'direct')
     if dtype not in DATATERMS:
         raise Exception(f"data term {dtype!r} is not a standard data term")
-    return compute_chisqdata_term(Obsdata, Prior, mask, dtype,
-                                  ttype=ttype, pol=pol, **kwargs)
+    config = ImagerConfig(
+        pol=pol, transforms=[], ttype=ttype, mf=False,
+        mf_config=MfConfig(mf_order=0, mf_order_pol=0, mf_rm=0, mf_cm=0),
+    )
+    return compute_chisqdata_term(Obsdata, Prior, mask, dtype, config, **kwargs)
 
 
 ##################################################################################################

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -109,7 +109,9 @@ def chisqdata(Obsdata, Prior, mask, dtype, pol='I', **kwargs):
     directly.
     """
     from ehtim.imaging.imager_backend import (
-        compute_chisqdata_term, ImagerConfig, MfConfig,
+        ImagerConfig,
+        MfConfig,
+        compute_chisqdata_term,
     )
     ttype = kwargs.pop('ttype', 'direct')
     if dtype not in DATATERMS:

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -409,7 +409,9 @@ def polchisqdata(Obsdata, Prior, mask, dtype, **kwargs):
     directly.
     """
     from ehtim.imaging.imager_backend import (
-        compute_chisqdata_term, ImagerConfig, MfConfig,
+        ImagerConfig,
+        MfConfig,
+        compute_chisqdata_term,
     )
     ttype = kwargs.pop('ttype', 'direct')
     pol = kwargs.pop('pol', 'I')

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -408,12 +408,18 @@ def polchisqdata(Obsdata, Prior, mask, dtype, **kwargs):
     backward compatibility. New code should call compute_chisqdata_term
     directly.
     """
-    from ehtim.imaging.imager_backend import compute_chisqdata_term
+    from ehtim.imaging.imager_backend import (
+        compute_chisqdata_term, ImagerConfig, MfConfig,
+    )
     ttype = kwargs.pop('ttype', 'direct')
+    pol = kwargs.pop('pol', 'I')
     if dtype not in DATATERMS_POL:
         raise Exception(f"data term {dtype!r} is not a polarimetric data term")
-    return compute_chisqdata_term(Obsdata, Prior, mask, dtype,
-                                  ttype=ttype, **kwargs)
+    config = ImagerConfig(
+        pol=pol, transforms=[], ttype=ttype, mf=False,
+        mf_config=MfConfig(mf_order=0, mf_order_pol=0, mf_rm=0, mf_cm=0),
+    )
+    return compute_chisqdata_term(Obsdata, Prior, mask, dtype, config, **kwargs)
 
 
 ##################################################################################################

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,6 +223,6 @@ def initialize_imager():
         imgr.init_imager()
 
         imcur = unpack_imarr(imgr._init_vec, imgr._init_arr, imgr._which_solve)
-        imcur = transform_imarr(imcur, imgr.transform_next, imgr._which_solve)
+        imcur = transform_imarr(imcur, imgr._config.transforms, imgr._which_solve)
         return imgr, imcur
     return _factory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,31 @@ import pytest
 import ehtim as eh
 from ehtim.imaging.imager_backend import (
     POLARIZATION_MODES,
+    ImagerConfig,
+    MfConfig,
     transform_imarr,
     unpack_imarr,
 )
+
+
+@pytest.fixture(scope="session")
+def make_test_config():
+    """Factory fixture: construct an ImagerConfig for backend-call tests.
+
+    Replaces the previous pattern of passing individual pol/mf/ttype/transforms
+    kwargs to backend functions. Tests call as
+    ``make_test_config(pol="IP", mf=True, mf_order=2)``.
+    """
+    def _factory(pol="I", transforms=("log", "mcv"), ttype="direct",
+                 mf=False, mf_order=0, mf_order_pol=0, mf_rm=0, mf_cm=0):
+        return ImagerConfig(
+            pol=pol, transforms=list(transforms), ttype=ttype, mf=mf,
+            mf_config=MfConfig(
+                mf_order=mf_order, mf_order_pol=mf_order_pol,
+                mf_rm=mf_rm, mf_cm=mf_cm,
+            ),
+        )
+    return _factory
 
 # ---------------------------------------------------------------------------
 # Paths

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -308,7 +308,7 @@ class TestComputeWhichSolve:
         imgr.init_imager()
         np.testing.assert_array_equal(
             imgr._which_solve,
-            compute_which_solve(imgr._full_imager_config()),
+            compute_which_solve(imgr._config),
         )
 
     def test_matches_imager_init_imager_polarimetric(self, gauss_im_pol, observe):
@@ -328,7 +328,7 @@ class TestComputeWhichSolve:
         imgr.init_imager()
         np.testing.assert_array_equal(
             imgr._which_solve,
-            compute_which_solve(imgr._full_imager_config()),
+            compute_which_solve(imgr._config),
         )
 
 
@@ -336,7 +336,7 @@ def _call_compute_data_tuples(imgr):
     """Call compute_data_tuples with the args init_imager would pass."""
     return compute_data_tuples(
         imgr.obslist_next, imgr.prior_next, imgr._embed_mask,
-        sorted(imgr.dat_term_next.keys()), imgr._full_imager_config(),
+        sorted(imgr.dat_term_next.keys()), imgr._config,
         imgr._full_data_weighting_params(),
         imgr._full_fft_params(),
     )
@@ -394,7 +394,7 @@ class TestComputeDataTuples:
         with pytest.raises(Exception, match="not recognized"):
             compute_data_tuples(
                 imgr.obslist_next, imgr.prior_next, imgr._embed_mask,
-                ["bogus"], imgr._full_imager_config(),
+                ["bogus"], imgr._config,
                 bogus_weighting, imgr._full_fft_params(),
             )
 
@@ -430,7 +430,7 @@ def _call_compute_init_state(imgr):
     return compute_init_state(
         imgr.obslist_next, imgr.init_next, imgr.prior_next,
         imgr.freq_list, imgr.reffreq,
-        imgr._full_imager_config(),
+        imgr._config,
         imgr.norm_init, imgr.flux_next, imgr.clipfloor_next,
         sorted(imgr.dat_term_next.keys()),
         imgr._full_data_weighting_params(),
@@ -526,7 +526,7 @@ class TestComputeInitState:
         state = compute_init_state(
             imgr.obslist_next, imgr.init_next, imgr.prior_next,
             imgr.freq_list, imgr.reffreq,
-            imgr._full_imager_config(),
+            imgr._config,
             imgr.norm_init, imgr.flux_next, imgr.clipfloor_next,
             sorted(imgr.dat_term_next.keys()),
             imgr._full_data_weighting_params(),
@@ -543,7 +543,7 @@ class TestComputeInitState:
                 imgr.obslist_next, imgr.init_next, imgr.prior_next,
                 imgr.freq_list + [230e9],  # length mismatch
                 imgr.reffreq,
-                imgr._full_imager_config(),
+                imgr._config,
                 imgr.norm_init, imgr.flux_next, imgr.clipfloor_next,
                 sorted(imgr.dat_term_next.keys()),
                 imgr._full_data_weighting_params(),
@@ -559,7 +559,7 @@ class TestComputeInitState:
 def _call_backend_chisq_dict(imgr, imcur):
     """Call compute_chisq_dict with args pulled from an initialized Imager."""
     return compute_chisq_dict(
-        imcur, sorted(imgr.dat_term_next.keys()), imgr._full_imager_config(),
+        imcur, sorted(imgr.dat_term_next.keys()), imgr._config,
         imgr._data_tuples, imgr._logfreqratio_list, len(imgr.obslist_next),
         imgr._embed_mask,
     )
@@ -568,7 +568,7 @@ def _call_backend_chisq_dict(imgr, imcur):
 def _call_backend_chisqgrad_dict(imgr, imcur):
     """Call compute_chisqgrad_dict with args pulled from an initialized Imager."""
     return compute_chisqgrad_dict(
-        imcur, sorted(imgr.dat_term_next.keys()), imgr._full_imager_config(),
+        imcur, sorted(imgr.dat_term_next.keys()), imgr._config,
         imgr._data_tuples, imgr._logfreqratio_list, len(imgr.obslist_next),
         imgr._embed_mask,
         imgr._which_solve, imgr._nimage,
@@ -601,7 +601,7 @@ def _build_regparams(imgr, mf_flux=None):
 def _call_backend_reg_dict(imgr, imcur, mf_flux=None):
     """Call compute_reg_dict with args pulled from an initialized Imager."""
     return compute_reg_dict(
-        imcur, sorted(imgr.reg_term_next.keys()), imgr._full_imager_config(),
+        imcur, sorted(imgr.reg_term_next.keys()), imgr._config,
         imgr._logfreqratio_list, len(imgr.obslist_next),
         imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr, mf_flux=mf_flux),
         imgr._embed_mask,
@@ -611,7 +611,7 @@ def _call_backend_reg_dict(imgr, imcur, mf_flux=None):
 def _call_backend_reggrad_dict(imgr, imcur, mf_flux=None):
     """Call compute_reggrad_dict with args pulled from an initialized Imager."""
     return compute_reggrad_dict(
-        imcur, sorted(imgr.reg_term_next.keys()), imgr._full_imager_config(),
+        imcur, sorted(imgr.reg_term_next.keys()), imgr._config,
         imgr._logfreqratio_list, len(imgr.obslist_next),
         imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr, mf_flux=mf_flux),
         imgr._embed_mask,
@@ -622,7 +622,7 @@ def _call_backend_reggrad_dict(imgr, imcur, mf_flux=None):
 def _call_backend_objective(imgr, imvec):
     """Call compute_objective with args pulled from an initialized Imager."""
     return compute_objective(
-        imvec, imgr._init_arr, imgr._full_imager_config(),
+        imvec, imgr._init_arr, imgr._config,
         imgr._which_solve, imgr._data_tuples,
         imgr._logfreqratio_list, len(imgr.obslist_next),
         imgr.dat_term_next, imgr.reg_term_next,
@@ -634,7 +634,7 @@ def _call_backend_objective(imgr, imvec):
 def _call_backend_objective_grad(imgr, imvec):
     """Call compute_objective_grad with args pulled from an initialized Imager."""
     return compute_objective_grad(
-        imvec, imgr._init_arr, imgr._full_imager_config(),
+        imvec, imgr._init_arr, imgr._config,
         imgr._which_solve, imgr._data_tuples,
         imgr._logfreqratio_list, len(imgr.obslist_next),
         imgr.dat_term_next, imgr.reg_term_next,
@@ -749,7 +749,7 @@ class TestComputeChisqDict:
         imgr, imcur = initialize_imager(
             [obs_lo, obs_hi], im_lo, {"vis": 100}, mf=True, mf_order=1,
         )
-        assert imgr.mf_next is True
+        assert imgr._config.mf is True
         assert len(imgr._logfreqratio_list) == 2
 
         result = _call_backend_chisq_dict(imgr, imcur)
@@ -900,7 +900,7 @@ class TestComputeChisqgradDict:
         imgr, imcur = initialize_imager(
             [obs_lo, obs_hi], im_lo, {"vis": 100}, mf=True, mf_order=1,
         )
-        assert imgr.mf_next is True
+        assert imgr._config.mf is True
 
         result = _call_backend_chisqgrad_dict(imgr, imcur)
         assert set(result.keys()) == {"vis_0", "vis_1"}
@@ -1039,7 +1039,7 @@ class TestComputeRegDict:
         # Bypass Imager.check_params by passing reg_term_keys directly.
         with pytest.raises(Exception, match="not recognized"):
             compute_reg_dict(
-                imcur, ["not_a_regularizer"], imgr._full_imager_config(),
+                imcur, ["not_a_regularizer"], imgr._config,
                 imgr._logfreqratio_list, len(imgr.obslist_next),
                 imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr),
                 imgr._embed_mask,
@@ -1166,7 +1166,7 @@ class TestComputeReggradDict:
         imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100})
         with pytest.raises(Exception, match="not recognized"):
             compute_reggrad_dict(
-                imcur, ["not_a_regularizer"], imgr._full_imager_config(),
+                imcur, ["not_a_regularizer"], imgr._config,
                 imgr._logfreqratio_list, len(imgr.obslist_next),
                 imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr),
                 imgr._embed_mask,

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -425,10 +425,9 @@ def _call_compute_init_state(imgr):
     return compute_init_state(
         imgr.obslist_next, imgr.init_next, imgr.prior_next,
         imgr.freq_list, imgr.reffreq,
-        imgr.pol_next, imgr.mf_next, imgr.transform_next,
-        imgr.mf_order, imgr.mf_order_pol, imgr.mf_rm, imgr.mf_cm,
+        imgr._full_imager_config(),
         imgr.norm_init, imgr.flux_next, imgr.clipfloor_next,
-        sorted(imgr.dat_term_next.keys()), imgr._ttype,
+        sorted(imgr.dat_term_next.keys()),
         imgr._full_data_weighting_params(),
         imgr._full_fft_params(),
     )
@@ -522,10 +521,9 @@ class TestComputeInitState:
         state = compute_init_state(
             imgr.obslist_next, imgr.init_next, imgr.prior_next,
             imgr.freq_list, imgr.reffreq,
-            imgr.pol_next, imgr.mf_next, imgr.transform_next,
-            imgr.mf_order, imgr.mf_order_pol, imgr.mf_rm, imgr.mf_cm,
+            imgr._full_imager_config(),
             imgr.norm_init, imgr.flux_next, imgr.clipfloor_next,
-            sorted(imgr.dat_term_next.keys()), imgr._ttype,
+            sorted(imgr.dat_term_next.keys()),
             imgr._full_data_weighting_params(),
             imgr._full_fft_params(),
             compute_data=False, prior_data_tuples=sentinel,
@@ -540,10 +538,9 @@ class TestComputeInitState:
                 imgr.obslist_next, imgr.init_next, imgr.prior_next,
                 imgr.freq_list + [230e9],  # length mismatch
                 imgr.reffreq,
-                imgr.pol_next, imgr.mf_next, imgr.transform_next,
-                imgr.mf_order, imgr.mf_order_pol, imgr.mf_rm, imgr.mf_cm,
+                imgr._full_imager_config(),
                 imgr.norm_init, imgr.flux_next, imgr.clipfloor_next,
-                sorted(imgr.dat_term_next.keys()), imgr._ttype,
+                sorted(imgr.dat_term_next.keys()),
                 imgr._full_data_weighting_params(),
                 imgr._full_fft_params(),
             )

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -184,34 +184,40 @@ class TestComputeWhichSolve:
 
     # --- single-frequency ---
 
-    def test_sf_stokes_i(self):
+    def test_sf_stokes_i(self, make_test_config):
         np.testing.assert_array_equal(
-            compute_which_solve("I", mf=False), np.array([1]),
+            compute_which_solve(make_test_config(pol="I", mf=False)),
+            np.array([1]),
         )
 
-    def test_sf_polarimetric_p(self):
+    def test_sf_polarimetric_p(self, make_test_config):
         np.testing.assert_array_equal(
-            compute_which_solve("P", mf=False), np.array([0, 1, 1, 0]),
+            compute_which_solve(make_test_config(pol="P", mf=False)),
+            np.array([0, 1, 1, 0]),
         )
 
-    def test_sf_polarimetric_ip(self):
+    def test_sf_polarimetric_ip(self, make_test_config):
         np.testing.assert_array_equal(
-            compute_which_solve("IP", mf=False), np.array([1, 1, 1, 0]),
+            compute_which_solve(make_test_config(pol="IP", mf=False)),
+            np.array([1, 1, 1, 0]),
         )
 
-    def test_sf_polarimetric_iv(self):
+    def test_sf_polarimetric_iv(self, make_test_config):
         np.testing.assert_array_equal(
-            compute_which_solve("IV", mf=False), np.array([1, 0, 0, 1]),
+            compute_which_solve(make_test_config(pol="IV", mf=False)),
+            np.array([1, 0, 0, 1]),
         )
 
-    def test_sf_polarimetric_ipv(self):
+    def test_sf_polarimetric_ipv(self, make_test_config):
         np.testing.assert_array_equal(
-            compute_which_solve("IPV", mf=False), np.array([1, 1, 1, 1]),
+            compute_which_solve(make_test_config(pol="IPV", mf=False)),
+            np.array([1, 1, 1, 1]),
         )
 
-    def test_sf_polarimetric_v(self):
+    def test_sf_polarimetric_v(self, make_test_config):
         np.testing.assert_array_equal(
-            compute_which_solve("V", mf=False), np.array([0, 0, 0, 1]),
+            compute_which_solve(make_test_config(pol="V", mf=False)),
+            np.array([0, 0, 0, 1]),
         )
 
     # --- multi-frequency Stokes I ---
@@ -221,43 +227,46 @@ class TestComputeWhichSolve:
         (1, [1, 1, 0]),
         (2, [1, 1, 1]),
     ])
-    def test_mf_stokes_i_order(self, mf_order, expected):
+    def test_mf_stokes_i_order(self, make_test_config, mf_order, expected):
         np.testing.assert_array_equal(
-            compute_which_solve("I", mf=True, mf_order=mf_order),
+            compute_which_solve(make_test_config(pol="I", mf=True, mf_order=mf_order)),
             np.array(expected),
         )
 
     # --- multi-frequency polarimetric ---
 
-    def test_mf_polarimetric_minimal(self):
+    def test_mf_polarimetric_minimal(self, make_test_config):
         """MF + IP + all spectral orders 0 + no RM/CM."""
         np.testing.assert_array_equal(
-            compute_which_solve("IP", mf=True,
-                                mf_order=0, mf_order_pol=0,
-                                mf_rm=False, mf_cm=False),
+            compute_which_solve(make_test_config(
+                pol="IP", mf=True,
+                mf_order=0, mf_order_pol=0, mf_rm=0, mf_cm=0,
+            )),
             np.array([1, 1, 1, 0,  # I, rho, phi, psi
                       0, 0,         # alpha, beta
                       0, 0,         # alpha_p, beta_p
                       0, 0]),       # RM, CM
         )
 
-    def test_mf_polarimetric_all_on(self):
+    def test_mf_polarimetric_all_on(self, make_test_config):
         """MF + IP with everything enabled."""
         np.testing.assert_array_equal(
-            compute_which_solve("IP", mf=True,
-                                mf_order=2, mf_order_pol=2,
-                                mf_rm=True, mf_cm=True),
+            compute_which_solve(make_test_config(
+                pol="IP", mf=True,
+                mf_order=2, mf_order_pol=2, mf_rm=1, mf_cm=1,
+            )),
             np.array([1, 1, 1, 0,
                       1, 1,
                       1, 1,
                       1, 1]),
         )
 
-    def test_mf_polarimetric_rm_only(self):
+    def test_mf_polarimetric_rm_only(self, make_test_config):
         np.testing.assert_array_equal(
-            compute_which_solve("IP", mf=True,
-                                mf_order=1, mf_order_pol=1,
-                                mf_rm=True, mf_cm=False),
+            compute_which_solve(make_test_config(
+                pol="IP", mf=True,
+                mf_order=1, mf_order_pol=1, mf_rm=1, mf_cm=0,
+            )),
             np.array([1, 1, 1, 0,
                       1, 0,
                       1, 0,
@@ -266,22 +275,25 @@ class TestComputeWhichSolve:
 
     # --- error cases ---
 
-    def test_raises_on_invalid_mf_order(self):
+    def test_raises_on_invalid_mf_order(self, make_test_config):
         with pytest.raises(Exception, match="mf_order must be 0, 1, or 2"):
-            compute_which_solve("I", mf=True, mf_order=3)
+            compute_which_solve(make_test_config(pol="I", mf=True, mf_order=3))
 
-    def test_raises_on_invalid_mf_order_pol(self):
+    def test_raises_on_invalid_mf_order_pol(self, make_test_config):
         with pytest.raises(Exception, match="mf_order_pol must be 0, 1, or 2"):
-            compute_which_solve("IP", mf=True, mf_order=1, mf_order_pol=3)
+            compute_which_solve(make_test_config(
+                pol="IP", mf=True, mf_order=1, mf_order_pol=3))
 
-    def test_raises_on_mf_pol_without_p(self):
+    def test_raises_on_mf_pol_without_p(self, make_test_config):
         with pytest.raises(Exception, match="requires pol_next=P"):
-            compute_which_solve("IV", mf=True, mf_order=1, mf_order_pol=1)
+            compute_which_solve(make_test_config(
+                pol="IV", mf=True, mf_order=1, mf_order_pol=1))
 
-    def test_raises_on_mf_pol_with_v(self):
+    def test_raises_on_mf_pol_with_v(self, make_test_config):
         # 'IPV' contains both 'P' and 'V'; the V check fires.
         with pytest.raises(Exception, match="Stokes V not yet implemented"):
-            compute_which_solve("IPV", mf=True, mf_order=1, mf_order_pol=1)
+            compute_which_solve(make_test_config(
+                pol="IPV", mf=True, mf_order=1, mf_order_pol=1))
 
     # --- parity with init_imager ---
 
@@ -296,10 +308,7 @@ class TestComputeWhichSolve:
         imgr.init_imager()
         np.testing.assert_array_equal(
             imgr._which_solve,
-            compute_which_solve(imgr.pol_next, imgr.mf_next,
-                                mf_order=imgr.mf_order,
-                                mf_order_pol=imgr.mf_order_pol,
-                                mf_rm=imgr.mf_rm, mf_cm=imgr.mf_cm),
+            compute_which_solve(imgr._full_imager_config()),
         )
 
     def test_matches_imager_init_imager_polarimetric(self, gauss_im_pol, observe):
@@ -319,10 +328,7 @@ class TestComputeWhichSolve:
         imgr.init_imager()
         np.testing.assert_array_equal(
             imgr._which_solve,
-            compute_which_solve(imgr.pol_next, imgr.mf_next,
-                                mf_order=imgr.mf_order,
-                                mf_order_pol=imgr.mf_order_pol,
-                                mf_rm=imgr.mf_rm, mf_cm=imgr.mf_cm),
+            compute_which_solve(imgr._full_imager_config()),
         )
 
 
@@ -330,8 +336,7 @@ def _call_compute_data_tuples(imgr):
     """Call compute_data_tuples with the args init_imager would pass."""
     return compute_data_tuples(
         imgr.obslist_next, imgr.prior_next, imgr._embed_mask,
-        sorted(imgr.dat_term_next.keys()), imgr.pol_next,
-        imgr._ttype,
+        sorted(imgr.dat_term_next.keys()), imgr._full_imager_config(),
         imgr._full_data_weighting_params(),
         imgr._full_fft_params(),
     )
@@ -389,8 +394,8 @@ class TestComputeDataTuples:
         with pytest.raises(Exception, match="not recognized"):
             compute_data_tuples(
                 imgr.obslist_next, imgr.prior_next, imgr._embed_mask,
-                ["bogus"], imgr.pol_next,
-                imgr._ttype, bogus_weighting, imgr._full_fft_params(),
+                ["bogus"], imgr._full_imager_config(),
+                bogus_weighting, imgr._full_fft_params(),
             )
 
     def test_matches_imager_init_imager(self, gauss_im, observe,
@@ -554,20 +559,18 @@ class TestComputeInitState:
 def _call_backend_chisq_dict(imgr, imcur):
     """Call compute_chisq_dict with args pulled from an initialized Imager."""
     return compute_chisq_dict(
-        imcur, sorted(imgr.dat_term_next.keys()),
-        imgr.mf_next, imgr.pol_next,
+        imcur, sorted(imgr.dat_term_next.keys()), imgr._full_imager_config(),
         imgr._data_tuples, imgr._logfreqratio_list, len(imgr.obslist_next),
-        imgr._ttype, imgr._embed_mask,
+        imgr._embed_mask,
     )
 
 
 def _call_backend_chisqgrad_dict(imgr, imcur):
     """Call compute_chisqgrad_dict with args pulled from an initialized Imager."""
     return compute_chisqgrad_dict(
-        imcur, sorted(imgr.dat_term_next.keys()),
-        imgr.mf_next, imgr.pol_next,
+        imcur, sorted(imgr.dat_term_next.keys()), imgr._full_imager_config(),
         imgr._data_tuples, imgr._logfreqratio_list, len(imgr.obslist_next),
-        imgr._ttype, imgr._embed_mask,
+        imgr._embed_mask,
         imgr._which_solve, imgr._nimage,
     )
 
@@ -598,8 +601,7 @@ def _build_regparams(imgr, mf_flux=None):
 def _call_backend_reg_dict(imgr, imcur, mf_flux=None):
     """Call compute_reg_dict with args pulled from an initialized Imager."""
     return compute_reg_dict(
-        imcur, sorted(imgr.reg_term_next.keys()),
-        imgr.mf_next, imgr.pol_next,
+        imcur, sorted(imgr.reg_term_next.keys()), imgr._full_imager_config(),
         imgr._logfreqratio_list, len(imgr.obslist_next),
         imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr, mf_flux=mf_flux),
         imgr._embed_mask,
@@ -609,8 +611,7 @@ def _call_backend_reg_dict(imgr, imcur, mf_flux=None):
 def _call_backend_reggrad_dict(imgr, imcur, mf_flux=None):
     """Call compute_reggrad_dict with args pulled from an initialized Imager."""
     return compute_reggrad_dict(
-        imcur, sorted(imgr.reg_term_next.keys()),
-        imgr.mf_next, imgr.pol_next,
+        imcur, sorted(imgr.reg_term_next.keys()), imgr._full_imager_config(),
         imgr._logfreqratio_list, len(imgr.obslist_next),
         imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr, mf_flux=mf_flux),
         imgr._embed_mask,
@@ -621,26 +622,24 @@ def _call_backend_reggrad_dict(imgr, imcur, mf_flux=None):
 def _call_backend_objective(imgr, imvec):
     """Call compute_objective with args pulled from an initialized Imager."""
     return compute_objective(
-        imvec, imgr._init_arr,
-        imgr.mf_next, imgr.pol_next,
+        imvec, imgr._init_arr, imgr._full_imager_config(),
         imgr._which_solve, imgr._data_tuples,
         imgr._logfreqratio_list, len(imgr.obslist_next),
         imgr.dat_term_next, imgr.reg_term_next,
         imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr),
-        imgr.transform_next, imgr._embed_mask, imgr._ttype,
+        imgr._embed_mask,
     )
 
 
 def _call_backend_objective_grad(imgr, imvec):
     """Call compute_objective_grad with args pulled from an initialized Imager."""
     return compute_objective_grad(
-        imvec, imgr._init_arr,
-        imgr.mf_next, imgr.pol_next,
+        imvec, imgr._init_arr, imgr._full_imager_config(),
         imgr._which_solve, imgr._data_tuples,
         imgr._logfreqratio_list, len(imgr.obslist_next),
         imgr.dat_term_next, imgr.reg_term_next,
         imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr),
-        imgr.transform_next, imgr._embed_mask, imgr._ttype, imgr._nimage,
+        imgr._embed_mask, imgr._nimage,
     )
 
 
@@ -1040,8 +1039,7 @@ class TestComputeRegDict:
         # Bypass Imager.check_params by passing reg_term_keys directly.
         with pytest.raises(Exception, match="not recognized"):
             compute_reg_dict(
-                imcur, ["not_a_regularizer"],
-                imgr.mf_next, imgr.pol_next,
+                imcur, ["not_a_regularizer"], imgr._full_imager_config(),
                 imgr._logfreqratio_list, len(imgr.obslist_next),
                 imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr),
                 imgr._embed_mask,
@@ -1168,8 +1166,7 @@ class TestComputeReggradDict:
         imgr, imcur = initialize_imager(obs, gauss_im, {"vis": 100})
         with pytest.raises(Exception, match="not recognized"):
             compute_reggrad_dict(
-                imcur, ["not_a_regularizer"],
-                imgr.mf_next, imgr.pol_next,
+                imcur, ["not_a_regularizer"], imgr._full_imager_config(),
                 imgr._logfreqratio_list, len(imgr.obslist_next),
                 imgr._prior_arr, imgr.norm_reg, _build_regparams(imgr),
                 imgr._embed_mask,
@@ -2806,6 +2803,14 @@ class TestComputeChisqdataTerm:
     POL_DTYPES = ['pvis', 'm', 'vvis']
 
     @staticmethod
+    def _config(ttype='direct', pol='I'):
+        """Build an ImagerConfig with the (ttype, pol) under test."""
+        return ImagerConfig(
+            pol=pol, transforms=[], ttype=ttype, mf=False,
+            mf_config=MfConfig(mf_order=0, mf_order_pol=0, mf_rm=0, mf_cm=0),
+        )
+
+    @staticmethod
     def _kwargs():
         """Kwargs matching compute_data_tuples' current call into chisqdata."""
         return dict(
@@ -2866,7 +2871,7 @@ class TestComputeChisqdataTerm:
         legacy = chisqdata(obs_direct, gauss_im, mask, dtype, pol='I',
                            ttype='direct', **kw)
         new = compute_chisqdata_term(obs_direct, gauss_im, mask, dtype,
-                                     ttype='direct', pol='I', **kw)
+                                     self._config(ttype='direct', pol='I'), **kw)
         self._data_sigma_equal(legacy, new)
 
     @pytest.mark.parametrize("dtype", STD_DTYPES)
@@ -2877,7 +2882,7 @@ class TestComputeChisqdataTerm:
         legacy = chisqdata(obs_fast, gauss_im, mask, dtype, pol='I',
                            ttype='fast', **kw)
         new = compute_chisqdata_term(obs_fast, gauss_im, mask, dtype,
-                                     ttype='fast', pol='I', **kw)
+                                     self._config(ttype='fast', pol='I'), **kw)
         self._data_sigma_equal(legacy, new)
 
     @pytest.mark.parametrize("dtype", STD_DTYPES)
@@ -2888,7 +2893,7 @@ class TestComputeChisqdataTerm:
         legacy = chisqdata(obs_nfft, gauss_im, mask, dtype, pol='I',
                            ttype='nfft', **kw)
         new = compute_chisqdata_term(obs_nfft, gauss_im, mask, dtype,
-                                     ttype='nfft', pol='I', **kw)
+                                     self._config(ttype='nfft', pol='I'), **kw)
         self._data_sigma_equal(legacy, new)
 
     @pytest.mark.parametrize("dtype", POL_DTYPES)
@@ -2899,7 +2904,7 @@ class TestComputeChisqdataTerm:
         legacy = polchisqdata(obs_direct, gauss_im_pol, mask, dtype,
                               ttype='direct', **kw_fft)
         new = compute_chisqdata_term(obs_direct, gauss_im_pol, mask, dtype,
-                                     ttype='direct', pol='IP', **kw_fft)
+                                     self._config(ttype='direct', pol='IP'), **kw_fft)
         self._data_sigma_equal(legacy, new)
 
     @pytest.mark.parametrize("dtype", POL_DTYPES)
@@ -2910,26 +2915,26 @@ class TestComputeChisqdataTerm:
         legacy = polchisqdata(obs_nfft, gauss_im_pol, mask, dtype,
                               ttype='nfft', **kw_fft)
         new = compute_chisqdata_term(obs_nfft, gauss_im_pol, mask, dtype,
-                                     ttype='nfft', pol='IP', **kw_fft)
+                                     self._config(ttype='nfft', pol='IP'), **kw_fft)
         self._data_sigma_equal(legacy, new)
 
     def test_unknown_dtype_raises(self, gauss_im, obs_direct):
         mask = self._full_mask(gauss_im)
         with pytest.raises(Exception, match="data term .* not recognized"):
             compute_chisqdata_term(obs_direct, gauss_im, mask, 'bogus',
-                                   ttype='direct', pol='I')
+                                   self._config(ttype='direct', pol='I'))
 
     def test_pol_with_fast_raises(self, gauss_im_pol, obs_direct):
         mask = self._full_mask(gauss_im_pol)
         with pytest.raises(Exception, match="not supported for dtype"):
             compute_chisqdata_term(obs_direct, gauss_im_pol, mask, 'pvis',
-                                   ttype='fast', pol='IP')
+                                   self._config(ttype='fast', pol='IP'))
 
     def test_invalid_ttype_raises(self, gauss_im, obs_direct):
         mask = self._full_mask(gauss_im)
         with pytest.raises(Exception, match="Possible ttype values"):
             compute_chisqdata_term(obs_direct, gauss_im, mask, 'vis',
-                                   ttype='bogus', pol='I')
+                                   self._config(ttype='bogus', pol='I'))
 
     def test_standard_dtype_in_pol_mode_uses_stokes_I(self, gauss_im_pol, obs_direct):
         """In pol='IP' mode, a standard dtype ('vis') reads Stokes-I data.
@@ -2943,7 +2948,7 @@ class TestComputeChisqdataTerm:
         legacy_I = chisqdata(obs_direct, gauss_im_pol, mask, 'vis',
                              pol='I', ttype='direct', **kw)
         new_IP = compute_chisqdata_term(obs_direct, gauss_im_pol, mask, 'vis',
-                                        ttype='direct', pol='IP', **kw)
+                                        self._config(ttype='direct', pol='IP'), **kw)
         self._data_sigma_equal(legacy_I, new_IP)
 
     def test_standard_dtype_with_no_stokes_I_pol_raises(self, gauss_im_pol, obs_direct):
@@ -2951,7 +2956,8 @@ class TestComputeChisqdataTerm:
         mask = self._full_mask(gauss_im_pol)
         with pytest.raises(Exception, match="cannot use dterm vis with pol=P"):
             compute_chisqdata_term(obs_direct, gauss_im_pol, mask, 'vis',
-                                   ttype='direct', pol='P', **self._kwargs())
+                                   self._config(ttype='direct', pol='P'),
+                                   **self._kwargs())
 
 
 class _ChisqTermFixtures:
@@ -2992,8 +2998,12 @@ class _ChisqTermFixtures:
     @staticmethod
     def _data_tuple(obs, prior, mask, dtype, ttype, pol):
         """Get (A, data, sigma) for this (dtype, ttype) via the unified data-tuple dispatcher."""
+        config = ImagerConfig(
+            pol=pol, transforms=[], ttype=ttype, mf=False,
+            mf_config=MfConfig(mf_order=0, mf_order_pol=0, mf_rm=0, mf_cm=0),
+        )
         data, sigma, A = compute_chisqdata_term(
-            obs, prior, mask, dtype, ttype=ttype, pol=pol,
+            obs, prior, mask, dtype, config,
         )
         return A, data, sigma
 

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -382,8 +382,8 @@ class TestComputeDataTuples:
     def test_unrecognized_term_raises(self, gauss_im, observe,
                                       initialize_imager):
         imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 1})
-        bogus_weighting = {**imgr._full_data_weighting_params(),
-                           'snrcut': {'bogus': 0.0}}
+        bogus_weighting = imgr._full_data_weighting_params()._replace(
+            snrcut={'bogus': 0.0})
         with pytest.raises(Exception, match="not recognized"):
             compute_data_tuples(
                 imgr.obslist_next, imgr.prior_next, imgr._embed_mask,

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -1363,7 +1363,9 @@ class TestDataWeighting:
             data_term={"vis": 100}, ttype="direct", pol="I",
             debias=True, weighting="uniform", systematic_noise=0.05,
         )
-        imgr.check_params(); imgr.check_limits(); imgr.init_imager()
+        imgr.check_params()
+        imgr.check_limits()
+        imgr.init_imager()
         dw = imgr._full_data_weighting_params()
         assert dw.debias is True
         assert dw.weighting == "uniform"
@@ -1419,7 +1421,9 @@ class TestFourierGridParams:
             fft_pad_factor=4, fft_conv_func="pillbox", fft_gridder_prad=3,
             fft_interp_order=5,
         )
-        imgr.check_params(); imgr.check_limits(); imgr.init_imager()
+        imgr.check_params()
+        imgr.check_limits()
+        imgr.init_imager()
         fp = imgr._full_fft_params()
         assert fp.fft_pad_factor == 4
         assert fp.fft_conv_func == "pillbox"
@@ -1428,8 +1432,10 @@ class TestFourierGridParams:
 
     def test_defaults_preserved(self, gauss_im, observe, initialize_imager):
         from ehtim.imager import (
-            FFT_INTERP_DEFAULT, FFT_PAD_DEFAULT,
-            GRIDDER_CONV_FUNC_DEFAULT, GRIDDER_P_RAD_DEFAULT,
+            FFT_INTERP_DEFAULT,
+            FFT_PAD_DEFAULT,
+            GRIDDER_CONV_FUNC_DEFAULT,
+            GRIDDER_P_RAD_DEFAULT,
         )
         imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
         fp = imgr._full_fft_params()

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -10,7 +10,9 @@ import pytest
 import ehtim as eh
 import ehtim.const_def as ehc
 from ehtim.imaging.imager_backend import (
+    ImagerConfig,
     ImagerInitState,
+    MfConfig,
     RegParams,
     _pol_solve_block,
     compute_chisq_dict,
@@ -2383,7 +2385,20 @@ class TestValidateParams:
 
     @staticmethod
     def _call(**kwargs):
-        return validate_params(**kwargs)
+        # Assemble the per-test config kwargs into an ImagerConfig, pass the rest through.
+        config = ImagerConfig(
+            pol=kwargs.pop('pol'),
+            transforms=kwargs.pop('transforms'),
+            ttype=kwargs.pop('ttype'),
+            mf=kwargs.pop('mf'),
+            mf_config=MfConfig(
+                mf_order=kwargs.pop('mf_order'),
+                mf_order_pol=kwargs.pop('mf_order_pol'),
+                mf_rm=kwargs.pop('mf_rm', 0),
+                mf_cm=kwargs.pop('mf_cm', 0),
+            ),
+        )
+        return validate_params(config=config, **kwargs)
 
     # Sanity: the baseline does not raise.
     def test_baseline_ok(self, gauss_im):

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -339,8 +339,8 @@ def _call_compute_data_tuples(imgr):
     return compute_data_tuples(
         imgr.obslist_next, imgr.prior_next, imgr._embed_mask,
         sorted(imgr.dat_term_next.keys()), imgr._config,
-        imgr._full_data_weighting_params(),
-        imgr._full_fft_params(),
+        imgr._data_weighting_params(),
+        imgr._fft_params(),
     )
 
 
@@ -391,13 +391,13 @@ class TestComputeDataTuples:
     def test_unrecognized_term_raises(self, gauss_im, observe,
                                       initialize_imager):
         imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 1})
-        bogus_weighting = imgr._full_data_weighting_params()._replace(
+        bogus_weighting = imgr._data_weighting_params()._replace(
             snrcut={'bogus': 0.0})
         with pytest.raises(Exception, match="not recognized"):
             compute_data_tuples(
                 imgr.obslist_next, imgr.prior_next, imgr._embed_mask,
                 ["bogus"], imgr._config,
-                bogus_weighting, imgr._full_fft_params(),
+                bogus_weighting, imgr._fft_params(),
             )
 
     def test_matches_imager_init_imager(self, gauss_im, observe,
@@ -435,8 +435,8 @@ def _call_compute_init_state(imgr):
         imgr._config,
         imgr.norm_init, imgr.flux_next, imgr.clipfloor_next,
         sorted(imgr.dat_term_next.keys()),
-        imgr._full_data_weighting_params(),
-        imgr._full_fft_params(),
+        imgr._data_weighting_params(),
+        imgr._fft_params(),
     )
 
 
@@ -531,8 +531,8 @@ class TestComputeInitState:
             imgr._config,
             imgr.norm_init, imgr.flux_next, imgr.clipfloor_next,
             sorted(imgr.dat_term_next.keys()),
-            imgr._full_data_weighting_params(),
-            imgr._full_fft_params(),
+            imgr._data_weighting_params(),
+            imgr._fft_params(),
             compute_data=False, prior_data_tuples=sentinel,
         )
         assert state.data_tuples is sentinel
@@ -548,8 +548,8 @@ class TestComputeInitState:
                 imgr._config,
                 imgr.norm_init, imgr.flux_next, imgr.clipfloor_next,
                 sorted(imgr.dat_term_next.keys()),
-                imgr._full_data_weighting_params(),
-                imgr._full_fft_params(),
+                imgr._data_weighting_params(),
+                imgr._fft_params(),
             )
 
 
@@ -1223,7 +1223,7 @@ def test_reg_and_reggrad_share_keys(gauss_im, observe, initialize_imager):
 
 
 class TestRegParams:
-    """Tests for the RegParams NamedTuple bundle and Imager._full_regparams()."""
+    """Tests for the RegParams NamedTuple bundle and Imager._regparams()."""
 
     EXPECTED_FIELDS = (
         "flux", "pflux", "vflux",
@@ -1232,12 +1232,12 @@ class TestRegParams:
         "major", "minor", "PA", "alpha_A", "epsilon_tv",
     )
 
-    def test_full_regparams_returns_namedtuple(self, gauss_im, observe,
+    def test_regparams_returns_namedtuple(self, gauss_im, observe,
                                                 initialize_imager):
-        """Imager._full_regparams() returns a RegParams instance."""
+        """Imager._regparams() returns a RegParams instance."""
         obs = observe(gauss_im)
         imgr, _ = initialize_imager(obs, gauss_im, {"vis": 100})
-        regp = imgr._full_regparams()
+        regp = imgr._regparams()
         assert isinstance(regp, RegParams)
 
     def test_field_access_matches_imager_attrs(self, gauss_im, observe,
@@ -1245,7 +1245,7 @@ class TestRegParams:
         """Every RegParams field reads back the corresponding Imager attribute."""
         obs = observe(gauss_im)
         imgr, _ = initialize_imager(obs, gauss_im, {"vis": 100})
-        regp = imgr._full_regparams()
+        regp = imgr._regparams()
 
         assert regp.flux == imgr.flux_next
         assert regp.pflux == imgr.pflux_next
@@ -1267,7 +1267,7 @@ class TestRegParams:
         2.18/2.19 promotions don't silently drop/add a key."""
         obs = observe(gauss_im)
         imgr, _ = initialize_imager(obs, gauss_im, {"vis": 100})
-        keys = imgr._full_regparams()._asdict().keys()
+        keys = imgr._regparams()._asdict().keys()
         assert tuple(keys) == self.EXPECTED_FIELDS
 
     def test_immutability(self, gauss_im, observe, initialize_imager):
@@ -1275,7 +1275,7 @@ class TestRegParams:
         semantics: any update must go through ._replace(...)."""
         obs = observe(gauss_im)
         imgr, _ = initialize_imager(obs, gauss_im, {"vis": 100})
-        regp = imgr._full_regparams()
+        regp = imgr._regparams()
         with pytest.raises(AttributeError):
             regp.flux = 2.0
 
@@ -1294,7 +1294,7 @@ class TestRegParams:
         imgr.check_params()
         imgr.check_limits()
         imgr.init_imager()
-        regp = imgr._full_regparams()
+        regp = imgr._regparams()
         assert regp.major == custom_major
         assert regp.epsilon_tv == custom_eps
         # Unspecified REGPARAMS_DEFAULT fields keep their defaults.
@@ -1315,12 +1315,12 @@ class TestRegParams:
             mf=True, mf_order=1,
             mf_flux=[1.0, 2.0],
         )
-        regp = imgr._full_regparams()
+        regp = imgr._regparams()
         assert regp.mf_flux == [1.0, 2.0]
 
 
 class TestDataWeighting:
-    """Pins the DataWeighting bundle returned by Imager._full_data_weighting_params():
+    """Pins the DataWeighting bundle returned by Imager._data_weighting_params():
     field set, immutability, parity with Imager attrs, and kwarg overrides /
     defaults landing in the right slots."""
 
@@ -1332,12 +1332,12 @@ class TestDataWeighting:
     def test_full_data_weighting_returns_namedtuple(self, gauss_im, observe,
                                                      initialize_imager):
         imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
-        assert isinstance(imgr._full_data_weighting_params(), DataWeighting)
+        assert isinstance(imgr._data_weighting_params(), DataWeighting)
 
     def test_field_access_matches_imager_attrs(self, gauss_im, observe,
                                                  initialize_imager):
         imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
-        dw = imgr._full_data_weighting_params()
+        dw = imgr._data_weighting_params()
         assert dw.maxset == imgr.maxset_next
         assert dw.debias == imgr.debias_next
         assert dw.snrcut == imgr.snrcut_next
@@ -1348,11 +1348,11 @@ class TestDataWeighting:
 
     def test_asdict_has_expected_keys(self, gauss_im, observe, initialize_imager):
         imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
-        assert tuple(imgr._full_data_weighting_params()._asdict().keys()) == self.EXPECTED_FIELDS
+        assert tuple(imgr._data_weighting_params()._asdict().keys()) == self.EXPECTED_FIELDS
 
     def test_immutability(self, gauss_im, observe, initialize_imager):
         imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
-        dw = imgr._full_data_weighting_params()
+        dw = imgr._data_weighting_params()
         with pytest.raises(AttributeError):
             dw.maxset = True
 
@@ -1366,14 +1366,14 @@ class TestDataWeighting:
         imgr.check_params()
         imgr.check_limits()
         imgr.init_imager()
-        dw = imgr._full_data_weighting_params()
+        dw = imgr._data_weighting_params()
         assert dw.debias is True
         assert dw.weighting == "uniform"
         assert dw.systematic_noise == 0.05
 
     def test_defaults_preserved(self, gauss_im, observe, initialize_imager):
         imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
-        dw = imgr._full_data_weighting_params()
+        dw = imgr._data_weighting_params()
         assert dw.maxset is False
         assert dw.debias is False
         assert dw.weighting == "natural"
@@ -1382,7 +1382,7 @@ class TestDataWeighting:
 
 
 class TestFourierGridParams:
-    """Pins the FourierGridParams bundle returned by Imager._full_fft_params():
+    """Pins the FourierGridParams bundle returned by Imager._fft_params():
     field set, immutability, parity with the underlying _fft_* attrs, and
     kwarg overrides / defaults landing in the right slots."""
 
@@ -1392,12 +1392,12 @@ class TestFourierGridParams:
 
     def test_full_fft_returns_namedtuple(self, gauss_im, observe, initialize_imager):
         imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
-        assert isinstance(imgr._full_fft_params(), FourierGridParams)
+        assert isinstance(imgr._fft_params(), FourierGridParams)
 
     def test_field_access_matches_imager_attrs(self, gauss_im, observe,
                                                  initialize_imager):
         imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
-        fp = imgr._full_fft_params()
+        fp = imgr._fft_params()
         assert fp.fft_pad_factor == imgr._fft_pad_factor
         assert fp.fft_conv_func == imgr._fft_conv_func
         assert fp.fft_gridder_prad == imgr._fft_gridder_prad
@@ -1405,11 +1405,11 @@ class TestFourierGridParams:
 
     def test_asdict_has_expected_keys(self, gauss_im, observe, initialize_imager):
         imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
-        assert tuple(imgr._full_fft_params()._asdict().keys()) == self.EXPECTED_FIELDS
+        assert tuple(imgr._fft_params()._asdict().keys()) == self.EXPECTED_FIELDS
 
     def test_immutability(self, gauss_im, observe, initialize_imager):
         imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
-        fp = imgr._full_fft_params()
+        fp = imgr._fft_params()
         with pytest.raises(AttributeError):
             fp.fft_pad_factor = 4
 
@@ -1424,7 +1424,7 @@ class TestFourierGridParams:
         imgr.check_params()
         imgr.check_limits()
         imgr.init_imager()
-        fp = imgr._full_fft_params()
+        fp = imgr._fft_params()
         assert fp.fft_pad_factor == 4
         assert fp.fft_conv_func == "pillbox"
         assert fp.fft_gridder_prad == 3
@@ -1438,7 +1438,7 @@ class TestFourierGridParams:
             GRIDDER_P_RAD_DEFAULT,
         )
         imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
-        fp = imgr._full_fft_params()
+        fp = imgr._fft_params()
         assert fp.fft_pad_factor == FFT_PAD_DEFAULT
         assert fp.fft_conv_func == GRIDDER_CONV_FUNC_DEFAULT
         assert fp.fft_gridder_prad == GRIDDER_P_RAD_DEFAULT

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -10,6 +10,8 @@ import pytest
 import ehtim as eh
 import ehtim.const_def as ehc
 from ehtim.imaging.imager_backend import (
+    DataWeighting,
+    FourierGridParams,
     ImagerConfig,
     ImagerInitState,
     MfConfig,
@@ -1315,6 +1317,265 @@ class TestRegParams:
         )
         regp = imgr._full_regparams()
         assert regp.mf_flux == [1.0, 2.0]
+
+
+class TestDataWeighting:
+    """Pins the DataWeighting bundle returned by Imager._full_data_weighting_params():
+    field set, immutability, parity with Imager attrs, and kwarg overrides /
+    defaults landing in the right slots."""
+
+    EXPECTED_FIELDS = (
+        "maxset", "debias", "snrcut", "weighting",
+        "systematic_noise", "systematic_cphase_noise", "cp_uv_min",
+    )
+
+    def test_full_data_weighting_returns_namedtuple(self, gauss_im, observe,
+                                                     initialize_imager):
+        imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
+        assert isinstance(imgr._full_data_weighting_params(), DataWeighting)
+
+    def test_field_access_matches_imager_attrs(self, gauss_im, observe,
+                                                 initialize_imager):
+        imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
+        dw = imgr._full_data_weighting_params()
+        assert dw.maxset == imgr.maxset_next
+        assert dw.debias == imgr.debias_next
+        assert dw.snrcut == imgr.snrcut_next
+        assert dw.weighting == imgr.weighting_next
+        assert dw.systematic_noise == imgr.systematic_noise_next
+        assert dw.systematic_cphase_noise == imgr.systematic_cphase_noise_next
+        assert dw.cp_uv_min == imgr.cp_uv_min
+
+    def test_asdict_has_expected_keys(self, gauss_im, observe, initialize_imager):
+        imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
+        assert tuple(imgr._full_data_weighting_params()._asdict().keys()) == self.EXPECTED_FIELDS
+
+    def test_immutability(self, gauss_im, observe, initialize_imager):
+        imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
+        dw = imgr._full_data_weighting_params()
+        with pytest.raises(AttributeError):
+            dw.maxset = True
+
+    def test_kwarg_override(self, gauss_im, observe):
+        obs = observe(gauss_im)
+        imgr = eh.imager.Imager(
+            obs, gauss_im, prior_im=gauss_im, flux=gauss_im.total_flux(),
+            data_term={"vis": 100}, ttype="direct", pol="I",
+            debias=True, weighting="uniform", systematic_noise=0.05,
+        )
+        imgr.check_params(); imgr.check_limits(); imgr.init_imager()
+        dw = imgr._full_data_weighting_params()
+        assert dw.debias is True
+        assert dw.weighting == "uniform"
+        assert dw.systematic_noise == 0.05
+
+    def test_defaults_preserved(self, gauss_im, observe, initialize_imager):
+        imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
+        dw = imgr._full_data_weighting_params()
+        assert dw.maxset is False
+        assert dw.debias is False
+        assert dw.weighting == "natural"
+        assert dw.systematic_noise == 0.0
+        assert dw.systematic_cphase_noise == 0.0
+
+
+class TestFourierGridParams:
+    """Pins the FourierGridParams bundle returned by Imager._full_fft_params():
+    field set, immutability, parity with the underlying _fft_* attrs, and
+    kwarg overrides / defaults landing in the right slots."""
+
+    EXPECTED_FIELDS = (
+        "fft_pad_factor", "fft_conv_func", "fft_gridder_prad", "fft_interp_order",
+    )
+
+    def test_full_fft_returns_namedtuple(self, gauss_im, observe, initialize_imager):
+        imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
+        assert isinstance(imgr._full_fft_params(), FourierGridParams)
+
+    def test_field_access_matches_imager_attrs(self, gauss_im, observe,
+                                                 initialize_imager):
+        imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
+        fp = imgr._full_fft_params()
+        assert fp.fft_pad_factor == imgr._fft_pad_factor
+        assert fp.fft_conv_func == imgr._fft_conv_func
+        assert fp.fft_gridder_prad == imgr._fft_gridder_prad
+        assert fp.fft_interp_order == imgr._fft_interp_order
+
+    def test_asdict_has_expected_keys(self, gauss_im, observe, initialize_imager):
+        imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
+        assert tuple(imgr._full_fft_params()._asdict().keys()) == self.EXPECTED_FIELDS
+
+    def test_immutability(self, gauss_im, observe, initialize_imager):
+        imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
+        fp = imgr._full_fft_params()
+        with pytest.raises(AttributeError):
+            fp.fft_pad_factor = 4
+
+    def test_kwarg_override(self, gauss_im, observe):
+        obs = observe(gauss_im)
+        imgr = eh.imager.Imager(
+            obs, gauss_im, prior_im=gauss_im, flux=gauss_im.total_flux(),
+            data_term={"vis": 100}, ttype="direct", pol="I",
+            fft_pad_factor=4, fft_conv_func="pillbox", fft_gridder_prad=3,
+            fft_interp_order=5,
+        )
+        imgr.check_params(); imgr.check_limits(); imgr.init_imager()
+        fp = imgr._full_fft_params()
+        assert fp.fft_pad_factor == 4
+        assert fp.fft_conv_func == "pillbox"
+        assert fp.fft_gridder_prad == 3
+        assert fp.fft_interp_order == 5
+
+    def test_defaults_preserved(self, gauss_im, observe, initialize_imager):
+        from ehtim.imager import (
+            FFT_INTERP_DEFAULT, FFT_PAD_DEFAULT,
+            GRIDDER_CONV_FUNC_DEFAULT, GRIDDER_P_RAD_DEFAULT,
+        )
+        imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
+        fp = imgr._full_fft_params()
+        assert fp.fft_pad_factor == FFT_PAD_DEFAULT
+        assert fp.fft_conv_func == GRIDDER_CONV_FUNC_DEFAULT
+        assert fp.fft_gridder_prad == GRIDDER_P_RAD_DEFAULT
+        assert fp.fft_interp_order == FFT_INTERP_DEFAULT
+
+
+class TestMfConfig:
+    """Pins the MfConfig bundle nested inside ImagerConfig: field set,
+    immutability, _replace() semantics, and defaults."""
+
+    EXPECTED_FIELDS = ("mf_order", "mf_order_pol", "mf_rm", "mf_cm")
+
+    def test_returns_namedtuple(self, make_test_config):
+        cfg = make_test_config(mf=True, mf_order=1)
+        assert isinstance(cfg.mf_config, MfConfig)
+
+    def test_field_access(self, make_test_config):
+        cfg = make_test_config(mf=True, mf_order=2, mf_order_pol=1, mf_rm=1, mf_cm=0)
+        assert cfg.mf_config.mf_order == 2
+        assert cfg.mf_config.mf_order_pol == 1
+        assert cfg.mf_config.mf_rm == 1
+        assert cfg.mf_config.mf_cm == 0
+
+    def test_asdict_keys(self, make_test_config):
+        cfg = make_test_config()
+        assert tuple(cfg.mf_config._asdict().keys()) == self.EXPECTED_FIELDS
+
+    def test_immutability(self, make_test_config):
+        cfg = make_test_config()
+        with pytest.raises(AttributeError):
+            cfg.mf_config.mf_order = 2
+
+    def test_replace_returns_new_instance(self, make_test_config):
+        cfg = make_test_config(mf_order=0)
+        new_mf = cfg.mf_config._replace(mf_order=2)
+        assert new_mf.mf_order == 2
+        assert cfg.mf_config.mf_order == 0  # original unchanged
+
+    def test_defaults_preserved(self, make_test_config):
+        cfg = make_test_config()
+        assert cfg.mf_config.mf_order == 0
+        assert cfg.mf_config.mf_order_pol == 0
+        assert cfg.mf_config.mf_rm == 0
+        assert cfg.mf_config.mf_cm == 0
+
+
+class TestImagerConfig:
+    """Pins the ImagerConfig bundle assigned to Imager._config: field set,
+    immutability, kwarg propagation, and nested _replace() semantics that
+    Imager.make_image() relies on for parameter overrides."""
+
+    EXPECTED_FIELDS = ("pol", "transforms", "ttype", "mf", "mf_config")
+
+    def test_returns_namedtuple(self, gauss_im, observe, initialize_imager):
+        imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
+        assert isinstance(imgr._config, ImagerConfig)
+
+    def test_field_access_matches_kwargs(self, gauss_im, observe):
+        obs = observe(gauss_im)
+        imgr = eh.imager.Imager(
+            obs, gauss_im, prior_im=gauss_im, flux=gauss_im.total_flux(),
+            data_term={"vis": 100}, ttype="direct", pol="I",
+            transform=["log", "mcv"], mf=False,
+        )
+        assert imgr._config.pol == "I"
+        assert imgr._config.ttype == "direct"
+        assert imgr._config.mf is False
+        assert list(imgr._config.transforms) == ["log", "mcv"]
+
+    def test_asdict_keys(self, gauss_im, observe, initialize_imager):
+        imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
+        assert tuple(imgr._config._asdict().keys()) == self.EXPECTED_FIELDS
+
+    def test_immutability(self, gauss_im, observe, initialize_imager):
+        imgr, _ = initialize_imager(observe(gauss_im), gauss_im, {"vis": 100})
+        with pytest.raises(AttributeError):
+            imgr._config.pol = "IP"
+
+    def test_replace_nested_mf_config(self, make_test_config):
+        """_replace() semantics for nested updates — the make_image() override path."""
+        cfg = make_test_config(pol="I", mf=False, mf_order=0)
+        new_cfg = cfg._replace(
+            pol="IV",
+            mf_config=cfg.mf_config._replace(mf_order=2),
+        )
+        assert new_cfg.pol == "IV"
+        assert new_cfg.mf_config.mf_order == 2
+        # Original unchanged.
+        assert cfg.pol == "I"
+        assert cfg.mf_config.mf_order == 0
+
+    def test_mf_kwarg_propagation(self, gauss_im, observe, initialize_imager):
+        """Multifrequency kwargs land in mf_config nested fields."""
+        im_lo = gauss_im.copy()
+        im_lo.rf = REFFREQ_HZ
+        im_hi = gauss_im.copy()
+        im_hi.rf = MF_ALT_FREQ_HZ
+        imgr, _ = initialize_imager(
+            [observe(im_lo), observe(im_hi)], im_lo, {"vis": 100},
+            mf=True, mf_order=1,
+        )
+        assert imgr._config.mf is True
+        assert imgr._config.mf_config.mf_order == 1
+
+
+class TestMakeImageOverride:
+    """Regression tests for Imager.make_image(pol=..., mf_order=...) kwarg
+    overrides — under the NamedTuple refactor these update self._config via
+    NamedTuple._replace() instead of mutating the dropped pol_next /
+    mf_order attrs."""
+
+    def test_pol_override_updates_config(self, gauss_im_pol, observe):
+        """imgr.make_image(pol='IV') updates self._config.pol via _replace().
+
+        Uses transform=['log','vcv'] up front so post-override check_params accepts
+        IV — IV requires vcv (and vcv is mutually exclusive with mcv).
+        """
+        obs = observe(gauss_im_pol)
+        imgr = eh.imager.Imager(
+            obs, gauss_im_pol, prior_im=gauss_im_pol, flux=gauss_im_pol.total_flux(),
+            data_term={"amp": 1}, reg_term={"simple": 1},
+            ttype="direct", pol="I", maxit=1,
+            transform=["log", "vcv"],
+        )
+        imgr.make_image(pol="IV", show_updates=False)
+        assert imgr._config.pol == "IV"
+
+    def test_mf_order_override_updates_config(self, gauss_im, observe):
+        """imgr.make_image(mf=True, mf_order=2) updates self._config.mf_config via nested _replace()."""
+        im_lo = gauss_im.copy()
+        im_lo.rf = REFFREQ_HZ
+        im_hi = gauss_im.copy()
+        im_hi.rf = MF_ALT_FREQ_HZ
+        obs_lo = observe(im_lo)
+        obs_hi = observe(im_hi)
+        imgr = eh.imager.Imager(
+            [obs_lo, obs_hi], im_lo, prior_im=im_lo, flux=im_lo.total_flux(),
+            data_term={"amp": 1}, reg_term={"simple": 1},
+            ttype="direct", pol="I", maxit=1, mf_flux=[1.0, 1.0],
+        )
+        imgr.make_image(mf=True, mf_order=2, show_updates=False)
+        assert imgr._config.mf is True
+        assert imgr._config.mf_config.mf_order == 2
 
 
 class TestComputeObjective:


### PR DESCRIPTION
Promotes the two remaining flat-dict config helpers (`_full_data_weighting_params`, `_full_fft_params`) into typed NamedTuples, and bundles the 8 flat `*_next` / `_ttype` attrs on `Imager` into a single nested `ImagerConfig` containing an `MfConfig`. Every backend function that previously took individual `pol` / `mf` / `ttype` / `transforms` / `mf_*` args (8 functions) now takes one `config: ImagerConfig` instead. `Imager.make_image()` parameter overrides switch from attr mutation to `self._config._replace(...)`. `_append_image_history()` keeps the flat `ImagerRunState` schema (per design decision) but reads through `self._config`.

The 4 bundles (`DataWeighting`, `FourierGridParams`, `MfConfig`, `ImagerConfig`) are `typing.NamedTuple`-based — pytree-friendly for Aviad's JAX mirror, with the static-argname caveat documented on `ImagerConfig` (string leaves + `snrcut: dict` aren't traceable values).

## Roadmap tasks closed

- **2.18** — `_full_data_weighting_params()` → `DataWeighting` NamedTuple
- **2.19** — `_full_fft_params()` → `FourierGridParams` NamedTuple (renamed from `FFTParams` since `ttype='fast'` is legacy; the bundle holds grid params shared by `fast` + `nfft`)
- **2.21** — `ImagerConfig` (nested `MfConfig`) replaces 8 flat `*_next` attrs
- **2.22** — 60 access sites in `imager.py` migrated to `self._config.X` / `self._config.mf_config.X`
- **2.23** — flat `pol_next` / `transform_next` / `_ttype` / `mf_next` / `mf_order` / `mf_order_pol` / `mf_rm` / `mf_cm` attrs dropped; no shims (pre-2.0, per project decision)

## Design decisions

1. **Nested `MfConfig` inside `ImagerConfig`** — JAX-pytree cohesion + future spectral-mode extension headroom.
2. **Full backend migration** — every backend function consuming any config field takes `ImagerConfig`, not partial unpacking. 8 signatures total.
3. **`_replace()` for `make_image()` overrides** — idiomatic NamedTuple update; preserves immutability.
4. **`ImagerRunState` schema kept flat** — `_append_image_history()` reads `self._config.*` but writes the same per-field keys as before, so all `*_last()` accessors continue to work without churning consumers.
5. **NamedTuple field names match `Imager(...)` kwarg names** for grep-ability.

## Surface changes worth flagging

- `Imager(...)` kwargs (`pol=`, `transform=`, `ttype=`, `mf=`, `mf_order=`, etc.) stay back-compat; they continue to construct `ImagerConfig` internally.
- Internal `self.X_next` reads are gone — third-party code that read `imgr.pol_next`/etc. directly will `AttributeError`. Pre-2.0; expected per the JAX-first design decision.
- `polchisqdata` shim in `pol_imager_utils.py` now consumes a `pol` kwarg (previously absorbed inert via `**kwargs`). Used only to populate the synthetic `ImagerConfig.pol` field; behavior preserved for pol dtypes since `compute_chisqdata_term` ignores `pol` for them. Standard dtypes already raised — no regression.