### PR TITLE
Fix factor-of-2 bug in stv_pol_grad gradient

### DIFF
--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -1014,44 +1014,47 @@ def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT,
     im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
     im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
     im_r1l2 = np.roll(np.roll(impad, 1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
-    im_l1r2 = np.roll(np.roll(impad, 1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
-    
+    im_l1r2 = np.roll(np.roll(impad, -1, axis=0), 1, axis=1)[1:ny+1, 1:nx+1]
+
     # Denominators
     d1 = np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2)
     d2 = np.sqrt(np.abs(im_r1 - im)**2 + np.abs(im_r1l2 - im_r1)**2)
     d3 = np.sqrt(np.abs(im_r2 - im)**2 + np.abs(im_l1r2 - im_r2)**2)
 
+    # Numerators use cos/sin of the single-angle difference between neighbors,
+    # from d|P_l1 - P|^2 / d|P| = 2|P| - 2|P_l1|*cos(angle(P_l1) - angle(P)).
+
     # dS/dI Numerators
     if pol_solve[0]!=0:
-        m1 = 2*np.abs(im*im) - np.abs(im*im_l1)*np.cos(2*(np.angle(im_l1) - np.angle(im))) - np.abs(im*im_l2)*np.cos(2*(np.angle(im_l2) - np.angle(im)))
-        m2 = np.abs(im*im) - np.abs(im*im_r1)*np.cos(2*(np.angle(im) - np.angle(im_r1)))
-        m3 = np.abs(im*im) - np.abs(im*im_r2)*np.cos(2*(np.angle(im) - np.angle(im_r2)))
+        m1 = 2*np.abs(im*im) - np.abs(im*im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im*im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
+        m2 = np.abs(im*im) - np.abs(im*im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
+        m3 = np.abs(im*im) - np.abs(im*im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
         gradi = -(1./iimage)*(m1/d1 + m2/d2 + m3/d3).flatten()
         gradout[0] = gradi
 
     # dS/dm numerators
     if pol_solve[1]!=0:
-        m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(2*(np.angle(im_l1) - np.angle(im))) - np.abs(im_l2)*np.cos(2*(np.angle(im_l2) - np.angle(im)))
-        m2 = np.abs(im) - np.abs(im_r1)*np.cos(2*(np.angle(im) - np.angle(im_r1)))
-        m3 = np.abs(im) - np.abs(im_r2)*np.cos(2*(np.angle(im) - np.angle(im_r2)))
+        m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
+        m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
+        m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
         gradm = -iimage*(m1/d1 + m2/d2 + m3/d3).flatten()
         gradrho = gradm * np.cos(psiimage)        
         gradout[1] = gradrho
 
     # dS/dchi numerators
     if pol_solve[2]!=0:
-        c1 = -2*np.abs(im*im_l1)*np.sin(2*(np.angle(im_l1) - np.angle(im))) - 2*np.abs(im*im_l2)*np.sin(2*(np.angle(im_l2) - np.angle(im)))
-        c2 = 2*np.abs(im*im_r1)*np.sin(2*(np.angle(im) - np.angle(im_r1)))
-        c3 = 2*np.abs(im*im_r2)*np.sin(2*(np.angle(im) - np.angle(im_r2)))
+        c1 = -2*np.abs(im*im_l1)*np.sin(np.angle(im_l1) - np.angle(im)) - 2*np.abs(im*im_l2)*np.sin(np.angle(im_l2) - np.angle(im))
+        c2 = 2*np.abs(im*im_r1)*np.sin(np.angle(im) - np.angle(im_r1))
+        c3 = 2*np.abs(im*im_r2)*np.sin(np.angle(im) - np.angle(im_r2))
         gradchi = -(c1/d1 + c2/d2 + c3/d3).flatten()
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
 
     # dS/dpsi
     if pol_solve[3]!=0:
-        m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(2*(np.angle(im_l1) - np.angle(im))) - np.abs(im_l2)*np.cos(2*(np.angle(im_l2) - np.angle(im)))
-        m2 = np.abs(im) - np.abs(im_r1)*np.cos(2*(np.angle(im) - np.angle(im_r1)))
-        m3 = np.abs(im) - np.abs(im_r2)*np.cos(2*(np.angle(im) - np.angle(im_r2)))
+        m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
+        m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
+        m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
         gradm = -iimage*(m1/d1 + m2/d2 + m3/d3).flatten()
         gradpsi = gradm * (-mimage*np.tan(psiimage))
         gradout[3] = gradpsi     

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -53,7 +53,7 @@ RANDOMFLOOR=True
 
 NORM_REGULARIZER = True
 DATATERMS_POL = ['pvis', 'm','vvis']
-REGULARIZERS_POL = ['msimple', 'hw', 'ptv','l1v','l2v','vtv','v2tv2','vflux']
+REGULARIZERS_POL = ['msimple', 'hw', 'ptv', 'l1v', 'l2v', 'vtv', 'vtv2', 'vflux']
 
 nit = 0 # global variable to track the iteration number in the plotting callback
 

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -1041,7 +1041,7 @@ def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT,
         gradrho = gradm * np.cos(psiimage)        
         gradout[1] = gradrho
 
-    # dS/dphi numerators
+    # dS/dphi numerators (\phi=2\chi)
     if pol_solve[2]!=0:
         c1 = -2*np.abs(im*im_l1)*np.sin(np.angle(im_l1) - np.angle(im)) - 2*np.abs(im*im_l2)*np.sin(np.angle(im_l2) - np.angle(im))
         c2 = 2*np.abs(im*im_r1)*np.sin(np.angle(im) - np.angle(im_r1))

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -1041,7 +1041,7 @@ def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT,
         gradrho = gradm * np.cos(psiimage)        
         gradout[1] = gradrho
 
-    # dS/dchi numerators
+    # dS/dphi numerators
     if pol_solve[2]!=0:
         c1 = -2*np.abs(im*im_l1)*np.sin(np.angle(im_l1) - np.angle(im)) - 2*np.abs(im*im_l2)*np.sin(np.angle(im_l2) - np.angle(im))
         c2 = 2*np.abs(im*im_r1)*np.sin(np.angle(im) - np.angle(im_r1))


### PR DESCRIPTION
Two bug fixes in `pol_imager_utils.py` extracted from PR #238 per @achael's request, targeted at `dev` so they can land in main quickly.

## 1. `stv_pol_grad` factor-of-2 + neighbor-roll bug (the urgent one)

**Root cause**: when the multifrequency pol update changed the imager primitive in `make_p_image` from EVPA `χ` to `φ = 2χ` (pushed to `main` in v1.2.11 in April 2026, on `dev` since June 2024), the matching update to `stv_pol_grad` was missed. Every analytic gradient slot in `stv_pol_grad` had `cos(2·(angle(P_l1) − angle(P)))` and `sin(2·(angle(P_l1) − angle(P)))`, but since `angle(P) = φ` is already the new primitive, the gradient should be `cos(angle(P_l1) − angle(P))` and `sin(angle(P_l1) − angle(P))` — no factor of 2.

Net impact: every imaging run using `ptv` (polarimetric total variation) regularization since the `make_p_image` change has been optimizing against a wrong gradient. Finite-difference vs analytic median fractional diff was ~0.45 before this fix, ~4e-6 after.

**Secondary bug, same function:** `im_l1r2` was a copy-paste duplicate of `im_r1l2` (both used `np.roll(impad, 1, axis=0), -1, axis=1`). Correct rolls for `im_l1r2` are the opposite — `-1, axis=0` and `+1, axis=1`. Visible at the `d3` denominator in the same function.

## 2. `vtv2` typo in `REGULARIZERS_POL`

`REGULARIZERS_POL = ['msimple', 'hw', 'ptv', 'l1v', 'l2v', 'vtv', 'v2tv2', 'vflux']` had `'v2tv2'` where the dispatcher elsewhere uses `'vtv2'`. Anyone trying `reg_term={'vtv2': 1}` would get a "not recognized" path because the name wasn't in the list. 

## Audit done

Double-checked the other pol regularizer gradients and pol chisq gradients for similar staleness against the `χ → 2χ` primitive change. 