### PR TITLE
Remove cached closure tables from Obsdata

### DIFF
--- a/ehtim/calibrating/self_cal.py
+++ b/ehtim/calibrating/self_cal.py
@@ -50,12 +50,11 @@ STOP = 1e-6  # convergence criterion
 ###################################################################################################
 
 
-def self_cal(obs, im, sites=[], pol='I', apply_singlepol=False, method="both", 
+def self_cal(obs, im, sites=[], pol='I', apply_singlepol=False, method="both",
              minimizer_method='BFGS',
              pad_amp=0., gain_tol=.2, solution_interval=0.0, scan_solutions=False,
              ttype='direct', fft_pad_factor=2, caltable=False,
              debias=True, apply_dterms=False,
-             copy_closure_tables=False,
              processes=-1, show_solution=False, msgtype='bar',
              use_grad=False):
     """Self-calibrate a dataset to an image.
@@ -206,10 +205,6 @@ def self_cal(obs, im, sites=[], pol='I', apply_singlepol=False, method="both",
         arglist, argdict = obs.obsdata_args()
         arglist[4] = np.concatenate(scans_cal)
         out = ehtim.obsdata.Obsdata(*arglist, **argdict)
-        if copy_closure_tables:
-            out.camp = obs.camp
-            out.logcamp = obs.logcamp
-            out.cphase = obs.cphase
 
     # close multiprocessing jobs
     if processes >= 0:

--- a/ehtim/calibrating/self_cal.py
+++ b/ehtim/calibrating/self_cal.py
@@ -17,27 +17,21 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
+import copy
+import time
+import warnings
+from multiprocessing import Pool, cpu_count
 
 import numpy as np
 import scipy.optimize as opt
-import time
-import copy
-from multiprocessing import cpu_count, Pool
 
-import ehtim.obsdata
-import ehtim.parloop as parloop
-from . import cal_helpers as calh
-from ehtim.observing.obs_simulate import add_jones_and_noise
-import ehtim.observing.obs_helpers as obsh
 import ehtim.const_def as ehc
+import ehtim.obsdata
+import ehtim.observing.obs_helpers as obsh
+import ehtim.parloop as parloop
+from ehtim.observing.obs_simulate import add_jones_and_noise
 
-import warnings
 warnings.filterwarnings("ignore", message="divide by zero encountered in log")
 
 MAXIT = 10000  # maximum number of iterations in self-cal minimizer
@@ -66,10 +60,10 @@ def self_cal(obs, im, sites=[], pol='I', apply_singlepol=False, method="both",
                          empty list calibrates all sites
 
            pol (str): which image polarization to self-calibrate visibilities to
-           apply_singlepol (str): if calibrating to pol='RR' or pol='LL', 
+           apply_singlepol (str): if calibrating to pol='RR' or pol='LL',
                                   apply solution only to the single polarization
 
-           method (str): chooses what to calibrate, 'amp', 'phase', or 'both'           
+           method (str): chooses what to calibrate, 'amp', 'phase', or 'both'
            minimizer_method (str): Method for scipy.optimize.minimize (e.g., 'CG', 'BFGS')
 
            pad_amp (float): adds fractional uncertainty to amplitude sigmas in quadrature
@@ -92,7 +86,7 @@ def self_cal(obs, im, sites=[], pol='I', apply_singlepol=False, method="both",
            show_solution (bool): if True, display the solution as it is calculated
            msgtype (str): type of progress message to be printed, default is 'bar'
            use_grad (bool): if True, use gradients in minimizer
-           
+
        Returns:
            (Obsdata): the calibrated observation, if caltable==False
            (Caltable): the derived calibration table, if caltable==True
@@ -110,10 +104,10 @@ def self_cal(obs, im, sites=[], pol='I', apply_singlepol=False, method="both",
         im = im.switch_polrep('circ', pol)
     else:
         raise Exception("Can only self-calibrate to I, Q, U, V, RR, or LL images!")
-        
+
     if apply_singlepol and obs.polrep!='circ':
         raise Exception("apply_singlepol must be False unless self-calibrating to 'RR' or 'LL'")
-                
+
     # V = model visibility, V' = measured visibility, G_i = site gain
     # G_i * conj(G_j) * V_ij = V'_ij
     if len(sites) == 0:
@@ -127,12 +121,12 @@ def self_cal(obs, im, sites=[], pol='I', apply_singlepol=False, method="both",
     # apply dterms
     # TODO check!
     if apply_dterms:
-        print("Applying dterms in obs.tarr to clean visibilities before selfcal!")    
-        obsdata_dterms = add_jones_and_noise(obs_clean, 
+        print("Applying dterms in obs.tarr to clean visibilities before selfcal!")
+        obsdata_dterms = add_jones_and_noise(obs_clean,
                          add_th_noise=False, ampcal=True, phasecal=True, opacitycal=True,
                          dcal=False, frcal=True, dterm_offset=0.0)
         obs_clean.data = obsdata_dterms
-                
+
     # Partition the list of observed visibilities into scans
     scans = obs.tlist(t_gather=solution_interval, scan_gather=scan_solutions)
     scans_cal = copy.copy(scans)
@@ -144,12 +138,12 @@ def self_cal(obs, im, sites=[], pol='I', apply_singlepol=False, method="both",
     # Make the pool for parallel processing
     if processes > 0:
         counter = parloop.Counter(initval=0, maxval=len(scans))
-        print("Using Multiprocessing with %d Processes" % processes)
+        print(f"Using Multiprocessing with {processes} Processes")
         pool = Pool(processes=processes, initializer=init, initargs=(counter,))
     elif processes == 0:
         counter = parloop.Counter(initval=0, maxval=len(scans))
         processes = int(cpu_count())
-        print("Using Multiprocessing with %d Processes" % processes)
+        print(f"Using Multiprocessing with {processes} Processes")
         pool = Pool(processes=processes, initializer=init, initargs=(counter,))
     else:
         print("Not Using Multiprocessing")
@@ -173,8 +167,8 @@ def self_cal(obs, im, sites=[], pol='I', apply_singlepol=False, method="both",
             scans_cal[i] = self_cal_scan(scans[i], im, V_scan=V_scans[i], sites=sites,
                                          polrep=obs.polrep, pol=pol, apply_singlepol=apply_singlepol,
                                          method=method, minimizer_method=minimizer_method,
-                                         show_solution=show_solution, 
-                                         pad_amp=pad_amp, gain_tol=gain_tol, 
+                                         show_solution=show_solution,
+                                         pad_amp=pad_amp, gain_tol=gain_tol,
                                          debias=debias, caltable=caltable,
                                          use_grad=use_grad)
 
@@ -229,9 +223,9 @@ def self_cal_scan(scan, im, V_scan=[], sites=[], polrep='stokes', pol='I', apply
 
            polrep (str): 'stokes' or 'circ' to specify the  polarization products in scan
            pol (str): which image polarization to self-calibrate visibilities to
-           apply_singlepol (str): if calibrating to pol='RR' or pol='LL', 
+           apply_singlepol (str): if calibrating to pol='RR' or pol='LL',
                                   apply solution only to the single polarization
-           
+
            method (str): chooses what to calibrate, 'amp', 'phase', or 'both'
            minimizer_method (str): Method for scipy.optimize.minimize
                                   (e.g., 'CG', 'BFGS', 'Nelder-Mead', etc.)
@@ -244,15 +238,15 @@ def self_cal_scan(scan, im, V_scan=[], sites=[], polrep='stokes', pol='I', apply
            caltable (bool): if True, returns a Caltable instead of an Obsdata
            show_solution (bool): if True, display the solution as it is calculated
            use_grad (bool): if True, use gradients in minimizer
-           
+
        Returns:
            (Obsdata): the calibrated observation, if caltable==False
            (Caltable): the derived calibration table, if caltable==True
     """
-    
+
     if use_grad and (method=='phase' or method=='amp'):
         raise Exception("errfunc_grad in self_cal only works with method=='both'!")
-        
+
     if len(sites) == 0:
         print("No stations specified in self cal: defaulting to calibrating all !")
         sites = list(set(scan['t1']).union(set(scan['t2'])))
@@ -268,7 +262,7 @@ def self_cal_scan(scan, im, V_scan=[], sites=[], polrep='stokes', pol='I', apply
         gain_tol = {'default':gain_tol}
     # convert any 1-sided tolerance to 2-sided tolerance parameterization
     for (key, val) in gain_tol.items():
-        if type(val) == float or type(val) == int:
+        if isinstance(val, (float, int)):
             gain_tol[key] = [val, val]
 
     # create a dictionary to keep track of gains
@@ -321,13 +315,13 @@ def self_cal_scan(scan, im, V_scan=[], sites=[], polrep='stokes', pol='I', apply
                    'ftol': STOP, 'gtol': STOP,
                    'maxcor': NHIST, 'maxls': MAXLS}
     else:
-        optdict = {'maxiter': MAXIT}  
-        
-    if use_grad:                   
+        optdict = {'maxiter': MAXIT}
+
+    if use_grad:
         res = opt.minimize(errfunc, gpar_guess, method=minimizer_method, options=optdict, jac=errfunc_grad)
     else:
         res = opt.minimize(errfunc, gpar_guess, method=minimizer_method, options=optdict)
-        
+
     # save the solution
     g_fit = res.x.view(np.complex128)
 
@@ -360,7 +354,7 @@ def self_cal_scan(scan, im, V_scan=[], sites=[], polrep='stokes', pol='I', apply
                     rscale = g_fit[site_key]**-1
                     lscale = np.ones(g_fit[site_key].shape)
                 elif pol=='LL':
-                    rscale = np.ones(g_fit[site_key].shape)                
+                    rscale = np.ones(g_fit[site_key].shape)
                     lscale = g_fit[site_key]**-1
             else:
                 rscale = g_fit[site_key]**-1
@@ -382,43 +376,43 @@ def self_cal_scan(scan, im, V_scan=[], sites=[], polrep='stokes', pol='I', apply
             g1_fit = g_fit[g1_keys]
             g2_fit = g_fit[g2_keys]
             gij_inv = (g1_fit * g2_fit.conj())**(-1)
-        
+
             # scale visibilities
             for vistype in ['vis', 'qvis', 'uvis', 'vvis']:
                 scan[vistype] *= gij_inv
             # scale sigmas
             for sigtype in ['sigma', 'qsigma', 'usigma', 'vsigma']:
                 scan[sigtype] *= np.abs(gij_inv)
-                
+
         elif polrep == 'circ':
             if apply_singlepol: #scale only solved polarization
                 if pol=='RR':
                     grr_inv = (g1_fit * g2_fit.conj())**(-1)
                     gll_inv = np.ones(g1_fit.shape)
                     grl_inv = (g1_fit)**(-1)
-                    glr_inv = (g2_fit.conj())**(-1)                        
-                                                        
+                    glr_inv = (g2_fit.conj())**(-1)
+
                 elif pol=='LL':
-                    grr_inv = np.ones(g1_fit.shape)                
+                    grr_inv = np.ones(g1_fit.shape)
                     gll_inv = (g1_fit * g2_fit.conj())**(-1)
                     grl_inv = (g2_fit.conj())**(-1)
-                    glr_inv = (g1_fit)**(-1) 
-                       
-                # scale visibilities    
-                scan['rrvis'] *= grr_inv  
-                scan['llvis'] *= gll_inv  
-                scan['rlvis'] *= grl_inv  
-                scan['lrvis'] *= glr_inv  
+                    glr_inv = (g1_fit)**(-1)
 
-                # scale sigmas    
-                scan['rrsigma'] *= np.abs(grr_inv)  
-                scan['llsigma'] *= np.abs(gll_inv) 
-                scan['rlsigma'] *= np.abs(grl_inv) 
-                scan['lrsigma'] *= np.abs(glr_inv)   
-                                                                                                 
+                # scale visibilities
+                scan['rrvis'] *= grr_inv
+                scan['llvis'] *= gll_inv
+                scan['rlvis'] *= grl_inv
+                scan['lrvis'] *= glr_inv
+
+                # scale sigmas
+                scan['rrsigma'] *= np.abs(grr_inv)
+                scan['llsigma'] *= np.abs(gll_inv)
+                scan['rlsigma'] *= np.abs(grl_inv)
+                scan['lrsigma'] *= np.abs(glr_inv)
+
             else: #scale both polarizations
-                gij_inv = (g1_fit * g2_fit.conj())**(-1)          
-                                                                          
+                gij_inv = (g1_fit * g2_fit.conj())**(-1)
+
                 # scale visibilities
                 for vistype in ['rrvis', 'llvis', 'rlvis', 'lrvis']:
                     scan[vistype] *= gij_inv
@@ -452,7 +446,7 @@ def get_selfcal_scan_cal2(i, n, scan, im, V_scan, sites, polrep, pol, apply_sing
                          show_solution=show_solution,
                          pad_amp=pad_amp, gain_tol=gain_tol, debias=debias, caltable=caltable,
                          use_grad=use_grad)
-                         
+
 # error function
 def errfunc_full(gpar, vis, v_scan, sigma_inv, gain_tol, sites, g1_keys, g2_keys, method):
     # all the forward site gains (complex)
@@ -488,30 +482,30 @@ def errfunc_full(gpar, vis, v_scan, sigma_inv, gain_tol, sites, g1_keys, g2_keys
     # don't count the last (default missing site) gain dummy value
     tolsq = ((np.abs(g[:-1]) > 1) * tol0 + (np.abs(g[:-1]) <= 1) * tol1)**2
     chisq_g = np.sum(np.log(np.abs(g[:-1]))**2 / tolsq)
-    
+
     # total chi^2
     chisqtot = chisq + chisq_g
     return chisqtot
-                                 
+
 def errfunc_grad_full(gpar, vis, v_scan, sigma_inv, gain_tol, sites, g1_keys, g2_keys, method):
     # does not work for method=='phase' or method=='amp'
     if method=='phase' or method=='amp':
         raise Exception("errfunc_grad in self_cal only works with method=='both'!")
-        
+
     # all the forward site gains (complex)
     g = gpar.astype(np.float64).view(dtype=np.complex128)
     gr = np.real(g)
     gi = np.imag(g)
-    
+
     # build site specific tolerance parameters
     tol0 = np.array([gain_tol.get(s, gain_tol['default'])[0] for s in sites])
     tol1 = np.array([gain_tol.get(s, gain_tol['default'])[1] for s in sites])
-       
+
     # append the default values to g for missing gains
-    g = np.append(g, 1.)    
+    g = np.append(g, 1.)
     g1 = g[g1_keys]
     g2 = g[g2_keys]
-    
+
     g1r = np.real(g1)
     g1i = np.imag(g1)
     g2r = np.real(g2)
@@ -522,59 +516,59 @@ def errfunc_grad_full(gpar, vis, v_scan, sigma_inv, gain_tol, sites, g1_keys, g2
     g2sq = g2*(g2.conj())
 
     ###################################
-    # data term chi^2 derivitive    
+    # data term chi^2 derivitive
     ###################################
-        
+
     # chi^2 term gradients
     dchisq_dg1r = (-g2.conj()*vis.conj()*v_scan - g2*vis*v_scan.conj() + 2*g1r*g2sq*v_scan_sq)
     dchisq_dg1i = (-1j*g2.conj()*vis.conj()*v_scan + 1j*g2*vis*v_scan.conj() + 2*g1i*g2sq*v_scan_sq)
-   
+
     dchisq_dg2r = (-g1*vis.conj()*v_scan - g1.conj()*vis*v_scan.conj() + 2*g2r*g1sq*v_scan_sq)
-    dchisq_dg2i = (1j*g1*vis.conj()*v_scan - 1j*g1.conj()*vis*v_scan.conj() + 2*g2i*g1sq*v_scan_sq)  
+    dchisq_dg2i = (1j*g1*vis.conj()*v_scan - 1j*g1.conj()*vis*v_scan.conj() + 2*g2i*g1sq*v_scan_sq)
 
 
     dchisq_dg1r *= ((sigma_inv)**2)
     dchisq_dg1i *= ((sigma_inv)**2)
     dchisq_dg2r *= ((sigma_inv)**2)
-    dchisq_dg2i *= ((sigma_inv)**2)    
+    dchisq_dg2i *= ((sigma_inv)**2)
 
     # same masking function as in errfunc
     # preserve length of dchisq arrays
     verr = vis - g1 * g2.conj() * v_scan
     nan_mask = np.isnan(verr)
-    
+
     dchisq_dg1r[nan_mask] = 0
     dchisq_dg1i[nan_mask] = 0
     dchisq_dg2r[nan_mask] = 0
     dchisq_dg2i[nan_mask] = 0
-    
-    # derivitives of real and imaginary gains                
-    dchisq_dgr = np.zeros(len(gpar)//2) #len(gpar) must be even 
-    dchisq_dgi = np.zeros(len(gpar)//2)    
-    
-    # TODO faster than a for loop?     
+
+    # derivitives of real and imaginary gains
+    dchisq_dgr = np.zeros(len(gpar)//2) #len(gpar) must be even
+    dchisq_dgi = np.zeros(len(gpar)//2)
+
+    # TODO faster than a for loop?
     for i in range(len(gpar)//2):
         g1idx = np.argwhere(np.array(g1_keys)==i)
         g2idx = np.argwhere(np.array(g2_keys)==i)
-        
-        dchisq_dgr[i] = np.sum(dchisq_dg1r[g1idx]) + np.sum(dchisq_dg2r[g2idx])                
+
+        dchisq_dgr[i] = np.sum(dchisq_dg1r[g1idx]) + np.sum(dchisq_dg2r[g2idx])
         dchisq_dgi[i] = np.sum(dchisq_dg1i[g1idx]) + np.sum(dchisq_dg2i[g2idx])
-                
-    ###################################                        
-    # prior term chi^2 derivitive 
+
     ###################################
-        
+    # prior term chi^2 derivitive
+    ###################################
+
     # NOTE this derivitive doesn't account for possible sharp change in tol at g=1
     gsq = np.abs(g[:-1])**2 # don't count default missing site dummy value
     tolsq = ((np.abs(g[:-1]) > 1) * tol0 + (np.abs(g[:-1]) <= 1) * tol1)**2
-    
+
     dchisqg_dgr = gr*np.log(gsq)/gsq/tolsq
     dchisqg_dgi = gi*np.log(gsq)/gsq/tolsq
-    
+
     # total derivative
     dchisqtot_dgr = dchisq_dgr + dchisqg_dgr
     dchisqtot_dgi = dchisq_dgi + dchisqg_dgi
-    
+
     # interleave final derivs
     dchisqtot_dgpar = np.zeros(len(gpar))
     dchisqtot_dgpar[0::2] = dchisqtot_dgr
@@ -582,8 +576,8 @@ def errfunc_grad_full(gpar, vis, v_scan, sigma_inv, gain_tol, sites, g1_keys, g2
 
     # any imaginary parts??? should all be real
     dchisqtot_dgpar = np.real(dchisqtot_dgpar)
-    
+
     return dchisqtot_dgpar
-                     
-                     
-                         
+
+
+

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -429,7 +429,7 @@ class Caltable(object):
                         source=self.source, mjd=self.mjd, timetype=self.timetype)
 
     def applycal(self, obs, interp='linear', extrapolate=None,
-                 force_singlepol=False, copy_closure_tables=True):
+                 force_singlepol=False):
         """Apply the calibration table to an observation.
 
            Args:
@@ -450,7 +450,6 @@ class Caltable(object):
         else:
             fill_value = extrapolate
 
-        obs_orig = obs.copy()  # Need to do this before switch_polrep to keep tables
         orig_polrep = obs.polrep
         obs = obs.switch_polrep('circ')
 
@@ -526,11 +525,6 @@ class Caltable(object):
                                        opacitycal=obs.opacitycal, dcal=obs.dcal,
                                        frcal=obs.frcal, timetype=obs.timetype)
         calobs = calobs.switch_polrep(orig_polrep)
-
-        if copy_closure_tables:
-            calobs.camp = obs_orig.camp
-            calobs.logcamp = obs_orig.logcamp
-            calobs.cphase = obs_orig.cphase
 
         return calobs
 

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -16,32 +16,25 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
-
-import numpy as np
-import matplotlib.pyplot as plt
-import os
 import copy
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
 import scipy.interpolate
 
-import ehtim.io.save
-import ehtim.io.load
-
 import ehtim.const_def as ehc
+import ehtim.io.load
+import ehtim.io.save
 import ehtim.observing.obs_helpers as obsh
-
 
 ##################################################################################################
 # Caltable object
 ##################################################################################################
 
 
-class Caltable(object):
+class Caltable:
     """
        Attributes:
            source (str): The source name
@@ -122,13 +115,13 @@ class Caltable(object):
                label (str) : title for plot
                legend (bool) : add telescope legend or not
                clist (list) : list of colors for different stations
-               rangex (list) : lower and upper x-axis limits  
-               rangey (list) : lower and upper y-axis limits 
+               rangex (list) : lower and upper x-axis limits
+               rangey (list) : lower and upper y-axis limits
                markersize (float) : marker size
                show (bool) : display the plot or not
                grid (bool) : add a grid to the plot or not
-               export_pdf (str) : save a pdf file to this path 
-               
+               export_pdf (str) : save a pdf file to this path
+
            Returns:
                matplotlib.axes
         """
@@ -138,10 +131,10 @@ class Caltable(object):
 
         if isinstance(sites,str):
             sites = [sites]
-            
+
         if len(sites)==0:
             sites = list(self.data.keys())
-                  
+
         keys = [self.tkey[site] for site in sites]
 
         axes = plot_tarr_dterms(self.tarr, keys=keys, label=label, legend=legend, clist=clist,
@@ -211,7 +204,7 @@ class Caltable(object):
             sites = [sites]
 
         if len(sites)==0:
-            sites = sorted(list(self.data.keys()))       
+            sites = sorted(list(self.data.keys()))
 
         if len(markersize) == 1:
             markersize = markersize * np.ones(len(sites))
@@ -275,7 +268,7 @@ class Caltable(object):
         if axislabels:
             x.set_xlabel(self.timetype + ' (hr)')
             x.set_ylabel(ylabel)
-            plt.title('Caltable gains for %s on day %s' % (self.source, self.mjd))
+            plt.title(f'Caltable gains for {self.source} on day {self.mjd}')
 
         if legend:
             plt.legend()
@@ -463,7 +456,7 @@ class Caltable(object):
                 self.data[site]
             except KeyError:
                 skipsites.append(site)
-                print("No Calibration  Data for %s !" % site)
+                print(f"No Calibration  Data for {site} !")
                 continue
 
             time_mjd = self.data[site]['time'] / 24.0 + self.mjd
@@ -627,7 +620,7 @@ class Caltable(object):
            Args:
                obs (ehtim.Obsdata) : input observation
                incoherent (bool) : True to average gain amps, False to average amps+phase
-               
+
            Returns:
                (Caltable): the averaged Caltable object
         """
@@ -713,11 +706,11 @@ def load_caltable(obs, datadir, sqrt_gains=False):
         filename = os.path.join(datadir, obs.source + '_' + site + '.txt')
         try:
             data = np.loadtxt(filename, dtype=bytes).astype(str)
-        except IOError:
+        except OSError:
             try:
                 filename = datadir + site + '.txt'
                 data = np.loadtxt(filename, dtype=bytes).astype(str)
-            except IOError:
+            except OSError:
                 continue
 
 
@@ -745,7 +738,7 @@ def load_caltable(obs, datadir, sqrt_gains=False):
         caltable = Caltable(obs.ra, obs.dec, obs.rf, obs.bw, datatables, tarr,
                             source=obs.source, mjd=obs.mjd, timetype=obs.timetype)
     else:
-        print("COULD NOT FIND CALTABLE IN DIRECTORY %s" % datadir)
+        print(f"COULD NOT FIND CALTABLE IN DIRECTORY {datadir}")
         caltable = False
     return caltable
 
@@ -944,7 +937,7 @@ def plot_compare_gains(caltab1, caltab2, obs, sites='all', pol='R', gain_type='a
 
     if len(sites)==0:
         sites = list(set(caltab1.data.keys()).intersection(caltab2.data.keys()))
-        
+
     if site_name_dict is None:
         print('hi')
         site_name_dict = {}

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -16,44 +16,38 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
-
-import sys
 import copy
 import math
-import numpy as np
-import numpy.matlib as matlib
+
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+import numpy as np
+import numpy.matlib as matlib
+import scipy.interpolate
+import scipy.ndimage.filters as filt
 import scipy.optimize as opt
 import scipy.signal
-import scipy.ndimage.filters as filt
-import scipy.interpolate
 from scipy import ndimage as ndi
 
+import ehtim.const_def as ehc
+import ehtim.imaging.pol_imager_utils as polutils
+import ehtim.io.load
+import ehtim.io.save
+import ehtim.observing.obs_helpers as obsh
 import ehtim.observing.obs_simulate as simobs
 import ehtim.observing.pulses as pulses
-import ehtim.io.save
-import ehtim.io.load
-import ehtim.const_def as ehc
-import ehtim.observing.obs_helpers as obsh
-import ehtim.imaging.pol_imager_utils as polutils
 
 # TODO : add time to all images
 # TODO : add arbitrary center location
-
 from ehtim.imaging.multifreq_imager_utils import DD_RHOPOL
+
 ###################################################################################################
 # Image object
 ###################################################################################################
 
 
-class Image(object):
+class Image:
 
     """A polarimetric image (in units of Jy/pixel).
 
@@ -138,12 +132,12 @@ class Image(object):
         # multifrequency spectral index, curvature arrays
         # TODO -- higher orders?
         # TODO -- don't initialize to zero?
-        avec = np.array([]) 
+        avec = np.array([])
         bvec = np.array([])
-        avec_pol = np.array([]) 
+        avec_pol = np.array([])
         bvec_pol = np.array([])
         rmvec = np.array([])
-        cmvec = np.array([])        
+        cmvec = np.array([])
         self._mflist = [avec, bvec, avec_pol, bvec_pol, rmvec, cmvec]
 
         # Save the image dimension data
@@ -237,7 +231,7 @@ class Image(object):
         if len(vec) != self.xdim * self.ydim:
             raise Exception("vec size is not consistent with xdim*ydim!")
         self._mflist[4] = vec
-        
+
     @property
     def cmvec(self):
         cmvec = self._mflist[5]
@@ -248,7 +242,7 @@ class Image(object):
         if len(vec) != self.xdim * self.ydim:
             raise Exception("vec size is not consistent with xdim*ydim!")
         self._mflist[5] = vec
-        
+
     @property
     def ivec(self):
         ivec = np.array([])
@@ -466,7 +460,7 @@ class Image(object):
         """Return the circular Poincare angle"""
         psivec = np.arctan2(self.vvec , self.pvec)
         return psivec
-               
+
 
     @property
     def evec(self):
@@ -599,7 +593,7 @@ class Image(object):
 
         # Copy over spectral information
         newim._mflist = copy.deepcopy(self._mflist)
-                
+
         return newim
 
     def copy_pol_images(self, old_image):
@@ -631,9 +625,8 @@ class Image(object):
             raise Exception("new pol in add_pol_image is the same as pol_prim!")
         if image.shape != (self.ydim, self.xdim):
             raise Exception("add_pol_image image shapes incompatible with primary image!")
-        if not (pol in list(self._imdict.keys())):
-            raise Exception("for polrep==%s, pol in add_pol_image in " %
-                            self.polrep + ",".join(list(self._imdict.keys())))
+        if pol not in list(self._imdict.keys()):
+            raise Exception(f"for polrep=={self.polrep}, pol in add_pol_image in " + ",".join(list(self._imdict.keys())))
 
         if self.polrep == 'stokes':
             if pol == 'I':
@@ -755,8 +748,7 @@ class Image(object):
         # Assemble the new image
         imvec = imdict[pol_prim_out]
         if len(imvec) == 0:
-            raise Exception("for switch_polrep to %s with pol_prim_out=%s, \n" %
-                            (polrep_out, pol_prim_out) + "output image is not defined")
+            raise Exception(f"for switch_polrep to {polrep_out} with pol_prim_out={pol_prim_out}, \n" + "output image is not defined")
 
         arglist, argdict = self.image_args()
         arglist[0] = imvec.reshape(self.ydim, self.xdim)
@@ -799,7 +791,7 @@ class Image(object):
     def get_image_mf(self, nu):
         """Get image at a given frequency given the spectral information in self._mflist
            NOTE: Only to 2nd order at the moment!!
-           
+
            Args:
                nu (float): frequency in Hz
 
@@ -818,67 +810,67 @@ class Image(object):
             if mfvec.size:
                 log_imvec += mfvec * (log_nufrac**(n + 1))
         imvec = np.exp(log_imvec)
-        
+
         arglist, argdict = self.image_args()
         arglist[0] = imvec.reshape(self.ydim, self.xdim)
         argdict['rf'] = nu
         outim = Image(*arglist, **argdict)
 
-        
+
         # Polarization
         do_mf_pol=False
         for n in range(4):
-            if self._mflist[n+2].size: 
+            if self._mflist[n+2].size:
                 do_mf_pol=True
-           
+
         if do_mf_pol and not(self.qvec.size and self.uvec.size and self.vvec.size):
             print("WARNING: polarization multifrequency terms exist but not all Stokes parameters are defined""")
             print("Cannot apply spectral terms to polarization in get_image_mf")
             do_mf_pol=False
-        
+
         if do_mf_pol:
             outim = outim.switch_polrep(polrep_out='stokes')
             im_stokes = self.switch_polrep(polrep_out='stokes')
             rhovec = im_stokes.rhovec
             phivec = im_stokes.phivec
             psivec = im_stokes.psivec
-            
-            if self.specvec_pol.size: 
+
+            if self.specvec_pol.size:
                 alpha_pol = self.specvec_pol
             else:
                 alpha_pol = 0
-            if self.curvvec_pol.size: 
+            if self.curvvec_pol.size:
                 beta_pol = self.curvvec_pol
             else:
                 beta_pol = 0
-            if self.rmvec.size: 
+            if self.rmvec.size:
                 rm = self.rmvec
             else:
-                rm = 0         
-            if self.cmvec.size: 
+                rm = 0
+            if self.cmvec.size:
                 print("WARNING: cmvec exists, but Stokes V spectral behavior is not implemented yet!")
             else:
                 cm = 0
-            
+
             # TODO: can we use the same function as multifreq_imager_utils.image_at_freq??
             logrhovec_prime = np.log(rhovec) + alpha_pol*log_nufrac + beta_pol*log_nufrac*log_nufrac
             rhovec_prime = np.exp(logrhovec_prime)
-            
+
             # transformation of rhovec to ensure it is always < 1 at any frequency
             rhovec = (rhovec_prime**(-DD_RHOPOL) + 1)**(-1/DD_RHOPOL)
-            
-            # we use dimensionless rm scaled by lambda0^2 = c^2/nu0^2   
-            phivec = phivec + rm*(np.exp(-2*log_nufrac)-1)                               
+
+            # we use dimensionless rm scaled by lambda0^2 = c^2/nu0^2
+            phivec = phivec + rm*(np.exp(-2*log_nufrac)-1)
             psivec = psivec # Stokes V spectral behavior not implemented yet
-            
+
             polarr_out = np.array((imvec, rhovec, phivec, psivec))
             qimage_out = polutils.make_q_image(polarr_out)
             uimage_out = polutils.make_u_image(polarr_out)
             vimage_out = polutils.make_v_image(polarr_out)
-            outim.add_pol_image(qimage_out.reshape(outim.ydim, outim.xdim), 'Q')  
-            outim.add_pol_image(uimage_out.reshape(outim.ydim, outim.xdim), 'U')            
-            outim.add_pol_image(vimage_out.reshape(outim.ydim, outim.xdim), 'V') 
-            outim = outim.switch_polrep(polrep_out=self.polrep)           
+            outim.add_pol_image(qimage_out.reshape(outim.ydim, outim.xdim), 'Q')
+            outim.add_pol_image(uimage_out.reshape(outim.ydim, outim.xdim), 'U')
+            outim.add_pol_image(vimage_out.reshape(outim.ydim, outim.xdim), 'V')
+            outim = outim.switch_polrep(polrep_out=self.polrep)
 
         else:
             outim.copy_pol_images(self)
@@ -987,7 +979,7 @@ class Image(object):
             frac = np.angle(np.sum(self.rlvec))
 
         return frac
-        
+
     def circ_polfrac(self):
         """Return the total fractional circular polarized flux
 
@@ -1036,11 +1028,11 @@ class Image(object):
     def betamodes(self, ms=[2], r_min=0, r_max=None, output_fluxes=False, verbose=True):
         """Return Palumbo+2020 linear beta_m modes integrated between image radius r_min, r_max
            Does not center the image
-           
+
            Args:
                 ms : list of integers m to compute beta modes for
                 r_min (float): minimum image radius for calculation (in rad)
-                r_max (float): maximum image radius for calculation (in rad). 
+                r_max (float): maximum image radius for calculation (in rad).
                                if None, use the full image
                 output_fluxes (bool): return ring fluxes
                 verbose (bool): print details
@@ -1049,7 +1041,7 @@ class Image(object):
         """
         if not (isinstance(ms, np.ndarray) or isinstance(ms, list)):
             ms = [ms]
-        
+
         if self.polrep == 'stokes':
             parr = (self.qvec + 1j*self.uvec).reshape(self.ydim, self.xdim)
             iarr = self.imvec.reshape(self.ydim, self.xdim)
@@ -1062,34 +1054,35 @@ class Image(object):
                            np.flip(np.fft.fftshift(np.fft.fftfreq(self.ydim, d=1.0 / self.ydim))))
         s = s + .5  # .5 offset to reference to pixel center
         t = t + .5  # .5 offset to reference to pixel center
-        
+
         imdist = np.sqrt(s**2 + t**2) # distance from the center in pixels
         imangle = np.arctan2(s, t)
         imangle[imangle<0.] += 2.*np.pi
 
         # define masked region
         if (r_min is not None) and (r_max is not None):
-            if verbose: print ("restricting betamodes to annulus between %.2f to %.2f uas!"%(r_min/ehc.RADPERUAS, r_max/ehc.RADPERUAS))
+            if verbose:
+                print(f"restricting betamodes to annulus between {r_min/ehc.RADPERUAS:.2f} to {r_max/ehc.RADPERUAS:.2f} uas!")
             mask = (imdist<=(r_max/self.psize)) * (imdist>=(r_min/self.psize))
         else:
             mask = np.ones(iarr.shape).astype(bool)
-        
+
         # total flux in annulus
-        flux = np.abs(np.sum(iarr[mask])) 
+        flux = np.abs(np.sum(iarr[mask]))
         pflux = np.abs(np.sum(np.abs(parr[mask])))
         area = (self.psize)**2 * (np.sum(mask))
-        
+
         # compute beta modes
         outlist = []
         for m in ms:
-            
+
             if not isinstance(m,int):
                 raise Exception("each element of 'ms' should be an integer in betamodes!")
-                 
+
             integrand = (parr*np.exp(-1j*m*imangle))[mask]
             coeff = np.sum(integrand)/flux
             outlist.append(coeff)
-        
+
         if output_fluxes:
             out = [outlist, flux, pflux, area]
         else:
@@ -1132,7 +1125,7 @@ class Image(object):
             y0 = np.sum(np.outer(ylist, 0.0 * xlist + 1.0).ravel() * imvec) / np.sum(imvec)
             centroid = np.array([x0, y0])
         else:
-            raise Exception("No %s image found!" % pol)
+            raise Exception(f"No {pol} image found!")
 
         return centroid
 
@@ -1371,7 +1364,7 @@ class Image(object):
             return imarr_rot
 
         # pol_prim needs to be RR,LL,I,or V for a simple rotation to work!
-        if(not (self.pol_prim in ['RR', 'LL', 'I', 'V'])):
+        if(self.pol_prim not in ['RR', 'LL', 'I', 'V']):
             raise Exception("im.pol_prim must be a scalar ('I','V','RR','LL') for simple rotation!")
 
         # Make new image
@@ -1594,8 +1587,8 @@ class Image(object):
            Args:
                fwhm_i (float): circular beam size for Stokes I  blurring in  radian
                fwhm_pol (float): circular beam size for Stokes Q,U,V  blurring in  radian
-               filttype (str): "gauss" or "butter" 
-               
+               filttype (str): "gauss" or "butter"
+
            Returns:
                (Image): output image
         """
@@ -1604,7 +1597,7 @@ class Image(object):
         sigmap = sigma / self.psize
         fwhmp = fwhm_i / self.psize
         fwhmp_pol = fwhm_pol / self.psize
-        
+
         # Define a convolution function
         def blur_gauss(imarr, fwhm):
             sigma = fwhmp / (2. * np.sqrt(2. * np.log(2.)))
@@ -1612,33 +1605,33 @@ class Image(object):
                 return blur(np.real(imarr), sigma) + 1j * blur(np.imag(imarr), sigma)
             imarr_blur = filt.gaussian_filter(imarr, (sigma, sigma))
             return imarr_blur
-            
+
         def blur_butter(imarr, size):
 
             if size==0:
                 return imarr
-            
-            cutoff = 1/size    
+
+            cutoff = 1/size
             Nx = self.xdim
             Ny = self.ydim
 
             s, t = np.meshgrid(np.fft.fftfreq(Nx, d=1.0 ), np.fft.fftfreq(Ny, d=1.0 ))
             r = np.sqrt(s**2 + t**2)
-            
+
             bfilt = 1./np.sqrt(1 + (r/cutoff)**4)
 
             imarr = self.imvec.reshape((Ny, Nx))
             imarr_filt = np.real(np.fft.ifft2(np.fft.fft2(imarr) * bfilt))
             return imarr_filt
-            
-            
+
+
         if filttype=='gauss':
             blur = blur_gauss
         elif filttype=='butter':
             blur = blur_butter
         else:
             raise Exception("filttype not recognized in blur_circ!")
-            
+
         # Blur the primary image
         imarr = self.imvec.reshape(self.ydim, self.xdim)
         imarr_blur = blur(imarr, fwhmp)
@@ -1680,62 +1673,62 @@ class Image(object):
 
            Args:
                freqs (float): Frequencies to include in the blurring & spectral index fit
-               fwhm (float): circular beam size 
+               fwhm (float): circular beam size
                fit_order (int): how many orders to fit spectrum: 1 or 2
-               filttype (str): "gauss" or "butter" 
-               
+               filttype (str): "gauss" or "butter"
+
            Returns:
-               (Image): output image          
-           
+               (Image): output image
+
         """
-        if fit_order not in [1,2]: 
+        if fit_order not in [1,2]:
             raise Exception("fit_order must be 1 or 2 in blur_mf!")
-           
+
         reffreq = self.rf
 
-        # remove any zeros in the images               
+        # remove any zeros in the images
         imlist = [self.get_image_mf(rf).blur_circ(fwhm, fwhm, filttype=filttype) for rf in freqs]
         imvecs = np.array([im.imvec for im in imlist])
-        
+
         if np.any(imvecs<=0):
             imvecs[imvecs<=0] = np.min(imvecs[imvecs<=0])
-        
+
         # total intensity
         xfit = np.log(np.array(freqs)/reffreq)
         yfit = np.log(imvecs)
-        
+
         if fit_order == 2:
             coeffs = np.polyfit(xfit,yfit,2)
             beta = coeffs[0]
-            alpha = coeffs[1]    
+            alpha = coeffs[1]
         elif fit_order == 1:
             coeffs = np.polyfit(xfit,yfit,1)
-            alpha = coeffs[0]    
+            alpha = coeffs[0]
             beta = 0*alpha
         else:
             alpha = 0*yfit
             beta = 0*yfit
-            
+
         # base image
         outim = self.blur_circ(fwhm, fwhm, filttype=filttype)
         outim.specvec = alpha
         outim.curvvec = beta
-                
+
         # polarization
         do_mf_pol=False
         for n in range(4):
-            if self._mflist[n+2].size: 
+            if self._mflist[n+2].size:
                 do_mf_pol=True
-           
+
         if do_mf_pol and not(self.qvec.size and self.uvec.size and self.vvec.size):
             print("WARNING: polarization multifrequency terms exist but not all Stokes parameters are defined""")
             print("Cannot apply spectral terms to polarization in get_image_mf")
             do_mf_pol=False
-        
+
         if do_mf_pol: # blur mulitfrequency polarizaiton
 
             rhovecs = np.array([im.rhovec for im in imlist])
-            phivecs = np.array([im.phivec for im in imlist])                    
+            phivecs = np.array([im.phivec for im in imlist])
             if np.any(rhovecs<=0):
                 rhovecs[rhovecs<=0] = np.min(rhovecs[imvecs<=0])
 
@@ -1745,30 +1738,30 @@ class Image(object):
             if fit_order_pol == 2:
                 coeffs = np.polyfit(xfit,yfit,2)
                 betap = coeffs[0]
-                alphap = coeffs[1]    
+                alphap = coeffs[1]
             elif fit_order_pol == 1:
                 coeffs = np.polyfit(xfit,yfit,1)
-                alphap = coeffs[0]    
+                alphap = coeffs[0]
                 betap = 0*alpha
             else:
                 alphap = 0*yfit
-                betap = 0*yfit                        
+                betap = 0*yfit
             outim.specvec_pol = alphap
             outim.curvvec_pol = betap
- 
-            # fit rm           
-            # TODO what about phase wraps? 
+
+            # fit rm
+            # TODO what about phase wraps?
             xfit = np.exp(-2*np.log(np.array(freqs)/reffreq))-1
             yfit = phivecs
             coeffs = np.polyfit(xfit,yfit,1)
-            rm = coeffs[0]    
+            rm = coeffs[0]
             outim.rmvec = rm
-            
+
             # TODO: no multifrequency V/\psi allowed
             outim.cmvec = np.zeros(outim.imvec.shape)
 
         return outim
-        
+
     def grad(self, gradtype='abs'):
         """Return the gradient image
 
@@ -1967,11 +1960,10 @@ class Image(object):
 
         if pol is None:
             pol = self.pol_prim
-        if not (pol in list(self._imdict.keys())):
-            raise Exception("for polrep==%s, pol must be in " %
-                            self.polrep + ",".join(list(self._imdict.keys())))
+        if pol not in list(self._imdict.keys()):
+            raise Exception(f"for polrep=={self.polrep}, pol must be in " + ",".join(list(self._imdict.keys())))
         if not len(self._imdict[pol]):
-            raise Exception("no image for pol %s" % pol)
+            raise Exception(f"no image for pol {pol}")
 
         # Make a flat image array
         flatarr = ((flux / float(len(self.imvec))) * np.ones(len(self.imvec)))
@@ -2016,11 +2008,10 @@ class Image(object):
 
         if pol is None:
             pol = self.pol_prim
-        if not (pol in list(self._imdict.keys())):
-            raise Exception("for polrep==%s, pol must be in " %
-                            self.polrep + ",".join(list(self._imdict.keys())))
+        if pol not in list(self._imdict.keys()):
+            raise Exception(f"for polrep=={self.polrep}, pol must be in " + ",".join(list(self._imdict.keys())))
         if not len(self._imdict[pol]):
-            raise Exception("no image for pol %s" % pol)
+            raise Exception(f"no image for pol {pol}")
 
         # Make a tophat image array
         xlist = np.arange(0, -self.xdim, -1) * self.psize + \
@@ -2074,11 +2065,10 @@ class Image(object):
 
         if pol is None:
             pol = self.pol_prim
-        if not (pol in list(self._imdict.keys())):
-            raise Exception("for polrep==%s, pol must be in " %
-                            self.polrep + ",".join(list(self._imdict.keys())))
+        if pol not in list(self._imdict.keys()):
+            raise Exception(f"for polrep=={self.polrep}, pol must be in " + ",".join(list(self._imdict.keys())))
         if not len(self._imdict[pol]):
-            raise Exception("no image for pol %s" % pol)
+            raise Exception(f"no image for pol {pol}")
 
         # Make a Gaussian image
         try:
@@ -2150,11 +2140,10 @@ class Image(object):
 
         if pol is None:
             pol = self.pol_prim
-        if not (pol in list(self._imdict.keys())):
-            raise Exception("for polrep==%s, pol must be in " %
-                            self.polrep + ",".join(list(self._imdict.keys())))
+        if pol not in list(self._imdict.keys()):
+            raise Exception(f"for polrep=={self.polrep}, pol must be in " + ",".join(list(self._imdict.keys())))
         if not len(self._imdict[pol]):
-            raise Exception("no image for pol %s" % pol)
+            raise Exception(f"no image for pol {pol}")
 
         # Make a crescent image
         xlist = np.arange(0, -self.xdim, -1) * self.psize + \
@@ -2215,11 +2204,10 @@ class Image(object):
 
         if pol is None:
             pol = self.pol_prim
-        if not (pol in list(self._imdict.keys())):
-            raise Exception("for polrep==%s, pol must be in " %
-                            self.polrep + ",".join(list(self._imdict.keys())))
+        if pol not in list(self._imdict.keys()):
+            raise Exception(f"for polrep=={self.polrep}, pol must be in " + ",".join(list(self._imdict.keys())))
         if not len(self._imdict[pol]):
-            raise Exception("no image for pol %s" % pol)
+            raise Exception(f"no image for pol {pol}")
 
         # Make a ring image
         flux = I0 - 0.5 * I1
@@ -2421,7 +2409,7 @@ class Image(object):
                beta_pol (float): polarization fraction spectral curvature
                rm (float): rotation measure (dimensionless at reference freq)
                cm (float): conversion measure (not yet implemented)
-               
+
            Returns:
                 (Image): output image with constant mf information added
         """
@@ -2438,7 +2426,7 @@ class Image(object):
             bpvec = beta_pol* np.ones(len(self.imvec))
         else:
             bpvec = np.array([])
-            
+
         if rm is not None:
             rmvec = rm* np.ones(len(self.imvec))
         else:
@@ -2448,7 +2436,7 @@ class Image(object):
             cmvec = cm* np.ones(len(self.imvec))
         else:
             cmvec = np.array([])
-                                            
+
         # create the new image object
         outim = self.copy()
         outim._mflist = [avec, bvec, apvec,bpvec,rmvec,cmvec ]
@@ -2563,9 +2551,10 @@ class Image(object):
             raise Exception("Image frequency is not the same as observation frequency!")
 
         if (ttype == 'direct' or ttype == 'fast' or ttype == 'nfft'):
-            if verbose: print("Producing clean visibilities from image with " + ttype + " FT . . . ")
+            if verbose:
+                print("Producing clean visibilities from image with " + ttype + " FT . . . ")
         else:
-            raise Exception("ttype=%s, options for ttype are 'direct', 'fast', 'nfft'" % ttype)
+            raise Exception(f"ttype={ttype}, options for ttype are 'direct', 'fast', 'nfft'")
 
         # Copy data to be safe
         obsdata = copy.deepcopy(obs.data)
@@ -2579,16 +2568,16 @@ class Image(object):
         # put visibilities into the obsdata
         if obs.polrep == 'stokes':
             obsdata['vis'] = data[0]
-            if not(data[1] is None):
+            if data[1] is not None:
                 obsdata['qvis'] = data[1]
                 obsdata['uvis'] = data[2]
                 obsdata['vvis'] = data[3]
 
         elif obs.polrep == 'circ':
             obsdata['rrvis'] = data[0]
-            if not(data[1] is None):
+            if data[1] is not None:
                 obsdata['llvis'] = data[1]
-            if not(data[2] is None):
+            if data[2] is not None:
                 obsdata['rlvis'] = data[2]
                 obsdata['lrvis'] = data[3]
 
@@ -2746,7 +2735,7 @@ class Image(object):
     def observe(self, array, tint, tadv, tstart, tstop, bw,
                 mjd=None, timetype='UTC', polrep_obs=None,
                 elevmin=ehc.ELEV_LOW, elevmax=ehc.ELEV_HIGH,
-                no_elevcut_space=False,                
+                no_elevcut_space=False,
                 ttype='nfft', fft_pad_factor=2, fix_theta_GMST=False,
                 sgrscat=False, add_th_noise=True,
                 jones=False, inv_jones=False,
@@ -2777,7 +2766,7 @@ class Image(object):
                elevmin (float): station minimum elevation in degrees
                elevmax (float): station maximum elevation in degrees
                no_elevcut_space (bool): if True, do not apply elevation cut to orbiters
-           
+
                ttype (str): "fast", "nfft" or "dtft"
                fft_pad_factor (float): zero pad the image to fft_pad_factor * image size in the FFT
                fix_theta_GMST (bool): if True, stops earth rotation to sample fixed u,v
@@ -2798,7 +2787,7 @@ class Image(object):
                stabilize_scan_phase (bool): if True, random phase errors are constant over scans
                stabilize_scan_amp (bool): if True, random amplitude errors are constant over scans
                neggains (bool): if True, force the applied gains to be <1
-               
+
                tau (float): the base opacity at all sites, or a dict giving one opacity per site
                taup (float): the fractional std. dev. of the random error on the opacities
                gainp (float): the fractional std. dev. of the random error on the gains
@@ -2838,7 +2827,8 @@ class Image(object):
         """
 
         # Generate empty observation
-        if verbose: print("Generating empty observation file . . . ")
+        if verbose:
+            print("Generating empty observation file . . . ")
 
         if mjd is None:
             mjd = self.mjd
@@ -2846,9 +2836,9 @@ class Image(object):
             polrep_obs = self.polrep
 
         obs = array.obsdata(self.ra, self.dec, self.rf, bw, tint, tadv, tstart, tstop, mjd=mjd,
-                            polrep=polrep_obs, tau=tau, 
-                            elevmin=elevmin, elevmax=elevmax, 
-                            no_elevcut_space=no_elevcut_space,                            
+                            polrep=polrep_obs, tau=tau,
+                            elevmin=elevmin, elevmax=elevmax,
+                            no_elevcut_space=no_elevcut_space,
                             timetype=timetype, fix_theta_GMST=fix_theta_GMST)
 
         # Observe on the same baselines as the empty observation and add noise
@@ -3071,7 +3061,7 @@ class Image(object):
         if 'nxcorr' in metric:
             error.append(xcorr[idx[0], idx[1]] / (im1_pad.xdim * im1_pad.ydim))
         if 'nrmse' in metric:
-            error.append(np.sqrt(np.sum((np.abs(imvec1 - imvec2)**2 * im1_pad.psize**2)) /
+            error.append(np.sqrt(np.sum(np.abs(imvec1 - imvec2)**2 * im1_pad.psize**2) /
                                  np.sum((imvec1)**2 * im1_pad.psize**2)))
         if 'rssd' in metric:
             error.append(np.sqrt(np.sum(np.abs(imvec1 - imvec2)**2) * im1_pad.psize**2))
@@ -3323,7 +3313,7 @@ class Image(object):
                 contour_im=False, power=0, beamcolor='w',
                 export_pdf="", show=True, beamparams=None, cbar_orientation="vertical",
                 scale_lw=1, beam_lw=1, cbar_fontsize=12, axis=None, scale_fontsize=12):
-        """Display the image in a contour plot.
+        r"""Display the image in a contour plot.
 
            Args:
                contour_levels (arr): the fractional contour levels relative to the max flux plotted
@@ -3437,9 +3427,9 @@ class Image(object):
         count = 0.
 
         for level in contour_levels:
-            if not(contour_cfun is None):
+            if contour_cfun is not None:
                 rgbval = contour_cfun(count / len(contour_levels))
-                rgbstring = '#%02x%02x%02x' % (rgbval[0] * 256, rgbval[1] * 256, rgbval[2] * 256)
+                rgbstring = f'#{rgbval[0] * 256:02x}{rgbval[1] * 256:02x}{rgbval[2] * 256:02x}'
             else:
                 rgbstring = color
             cs = plt.contour(x, y, z, levels=[level * maxz], colors=rgbstring, cmap=None)
@@ -3451,7 +3441,7 @@ class Image(object):
         if show:
             #plt.show(block=False)
             ehc.show_noblock()
-            
+
         if export_pdf != "":
             ax.savefig(export_pdf, bbox_inches='tight', pad_inches=0)
 
@@ -3470,10 +3460,10 @@ class Image(object):
                 export_pdf="", pdf_pad_inches=0.0, show=True, beamparams=None,
                 cbar_orientation="vertical", scinot=False,
                 scale_lw=1, beam_lw=1, cbar_fontsize=12, axis=None,
-                scale_fontsize=12, 
-                power=0, 
+                scale_fontsize=12,
+                power=0,
                 beamcolor='w', beampos='right', scalecolor='w',dpi=500):
-        """Display the image.
+        r"""Display the image.
 
            Args:
                pol (str): which polarization image to plot. Default is self.pol_prim
@@ -3492,13 +3482,13 @@ class Image(object):
                nvec (int): number of polarimetric vectors to plot
                vec_cfun (str): color function for vectors colored by lin pol frac
                vec_cbar_lims (tuple): lower and upper limit of the fractional polarization colormap
-               
+
                scut (float): minimum fractional stokes I value for displaying spectral index
                pcut (float): minimum fractional stokes I value for displaying polarimetric vectors
                mcut (float): minimum fractional polarization value for displaying vectors
                scale_ticks (bool): if True, scale polarization ticks by linear polarization magnitude
-               
-               
+
+
                label_type (string): specifies the type of axes labeling: 'ticks', 'scale', 'none'
                has_title (bool): True if you want a title on the plot
                has_cbar (bool): True if you want a colorbar on the plot
@@ -3518,7 +3508,7 @@ class Image(object):
 
                power (float): Passed to colorbar for division of ticks by 1e(power)
                beamcolor (str): color of the beam overlay
-               scalecolor (str): color of the scale label overlay            
+               scalecolor (str): color of the scale label overlay
            Returns:
                (matplotlib.figure.Figure): figure object with image
 
@@ -3623,7 +3613,7 @@ class Image(object):
             raise ValueError('cbar_unit ' + cbar_unit[1] + ' is not a possible option')
 
         # Plot a single polarization image
-        if not plotp:  
+        if not plotp:
             cbar_lims_p = ()
 
             if pol.lower() == 'spec':
@@ -3688,7 +3678,7 @@ class Image(object):
                             im2 = self.switch_polrep('stokes')
                         imvec = np.array(im2._imdict[pol]).reshape(-1) / (10.**power)
                     except KeyError:
-                        raise Exception("Cannot make pol %s image in display()!" % pol)
+                        raise Exception(f"Cannot make pol {pol} image in display()!")
 
                 unit = fluxunit
                 if areaunit != '':
@@ -3728,7 +3718,7 @@ class Image(object):
                 imarr[imarr < cbar_lims[0]] = cbar_lims[0]
 
             if has_title:
-                plt.title("%s %.2f GHz %s" % (self.source, self.rf / 1e9, pol), fontsize=16)
+                plt.title(f"{self.source} {self.rf / 1e9:.2f} GHz {pol}", fontsize=16)
 
             if not cfun:
                 cfun = cfun_p
@@ -3747,7 +3737,7 @@ class Image(object):
                                   +.4 * self.fovx(), -.4 * self.fovy()]
                 else:
                     beamparams = [beamparams[0], beamparams[1], beamparams[2],
-                                  -.35 * self.fovx(), -.35 * self.fovy()]                              
+                                  -.35 * self.fovx(), -.35 * self.fovy()]
                 beamimage = self.copy()
                 beamimage.imvec *= 0
                 beamimage = beamimage.add_gauss(1, beamparams)
@@ -3772,9 +3762,9 @@ class Image(object):
                     cb.update_ticks()
 
         # plot polarization with ticks!
-        else:  
+        else:
 
-                    
+
             im_stokes = self.switch_polrep(polrep_out='stokes')
             imvec = np.array(im_stokes.imvec).reshape(-1) / (10**power)
             qvec = np.array(im_stokes.qvec).reshape(-1) / (10**power)
@@ -3817,7 +3807,7 @@ class Image(object):
             if scale == 'gamma':
                 #if (imarr2 < 0.0).any():
                 #    print('clipping values leq 0 in display')
-                #    imarr2[imarr2 <= 0.0] = 1.e-16*np.min(imarr2[imarr2>0]) #0 
+                #    imarr2[imarr2 <= 0.0] = 1.e-16*np.min(imarr2[imarr2>0]) #0
                 imarr2 = (imarr2 + np.max(imarr2) / dynamic_range)**(gamma)
                 unit = '(' + unit + ')^gamma'
 
@@ -4014,12 +4004,12 @@ class Image(object):
 
                 if not vec_cbar_lims:
                     vec_cbar_lims = (0,1)
-                    
-                plt.clim(vec_cbar_lims[0],vec_cbar_lims[1])                
-                mcbar = plt.colorbar(pad=0.04,fraction=0.046, orientation="horizontal") 
+
+                plt.clim(vec_cbar_lims[0],vec_cbar_lims[1])
+                mcbar = plt.colorbar(pad=0.04,fraction=0.046, orientation="horizontal")
                 mcbar.set_label(r'Fractional Linear Polarization $|m|$', fontsize=cbar_fontsize)
-                mcbar.ax.tick_params(labelsize=cbar_fontsize) 
-                            
+                mcbar.ax.tick_params(labelsize=cbar_fontsize)
+
             if not(beamparams is None or beamparams is False):
                 beamparams = [beamparams[0], beamparams[1], beamparams[2],
                               -.35 * self.fovx(), -.35 * self.fovy()]
@@ -4038,9 +4028,7 @@ class Image(object):
                 if cbar_lims:
                     plt.clim(cbar_lims[0], cbar_lims[1])
             if has_title:
-                plt.title("%s %.1f GHz : m=%.1f%% , v=%.1f%%" % (self.source, self.rf / 1e9,
-                                                                 self.lin_polfrac() * 100,
-                                                                 self.circ_polfrac() * 100),
+                plt.title(f"{self.source} {self.rf / 1e9:.1f} GHz : m={self.lin_polfrac() * 100:.1f}% , v={self.circ_polfrac() * 100:.1f}%",
                           fontsize=12)
             f.subplots_adjust(hspace=.1, wspace=0.3)
 
@@ -4084,7 +4072,7 @@ class Image(object):
         if show:
             #plt.show(block=False)
             ehc.show_noblock()
-            
+
         if export_pdf != "":
             f.savefig(export_pdf, bbox_inches='tight', pad_inches=pdf_pad_inches, dpi=dpi)
 
@@ -4180,7 +4168,7 @@ class Image(object):
             composite_img = composite_img / np.max(np.max(np.max(composite_img)))
 
         plt.subplot(111)
-        plt.title('%s   MJD %i  %.2f GHz' % (self.source, self.mjd, self.rf / 1e9), fontsize=20)
+        plt.title(f'{self.source}   MJD {self.mjd:d}  {self.rf / 1e9:.2f} GHz', fontsize=20)
         plt.imshow(composite_img, interpolation=interp)
         xticks = obsh.ticks(im0_pad.xdim, im0_pad.psize / ehc.RADPERAS / 1e-6)
         yticks = obsh.ticks(im0_pad.ydim, im0_pad.psize / ehc.RADPERAS / 1e-6)
@@ -4308,7 +4296,7 @@ def load_image(image, display=False, aipscc=False):
             im = ehtim.io.load.load_im_hdf5(image)
         else:
             print("Image format is not recognized. Was expecting .fits, .txt, or Image.")
-            print(" Got <.{0}>. Returning False.".format(image.split('.')[-1]))
+            print(" Got <.{}>. Returning False.".format(image.split('.')[-1]))
             return False
 
     elif isinstance(image, ehtim.image.Image):
@@ -4316,7 +4304,7 @@ def load_image(image, display=False, aipscc=False):
 
     else:
         print("Image format is not recognized. Was expecting .fits, .txt, or Image.")
-        print(" Got {0}. Returning False.".format(type(image)))
+        print(f" Got {type(image)}. Returning False.")
         return False
 
     if display:
@@ -4361,7 +4349,7 @@ def load_fits(fname, aipscc=False, pulse=ehc.PULSE_DEFAULT,
 
     return ehtim.io.load.load_im_fits(fname, aipscc=aipscc, pulse=pulse,
                                       polrep=polrep, pol_prim=pol_prim, zero_pol=zero_pol)
-                                      
+
 def avg_imlist(imlist):
     """Average a list of images.
 
@@ -4371,7 +4359,7 @@ def avg_imlist(imlist):
        Returns:
            (Image): average image object
     """
-    
+
     imavg = imlist[0]
 
     if np.any(np.array([im.polrep for im in imlist]) != imavg.polrep):
@@ -4380,9 +4368,9 @@ def avg_imlist(imlist):
         raise Exception("im.source in all images are not the same in avg_imlist!")
     if np.any(np.array([im.rf for im in imlist]) != imavg.rf):
         raise Exception("im.rf in all images are not the same in avg_imlist!")
-           
+
     keys = imavg._imdict.keys()
-                
+
     for im in imlist[1:]:
         for key in keys:
             imavg._imdict[key] += im._imdict[key]
@@ -4390,7 +4378,7 @@ def avg_imlist(imlist):
     for key in keys:
         imavg._imdict[key] /= float(len(imlist))
 
-    
+
     return imavg
 
 def get_specim(imlist, reffreq, fit_order=2):
@@ -4400,7 +4388,7 @@ def get_specim(imlist, reffreq, fit_order=2):
     # remove any zeros in the images
     for im in imlist:
         im.imvec[im.imvec<=0] = np.min(im.imvec[im.imvec!=0])
-    
+
     # fit
     xfit = np.log(np.array(freqs)/reffreq)
     yfit = np.log(np.array([im.imvec for im in imlist]))
@@ -4408,21 +4396,21 @@ def get_specim(imlist, reffreq, fit_order=2):
     if fit_order == 2:
         coeffs = np.polyfit(xfit,yfit,2)
         beta = coeffs[0]
-        alpha = coeffs[1] 
-        imvec = np.exp(coeffs[2])   
+        alpha = coeffs[1]
+        imvec = np.exp(coeffs[2])
     elif fit_order == 1:
         coeffs = np.polyfit(xfit,yfit,1)
-        alpha = coeffs[0]    
+        alpha = coeffs[0]
         beta = 0*alpha
         imvec = np.exp(coeffs[1])
     else:
         raise Exception()
-        
+
     outim = imlist[0].copy() #TODO no polarization
     outim.imvec = imvec
     outim.rf = reffreq
     outim.specvec = alpha
     outim.curvvec = beta
-    
+
     return outim
 

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -2490,9 +2490,8 @@ class Image(object):
 
         # calculate the amount of flux to include in the Gaussian
         obs_zerobl = obs.flag_uvdist(uv_max=uv_min)
-        obs_zerobl.add_amp(debias=debias)
-        orig_totflux = np.sum(obs_zerobl.amp['amp'] * (1 / obs_zerobl.amp['sigma']**2))
-        orig_totflux /= np.sum(1 / obs_zerobl.amp['sigma']**2)
+        amps = obs_zerobl.unpack(['amp', 'sigma'], debias=debias)
+        orig_totflux = np.sum(amps['amp'] / amps['sigma']**2) / np.sum(1 / amps['sigma']**2)
 
         if zblval is None:
             addedflux = orig_totflux - np.sum(self.imvec)

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -2639,14 +2639,7 @@ def chisqdata_amp(Obsdata, Prior, mask, pol='I', **kwargs):
     vtype = ehc.vis_poldict[pol]
     atype = ehc.amp_poldict[pol]
     etype = ehc.sig_poldict[pol]
-    if (Obsdata.amp is None) or (len(Obsdata.amp) == 0) or pol != 'I':
-        data_arr = Obsdata.unpack(['t1', 't2', 'u', 'v', vtype, atype, etype], debias=debias)
-
-    else:  # TODO -- pre-computed  with not stokes I?
-        print("Using pre-computed amplitude table in amplitude chi^2!")
-        if type(Obsdata.amp) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed amplitude table is not a numpy rec array!")
-        data_arr = Obsdata.amp
+    data_arr = Obsdata.unpack(['t1', 't2', 'u', 'v', vtype, atype, etype], debias=debias)
 
     # apply systematic noise and SNR cut
     # TODO -- after pre-computed??
@@ -2679,17 +2672,7 @@ def chisqdata_bs(Obsdata, Prior, mask, pol='I', **kwargs):
 
     # unpack data
     vtype = ehc.vis_poldict[pol]
-    if (Obsdata.bispec is None) or (len(Obsdata.bispec) == 0) or pol != 'I':
-        biarr = Obsdata.bispectra(mode="all", vtype=vtype, count=count, snrcut=snrcut)
-
-    else:  # TODO -- pre-computed  with not stokes I?
-        print("Using pre-computed bispectrum table in cphase chi^2!")
-        if type(Obsdata.bispec) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed bispectrum table is not a numpy rec array!")
-        biarr = Obsdata.bispec
-        # reduce to a minimal set
-        if count != 'max':
-            biarr = obsh.reduce_tri_minimal(Obsdata, biarr)
+    biarr = Obsdata.bispectra(mode="all", vtype=vtype, count=count, snrcut=snrcut)
 
     uv1 = np.hstack((biarr['u1'].reshape(-1, 1), biarr['v1'].reshape(-1, 1)))
     uv2 = np.hstack((biarr['u2'].reshape(-1, 1), biarr['v2'].reshape(-1, 1)))
@@ -2731,17 +2714,8 @@ def chisqdata_cphase(Obsdata, Prior, mask, pol='I', **kwargs):
 
     # unpack data
     vtype = ehc.vis_poldict[pol]
-    if (Obsdata.cphase is None) or (len(Obsdata.cphase) == 0) or pol != 'I':
-        clphasearr = Obsdata.c_phases(mode="all", vtype=vtype,
-                                      count=count, uv_min=uv_min, snrcut=snrcut)
-    else:  # TODO precomputed with not Stokes I
-        print("Using pre-computed cphase table in cphase chi^2!")
-        if type(Obsdata.cphase) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed closure phase table is not a numpy rec array!")
-        clphasearr = Obsdata.cphase
-        # reduce to a minimal set
-        if count != 'max':
-            clphasearr = obsh.reduce_tri_minimal(Obsdata, clphasearr)
+    clphasearr = Obsdata.c_phases(mode="all", vtype=vtype,
+                                  count=count, uv_min=uv_min, snrcut=snrcut)
 
     uv1 = np.hstack((clphasearr['u1'].reshape(-1, 1), clphasearr['v1'].reshape(-1, 1)))
     uv2 = np.hstack((clphasearr['u2'].reshape(-1, 1), clphasearr['v2'].reshape(-1, 1)))
@@ -2840,17 +2814,8 @@ def chisqdata_camp(Obsdata, Prior, mask, pol='I', **kwargs):
 
     # unpack data & mask low snr points
     vtype = ehc.vis_poldict[pol]
-    if (Obsdata.camp is None) or (len(Obsdata.camp) == 0) or pol != 'I':
-        clamparr = Obsdata.c_amplitudes(mode='all', count=count,
-                                        vtype=vtype, ctype='camp', debias=debias, snrcut=snrcut)
-    else:  # TODO -- pre-computed  with not stokes I?
-        print("Using pre-computed closure amplitude table in closure amplitude chi^2!")
-        if type(Obsdata.camp) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed closure amplitude table is not a numpy rec array!")
-        clamparr = Obsdata.camp
-        # reduce to a minimal set
-        if count != 'max':
-            clamparr = obsh.reduce_quad_minimal(Obsdata, clamparr, ctype='camp')
+    clamparr = Obsdata.c_amplitudes(mode='all', count=count,
+                                    vtype=vtype, ctype='camp', debias=debias, snrcut=snrcut)
 
     uv1 = np.hstack((clamparr['u1'].reshape(-1, 1), clamparr['v1'].reshape(-1, 1)))
     uv2 = np.hstack((clamparr['u2'].reshape(-1, 1), clamparr['v2'].reshape(-1, 1)))
@@ -2889,17 +2854,8 @@ def chisqdata_logcamp(Obsdata, Prior, mask, pol='I', **kwargs):
 
     # unpack data & mask low snr points
     vtype = ehc.vis_poldict[pol]
-    if (Obsdata.logcamp is None) or (len(Obsdata.logcamp) == 0) or pol != 'I':
-        clamparr = Obsdata.c_amplitudes(mode='all', count=count,
-                                        vtype=vtype, ctype='logcamp', debias=debias, snrcut=snrcut)
-    else:  # TODO -- pre-computed  with not stokes I?
-        print("Using pre-computed log closure amplitude table in log closure amplitude chi^2!")
-        if type(Obsdata.logcamp) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed log closure amplitude table is not a numpy rec array!")
-        clamparr = Obsdata.logcamp
-        # reduce to a minimal set
-        if count != 'max':
-            clamparr = obsh.reduce_quad_minimal(Obsdata, clamparr, ctype='logcamp')
+    clamparr = Obsdata.c_amplitudes(mode='all', count=count,
+                                    vtype=vtype, ctype='logcamp', debias=debias, snrcut=snrcut)
 
     uv1 = np.hstack((clamparr['u1'].reshape(-1, 1), clamparr['v1'].reshape(-1, 1)))
     uv2 = np.hstack((clamparr['u2'].reshape(-1, 1), clamparr['v2'].reshape(-1, 1)))
@@ -3046,13 +3002,7 @@ def chisqdata_amp_fft(Obsdata, Prior, pol='I', **kwargs):
     vtype = ehc.vis_poldict[pol]
     atype = ehc.amp_poldict[pol]
     etype = ehc.sig_poldict[pol]
-    if (Obsdata.amp is None) or (len(Obsdata.amp) == 0) or pol != 'I':
-        data_arr = Obsdata.unpack(['t1', 't2', 'u', 'v', vtype, atype, etype], debias=debias)
-    else:  # TODO -- pre-computed  with not stokes I?
-        print("Using pre-computed amplitude table in amplitude chi^2!")
-        if type(Obsdata.amp) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed amplitude table is not a numpy rec array!")
-        data_arr = Obsdata.amp
+    data_arr = Obsdata.unpack(['t1', 't2', 'u', 'v', vtype, atype, etype], debias=debias)
 
     # apply systematic noise
     (uv, vis, amp, sigma) = apply_systematic_noise_snrcut(data_arr, systematic_noise, snrcut, pol)
@@ -3095,16 +3045,7 @@ def chisqdata_bs_fft(Obsdata, Prior, pol='I', **kwargs):
 
     # unpack data
     vtype = ehc.vis_poldict[pol]
-    if (Obsdata.bispec is None) or (len(Obsdata.bispec) == 0) or pol != 'I':
-        biarr = Obsdata.bispectra(mode="all", vtype=vtype, count=count, snrcut=snrcut)
-    else:  # TODO -- pre-computed  with not stokes I?
-        print("Using pre-computed bispectrum table in cphase chi^2!")
-        if type(Obsdata.bispec) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed bispectrum table is not a numpy rec array!")
-        biarr = Obsdata.bispec
-        # reduce to a minimal set
-        if count != 'max':
-            biarr = obsh.reduce_tri_minimal(Obsdata, biarr)
+    biarr = Obsdata.bispectra(mode="all", vtype=vtype, count=count, snrcut=snrcut)
 
     uv1 = np.hstack((biarr['u1'].reshape(-1, 1), biarr['v1'].reshape(-1, 1)))
     uv2 = np.hstack((biarr['u2'].reshape(-1, 1), biarr['v2'].reshape(-1, 1)))
@@ -3157,17 +3098,8 @@ def chisqdata_cphase_fft(Obsdata, Prior, pol='I', **kwargs):
 
     # unpack data
     vtype = ehc.vis_poldict[pol]
-    if (Obsdata.cphase is None) or (len(Obsdata.cphase) == 0) or pol != 'I':
-        clphasearr = Obsdata.c_phases(mode="all", vtype=vtype,
-                                      count=count, uv_min=uv_min, snrcut=snrcut)
-    else:  # TODO precomputed with not Stokes I
-        print("Using pre-computed cphase table in cphase chi^2!")
-        if type(Obsdata.cphase) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed closure phase table is not a numpy rec array!")
-        clphasearr = Obsdata.cphase
-        # reduce to a minimal set
-        if count != 'max':
-            clphasearr = obsh.reduce_tri_minimal(Obsdata, clphasearr)
+    clphasearr = Obsdata.c_phases(mode="all", vtype=vtype,
+                                  count=count, uv_min=uv_min, snrcut=snrcut)
 
     uv1 = np.hstack((clphasearr['u1'].reshape(-1, 1), clphasearr['v1'].reshape(-1, 1)))
     uv2 = np.hstack((clphasearr['u2'].reshape(-1, 1), clphasearr['v2'].reshape(-1, 1)))
@@ -3302,17 +3234,8 @@ def chisqdata_camp_fft(Obsdata, Prior, pol='I', **kwargs):
 
     # unpack data
     vtype = ehc.vis_poldict[pol]
-    if (Obsdata.camp is None) or (len(Obsdata.camp) == 0) or pol != 'I':
-        clamparr = Obsdata.c_amplitudes(mode='all', count=count,
-                                        vtype=vtype, ctype='camp', debias=debias, snrcut=snrcut)
-    else:  # TODO -- pre-computed  with not stokes I?
-        print("Using pre-computed closure amplitude table in closure amplitude chi^2!")
-        if type(Obsdata.camp) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed closure amplitude table is not a numpy rec array!")
-        clamparr = Obsdata.camp
-        # reduce to a minimal set
-        if count != 'max':
-            clamparr = obsh.reduce_quad_minimal(Obsdata, clamparr, ctype='camp')
+    clamparr = Obsdata.c_amplitudes(mode='all', count=count,
+                                    vtype=vtype, ctype='camp', debias=debias, snrcut=snrcut)
 
     uv1 = np.hstack((clamparr['u1'].reshape(-1, 1), clamparr['v1'].reshape(-1, 1)))
     uv2 = np.hstack((clamparr['u2'].reshape(-1, 1), clamparr['v2'].reshape(-1, 1)))
@@ -3364,17 +3287,8 @@ def chisqdata_logcamp_fft(Obsdata, Prior, pol='I', **kwargs):
 
     # unpack data
     vtype = ehc.vis_poldict[pol]
-    if (Obsdata.logcamp is None) or (len(Obsdata.logcamp) == 0) or pol != 'I':
-        clamparr = Obsdata.c_amplitudes(mode='all', count=count,
-                                        vtype=vtype, ctype='logcamp', debias=debias, snrcut=snrcut)
-    else:  # TODO -- pre-computed  with not stokes I?
-        print("Using pre-computed log closure amplitude table in log closure amplitude chi^2!")
-        if type(Obsdata.logcamp) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed log closure amplitude table is not a numpy rec array!")
-        clamparr = Obsdata.logcamp
-        # reduce to a minimal set
-        if count != 'max':
-            clamparr = obsh.reduce_quad_minimal(Obsdata, clamparr, ctype='logcamp')
+    clamparr = Obsdata.c_amplitudes(mode='all', count=count,
+                                    vtype=vtype, ctype='logcamp', debias=debias, snrcut=snrcut)
 
     uv1 = np.hstack((clamparr['u1'].reshape(-1, 1), clamparr['v1'].reshape(-1, 1)))
     uv2 = np.hstack((clamparr['u2'].reshape(-1, 1), clamparr['v2'].reshape(-1, 1)))
@@ -3553,13 +3467,7 @@ def chisqdata_amp_nfft(Obsdata, Prior, pol='I', **kwargs):
     vtype = ehc.vis_poldict[pol]
     atype = ehc.amp_poldict[pol]
     etype = ehc.sig_poldict[pol]
-    if (Obsdata.amp is None) or (len(Obsdata.amp) == 0) or pol != 'I':
-        data_arr = Obsdata.unpack(['t1', 't2', 'u', 'v', vtype, atype, etype], debias=debias)
-    else:  # TODO -- pre-computed  with not stokes I?
-        print("Using pre-computed amplitude table in amplitude chi^2!")
-        if type(Obsdata.amp) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed amplitude table is not a numpy rec array!")
-        data_arr = Obsdata.amp
+    data_arr = Obsdata.unpack(['t1', 't2', 'u', 'v', vtype, atype, etype], debias=debias)
 
     # apply systematic noise
     (uv, vis, amp, sigma) = apply_systematic_noise_snrcut(data_arr, systematic_noise, snrcut, pol)
@@ -3597,16 +3505,7 @@ def chisqdata_bs_nfft(Obsdata, Prior, pol='I', **kwargs):
 
     # unpack data
     vtype = ehc.vis_poldict[pol]
-    if (Obsdata.bispec is None) or (len(Obsdata.bispec) == 0) or pol != 'I':
-        biarr = Obsdata.bispectra(mode="all", vtype=vtype, count=count, snrcut=snrcut)
-    else:  # TODO -- pre-computed  with not stokes I?
-        print("Using pre-computed bispectrum table in cphase chi^2!")
-        if type(Obsdata.bispec) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed bispectrum table is not a numpy rec array!")
-        biarr = Obsdata.bispec
-        # reduce to a minimal set
-        if count != 'max':
-            biarr = obsh.reduce_tri_minimal(Obsdata, biarr)
+    biarr = Obsdata.bispectra(mode="all", vtype=vtype, count=count, snrcut=snrcut)
 
     uv1 = np.hstack((biarr['u1'].reshape(-1, 1), biarr['v1'].reshape(-1, 1)))
     uv2 = np.hstack((biarr['u2'].reshape(-1, 1), biarr['v2'].reshape(-1, 1)))
@@ -3653,17 +3552,8 @@ def chisqdata_cphase_nfft(Obsdata, Prior, pol='I', **kwargs):
 
     # unpack data
     vtype = ehc.vis_poldict[pol]
-    if (Obsdata.cphase is None) or (len(Obsdata.cphase) == 0) or pol != 'I':
-        clphasearr = Obsdata.c_phases(mode="all", vtype=vtype,
-                                      count=count, uv_min=uv_min, snrcut=snrcut)
-    else:  # TODO precomputed with not Stokes I
-        print("Using pre-computed cphase table in cphase chi^2!")
-        if type(Obsdata.cphase) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed closure phase table is not a numpy rec array!")
-        clphasearr = Obsdata.cphase
-        # reduce to a minimal set
-        if count != 'max':
-            clphasearr = obsh.reduce_tri_minimal(Obsdata, clphasearr)
+    clphasearr = Obsdata.c_phases(mode="all", vtype=vtype,
+                                  count=count, uv_min=uv_min, snrcut=snrcut)
 
     uv1 = np.hstack((clphasearr['u1'].reshape(-1, 1), clphasearr['v1'].reshape(-1, 1)))
     uv2 = np.hstack((clphasearr['u2'].reshape(-1, 1), clphasearr['v2'].reshape(-1, 1)))
@@ -3785,17 +3675,8 @@ def chisqdata_camp_nfft(Obsdata, Prior, pol='I', **kwargs):
 
     # unpack data
     vtype = ehc.vis_poldict[pol]
-    if (Obsdata.camp is None) or (len(Obsdata.camp) == 0) or pol != 'I':
-        clamparr = Obsdata.c_amplitudes(mode='all', count=count,
-                                        vtype=vtype, ctype='camp', debias=debias, snrcut=snrcut)
-    else:  # TODO -- pre-computed  with not stokes I?
-        print("Using pre-computed closure amplitude table in closure amplitude chi^2!")
-        if type(Obsdata.camp) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed closure amplitude table is not a numpy rec array!")
-        clamparr = Obsdata.camp
-        # reduce to a minimal set
-        if count != 'max':
-            clamparr = obsh.reduce_quad_minimal(Obsdata, clamparr, ctype='camp')
+    clamparr = Obsdata.c_amplitudes(mode='all', count=count,
+                                    vtype=vtype, ctype='camp', debias=debias, snrcut=snrcut)
 
     uv1 = np.hstack((clamparr['u1'].reshape(-1, 1), clamparr['v1'].reshape(-1, 1)))
     uv2 = np.hstack((clamparr['u2'].reshape(-1, 1), clamparr['v2'].reshape(-1, 1)))
@@ -3840,17 +3721,8 @@ def chisqdata_logcamp_nfft(Obsdata, Prior, pol='I', **kwargs):
 
     # unpack data
     vtype = ehc.vis_poldict[pol]
-    if (Obsdata.logcamp is None) or (len(Obsdata.logcamp) == 0) or pol != 'I':
-        clamparr = Obsdata.c_amplitudes(mode='all', count=count,
-                                        vtype=vtype, ctype='logcamp', debias=debias, snrcut=snrcut)
-    else:  # TODO -- pre-computed  with not stokes I?
-        print("Using pre-computed log closure amplitude table in log closure amplitude chi^2!")
-        if type(Obsdata.logcamp) not in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed log closure amplitude table is not a numpy rec array!")
-        clamparr = Obsdata.logcamp
-        # reduce to a minimal set
-        if count != 'max':
-            clamparr = obsh.reduce_quad_minimal(Obsdata, clamparr, ctype='logcamp')
+    clamparr = Obsdata.c_amplitudes(mode='all', count=count,
+                                    vtype=vtype, ctype='logcamp', debias=debias, snrcut=snrcut)
 
     uv1 = np.hstack((clamparr['u1'].reshape(-1, 1), clamparr['v1'].reshape(-1, 1)))
     uv2 = np.hstack((clamparr['u2'].reshape(-1, 1), clamparr['v2'].reshape(-1, 1)))

--- a/ehtim/io/load.py
+++ b/ehtim/io/load.py
@@ -1635,31 +1635,24 @@ def load_obs_maps(arrfile, obsspec, ifile, qfile=0, ufile=0, vfile=0,
     return ehtim.obsdata.Obsdata(ra, dec, rf, bw, datatable, tdata,
                                  source=src, mjd=mjd, polrep='stokes')
 
-def load_dtype_txt(obs, filename, dtype='cphase'):
+def load_dtype_txt(filename, dtype='cphase'):
 
-    """Load the dtype data in a text file and put it in the already-created obs object
+    """Load a derived-data text file produced by save_dtype_txt.
+
        Args:
-            obs (Obsdata): obsdata object
-            filename (str): path to output text file
-            dtype (str): desired data type
+            filename (str): path to text file
+            dtype (str): one of 'cphase', 'logcamp', 'camp', 'bs', 'amp'.
+                         The returned recarray's dtype matches the
+                         corresponding ehtim.const_def schema
+                         (DTCPHASE, DTCAMP, DTBIS, DTAMP).
        Returns:
+            (np.ndarray): recarray of the requested closure / amplitude
+                          table. The header parameters in the file are
+                          ignored; callers should already have an Obsdata
+                          object if they need RA/dec/mjd/etc.
     """
 
     print("Loading text observation: ", filename)
-
-    # Read the header parameters
-    file = open(filename)
-    src = ' '.join(file.readline().split()[2:])
-    ra = file.readline().split()
-    ra = float(ra[2]) + float(ra[4]) / 60.0 + float(ra[6]) / 3600.0
-    dec = file.readline().split()
-    dec = np.sign(float(dec[2])) * (abs(float(dec[2])) +
-                                    float(dec[4]) / 60.0 + float(dec[6]) / 3600.0)
-    mjd = float(file.readline().split()[2])
-    rf = float(file.readline().split()[2]) * 1e9
-    bw = float(file.readline().split()[2]) * 1e9
-    phasecal = bool(file.readline().split()[2])
-    ampcal = bool(file.readline().split()[2])
 
     # Load the data, convert to list format, return object
     datatable = np.loadtxt(filename, dtype=bytes).astype(str)
@@ -1681,7 +1674,7 @@ def load_dtype_txt(obs, filename, dtype='cphase'):
             sigmacp = float(row[11])
             datatable2.append(np.array((time, t1, t2, t3, u1, v1, u2, v2,
                                         u3, v3, cphase, sigmacp), dtype=ehc.DTCPHASE))
-        obs.cphase = np.array(datatable2)
+        return np.array(datatable2)
 
     elif dtype == 'logcamp':
         datatable2 = []
@@ -1703,7 +1696,7 @@ def load_dtype_txt(obs, filename, dtype='cphase'):
             sigmalogcamp = float(row[14])
             datatable2.append(np.array((time, t1, t2, t3, t4, u1, v1, u2, v2, u3,
                                         v3, u4, v4, logcamp, sigmalogcamp), dtype=ehc.DTCAMP))
-        obs.logcamp = np.array(datatable2)
+        return np.array(datatable2)
 
     elif dtype == 'camp':
         datatable2 = []
@@ -1725,7 +1718,7 @@ def load_dtype_txt(obs, filename, dtype='cphase'):
             sigmacamp = float(row[14])
             datatable2.append(np.array((time, t1, t2, t3, t4, u1, v1, u2, v2,
                                         u3, v3, u4, v4, camp, sigmacamp), dtype=ehc.DTCAMP))
-        obs.camp = np.array(datatable2)
+        return np.array(datatable2)
 
     elif dtype == 'bs':
         datatable2 = []
@@ -1744,7 +1737,7 @@ def load_dtype_txt(obs, filename, dtype='cphase'):
             sigmab = float(row[11])
             datatable2.append(np.array((time, t1, t2, t3, u1, v1, u2,
                                         v2, u3, v3, bispec, sigmab), dtype=ehc.DTBIS))
-        obs.bispec = np.array(datatable2)
+        return np.array(datatable2)
 
     elif dtype == 'amp':
         datatable2 = []
@@ -1758,9 +1751,7 @@ def load_dtype_txt(obs, filename, dtype='cphase'):
             amp = float(row[6])
             sigmaamp = float(row[7])
             datatable2.append(np.array((time, tint, t1, t2, u, v, amp, sigmaamp), dtype=ehc.DTAMP))
-        obs.amp = np.array(datatable2)
+        return np.array(datatable2)
 
     else:
         raise Exception(dtype + ' is not a possible data type!')
-
-    return

--- a/ehtim/io/save.py
+++ b/ehtim/io/save.py
@@ -831,14 +831,48 @@ def save_obs_uvfits(obs, fname=None, force_singlepol=None, polrep_out='circ'):
     return hdulist_new.copy()
 
 
-def save_dtype_txt(obs, fname, dtype='cphase'):
-    """Save the data product of type 'dtype' in a text file.
+_DTYPE_TXT_SPECS = {
+    'cphase':  (ehc.DTCPHASE,
+                "time (hr)     T1     T2      T3        U1 (lambda)     V1 (lambda)     U2 (lambda)     V2 (lambda)         U3 (lambda)     V3 (lambda)         Cphase (d) Sigmacp",
+                "%011.8f %6s %6s  %6s  %16.4f %16.4f  %16.4f  %16.4f  %16.4f  %16.4f  %10.4f  %10.8f"),
+    'logcamp': (ehc.DTCAMP,
+                "time (hr)     T1     T2      T3     T4     U1 (lambda)     V1 (lambda)      U2 (lambda)      V2 (lambda)         U3 (lambda)     V3 (lambda)       U4 (lambda)      V4 (lambda)           Logcamp     Sigmalogca",
+                "%011.8f %6s %6s  %6s %6s  %16.4f %16.4f  %16.4f  %16.4f  %16.4f %16.4f  %16.4f  %16.4f  %10.4f  %10.8f"),
+    'camp':    (ehc.DTCAMP,
+                "time (hr)     T1     T2      T3     T4     U1 (lambda)     V1 (lambda)      U2 (lambda)      V2 (lambda)         U3 (lambda)     V3 (lambda)       U4 (lambda)      V4 (lambda)           Camp     Sigmaca",
+                "%011.8f %6s %6s  %6s %6s  %16.4f %16.4f  %16.4f  %16.4f  %16.4f %16.4f  %16.4f  %16.4f  %10.4f  %10.8f"),
+    'bs':      (ehc.DTBIS,
+                "time (hr)     T1     T2      T3        U1 (lambda)     V1 (lambda)     U2 (lambda)     V2 (lambda)         U3 (lambda)     V3 (lambda)          Bispec   Sigmab",
+                "%011.8f %6s %6s  %6s  %16.4f %16.4f  %16.4f  %16.4f  %16.4f  %16.4f  %10.4f  %10.8f"),
+    'amp':     (ehc.DTAMP,
+                "time (hr) tint     T1     T2       U (lambda)     V (lambda)       Amp (Jy)     Ampsigma",
+                "%011.8f %4.2f %6s %6s  %16.4f %16.4f  %10.8f  %10.8f"),
+}
+
+
+def save_dtype_txt(obs, fname, data, dtype='cphase'):
+    """Save a derived data product as text. The header is taken from obs;
+       the table is passed in explicitly (typically the output of
+       obs.bispectra(), obs.c_phases(), or obs.c_amplitudes()).
+
        Args:
-            obs (Obsdata): obsdata object
+            obs (Obsdata): obsdata object (header info only)
             fname (str): path to output text file
-            dtype (str): desired data type
+            data (np.recarray): the closure / amplitude table to save;
+                                its dtype must match the expected schema
+                                for `dtype` (see const_def.py: DTCPHASE,
+                                DTCAMP, DTBIS, DTAMP).
+            dtype (str): one of 'cphase', 'logcamp', 'camp', 'bs', 'amp'
        Returns:
     """
+
+    if dtype not in _DTYPE_TXT_SPECS:
+        raise Exception(dtype + ' is not a possible data type!')
+    expected_dtype, col_header, fmts = _DTYPE_TXT_SPECS[dtype]
+    if list(data.dtype.descr) != list(np.dtype(expected_dtype).descr):
+        raise Exception(
+            "save_dtype_txt: data.dtype does not match the schema expected "
+            "for dtype='%s' (see const_def.py)." % dtype)
 
     head = ("SRC: %s \n" % obs.source +
             "RA: " + obsh.rastring(obs.ra) + "\n" + "DEC: " + obsh.decstring(obs.dec) + "\n" +
@@ -867,48 +901,9 @@ def save_dtype_txt(obs, fname, dtype='cphase'):
                   (obs.tarr[i]['dl']).real, (obs.tarr[i]['dl']).imag
                   ))
 
-    if dtype == 'cphase':
-        outdata = obs.cphase
-        head += (
-            "----------------------------------------------------------------------" +
-            "------------------------------------------------------------------\n" +
-            "time (hr)     T1     T2      T3        U1 (lambda)     V1 (lambda)     U2 (lambda)     V2 (lambda)         U3 (lambda)     V3 (lambda)         Cphase (d) Sigmacp")
-        fmts = ("%011.8f %6s %6s  %6s  %16.4f %16.4f  %16.4f  %16.4f  %16.4f  %16.4f  %10.4f  %10.8f")
+    head += ("----------------------------------------------------------------------"
+             "------------------------------------------------------------------\n" +
+             col_header)
 
-    elif dtype == 'logcamp':
-        outdata = obs.logcamp
-        head += (
-            "----------------------------------------------------------------------" +
-            "------------------------------------------------------------------\n" +
-            "time (hr)     T1     T2      T3     T4     U1 (lambda)     V1 (lambda)      U2 (lambda)      V2 (lambda)         U3 (lambda)     V3 (lambda)       U4 (lambda)      V4 (lambda)           Logcamp     Sigmalogca")
-        fmts = ("%011.8f %6s %6s  %6s %6s  %16.4f %16.4f  %16.4f  %16.4f  %16.4f %16.4f  %16.4f  %16.4f  %10.4f  %10.8f")
-
-    elif dtype == 'camp':
-        outdata = obs.camp
-        head += (
-            "----------------------------------------------------------------------" +
-            "------------------------------------------------------------------\n" +
-            "time (hr)     T1     T2      T3     T4     U1 (lambda)     V1 (lambda)      U2 (lambda)      V2 (lambda)         U3 (lambda)     V3 (lambda)       U4 (lambda)      V4 (lambda)           Camp     Sigmaca")
-        fmts = ("%011.8f %6s %6s  %6s %6s  %16.4f %16.4f  %16.4f  %16.4f  %16.4f %16.4f  %16.4f  %16.4f  %10.4f  %10.8f")
-
-    elif dtype == 'bs':
-        outdata = obs.bispec
-        head += (
-            "----------------------------------------------------------------------" +
-            "------------------------------------------------------------------\n" +
-            "time (hr)     T1     T2      T3        U1 (lambda)     V1 (lambda)     U2 (lambda)     V2 (lambda)         U3 (lambda)     V3 (lambda)          Bispec   Sigmab")
-        fmts = ("%011.8f %6s %6s  %6s  %16.4f %16.4f  %16.4f  %16.4f  %16.4f  %16.4f  %10.4f  %10.8f")
-
-    elif dtype == 'amp':
-        outdata = obs.amp
-        head += (
-            "----------------------------------------------------------------------" +
-            "------------------------------------------------------------------\n" +
-            "time (hr) tint     T1     T2       U (lambda)     V (lambda)       Amp (Jy)     Ampsigma")
-        fmts = ("%011.8f %4.2f %6s %6s  %16.4f %16.4f  %10.8f  %10.8f")
-
-    else:
-        raise Exception(dtype + ' is not a possible data type!')
-
-    np.savetxt(fname, outdata, header=head, fmt=fmts)
+    np.savetxt(fname, data, header=head, fmt=fmts)
     return

--- a/ehtim/io/save.py
+++ b/ehtim/io/save.py
@@ -16,18 +16,11 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
 
-import numpy as np
 import astropy.io.fits as fits
-import datetime
 import h5py
-
+import numpy as np
 from astropy.time import Time
 
 import ehtim.const_def as ehc
@@ -96,12 +89,12 @@ def save_im_txt(im, fname, mjd=False, time=False):
         time = im.time
     mjd += (time/24.)
 
-    head = ("SRC: %s \n" % im.source +
+    head = (f"SRC: {im.source} \n" +
             "RA: " + obsh.rastring(im.ra) + "\n" + "DEC: " + obsh.decstring(im.dec) + "\n" +
-            "MJD: %.6f \n" % (float(mjd)) +
-            "RF: %.4f GHz \n" % (im.rf/1e9) +
-            "FOVX: %i pix %f as \n" % (im.xdim, pdimas * im.xdim) +
-            "FOVY: %i pix %f as \n" % (im.ydim, pdimas * im.ydim) +
+            f"MJD: {float(mjd):.6f} \n" +
+            f"RF: {im.rf/1e9:.4f} GHz \n" +
+            f"FOVX: {im.xdim:d} pix {pdimas * im.xdim:f} as \n" +
+            f"FOVY: {im.ydim:d} pix {pdimas * im.ydim:f} as \n" +
             "------------------------------------\n" + hf)
 
     # Save
@@ -244,7 +237,7 @@ def save_mov_fits(mov, fname, mjd=False):
 
     for i in range(mov.nframes):
         time_frame = mov.times[i]
-        fname_frame = fname + "%05d" % i
+        fname_frame = fname + f"{i:05d}"
         print('saving file '+fname_frame)
         frame_im = mov.get_frame(i)
         save_im_fits(frame_im, fname_frame, mjd=mjd, time=time_frame)
@@ -268,7 +261,7 @@ def save_mov_txt(mov, fname, mjd=False):
 
     for i in range(mov.nframes):
         time_frame = mov.times[i]
-        fname_frame = fname + "%05d" % i
+        fname_frame = fname + f"{i:05d}"
         print('saving file '+fname_frame)
         frame_im = mov.get_frame(i)
         save_im_txt(frame_im, fname_frame, mjd=mjd, time=time_frame)
@@ -290,12 +283,12 @@ def save_array_txt(arr, fname):
        Returns:
     """
 
-    if type(arr) == np.ndarray:
+    if isinstance(arr, np.ndarray):
         tarr = arr
     else:
         try:
             tarr = arr.tarr
-        except:
+        except AttributeError:
             print("Array format not recognized!")
 
     out = ("#Site      X(m)             Y(m)             Z(m)           " +
@@ -309,7 +302,8 @@ def save_array_txt(arr, fname):
                tarr[scope]['dr'].real, tarr[scope]['dr'].imag,
                tarr[scope]['dl'].real, tarr[scope]['dl'].imag
                )
-        out += "%-8s %15.5f  %15.5f  %15.5f  %8.2f   %8.2f  %5.2f   %5.2f   %5.2f  %8.4f %8.4f %8.4f %8.4f \n" % dat
+        out += ("{:<8s} {:15.5f}  {:15.5f}  {:15.5f}  {:8.2f}   {:8.2f}  "
+                "{:5.2f}   {:5.2f}   {:5.2f}  {:8.4f} {:8.4f} {:8.4f} {:8.4f} \n").format(*dat)
     f = open(fname, 'w')
     f.write(out)
     f.close()
@@ -347,16 +341,16 @@ def save_obs_txt(obs, fname):
     else:
         raise Exception("obs.polrep not 'stokes' or 'circ'!")
 
-    head = ("SRC: %s \n" % obs.source +
+    head = (f"SRC: {obs.source} \n" +
             "RA: " + obsh.rastring(obs.ra) + "\n" + "DEC: " + obsh.decstring(obs.dec) + "\n" +
-            "MJD: %i \n" % obs.mjd +
-            "RF: %.4f GHz \n" % (obs.rf/1e9) +
-            "BW: %.4f GHz \n" % (obs.bw/1e9) +
-            "PHASECAL: %i \n" % obs.phasecal +
-            "AMPCAL: %i \n" % obs.ampcal +
-            "OPACITYCAL: %i \n" % obs.opacitycal +
-            "DCAL: %i \n" % obs.dcal +
-            "FRCAL: %i \n" % obs.frcal +
+            f"MJD: {obs.mjd:d} \n" +
+            f"RF: {obs.rf/1e9:.4f} GHz \n" +
+            f"BW: {obs.bw/1e9:.4f} GHz \n" +
+            f"PHASECAL: {obs.phasecal:d} \n" +
+            f"AMPCAL: {obs.ampcal:d} \n" +
+            f"OPACITYCAL: {obs.opacitycal:d} \n" +
+            f"DCAL: {obs.dcal:d} \n" +
+            f"FRCAL: {obs.frcal:d} \n" +
             "----------------------------------------------------------------------" +
             "------------------------------------------------------------------\n" +
             "Site       X(m)             Y(m)             Z(m)           " +
@@ -365,14 +359,15 @@ def save_obs_txt(obs, fname):
             )
 
     for i in range(len(obs.tarr)):
-        head += ("%-8s %15.5f  %15.5f  %15.5f  %8.2f   %8.2f  %5.2f   %5.2f   %5.2f  %8.4f %8.4f %8.4f %8.4f \n" %
-                 (obs.tarr[i]['site'],
+        head += ("{:<8s} {:15.5f}  {:15.5f}  {:15.5f}  {:8.2f}   {:8.2f}  "
+                 "{:5.2f}   {:5.2f}   {:5.2f}  {:8.4f} {:8.4f} {:8.4f} {:8.4f} \n").format(
+                  obs.tarr[i]['site'],
                   obs.tarr[i]['x'], obs.tarr[i]['y'], obs.tarr[i]['z'],
                   obs.tarr[i]['sefdr'], obs.tarr[i]['sefdl'],
                   obs.tarr[i]['fr_par'], obs.tarr[i]['fr_elev'], obs.tarr[i]['fr_off'],
                   (obs.tarr[i]['dr']).real, (obs.tarr[i]['dr']).imag,
                   (obs.tarr[i]['dl']).real, (obs.tarr[i]['dl']).imag
-                  ))
+                  )
 
     if obs.polrep == 'stokes':
         head += (
@@ -409,7 +404,7 @@ def save_obs_uvfits(obs, fname=None, force_singlepol=None, polrep_out='circ'):
             polrep_out (str): 'circ' or 'stokes': how data should be stored in the uvfits file
        Returns:
             hdulist (astropy.io.fits.HDUList)
-            
+
     """
 
     # output times must be in utc
@@ -680,7 +675,7 @@ def save_obs_uvfits(obs, fname=None, force_singlepol=None, polrep_out='circ'):
     # TODO change the reference date
     #rdate_tt_new = Time(obs.mjd + MJD_0, format='jd', scale='utc', out_subfmt='date')
     #rdate_out = rdate_tt_new.iso
-    
+
     rdate_tt_new = Time(obs.mjd + MJD_0, format='jd', scale='utc')
     rdate_out = rdate_tt_new.iso[0:10]
 
@@ -726,10 +721,10 @@ def save_obs_uvfits(obs, fname=None, force_singlepol=None, polrep_out='circ'):
     col5 = np.array([1], dtype=np.int32).reshape([nif])  # sideband
 
     col1 = fits.Column(name="FRQSEL", format="1J", array=col1)
-    col2 = fits.Column(name="IF FREQ", format="%dD" % (nif), array=col2)
-    col3 = fits.Column(name="CH WIDTH", format="%dE" % (nif), array=col3)
-    col4 = fits.Column(name="TOTAL BANDWIDTH", format="%dE" % (nif), array=col4)
-    col5 = fits.Column(name="SIDEBAND", format="%dJ" % (nif), array=col5)
+    col2 = fits.Column(name="IF FREQ", format=f"{nif}D", array=col2)
+    col3 = fits.Column(name="CH WIDTH", format=f"{nif}E", array=col3)
+    col4 = fits.Column(name="TOTAL BANDWIDTH", format=f"{nif}E", array=col4)
+    col5 = fits.Column(name="SIDEBAND", format=f"{nif}J", array=col5)
     cols = fits.ColDefs([col1, col2, col3, col4, col5])
 
     # create table
@@ -783,8 +778,8 @@ def save_obs_uvfits(obs, fname=None, force_singlepol=None, polrep_out='circ'):
                     scan_times.append(scan_start + 0.5*scan_dur)  # - rdate_jd_out)
                     scan_time_ints.append(scan_dur)
                     ceilcut = np.ceil(comp_fac*scan_stop)
-                    while ((jj < len(fractimes) and
-                            np.floor(round(fractimes[jj], ROUND_SCAN_INT)*comp_fac) <= ceilcut)):
+                    while (jj < len(fractimes) and
+                            np.floor(round(fractimes[jj], ROUND_SCAN_INT)*comp_fac) <= ceilcut):
                         jj += 1
                     stop_vis.append(jj-1)
                 else:
@@ -872,18 +867,18 @@ def save_dtype_txt(obs, fname, data, dtype='cphase'):
     if list(data.dtype.descr) != list(np.dtype(expected_dtype).descr):
         raise Exception(
             "save_dtype_txt: data.dtype does not match the schema expected "
-            "for dtype='%s' (see const_def.py)." % dtype)
+            f"for dtype='{dtype}' (see const_def.py).")
 
-    head = ("SRC: %s \n" % obs.source +
+    head = (f"SRC: {obs.source} \n" +
             "RA: " + obsh.rastring(obs.ra) + "\n" + "DEC: " + obsh.decstring(obs.dec) + "\n" +
-            "MJD: %i \n" % obs.mjd +
-            "RF: %.4f GHz \n" % (obs.rf/1e9) +
-            "BW: %.4f GHz \n" % (obs.bw/1e9) +
-            "PHASECAL: %i \n" % obs.phasecal +
-            "AMPCAL: %i \n" % obs.ampcal +
-            "OPACITYCAL: %i \n" % obs.opacitycal +
-            "DCAL: %i \n" % obs.dcal +
-            "FRCAL: %i \n" % obs.frcal +
+            f"MJD: {obs.mjd:d} \n" +
+            f"RF: {obs.rf/1e9:.4f} GHz \n" +
+            f"BW: {obs.bw/1e9:.4f} GHz \n" +
+            f"PHASECAL: {obs.phasecal:d} \n" +
+            f"AMPCAL: {obs.ampcal:d} \n" +
+            f"OPACITYCAL: {obs.opacitycal:d} \n" +
+            f"DCAL: {obs.dcal:d} \n" +
+            f"FRCAL: {obs.frcal:d} \n" +
             "----------------------------------------------------------------------" +
             "------------------------------------------------------------------\n" +
             "Site       X(m)             Y(m)             Z(m)           " +
@@ -892,14 +887,15 @@ def save_dtype_txt(obs, fname, data, dtype='cphase'):
             )
 
     for i in range(len(obs.tarr)):
-        head += ("%-8s %15.5f  %15.5f  %15.5f  %8.2f   %8.2f  %5.2f   %5.2f   %5.2f  %8.4f %8.4f %8.4f %8.4f \n" %
-                 (obs.tarr[i]['site'],
+        head += ("{:<8s} {:15.5f}  {:15.5f}  {:15.5f}  {:8.2f}   {:8.2f}  "
+                 "{:5.2f}   {:5.2f}   {:5.2f}  {:8.4f} {:8.4f} {:8.4f} {:8.4f} \n").format(
+                  obs.tarr[i]['site'],
                   obs.tarr[i]['x'], obs.tarr[i]['y'], obs.tarr[i]['z'],
                   obs.tarr[i]['sefdr'], obs.tarr[i]['sefdl'],
                   obs.tarr[i]['fr_par'], obs.tarr[i]['fr_elev'], obs.tarr[i]['fr_off'],
                   (obs.tarr[i]['dr']).real, (obs.tarr[i]['dr']).imag,
                   (obs.tarr[i]['dl']).real, (obs.tarr[i]['dl']).imag
-                  ))
+                  )
 
     head += ("----------------------------------------------------------------------"
              "------------------------------------------------------------------\n" +

--- a/ehtim/modeling/modeling_utils.py
+++ b/ehtim/modeling/modeling_utils.py
@@ -2346,16 +2346,8 @@ def chisqdata_amp(Obsdata, pol='I',**kwargs):
     vtype=vis_poldict[pol]
     atype=amp_poldict[pol]
     etype=sig_poldict[pol]
-    if (Obsdata.amp is None) or (len(Obsdata.amp)==0) or pol!='I':
-        data_arr = Obsdata.unpack(['time','t1','t2','u','v',vtype,atype,etype,'el1','el2','par_ang1','par_ang2'], debias=debias)
+    data_arr = Obsdata.unpack(['time','t1','t2','u','v',vtype,atype,etype,'el1','el2','par_ang1','par_ang2'], debias=debias)
 
-    else: # TODO -- pre-computed  with not stokes I? 
-        print("Using pre-computed amplitude table in amplitude chi^2!")
-        if not type(Obsdata.amp) in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed amplitude table is not a numpy rec array!")
-        data_arr = Obsdata.amp
-
-   
     # apply systematic noise and SNR cut
     # TODO -- after pre-computed??
     (uv, vis, amp, sigma) = apply_systematic_noise_snrcut(data_arr, systematic_noise, snrcut, pol)
@@ -2384,17 +2376,7 @@ def chisqdata_bs(Obsdata, pol='I',**kwargs):
 
     # unpack data
     vtype=vis_poldict[pol]
-    if (Obsdata.bispec is None) or (len(Obsdata.bispec)==0) or pol!='I':
-        biarr = Obsdata.bispectra(mode="all", vtype=vtype, count=count,snrcut=snrcut)
-
-    else: # TODO -- pre-computed  with not stokes I? 
-        print("Using pre-computed bispectrum table in cphase chi^2!")
-        if not type(Obsdata.bispec) in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed bispectrum table is not a numpy rec array!")
-        biarr = Obsdata.bispec
-        # reduce to a minimal set 
-        if count!='max':   
-            biarr = reduce_tri_minimal(Obsdata, biarr)
+    biarr = Obsdata.bispectra(mode="all", vtype=vtype, count=count,snrcut=snrcut)
 
     uv1 = np.hstack((biarr['u1'].reshape(-1,1), biarr['v1'].reshape(-1,1)))
     uv2 = np.hstack((biarr['u2'].reshape(-1,1), biarr['v2'].reshape(-1,1)))
@@ -2427,16 +2409,7 @@ def chisqdata_cphase(Obsdata, pol='I',**kwargs):
 
     # unpack data
     vtype=vis_poldict[pol]
-    if (Obsdata.cphase is None) or (len(Obsdata.cphase)==0) or pol!='I':
-        clphasearr = Obsdata.c_phases(mode="all", vtype=vtype, count=count, uv_min=uv_min, snrcut=snrcut)
-    else: #TODO precomputed with not Stokes I
-        print("Using pre-computed cphase table in cphase chi^2!")
-        if not type(Obsdata.cphase) in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed closure phase table is not a numpy rec array!")
-        clphasearr = Obsdata.cphase
-        # reduce to a minimal set
-        if count!='max':       
-            clphasearr = reduce_tri_minimal(Obsdata, clphasearr)
+    clphasearr = Obsdata.c_phases(mode="all", vtype=vtype, count=count, uv_min=uv_min, snrcut=snrcut)
 
     uv1 = np.hstack((clphasearr['u1'].reshape(-1,1), clphasearr['v1'].reshape(-1,1)))
     uv2 = np.hstack((clphasearr['u2'].reshape(-1,1), clphasearr['v2'].reshape(-1,1)))
@@ -2522,16 +2495,7 @@ def chisqdata_camp(Obsdata, pol='I',**kwargs):
 
     # unpack data & mask low snr points
     vtype=vis_poldict[pol]
-    if (Obsdata.camp is None) or (len(Obsdata.camp)==0) or pol!='I':
-        clamparr = Obsdata.c_amplitudes(mode='all', count=count, ctype='camp', debias=debias, snrcut=snrcut)
-    else: # TODO -- pre-computed  with not stokes I? 
-        print("Using pre-computed closure amplitude table in closure amplitude chi^2!")
-        if not type(Obsdata.camp) in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed closure amplitude table is not a numpy rec array!")
-        clamparr = Obsdata.camp
-        # reduce to a minimal set
-        if count!='max':       
-            clamparr = reduce_quad_minimal(Obsdata, clamparr, ctype='camp')
+    clamparr = Obsdata.c_amplitudes(mode='all', count=count, ctype='camp', debias=debias, snrcut=snrcut)
 
     uv1 = np.hstack((clamparr['u1'].reshape(-1,1), clamparr['v1'].reshape(-1,1)))
     uv2 = np.hstack((clamparr['u2'].reshape(-1,1), clamparr['v2'].reshape(-1,1)))
@@ -2560,16 +2524,7 @@ def chisqdata_logcamp(Obsdata, pol='I', **kwargs):
 
     # unpack data & mask low snr points
     vtype=vis_poldict[pol]
-    if (Obsdata.logcamp is None) or (len(Obsdata.logcamp)==0)  or pol!='I':
-        clamparr = Obsdata.c_amplitudes(mode='all', count=count, vtype=vtype, ctype='logcamp', debias=debias, snrcut=snrcut)
-    else: # TODO -- pre-computed  with not stokes I? 
-        print("Using pre-computed log closure amplitude table in log closure amplitude chi^2!")
-        if not type(Obsdata.logcamp) in [np.ndarray, np.recarray]:
-            raise Exception("pre-computed log closure amplitude table is not a numpy rec array!")
-        clamparr = Obsdata.logcamp
-        # reduce to a minimal set
-        if count!='max':       
-            clamparr = reduce_quad_minimal(Obsdata, clamparr, ctype='logcamp')
+    clamparr = Obsdata.c_amplitudes(mode='all', count=count, vtype=vtype, ctype='logcamp', debias=debias, snrcut=snrcut)
 
     uv1 = np.hstack((clamparr['u1'].reshape(-1,1), clamparr['v1'].reshape(-1,1)))
     uv2 = np.hstack((clamparr['u2'].reshape(-1,1), clamparr['v2'].reshape(-1,1)))

--- a/ehtim/modeling/modeling_utils.py
+++ b/ehtim/modeling/modeling_utils.py
@@ -17,6 +17,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ## TODO ##
+# >> remove ruff exceptions in pyproject.toml after cleaning up this file
 # >> return jonesdict for all data types <- requires significant modification to eht-imaging
 # >> Deal with nans in fitting (mask chisqdata) <- mostly done
 # >> Add optional transform for leakage and gains

--- a/ehtim/modeling/modeling_utils.py
+++ b/ehtim/modeling/modeling_utils.py
@@ -21,30 +21,22 @@
 # >> Deal with nans in fitting (mask chisqdata) <- mostly done
 # >> Add optional transform for leakage and gains
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import range
-
-import string
+import copy
 import time
+
 import numpy as np
 import scipy.optimize as opt
-import scipy.ndimage as nd
-import scipy.ndimage.filters as filt
-import matplotlib.pyplot as plt
 import scipy.special as sps
-import scipy.stats as stats
-import copy 
 
-import ehtim.obsdata as obsdata
-import ehtim.image as image
-import ehtim.model as model
-import ehtim.caltable as caltable
-
-from ehtim.const_def import *
-from ehtim.observing.obs_helpers import *
-from ehtim.statistics.dataframes import *
+# Import order is load-bearing: obsdata pulls in ehtim.array → ehtim.caltable
+# transitively, which avoids the partial-load circular import in array.py.
+# See ehtim/array.py:36 (deferred lazy-import fix in CLAUDE.md).
+import ehtim.obsdata as obsdata  # isort: skip
+import ehtim.model as model  # isort: skip
+import ehtim.caltable as caltable  # isort: skip
+from ehtim.const_def import *  # isort: skip
+from ehtim.observing.obs_helpers import *  # isort: skip
+from ehtim.statistics.dataframes import *  # isort: skip
 
 #from IPython import display
 
@@ -70,13 +62,13 @@ nit = 0       # global variable to track the iteration number in the plotting ca
 globdict = {} # global dictionary with all parameters related to the model fitting (mainly for efficient parallelization, but also very useful for debugging)
 
 # Details on each fitted parameter (convenience rescaling factor and associated unit)
-PARAM_DETAILS = {'F0':[1.,'Jy'], 'FWHM':[RADPERUAS,'uas'], 'FWHM_maj':[RADPERUAS,'uas'], 'FWHM_min':[RADPERUAS,'uas'], 
-                 'd':[RADPERUAS,'uas'], 'PA':[np.pi/180.,'deg'], 'alpha':[RADPERUAS,'uas'], 'ff':[1.,''], 
-                 'x0':[RADPERUAS,'uas'], 'y0':[RADPERUAS,'uas'], 'stretch':[1.,''], 'stretch_PA':[np.pi/180.,'deg'], 
+PARAM_DETAILS = {'F0':[1.,'Jy'], 'FWHM':[RADPERUAS,'uas'], 'FWHM_maj':[RADPERUAS,'uas'], 'FWHM_min':[RADPERUAS,'uas'],
+                 'd':[RADPERUAS,'uas'], 'PA':[np.pi/180.,'deg'], 'alpha':[RADPERUAS,'uas'], 'ff':[1.,''],
+                 'x0':[RADPERUAS,'uas'], 'y0':[RADPERUAS,'uas'], 'stretch':[1.,''], 'stretch_PA':[np.pi/180.,'deg'],
                  'arg':[np.pi/180.,'deg'], 'evpa':[np.pi/180.,'deg'], 'phi':[np.pi/180.,'deg']}
 
-GAIN_PRIOR_DEFAULT = {'prior_type':'lognormal','sigma':0.1,'mu':0.0,'shift':-1.0} 
-LEAKAGE_PRIOR_DEFAULT = {'prior_type':'flat','min':-0.5,'max':0.5} 
+GAIN_PRIOR_DEFAULT = {'prior_type':'lognormal','sigma':0.1,'mu':0.0,'shift':-1.0}
+LEAKAGE_PRIOR_DEFAULT = {'prior_type':'flat','min':-0.5,'max':0.5}
 N_POSTERIOR_SAMPLES = 100
 
 ##################################################################################################
@@ -87,14 +79,14 @@ def cdf(x, prior_params):
     """Compute the cumulative distribution function CDF(x) of a given prior at a given point x
 
        Args:
-           x (float): Value at which to compute the CDF 
+           x (float): Value at which to compute the CDF
            prior_params (dict): Dictionary with information about the prior
 
        Returns:
            float: CDF(x)
-    """   
+    """
     if prior_params['prior_type'] == 'flat':
-        return (  (x > prior_params['max']) * 1.0   
+        return (  (x > prior_params['max']) * 1.0
                 + (x > prior_params['min']) * (x < prior_params['max']) * (x - prior_params['min'])/(prior_params['max'] - prior_params['min']))
     elif prior_params['prior_type'] == 'gauss':
         return 0.5 * (1.0 + sps.erf( (x - prior_params['mean'])/(prior_params['std'] * np.sqrt(2.0)) ))
@@ -115,12 +107,12 @@ def cdf_inverse(x, prior_params):
     """Compute the inverse cumulative distribution function of a given prior at a given point 0 <= x <= 1
 
        Args:
-           x (float): Value at which to compute the inverse CDF 
+           x (float): Value at which to compute the inverse CDF
            prior_params (dict): Dictionary with information about the prior
 
        Returns:
            float: Inverse CDF at x
-    """   
+    """
     if prior_params['prior_type'] == 'flat':
         return prior_params['min'] * (1.0 - x) + prior_params['max'] * x
     elif prior_params['prior_type'] == 'gauss':
@@ -146,7 +138,7 @@ def param_bounds(prior_params):
 
        Returns:
            list: 2-element list specifying the allowed parameter range: [min,max]
-    """   
+    """
     if prior_params.get('transform','') == 'cdf':
         bounds = [0.0, 1.0]
     elif prior_params['prior_type'] == 'flat':
@@ -177,8 +169,8 @@ def prior_func(x, prior_params):
            prior_params (dict): Dictionary with information about the prior
 
        Returns:
-           float: Prior value P(x) 
-    """   
+           float: Prior value P(x)
+    """
 
     if prior_params['prior_type'] == 'flat':
         return (x >= prior_params['min']) * (x <= prior_params['max']) * 1.0/(prior_params['max'] - prior_params['min']) + PRIOR_MIN
@@ -188,7 +180,7 @@ def prior_func(x, prior_params):
         return (1./prior_params['std'] * np.exp(-x/prior_params['std'])) * (x >= 0.0) + PRIOR_MIN
     elif prior_params['prior_type'] == 'lognormal':
         return (x > prior_params['shift']) * (
-                  1.0/((2.0*np.pi)**0.5 * prior_params['sigma'] * (x - prior_params['shift'])) 
+                  1.0/((2.0*np.pi)**0.5 * prior_params['sigma'] * (x - prior_params['shift']))
                 * np.exp( -(np.log(x - prior_params['shift']) - prior_params['mu'])**2/(2.0 * prior_params['sigma']**2) ) )
     elif prior_params['prior_type'] == 'positive':
         return (x >= 0.0) * 1.0 + PRIOR_MIN
@@ -208,8 +200,8 @@ def prior_grad_func(x, prior_params):
            prior_params (dict): Dictionary with information about the prior
 
        Returns:
-           float: Prior derivative value dP/dx(x) 
-    """   
+           float: Prior derivative value dP/dx(x)
+    """
 
     if prior_params['prior_type'] == 'flat':
         return 0.0
@@ -220,7 +212,7 @@ def prior_grad_func(x, prior_params):
     elif prior_params['prior_type'] == 'lognormal':
         return (x > prior_params['shift']) * (
                   (prior_params['mu'] - prior_params['sigma']**2 - np.log(x - prior_params['shift']))
-                / ((2.0*np.pi)**0.5 * prior_params['sigma']**3 * (x - prior_params['shift'])**2) 
+                / ((2.0*np.pi)**0.5 * prior_params['sigma']**3 * (x - prior_params['shift'])**2)
                 * np.exp( -(np.log(x - prior_params['shift']) - prior_params['mu'])**2/(2.0 * prior_params['sigma']**2) ) )
     elif prior_params['prior_type'] == 'positive':
         return 0.0
@@ -238,11 +230,11 @@ def transform_param(x, x_prior, inverse=True):
        Args:
            x (float): Untransformed value
            x_prior (dict): Dictionary with information about the transformation
-           inverse (bool): Whether to compute the forward or inverse transform. 
+           inverse (bool): Whether to compute the forward or inverse transform.
 
        Returns:
            float: Transformed parameter value
-    """  
+    """
 
     try:
         transform = x_prior['transform']
@@ -272,7 +264,7 @@ def transform_grad_param(x, x_prior):
 
        Returns:
            float: Gradient of transformation, dT/dx(x)
-    """  
+    """
 
     try:
         transform = x_prior['transform']
@@ -285,7 +277,7 @@ def transform_grad_param(x, x_prior):
     elif transform == 'cdf':
         return 1.0/prior_func(transform_param(x,x_prior),x_prior)
     else:
-        return 1.0        
+        return 1.0
 
 ##################################################################################################
 # Helper functions
@@ -300,7 +292,7 @@ def shrink_prior(prior, model, shrink=0.1):
 
        Returns:
            prior (list): Model prior with restricted volume
-    """ 
+    """
 
     prior_shrunk = copy.deepcopy(prior)
     f = 1.0
@@ -334,7 +326,7 @@ def selfcal(Obsdata, model,
        Args:
 
        Returns:
-    """  
+    """
 
     # This is just a convenience function. It will call modeler_func() scan-by-scan fitting only gains.
     # This function differs from ehtim.calibrating.self_cal in the inclusion of gain priors
@@ -345,7 +337,7 @@ def selfcal(Obsdata, model,
             prog_msg(j, len(tlist), msgtype, j-1)
         obs = Obsdata.copy()
         obs.data = tlist[j]
-        res_list.append(modeler_func(obs, model, model_prior=None, d1='amp', 
+        res_list.append(modeler_func(obs, model, model_prior=None, d1='amp',
                    fit_model=False, fit_gains=True,gain_init=gain_init,gain_prior=gain_prior,
                    minimizer_func=minimizer_func, minimizer_kwargs=minimizer_kwargs,
                    bounds=bounds, use_bounds=use_bounds, processes=-1, quiet=quiet, **kwargs))
@@ -376,8 +368,8 @@ def make_param_map(model_init, model_prior, minimizer_func, fit_model, fit_pol=F
     for j in range(model_init.N_models()):
         params = model.model_params(model_init.models[j],model_init.params[j], fit_pol=fit_pol, fit_cpol=fit_cpol)
         for param in params:
-            if fit_model == False:
-                param_mask.append(False)        
+            if not fit_model:
+                param_mask.append(False)
             elif model_prior[j][param]['prior_type'] != 'fixed':
                 param_mask.append(True)
                 param_type = param
@@ -399,20 +391,20 @@ def compute_likelihood_constants(d1, d2, d3, d4, sigma1, sigma2, sigma3, sigma4)
     # Compute the correct data weights (hyperparameters) and the correct extra constant for the log-likelihood
     alpha_d1 = alpha_d2 = alpha_d3 = alpha_d4 = ln_norm1 = ln_norm2 = ln_norm3 = ln_norm4 = 0.0
 
-    try: 
+    try:
         alpha_d1 = 0.5 * len(sigma1)
         ln_norm1 = -np.sum(np.log((2.0*np.pi)**0.5 * sigma1))
     except: pass
-    try: 
+    try:
         alpha_d2 = 0.5 * len(sigma2)
         ln_norm2 = -np.sum(np.log((2.0*np.pi)**0.5 * sigma2))
     except: pass
-    try: 
-        alpha_d3 = 0.5 * len(sigma3)        
+    try:
+        alpha_d3 = 0.5 * len(sigma3)
         ln_norm3 = -np.sum(np.log((2.0*np.pi)**0.5 * sigma3))
     except: pass
-    try: 
-        alpha_d4 = 0.5 * len(sigma4)        
+    try:
+        alpha_d4 = 0.5 * len(sigma4)
         ln_norm4 = -np.sum(np.log((2.0*np.pi)**0.5 * sigma4))
     except: pass
 
@@ -456,7 +448,7 @@ def caltable_to_gains(caltab, gain_list):
     gains = [np.abs(caltab.data[site]['rscale'][caltab.data[site]['time'] == time][0]) - 1.0 for (time, site) in gain_list]
     return gains
 
-def make_gain_map(Obsdata, gain_prior): 
+def make_gain_map(Obsdata, gain_prior):
     # gain_list gives all unique (time,site) pairs
     # gains_t1 gives the gain index for the first site in each measurement
     # gains_t2 gives the gain index for the second site in each measurement
@@ -475,7 +467,7 @@ def make_gain_map(Obsdata, gain_prior):
             return len(gain_list)
 
     gains_t1 = [gain_index(j, 't1') for j in range(len(Obsdata.data))]
-    gains_t2 = [gain_index(j, 't2') for j in range(len(Obsdata.data))]        
+    gains_t2 = [gain_index(j, 't2') for j in range(len(Obsdata.data))]
 
     return (gain_list, gains_t1, gains_t2)
 
@@ -510,7 +502,7 @@ def gain_factor(dtype,gains,gains_t1,gains_t2, fit_or_marginalize_gains):
     global globdict
 
     if not fit_or_marginalize_gains:
-        if globdict['gain_init'] == None:
+        if globdict['gain_init'] is None:
             return 1
         else:
             gains = globdict['gain_init']
@@ -518,7 +510,7 @@ def gain_factor(dtype,gains,gains_t1,gains_t2, fit_or_marginalize_gains):
     if globdict['marginalize_gains']:
         gains = globdict['gain_init']
 
-    if dtype in ['amp','vis']:    
+    if dtype in ['amp','vis']:
         gains_wzero = np.append(gains,0.0)
         return (1.0 + gains_wzero[gains_t1])*(1.0 + gains_wzero[gains_t2])
     else:
@@ -530,7 +522,7 @@ def gain_factor_separate(dtype,gains,gains_t1,gains_t2, fit_or_marginalize_gains
     global globdict
 
     if not fit_or_marginalize_gains:
-        if globdict['gain_init'] == None:
+        if globdict['gain_init'] is None:
             return (0., 0.)
         else:
             gains = globdict['gain_init']
@@ -538,7 +530,7 @@ def gain_factor_separate(dtype,gains,gains_t1,gains_t2, fit_or_marginalize_gains
     if globdict['marginalize_gains']:
         gains = globdict['gain_init']
 
-    if dtype in ['amp','vis']:    
+    if dtype in ['amp','vis']:
         gains_wzero = np.append(gains,0.0)
         return (gains_wzero[gains_t1], gains_wzero[gains_t2])
     else:
@@ -594,13 +586,13 @@ def set_params(params, trial_model, param_map, minimizer_func, model_prior):
             trial_model.params[param_map[j][0]][param_map[j][1]] = tparams[j] * param_map[j][2]
         else: # In this case, the parameter is a list of complex numbers, so the real/imaginary or abs/arg components need to be assigned
             if param_map[j][1].find('cpol') != -1:
-                param_type = 'beta_list_cpol' 
-                idx = int(param_map[j][1].split('_')[0][8:]) 
+                param_type = 'beta_list_cpol'
+                idx = int(param_map[j][1].split('_')[0][8:])
             elif param_map[j][1].find('pol') != -1:
-                param_type = 'beta_list_pol'                
-                idx = int(param_map[j][1].split('_')[0][7:]) + (len(trial_model.params[param_map[j][0]][param_type])-1)//2 
+                param_type = 'beta_list_pol'
+                idx = int(param_map[j][1].split('_')[0][7:]) + (len(trial_model.params[param_map[j][0]][param_type])-1)//2
             elif param_map[j][1].find('beta') != -1:
-                param_type = 'beta_list' 
+                param_type = 'beta_list'
                 idx = int(param_map[j][1].split('_')[0][4:]) - 1
             else:
                 raise Exception('Unsure how to interpret ' + param_map[j][1])
@@ -614,7 +606,7 @@ def set_params(params, trial_model, param_map, minimizer_func, model_prior):
                 trial_model.params[param_map[j][0]][param_type][idx] = tparams[j] * param_map[j][2] * 1j + np.real(curval)
             elif param_map[j][1][-3:] == 'abs':
                 trial_model.params[param_map[j][0]][param_type][idx] = tparams[j] * param_map[j][2] * np.exp(1j * np.angle(curval))
-            elif param_map[j][1][-3:] == 'arg': 
+            elif param_map[j][1][-3:] == 'arg':
                 trial_model.params[param_map[j][0]][param_type][idx] = np.abs(curval) * np.exp(1j * tparams[j] * param_map[j][2])
             else:
                 print('Parameter ' + param_map[j][1] + ' not understood!')
@@ -625,20 +617,20 @@ def prior(params, param_map, model_prior, minimizer_func):
     return np.sum([np.log(prior_func(tparams[j]*param_map[j][2], model_prior[param_map[j][0]][param_map[j][1]])) for j in range(len(params))])
 
 def prior_grad(params, param_map, model_prior, minimizer_func):
-    tparams = transform_params(params, param_map, minimizer_func, model_prior)        
+    tparams = transform_params(params, param_map, minimizer_func, model_prior)
     f  = np.array([prior_func(tparams[j]*param_map[j][2], model_prior[param_map[j][0]][param_map[j][1]]) for j in range(len(params))])
     df = np.array([prior_grad_func(tparams[j]*param_map[j][2], model_prior[param_map[j][0]][param_map[j][1]]) for j in range(len(params))])
     return df/f
 
 # Define constraint functions
 def flux_constraint(trial_model, alpha_flux, flux):
-    if alpha_flux == 0.0: 
+    if alpha_flux == 0.0:
         return 0.0
 
     return ((trial_model.total_flux() - flux)/flux)**2
 
 def flux_constraint_grad(trial_model, alpha_flux, flux, params, param_map):
-    if alpha_flux == 0.0: 
+    if alpha_flux == 0.0:
         return 0.0
 
     fluxmask = np.zeros_like(params)
@@ -655,7 +647,7 @@ def laplace_approximation(trial_model, dtype, data, uv, sigma, gains_t1, gains_t
     # Compute the approximate contribution to the log-likelihood by marginalizing over gains
     global globdict
 
-    if globdict['marginalize_gains'] == True and dtype == 'amp':
+    if globdict['marginalize_gains'] and dtype == 'amp':
         # Add the log-likelihood term from analytic gain marginalization
         # Create the Hessian matrix for the argument of the exponential
         gain_hess = np.zeros((len(globdict['gain_list']), len(globdict['gain_list'])))
@@ -684,10 +676,10 @@ def laplace_approximation(trial_model, dtype, data, uv, sigma, gains_t1, gains_t
                 gain_hess[j,j] += 0.0
             elif globdict['gain_prior'][t]['prior_type'] == 'exponential':
                 gain_hess[j,j] += 0.0
-            elif globdict['gain_prior'][t]['prior_type'] == 'fixed':                
+            elif globdict['gain_prior'][t]['prior_type'] == 'fixed':
                 gain_hess[j,j] += 0.0
             else:
-                raise Exception('Gain prior not implemented!')                
+                raise Exception('Gain prior not implemented!')
         return np.log((2.0 * np.pi)**(len(gain)/2.0) * np.abs(np.linalg.det(gain_hess))**-0.5)
     else:
         return 0.0
@@ -750,11 +742,11 @@ def update_leakage(leakage):
                     jonesdict2['DL1'] = np.array([station_leakages[jonesdict2['t1'][_]]['L'] for _ in range(len(jonesdict2['t1']))])
                     jonesdict2['DL2'] = np.array([station_leakages[jonesdict2['t2'][_]]['L'] for _ in range(len(jonesdict2['t1']))])
                     jonesdict2['leakage_fit'] = globdict['leakage_fit']
-        
+
 ##################################################################################################
 # Define the objective function and gradient
 ##################################################################################################
-def objfunc(params, force_posterior=False): 
+def objfunc(params, force_posterior=False):
     global globdict
     # Note: model parameters can have transformations applied; gains and leakage do not
     set_params(params[:globdict['n_params']], globdict['trial_model'], globdict['param_map'], globdict['minimizer_func'], globdict['model_prior'])
@@ -770,7 +762,7 @@ def objfunc(params, force_posterior=False):
         globdict = _globdict
 
     (chi2_1, chi2_2, chi2_3, chi2_4) = chisq_list(gains)
-    datterm  = ( globdict['alpha_d1'] * chi2_1 
+    datterm  = ( globdict['alpha_d1'] * chi2_1
                + globdict['alpha_d2'] * chi2_2
                + globdict['alpha_d3'] * chi2_3
                + globdict['alpha_d4'] * chi2_4)
@@ -780,7 +772,7 @@ def objfunc(params, force_posterior=False):
         datterm += l1 + l2 + l3 + l4
 
     if (globdict['minimizer_func'] not in ['dynesty_static','dynesty_dynamic','pymc3']) or force_posterior:
-        priterm  = prior(params[:globdict['n_params']], globdict['param_map'], globdict['model_prior'], globdict['minimizer_func']) 
+        priterm  = prior(params[:globdict['n_params']], globdict['param_map'], globdict['model_prior'], globdict['minimizer_func'])
         priterm += prior_gain(params[globdict['n_params']:(globdict['n_params'] + globdict['n_gains'])], globdict['gain_list'], globdict['gain_prior'], globdict['fit_gains'])
         priterm += prior_leakage(params[(globdict['n_params'] + globdict['n_gains']):], globdict['leakage_fit'], globdict['leakage_prior'], globdict['fit_leakage'])
     else:
@@ -796,17 +788,17 @@ def objgrad(params):
     leakage = params[(globdict['n_params'] + globdict['n_gains']):]
     update_leakage(leakage)
 
-    datterm  = ( globdict['alpha_d1'] * chisqgrad_wgain(globdict['trial_model'], globdict['d1'], globdict['data1'], globdict['uv1'], globdict['sigma1'], globdict['jonesdict1'], gains, globdict['gains_t1'], globdict['gains_t2'], globdict['fit_gains'] + globdict['marginalize_gains'], globdict['param_mask'], globdict['pol1'], globdict['fit_pol'], globdict['fit_cpol'], globdict['fit_leakage']) 
-               + globdict['alpha_d2'] * chisqgrad_wgain(globdict['trial_model'], globdict['d2'], globdict['data2'], globdict['uv2'], globdict['sigma2'], globdict['jonesdict2'], gains, globdict['gains_t1'], globdict['gains_t2'], globdict['fit_gains'] + globdict['marginalize_gains'], globdict['param_mask'], globdict['pol2'], globdict['fit_pol'], globdict['fit_cpol'], globdict['fit_leakage']) 
+    datterm  = ( globdict['alpha_d1'] * chisqgrad_wgain(globdict['trial_model'], globdict['d1'], globdict['data1'], globdict['uv1'], globdict['sigma1'], globdict['jonesdict1'], gains, globdict['gains_t1'], globdict['gains_t2'], globdict['fit_gains'] + globdict['marginalize_gains'], globdict['param_mask'], globdict['pol1'], globdict['fit_pol'], globdict['fit_cpol'], globdict['fit_leakage'])
+               + globdict['alpha_d2'] * chisqgrad_wgain(globdict['trial_model'], globdict['d2'], globdict['data2'], globdict['uv2'], globdict['sigma2'], globdict['jonesdict2'], gains, globdict['gains_t1'], globdict['gains_t2'], globdict['fit_gains'] + globdict['marginalize_gains'], globdict['param_mask'], globdict['pol2'], globdict['fit_pol'], globdict['fit_cpol'], globdict['fit_leakage'])
                + globdict['alpha_d3'] * chisqgrad_wgain(globdict['trial_model'], globdict['d3'], globdict['data3'], globdict['uv3'], globdict['sigma3'], globdict['jonesdict3'], gains, globdict['gains_t1'], globdict['gains_t2'], globdict['fit_gains'] + globdict['marginalize_gains'], globdict['param_mask'], globdict['pol3'], globdict['fit_pol'], globdict['fit_cpol'], globdict['fit_leakage'])
                + globdict['alpha_d4'] * chisqgrad_wgain(globdict['trial_model'], globdict['d4'], globdict['data4'], globdict['uv4'], globdict['sigma4'], globdict['jonesdict4'], gains, globdict['gains_t1'], globdict['gains_t2'], globdict['fit_gains'] + globdict['marginalize_gains'], globdict['param_mask'], globdict['pol4'], globdict['fit_pol'], globdict['fit_cpol'], globdict['fit_leakage']))
 
     if globdict['minimizer_func'] not in ['dynesty_static','dynesty_dynamic','pymc3']:
-        priterm  = np.concatenate([prior_grad(params[:globdict['n_params']], globdict['param_map'], 
-                                              globdict['model_prior'], globdict['minimizer_func']), 
-                                  prior_gain_grad(params[globdict['n_params']:(globdict['n_params'] + globdict['n_gains'])], 
+        priterm  = np.concatenate([prior_grad(params[:globdict['n_params']], globdict['param_map'],
+                                              globdict['model_prior'], globdict['minimizer_func']),
+                                  prior_gain_grad(params[globdict['n_params']:(globdict['n_params'] + globdict['n_gains'])],
                                               globdict['gain_list'], globdict['gain_prior'], globdict['fit_gains']),
-                                  prior_leakage_grad(params[(globdict['n_params'] + globdict['n_gains']):], globdict['leakage_fit'], 
+                                  prior_leakage_grad(params[(globdict['n_params'] + globdict['n_gains']):], globdict['leakage_fit'],
                                               globdict['leakage_prior'], globdict['fit_leakage'])])
     else:
         priterm  = 0.0
@@ -831,13 +823,13 @@ def objgrad(params):
                 j2 = j-globdict['n_params']
                 x = gains[j2]
                 prior_params = globdict['gain_prior'][globdict['gain_list'][j2][1]]
-                grad[j] /= prior_func(x, prior_params)                    
+                grad[j] /= prior_func(x, prior_params)
             else:
                 cparts = ['re','im']
                 j2 = j-globdict['n_params']-globdict['n_gains']
                 x = leakage[j2]
                 prior_params = globdict['leakage_prior'][globdict['leakage_fit'][j2//2][0]][globdict['leakage_fit'][j2//2][1]][cparts[j2%2]]
-                grad[j] /= prior_func(x, prior_params)                          
+                grad[j] /= prior_func(x, prior_params)
 
     if globdict['test_gradient']:
         print('Testing the gradient at ',params)
@@ -852,7 +844,7 @@ def objgrad(params):
                 dx = np.abs(params[j]) * 1e-6
 
             params2 = copy.deepcopy(params)
-            params2[j] += dx                
+            params2[j] += dx
             f2 = objfunc(params2)
             grad_numeric[j] = (f2 - f1)/dx
 
@@ -866,13 +858,13 @@ def objgrad(params):
                     j2 = j-globdict['n_params']
                     x = gains[j2]
                     prior_params = globdict['gain_prior'][globdict['gain_list'][j2][1]]
-                    grad_numeric[j] /= prior_func(x, prior_params)                    
+                    grad_numeric[j] /= prior_func(x, prior_params)
                 else:
                     cparts = ['re','im']
                     j2 = j-globdict['n_params']-globdict['n_gains']
                     x = leakage[j2]
                     prior_params = globdict['leakage_prior'][globdict['leakage_fit'][j2//2][0]][globdict['leakage_fit'][j2//2][1]][cparts[j2%2]]
-                    grad_numeric[j] /= prior_func(x, prior_params)    
+                    grad_numeric[j] /= prior_func(x, prior_params)
 
             if j < globdict['n_params']:
                 print('\nNumeric Gradient Check:',globdict['param_map'][j][0],globdict['param_map'][j][1],grad[j],grad_numeric[j])
@@ -887,9 +879,9 @@ def objgrad(params):
 def modeler_func(Obsdata, model_init, model_prior,
                    d1='vis', d2=False, d3=False, d4=False,
                    pol1='I', pol2='I', pol3='I', pol4='I',
-                   normchisq = False, alpha_d1=0, alpha_d2=0, alpha_d3=0, alpha_d4=0,                   
+                   normchisq = False, alpha_d1=0, alpha_d2=0, alpha_d3=0, alpha_d4=0,
                    flux=1.0, alpha_flux=0,
-                   fit_model=True, fit_pol=False, fit_cpol=False, 
+                   fit_model=True, fit_pol=False, fit_cpol=False,
                    fit_gains=False,marginalize_gains=False,gain_init=None,gain_prior=None,
                    fit_leakage=False, leakage_init=None, leakage_prior=None,
                    fit_noise_model=False,
@@ -899,7 +891,7 @@ def modeler_func(Obsdata, model_init, model_prior,
                    processes=-1,
                    test_gradient=False, quiet=False, **kwargs):
 
-    """Fit a specified model. 
+    """Fit a specified model.
 
        Args:
            Obsdata (Obsdata): The Obsdata object with VLBI data
@@ -911,8 +903,8 @@ def modeler_func(Obsdata, model_init, model_prior,
            d3 (str): The third data term; options are 'vis', 'bs', 'amp', 'cphase', 'cphase_diag' 'camp', 'logcamp', 'logcamp_diag', 'm'
            d4 (str): The fourth data term; options are 'vis', 'bs', 'amp', 'cphase', 'cphase_diag' 'camp', 'logcamp', 'logcamp_diag', 'm'
 
-           normchisq (bool): If False (default), automatically assign weights alpha_d1-3 to match the true log-likelihood. 
-           alpha_d1 (float): The first data term weighting. 
+           normchisq (bool): If False (default), automatically assign weights alpha_d1-3 to match the true log-likelihood.
+           alpha_d1 (float): The first data term weighting.
            alpha_d2 (float): The second data term weighting. Default value of zero will automatically assign weights to match the true log-likelihood.
            alpha_d3 (float): The third data term weighting. Default value of zero will automatically assign weights to match the true log-likelihood.
            alpha_d4 (float): The fourth data term weighting. Default value of zero will automatically assign weights to match the true log-likelihood.
@@ -925,9 +917,9 @@ def modeler_func(Obsdata, model_init, model_prior,
            fit_cpol (bool): Whether or not to fit circular polarization parameters
            fit_gains (bool): Whether or not to fit time-dependent amplitude gains for each station
            marginalize_gains (bool): Whether or not to perform analytic gain marginalization (via the Laplace approximation to the posterior)
-    
+
            gain_init (list or caltable): Initial gain amplitudes to apply; these can be specified even if gains aren't fitted
-           gain_prior (dict): Dictionary with the gain prior for each site. 
+           gain_prior (dict): Dictionary with the gain prior for each site.
 
            minimizer_func (str): Minimizer function to use. Current options are:
                                 'scipy.optimize.minimize'
@@ -936,7 +928,7 @@ def modeler_func(Obsdata, model_init, model_prior,
                                 'dynesty_static'
                                 'dynesty_dynamic'
                                 'pymc3'
-           minimizer_kwargs (dict): kwargs passed to the minimizer. 
+           minimizer_kwargs (dict): kwargs passed to the minimizer.
 
            bounds (list): List of parameter bounds for the fitted parameters (will automatically compute if needed)
            use_bounds (bool): Whether or not to use bounds when fitting (required for some minimizers)
@@ -945,19 +937,19 @@ def modeler_func(Obsdata, model_init, model_prior,
 
        Returns:
            dict: Dictionary with fitted model ('model') and other diagnostics that are minimizer-dependent
-    """    
+    """
 
     global nit, globdict
     nit = n_params = 0
     ln_norm = 0.0
 
-    if fit_model == False and fit_gains == False and fit_leakage == False:
+    if not fit_model and not fit_gains and not fit_leakage:
         raise Exception('Both fit_model, fit_gains, and fit_leakage are False. Must fit something!')
 
-    if fit_gains == True and marginalize_gains == True:
+    if fit_gains and marginalize_gains:
         raise Exception('Both fit_gains and marginalize_gains are True. Cannot do both!')
 
-    if fit_gains == False and marginalize_gains == False and gain_init is not None:
+    if not fit_gains and not marginalize_gains and gain_init is not None:
         if not quiet: print('Both fit_gains and marginalize_gains are False but gain_init was passed. Applying these gains as a fixed correction!')
 
     if minimizer_kwargs is None:
@@ -971,7 +963,7 @@ def modeler_func(Obsdata, model_init, model_prior,
     # Make sure data and regularizer options are ok
     if not d1 and not d2 and not d3 and not d4:
         raise Exception("Must have at least one data term!")
-    if (not ((d1 in DATATERMS) or d1==False)) or (not ((d2 in DATATERMS) or d2==False)) or (not ((d3 in DATATERMS) or d3==False)) or (not ((d4 in DATATERMS) or d4==False)):
+    if (not ((d1 in DATATERMS) or not d1)) or (not ((d2 in DATATERMS) or not d2)) or (not ((d3 in DATATERMS) or not d3)) or (not ((d4 in DATATERMS) or not d4)):
         raise Exception("Invalid data term: valid data terms are: " + ' '.join(DATATERMS))
 
     # Create the trial model
@@ -987,7 +979,7 @@ def modeler_func(Obsdata, model_init, model_prior,
         (data3, sigma3, uv3, jonesdict3) = chisqdata(Obsdata, d3, pol=pol3)
         (data4, sigma4, uv4, jonesdict4) = chisqdata(Obsdata, d4, pol=pol4)
     elif type(Obsdata) is list:
-        # Combine a list of observations into one. 
+        # Combine a list of observations into one.
         # Allow these to be from multiple sources for polarimetric zero-baseline purposes.
         # Main thing for different sources is to compute field rotation before combining
         def combine_data(d1,s1,u1,j1,d2,s2,u2,j2):
@@ -997,8 +989,8 @@ def modeler_func(Obsdata, model_init, model_prior,
             j = j1.copy()
             for key in ['fr1', 'fr2', 't1', 't2', 'DR1', 'DR2', 'DL1', 'DL2']:
                 j[key] = np.concatenate([j1[key],j2[key]])
-            return (d, s, u, j)        
-            
+            return (d, s, u, j)
+
         (data1, sigma1, uv1, jonesdict1) = chisqdata(Obsdata[0], d1, pol=pol1)
         (data2, sigma2, uv2, jonesdict2) = chisqdata(Obsdata[0], d2, pol=pol2)
         (data3, sigma3, uv3, jonesdict3) = chisqdata(Obsdata[0], d3, pol=pol3)
@@ -1009,13 +1001,13 @@ def modeler_func(Obsdata, model_init, model_prior,
             (data3b, sigma3b, uv3b, jonesdict3b) = chisqdata(Obsdata[j], d3, pol=pol3)
             (data4b, sigma4b, uv4b, jonesdict4b) = chisqdata(Obsdata[j], d4, pol=pol4)
 
-            if data1b is not False: 
+            if data1b is not False:
                 (data1, sigma1, uv1, jonesdict1) = combine_data(data1,sigma1,uv1,jonesdict1,data1b,sigma1b,uv1b,jonesdict1b)
-            if data2b is not False: 
+            if data2b is not False:
                 (data2, sigma2, uv2, jonesdict2) = combine_data(data2,sigma2,uv2,jonesdict2,data2b,sigma2b,uv2b,jonesdict2b)
-            if data3b is not False: 
+            if data3b is not False:
                 (data3, sigma3, uv3, jonesdict3) = combine_data(data3,sigma3,uv3,jonesdict3,data3b,sigma3b,uv3b,jonesdict3b)
-            if data4b is not False: 
+            if data4b is not False:
                 (data4, sigma4, uv4, jonesdict4) = combine_data(data4,sigma4,uv4,jonesdict4,data4b,sigma4b,uv4b,jonesdict4b)
 
         alldata = np.concatenate([_.data for _ in Obsdata])
@@ -1029,21 +1021,21 @@ def modeler_func(Obsdata, model_init, model_prior,
         # leakage_fit is a list of tuples [site, hand] that will be fitted
         leakage_fit = []
         if fit_leakage:
-            import copy # Error on the next line if this isn't done again. Why python, why?!?
+            import copy  # Error on the next line if this isn't done again. Why python, why?!?
             # Start with the list of all sites
             sites = list(set(np.concatenate(Obsdata.unpack(['t1','t2']).tolist())))
 
             # Add missing entries to leakage_prior
             # leakage_prior is a nested dictionary with keys of station, hand, re/im
             leakage_prior_init = copy.deepcopy(leakage_prior)
-            if leakage_prior_init is None: leakage_prior_init = {}                
+            if leakage_prior_init is None: leakage_prior_init = {}
             leakage_prior = {}
             for s in sites:
                 leakage_prior[s] = {}
                 for pol in ['R','L']:
                     leakage_prior[s][pol] = {}
                     for cpart in ['re','im']:
-                        # check to see if a prior is specified for the complex part, the pol, or the site (in that order)                        
+                        # check to see if a prior is specified for the complex part, the pol, or the site (in that order)
                         if leakage_prior_init.get(s,{}).get(pol,{}).get(cpart,{}).get('prior_type','') != '':
                             leakage_prior[s][pol][cpart] = leakage_prior_init[s][pol][cpart]
                         elif leakage_prior_init.get(s,{}).get(pol,{}).get('prior_type','') != '':
@@ -1053,10 +1045,10 @@ def modeler_func(Obsdata, model_init, model_prior,
                         else:
                             leakage_prior[s][pol][cpart] = copy.deepcopy(LEAKAGE_PRIOR_DEFAULT)
 
-            if Obsdata.polrep == 'stokes':                
+            if Obsdata.polrep == 'stokes':
                 for s in sites:
                     for pol in ['R','L']:
-                        if leakage_prior[s][pol]['re']['prior_type'] == 'fixed': continue                            
+                        if leakage_prior[s][pol]['re']['prior_type'] == 'fixed': continue
                         leakage_fit.append([s,pol])
             else:
                 vislist = Obsdata.unpack(['t1','t2','rlvis','lrvis'])
@@ -1066,7 +1058,7 @@ def modeler_func(Obsdata, model_init, model_prior,
                 [leakage_fit.append([s,'R']) for s in DR if leakage_prior[s]['R']['re']['prior_type'] != 'fixed']
                 [leakage_fit.append([s,'L']) for s in DL if leakage_prior[s]['L']['re']['prior_type'] != 'fixed']
                 sites = list(set(np.concatenate([DR,DL])))
-            
+
             if type(leakage_init) is dict:
                 station_leakages = copy.deepcopy(leakage_init)
             else:
@@ -1080,14 +1072,14 @@ def modeler_func(Obsdata, model_init, model_prior,
                     if 'R' not in station_leakages[s].keys():
                         station_leakages[s]['R'] = 0.0
                     if 'L' not in station_leakages[s].keys():
-                        station_leakages[s]['L'] = 0.0        
+                        station_leakages[s]['L'] = 0.0
     else:
         # Disable leakage computations
         jonesdict1 = jonesdict2 = jonesdict3 = None
         leakage_fit = []
         station_leakages = None
 
-    if normchisq == False:
+    if not normchisq:
         if not quiet: print('Assigning data weights to give the correct log-likelihood...')
         (alpha_d1, alpha_d2, alpha_d3, alpha_d4, ln_norm) = compute_likelihood_constants(d1, d2, d3, d4, sigma1, sigma2, sigma3, sigma4)
     else:
@@ -1129,8 +1121,8 @@ def modeler_func(Obsdata, model_init, model_prior,
                 gain_init = caltable_to_gains(gain_init, gain_list)
 
     if fit_leakage:
-        leakage_init = np.zeros(len(leakage_fit) * 2)  
-        for j in range(len(leakage_init)//2):            
+        leakage_init = np.zeros(len(leakage_fit) * 2)
+        for j in range(len(leakage_init)//2):
             leakage_init[2*j] = np.real(station_leakages[leakage_fit[j][0]][leakage_fit[j][1]])
             leakage_init[2*j + 1] = np.imag(station_leakages[leakage_fit[j][0]][leakage_fit[j][1]])
     else:
@@ -1144,13 +1136,13 @@ def modeler_func(Obsdata, model_init, model_prior,
             param_init.append(transform_param(model_init.params[pm[0]][pm[1]]/pm[2], model_prior[pm[0]][pm[1]],inverse=False))
         else: # In this case, the parameter is a list of complex numbers, so the real/imaginary or abs/arg components need to be assigned
             if param_map[j][1].find('cpol') != -1:
-                param_type = 'beta_list_cpol' 
-                idx = int(param_map[j][1].split('_')[0][8:]) 
+                param_type = 'beta_list_cpol'
+                idx = int(param_map[j][1].split('_')[0][8:])
             elif param_map[j][1].find('pol') != -1:
-                param_type = 'beta_list_pol'                
-                idx = int(param_map[j][1].split('_')[0][7:]) + (len(trial_model.params[param_map[j][0]][param_type])-1)//2 
+                param_type = 'beta_list_pol'
+                idx = int(param_map[j][1].split('_')[0][7:]) + (len(trial_model.params[param_map[j][0]][param_type])-1)//2
             elif param_map[j][1].find('beta') != -1:
-                param_type = 'beta_list' 
+                param_type = 'beta_list'
                 idx = int(param_map[j][1].split('_')[0][4:]) - 1
             else:
                 raise Exception('Unsure how to interpret ' + param_map[j][1])
@@ -1167,7 +1159,7 @@ def modeler_func(Obsdata, model_init, model_prior,
             elif param_map[j][1][-3:] == 'arg':
                 param_init.append(transform_param(np.angle(model_init.params[pm[0]][param_type][idx])/pm[2], model_prior[pm[0]][pm[1]],inverse=False))
             else:
-                if not quiet: print('Parameter ' + param_map[j][1] + ' not understood!')  
+                if not quiet: print('Parameter ' + param_map[j][1] + ' not understood!')
     n_params = len(param_init)
 
     # Note: model parameters can have transformations applied; gains and leakage do not
@@ -1175,38 +1167,38 @@ def modeler_func(Obsdata, model_init, model_prior,
         param_init += list(gain_init)
     if fit_leakage:
         param_init += list(leakage_init)
- 
+
     if minimizer_func not in ['dynesty_static','dynesty_dynamic','pymc3']:
         # Define bounds (irrelevant for dynesty or pymc3)
-        if use_bounds == False and minimizer_func in ['scipy.optimize.dual_annealing']:
+        if not use_bounds and minimizer_func in ['scipy.optimize.dual_annealing']:
             if not quiet: print('Bounds are required for ' + minimizer_func + '! Setting use_bounds=True.')
             use_bounds = True
-        if use_bounds == False and bounds is not None:
+        if not use_bounds and bounds is not None:
             if not quiet: print('Bounds passed but use_bounds=False; setting use_bounds=True.')
             use_bounds = True
         if bounds is None and use_bounds:
             if not quiet: print('No bounds passed. Setting nominal bounds.')
             bounds = make_bounds(model_prior, param_map, gain_prior, gain_list, n_gains, leakage_fit, leakage_prior)
-        if use_bounds == False:
+        if not use_bounds:
             bounds = None
 
-    # Gather global variables into a dictionary 
-    globdict = {'trial_model':trial_model, 
+    # Gather global variables into a dictionary
+    globdict = {'trial_model':trial_model,
                 'd1':d1, 'd2':d2, 'd3':d3, 'd4':d4,
                 'pol1':pol1, 'pol2':pol2, 'pol3':pol3, 'pol4':pol4,
                 'data1':data1, 'sigma1':sigma1, 'uv1':uv1, 'jonesdict1':jonesdict1,
                 'data2':data2, 'sigma2':sigma2, 'uv2':uv2, 'jonesdict2':jonesdict2,
                 'data3':data3, 'sigma3':sigma3, 'uv3':uv3, 'jonesdict3':jonesdict3,
                 'data4':data4, 'sigma4':sigma4, 'uv4':uv4, 'jonesdict4':jonesdict4,
-                'alpha_d1':alpha_d1, 'alpha_d2':alpha_d2, 'alpha_d3':alpha_d3, 'alpha_d4':alpha_d4,  
+                'alpha_d1':alpha_d1, 'alpha_d2':alpha_d2, 'alpha_d3':alpha_d3, 'alpha_d4':alpha_d4,
                 'n_params': n_params, 'n_gains':n_gains, 'n_leakage':len(leakage_init),
-                'model_prior':model_prior, 'param_map':param_map, 'param_mask':param_mask, 
+                'model_prior':model_prior, 'param_map':param_map, 'param_mask':param_mask,
                 'gain_prior':gain_prior, 'gain_list':gain_list, 'gain_init':gain_init,
                 'fit_leakage':fit_leakage, 'leakage_init':leakage_init, 'leakage_fit':leakage_fit, 'station_leakages':station_leakages, 'leakage_prior':leakage_prior,
-                'show_updates':show_updates, 'update_interval':update_interval, 'gains_t1':gains_t1, 'gains_t2':gains_t2, 
+                'show_updates':show_updates, 'update_interval':update_interval, 'gains_t1':gains_t1, 'gains_t2':gains_t2,
                 'minimizer_func':minimizer_func,'Obsdata':Obsdata,
                 'fit_pol':fit_pol, 'fit_cpol':fit_cpol,
-                'flux':flux, 'alpha_flux':alpha_flux, 'fit_gains':fit_gains, 'marginalize_gains':marginalize_gains, 'ln_norm':ln_norm, 'param_init':param_init, 'test_gradient':test_gradient}    
+                'flux':flux, 'alpha_flux':alpha_flux, 'fit_gains':fit_gains, 'marginalize_gains':marginalize_gains, 'ln_norm':ln_norm, 'param_init':param_init, 'test_gradient':test_gradient}
     if fit_leakage:
         update_leakage(leakage_init)
 
@@ -1214,7 +1206,7 @@ def modeler_func(Obsdata, model_init, model_prior,
     # Define the function that reports progress
     def plotcur(params_step, *args):
         global nit, globdict
-        if globdict['show_updates'] and (nit % globdict['update_interval'] == 0) and (quiet == False):
+        if globdict['show_updates'] and (nit % globdict['update_interval'] == 0) and (not quiet):
             if globdict['n_params'] > 0:
                 print('Params:',params_step[:globdict['n_params']])
                 print('Transformed Params:',transform_params(params_step[:globdict['n_params']], globdict['param_map'], globdict['minimizer_func'], globdict['model_prior']))
@@ -1228,8 +1220,8 @@ def modeler_func(Obsdata, model_init, model_prior,
         nit += 1
 
     # Print initial statistics
-    if not quiet: 
-        print("Initial Objective Function: %f" % (objfunc(param_init)))
+    if not quiet:
+        print(f"Initial Objective Function: {objfunc(param_init):f}")
         if d1 in DATATERMS:
             print("Total Data 1: ", (len(data1)))
         if d2 in DATATERMS:
@@ -1263,7 +1255,7 @@ def modeler_func(Obsdata, model_init, model_prior,
         res = opt.minimize(objfunc, param_init, jac=objgrad, callback=plotcur, bounds=bounds, **min_kwargs)
     elif minimizer_func == 'scipy.optimize.dual_annealing':
         min_kwargs = {}
-        min_kwargs['local_search_options'] = {'jac':objgrad, 
+        min_kwargs['local_search_options'] = {'jac':objgrad,
                                               'method':'L-BFGS-B','options':{'maxiter':MAXIT, 'ftol':STOP, 'maxcor':NHIST,'gtol':STOP,'maxls':MAXLS}}
         if 'local_search_options' in minimizer_kwargs.keys():
             for key in minimizer_kwargs['local_search_options'].keys():
@@ -1273,20 +1265,19 @@ def modeler_func(Obsdata, model_init, model_prior,
             if key in ['local_search_options']:
                 continue
             min_kwargs[key] = minimizer_kwargs[key]
-              
+
         res = opt.dual_annealing(objfunc, x0=param_init, bounds=bounds, callback=plotcur, **min_kwargs)
     elif minimizer_func == 'scipy.optimize.basinhopping':
         min_kwargs = {}
         for key in minimizer_kwargs.keys():
             min_kwargs[key] = minimizer_kwargs[key]
 
-        res = opt.basinhopping(objfunc, param_init, **min_kwargs)  
+        res = opt.basinhopping(objfunc, param_init, **min_kwargs)
     elif minimizer_func == 'pymc3':
         ########################
         ## Sample using pymc3 ##
         ########################
         import pymc3 as pm
-        import theano
         import theano.tensor as tt
 
         # To simplfy things, we'll use cdf transforms to map everything to a hypercube, as in dynesty
@@ -1305,9 +1296,9 @@ def modeler_func(Obsdata, model_init, model_prior,
 
             def prior_transform(self, u):
                 # This function transforms samples from the unit hypercube (u) to the target prior (x)
-                global globdict  
+                global globdict
                 cparts = ['re','im']
-                model_params_u   = u[:n_params]    
+                model_params_u   = u[:n_params]
                 gain_params_u    = u[n_params:(n_params+n_gains)]
                 leakage_params_u = u[(n_params+n_gains):]
                 model_params_x   = [cdf_inverse(  model_params_u[j], globdict['model_prior'][globdict['param_map'][j][0]][globdict['param_map'][j][1]]) for j in range(len(model_params_u))]
@@ -1329,7 +1320,7 @@ def modeler_func(Obsdata, model_init, model_prior,
             def grad(self, inputs, g):
                 # the method that calculates the vector-Jacobian product
                 # http://deeplearning.net/software/theano_versions/dev/extending/op.html#grad
-                theta, = inputs 
+                theta, = inputs
                 return [g[0]*self.logpgrad(theta)]
 
         class LogLikeGrad(tt.Op):
@@ -1346,9 +1337,9 @@ def modeler_func(Obsdata, model_init, model_prior,
 
             def prior_transform(self, u):
                 # This function transforms samples from the unit hypercube (u) to the target prior (x)
-                global globdict  
+                global globdict
                 cparts = ['re','im']
-                model_params_u   = u[:n_params]    
+                model_params_u   = u[:n_params]
                 gain_params_u    = u[n_params:(n_params+n_gains)]
                 leakage_params_u = u[(n_params+n_gains):]
                 model_params_x   = [cdf_inverse(  model_params_u[j], globdict['model_prior'][globdict['param_map'][j][0]][globdict['param_map'][j][1]]) for j in range(len(model_params_u))]
@@ -1369,10 +1360,10 @@ def modeler_func(Obsdata, model_init, model_prior,
         for key in minimizer_kwargs.keys():
             min_kwargs[key] = minimizer_kwargs[key]
 
-        # Define the initial value if not passed 
+        # Define the initial value if not passed
         if 'start' not in min_kwargs.keys():
             cparts = ['re','im']
-            model_params_x   = param_init[:n_params]    
+            model_params_x   = param_init[:n_params]
             gain_params_x    = param_init[n_params:(n_params+n_gains)]
             leakage_params_x = param_init[(n_params+n_gains):]
             model_params_u   = [cdf(  model_params_x[j], globdict['model_prior'][globdict['param_map'][j][0]][globdict['param_map'][j][1]]) for j in range(len(model_params_x))]
@@ -1387,11 +1378,11 @@ def modeler_func(Obsdata, model_init, model_prior,
         with pm.Model() as model:
             theta = tt.as_tensor_variable([ pm.Uniform('var' + str(j), lower=0., upper=1.) for j in range(len(param_init)) ])
             pm.DensityDist('likelihood', lambda v: logl(v), observed={'v': theta})
-            trace = pm.sample(**min_kwargs)            
+            trace = pm.sample(**min_kwargs)
 
         # Extract useful sampling diagnostics.
         samples_u = np.vstack([trace['var' + str(j)] for j in range(len(param_init))]).T # samples in the hypercube
-        samples = np.array([logl.prior_transform(u) for u in samples_u]) # samples 
+        samples = np.array([logl.prior_transform(u) for u in samples_u]) # samples
         mean    = np.mean(samples,axis=0)
         var     = np.var(samples,axis=0)
 
@@ -1404,7 +1395,7 @@ def modeler_func(Obsdata, model_init, model_prior,
         MAP  = samples[j_MAP]
 
         # Return a model determined by the MAP
-        set_params(MAP[:n_params], trial_model, param_map, minimizer_func, model_prior)                
+        set_params(MAP[:n_params], trial_model, param_map, minimizer_func, model_prior)
         gains = MAP[n_params:(n_params+n_gains)]
         leakage = MAP[(n_params+n_gains):]
         update_leakage(leakage)
@@ -1421,14 +1412,14 @@ def modeler_func(Obsdata, model_init, model_prior,
         posterior_models = []
         for j in range(N_POSTERIOR_SAMPLES):
             posterior_model = trial_model.copy()
-            set_params(samples[-j][:n_params], posterior_model, param_map, minimizer_func, model_prior)  
-            posterior_models.append(posterior_model)   
-        ret['posterior_models'] = posterior_models    
+            set_params(samples[-j][:n_params], posterior_model, param_map, minimizer_func, model_prior)
+            posterior_models.append(posterior_model)
+        ret['posterior_models'] = posterior_models
 
         # Return data that has been rescaled based on 'natural' units for each parameter
         import copy
         samples_natural = copy.deepcopy(samples)
-        samples_natural[:,:n_params] /= np.array([_[4] for _ in param_map])    
+        samples_natural[:,:n_params] /= np.array([_[4] for _ in param_map])
         ret['samples_natural'] = samples_natural
 
         # Return the names of the fitted parameters
@@ -1458,9 +1449,9 @@ def modeler_func(Obsdata, model_init, model_prior,
         # Define the functions that dynesty requires
         def prior_transform(u):
             # This function transforms samples from the unit hypercube (u) to the target prior (x)
-            global globdict  
+            global globdict
             cparts = ['re','im']
-            model_params_u   = u[:n_params]    
+            model_params_u   = u[:n_params]
             gain_params_u    = u[n_params:(n_params+n_gains)]
             leakage_params_u = u[(n_params+n_gains):]
             model_params_x   = [cdf_inverse(  model_params_u[j], globdict['model_prior'][globdict['param_map'][j][0]][globdict['param_map'][j][1]]) for j in range(len(model_params_u))]
@@ -1474,15 +1465,16 @@ def modeler_func(Obsdata, model_init, model_prior,
         def grad(x):
             return -objgrad(x)
 
-        # Setup a multiprocessing pool if needed 
+        # Setup a multiprocessing pool if needed
         if processes >= 0:
-            import pathos.multiprocessing as mp
             from multiprocessing import cpu_count
+
+            import pathos.multiprocessing as mp
             if processes == 0: processes = int(cpu_count())
 
             # Ensure efficient memory allocation among the processes and separate trial models for each
             def init(_globdict):
-                global globdict 
+                global globdict
                 globdict = _globdict
                 if processes >= 0:
                     globdict['trial_model'] = globdict['trial_model'].copy()
@@ -1493,7 +1485,7 @@ def modeler_func(Obsdata, model_init, model_prior,
             if not quiet: print('Using a pool with %d processes' % processes)
         else:
             pool = processes = None
-            
+
         # Setup the sampler
         if minimizer_func == 'dynesty_static':
             sampler = dynesty.NestedSampler(loglike, prior_transform, ndim=len(param_init), gradient=grad, pool=pool, queue_size=processes, **minimizer_kwargs)
@@ -1505,7 +1497,7 @@ def modeler_func(Obsdata, model_init, model_prior,
 
         # Print the sampler summary
         res = sampler.results
-        if not quiet: 
+        if not quiet:
             try: res.summary()
             except: pass
 
@@ -1517,7 +1509,6 @@ def modeler_func(Obsdata, model_init, model_prior,
         # Compute the log-posterior
         if not quiet: print('Calculating the posterior values for the samples...')
         if pool is not None:
-            from functools import partial
             def logpost(j):
                 return -objfunc(samples[j], force_posterior=True)
 
@@ -1534,10 +1525,10 @@ def modeler_func(Obsdata, model_init, model_prior,
         MAP  = samples[j_MAP]
 
         # Resample from the posterior
-        samples = dyfunc.resample_equal(samples, weights) 
+        samples = dyfunc.resample_equal(samples, weights)
 
         # Return a model determined by the MAP
-        set_params(MAP[:n_params], trial_model, param_map, minimizer_func, model_prior)                
+        set_params(MAP[:n_params], trial_model, param_map, minimizer_func, model_prior)
         gains = MAP[n_params:(n_params+n_gains)]
         leakage = MAP[(n_params+n_gains):]
         update_leakage(leakage)
@@ -1554,15 +1545,15 @@ def modeler_func(Obsdata, model_init, model_prior,
         posterior_models = []
         for j in range(N_POSTERIOR_SAMPLES):
             posterior_model = trial_model.copy()
-            set_params(samples[j][:n_params], posterior_model, param_map, minimizer_func, model_prior)  
-            posterior_models.append(posterior_model)   
-        ret['posterior_models'] = posterior_models    
+            set_params(samples[j][:n_params], posterior_model, param_map, minimizer_func, model_prior)
+            posterior_models.append(posterior_model)
+        ret['posterior_models'] = posterior_models
 
         # Return data that has been rescaled based on 'natural' units for each parameter
         import copy
         res_natural = copy.deepcopy(res)
-        res_natural.samples[:,:n_params] /= np.array([_[4] for _ in param_map])    
-        samples_natural = samples[:,:n_params]/np.array([_[4] for _ in param_map])    
+        res_natural.samples[:,:n_params] /= np.array([_[4] for _ in param_map])
+        samples_natural = samples[:,:n_params]/np.array([_[4] for _ in param_map])
         ret['res_natural'] = res_natural
         ret['samples_natural'] = samples_natural
 
@@ -1591,7 +1582,7 @@ def modeler_func(Obsdata, model_init, model_prior,
     tstop = time.time()
     trial_model = globdict['trial_model']
 
-    if not quiet: 
+    if not quiet:
         print("\ntime: %f s" % (tstop - tstart))
         print("\nFitted Parameters:")
     if minimizer_func not in ['dynesty_static','dynesty_dynamic','pymc3']:
@@ -1601,7 +1592,7 @@ def modeler_func(Obsdata, model_init, model_prior,
         leakage = out[(n_params + n_gains):]
         update_leakage(leakage)
         tparams = transform_params(out[:n_params], param_map, minimizer_func, model_prior)
-        if not quiet: 
+        if not quiet:
             cur_idx = -1
             if len(param_map):
                 print('Model Parameters:')
@@ -1611,18 +1602,18 @@ def modeler_func(Obsdata, model_init, model_prior,
                         print(model_init.models[cur_idx] + ' (component %d/%d):' % (cur_idx+1,model_init.N_models()))
                     print(('\t' + param_map[j][1] + ': %f ' + param_map[j][3]) % (tparams[j] * param_map[j][2]/param_map[j][4]))
                 print('\n')
-            
+
             if len(leakage_fit):
                 print('Leakage (%; re, im):')
                 for j in range(len(leakage_fit)):
-                    print('\t' + leakage_fit[j][0] + ', ' + leakage_fit[j][1] + ': %2.2f %2.2f' % (leakage[2*j]*100,leakage[2*j + 1]*100))
+                    print('\t' + leakage_fit[j][0] + ', ' + leakage_fit[j][1] + f': {leakage[2*j]*100:2.2f} {leakage[2*j + 1]*100:2.2f}')
                 print('\n')
 
-            print("Final Chi^2_1: %f Chi^2_2: %f  Chi^2_3: %f  Chi^2_4: %f" % chisq_list(gains))
-            print("J: %f" % res.fun)
+            print("Final Chi^2_1: {:f} Chi^2_2: {:f}  Chi^2_3: {:f}  Chi^2_4: {:f}".format(*chisq_list(gains)))
+            print(f"J: {res.fun:f}")
             print(res.message)
     else:
-        if not quiet: 
+        if not quiet:
             cur_idx = -1
             if len(param_map):
                 print('Model Parameters (mean and std):')
@@ -1638,25 +1629,25 @@ def modeler_func(Obsdata, model_init, model_prior,
                 for j in range(len(leakage_fit)):
                     j2 = 2*j + n_params + n_gains
                     print(('\t' + leakage_fit[j][0] + ', ' + leakage_fit[j][1]
-                                + ': %2.2f +/- %2.2f, %2.2f +/- %2.2f') 
+                                + ': %2.2f +/- %2.2f, %2.2f +/- %2.2f')
                                 % (mean[j2]*100,cov[j2,j2]**0.5 * 100,mean[j2+1]*100,cov[j2+1,j2+1]**0.5 * 100))
                 print('\n')
 
     # Return fitted model
     ret['model']     = trial_model
-    ret['param_map'] = param_map    
+    ret['param_map'] = param_map
     ret['chisq_list'] = chisq_list(gains)
     try: ret['res'] = res
     except: pass
 
     if fit_gains:
         ret['gains'] = gains
-    
+
         # Create and return a caltable
         caldict = {}
         for site in set(np.array(gain_list)[:,1]):
             caldict[site] = []
-    
+
         for j in range(len(gains)):
             caldict[gain_list[j][1]].append((gain_list[j][0], (1.0 + gains[j]), (1.0 + gains[j])))
 
@@ -1665,7 +1656,7 @@ def modeler_func(Obsdata, model_init, model_prior,
 
         ct = caltable.Caltable(Obsdata.ra, Obsdata.dec, Obsdata.rf, Obsdata.bw, caldict, Obsdata.tarr,
                                            source=Obsdata.source, mjd=Obsdata.mjd, timetype=Obsdata.timetype)
-        ret['caltable'] = ct 
+        ret['caltable'] = ct
 
     # If relevant, return useful quantities associated with the leakage
     if station_leakages is not None:
@@ -1675,7 +1666,7 @@ def modeler_func(Obsdata, model_init, model_prior,
             if 'R' in station_leakages[s].keys(): tarr[Obsdata.tkey[s]]['dr'] = station_leakages[s]['R']
             if 'L' in station_leakages[s].keys(): tarr[Obsdata.tkey[s]]['dl'] = station_leakages[s]['L']
         ret['tarr'] = tarr
-                
+
     return ret
 
 ##################################################################################################
@@ -1687,7 +1678,7 @@ def chisq(model, uv, data, sigma, dtype, pol='I', jonesdict=None):
     """
 
     chisq = 1
-    if not dtype in DATATERMS:
+    if dtype not in DATATERMS:
         return chisq
 
     if dtype == 'vis':
@@ -1735,12 +1726,12 @@ def chisqgrad(model, uv, data, sigma, jonesdict, dtype, param_mask, pol='I', fit
         gaingrad = np.array([])
 
     # Now we need to be sure to put the gradient in the correct order: model parameters, then gains, then leakage
-    param_mask_full   = np.zeros(len(chisqgrad), dtype=bool) 
-    leakage_mask_full = np.zeros(len(chisqgrad), dtype=bool) 
+    param_mask_full   = np.zeros(len(chisqgrad), dtype=bool)
+    leakage_mask_full = np.zeros(len(chisqgrad), dtype=bool)
     param_mask_full[:len(param_mask)] = param_mask
     leakage_mask_full[len(param_mask):] = ~leakage_mask_full[len(param_mask):]
 
-    if not dtype in DATATERMS:
+    if dtype not in DATATERMS:
         return np.concatenate([chisqgrad[param_mask_full],gaingrad,chisqgrad[leakage_mask_full]])
 
     if dtype == 'vis':
@@ -1854,7 +1845,7 @@ def chisq_bs(model, uv, bis, sigma, pol='I', jonesdict=None):
     """Bispectrum chi-squared"""
 
     bisamples = model.sample_uv(uv[0][:,0],uv[0][:,1],pol=pol,jonesdict=jonesdict) * model.sample_uv(uv[1][:,0],uv[1][:,1],pol=pol,jonesdict=jonesdict) * model.sample_uv(uv[2][:,0],uv[2][:,1],pol=pol,jonesdict=jonesdict)
-    chisq= np.sum(np.abs(((bis - bisamples)/sigma))**2)/(2.*len(bis))
+    chisq= np.sum(np.abs((bis - bisamples)/sigma)**2)/(2.*len(bis))
     return chisq
 
 def chisqgrad_bs(model, uv, bis, sigma, pol='I', fit_pol=False, fit_cpol=False, fit_leakage=False, jonesdict=None):
@@ -1866,7 +1857,7 @@ def chisqgrad_bs(model, uv, bis, sigma, pol='I', fit_pol=False, fit_cpol=False, 
     V1_grad = model.sample_grad_uv(uv[0][:,0],uv[0][:,1],pol=pol,fit_pol=fit_pol,fit_cpol=fit_cpol,jonesdict=jonesdict)
     V2_grad = model.sample_grad_uv(uv[1][:,0],uv[1][:,1],pol=pol,fit_pol=fit_pol,fit_cpol=fit_cpol,jonesdict=jonesdict)
     V3_grad = model.sample_grad_uv(uv[2][:,0],uv[2][:,1],pol=pol,fit_pol=fit_pol,fit_cpol=fit_cpol,jonesdict=jonesdict)
-    bisamples = V1 * V2 * V3 
+    bisamples = V1 * V2 * V3
     wdiff = ((bis - bisamples).conj())/(sigma**2)
     pt1 = wdiff * V2 * V3
     pt2 = wdiff * V1 * V3
@@ -1918,9 +1909,9 @@ def chisq_cphase_diag(model, uv, clphase_diag, sigma, pol='I', jonesdict=None):
 
     clphase_diag_samples = []
     for iA, uv3 in enumerate(uv_diag):
-        i1 = model.sample_uv(uv3[0][:,0],uv3[0][:,1],pol=pol,jonesdict=jonesdict)    
-        i2 = model.sample_uv(uv3[1][:,0],uv3[1][:,1],pol=pol,jonesdict=jonesdict)    
-        i3 = model.sample_uv(uv3[2][:,0],uv3[2][:,1],pol=pol,jonesdict=jonesdict)  
+        i1 = model.sample_uv(uv3[0][:,0],uv3[0][:,1],pol=pol,jonesdict=jonesdict)
+        i2 = model.sample_uv(uv3[1][:,0],uv3[1][:,1],pol=pol,jonesdict=jonesdict)
+        i3 = model.sample_uv(uv3[2][:,0],uv3[2][:,1],pol=pol,jonesdict=jonesdict)
 
         clphase_samples = np.angle(i1 * i2 * i3)
         clphase_diag_samples.append(np.dot(tform_mats[iA],clphase_samples))
@@ -1940,14 +1931,14 @@ def chisqgrad_cphase_diag(model, uv, clphase_diag, sigma, pol='I', fit_pol=False
     deriv = np.zeros(len(model.sample_grad_uv(0,0,pol=pol,fit_pol=fit_pol,fit_cpol=fit_cpol,jonesdict=jonesdict)))
     for iA, uv3 in enumerate(uv_diag):
 
-        i1 = model.sample_uv(uv3[0][:,0],uv3[0][:,1],pol=pol,jonesdict=jonesdict)    
-        i2 = model.sample_uv(uv3[1][:,0],uv3[1][:,1],pol=pol,jonesdict=jonesdict)    
-        i3 = model.sample_uv(uv3[2][:,0],uv3[2][:,1],pol=pol,jonesdict=jonesdict)   
+        i1 = model.sample_uv(uv3[0][:,0],uv3[0][:,1],pol=pol,jonesdict=jonesdict)
+        i2 = model.sample_uv(uv3[1][:,0],uv3[1][:,1],pol=pol,jonesdict=jonesdict)
+        i3 = model.sample_uv(uv3[2][:,0],uv3[2][:,1],pol=pol,jonesdict=jonesdict)
 
         i1_grad = model.sample_grad_uv(uv3[0][:,0],uv3[0][:,1],pol=pol,fit_pol=fit_pol,fit_cpol=fit_cpol,jonesdict=jonesdict)
         i2_grad = model.sample_grad_uv(uv3[1][:,0],uv3[1][:,1],pol=pol,fit_pol=fit_pol,fit_cpol=fit_cpol,jonesdict=jonesdict)
         i3_grad = model.sample_grad_uv(uv3[2][:,0],uv3[2][:,1],pol=pol,fit_pol=fit_pol,fit_cpol=fit_cpol,jonesdict=jonesdict)
- 
+
         clphase_samples = np.angle(i1 * i2 * i3)
         clphase_diag_samples = np.dot(tform_mats[iA],clphase_samples)
 
@@ -2043,10 +2034,10 @@ def chisq_logcamp_diag(model, uv, log_clamp_diag, sigma, pol='I', jonesdict=None
     log_clamp_diag_samples = []
     for iA, uv4 in enumerate(uv_diag):
 
-        a1 = np.abs(model.sample_uv(uv4[0][:,0],uv4[0][:,1],pol=pol,jonesdict=jonesdict))          
-        a2 = np.abs(model.sample_uv(uv4[1][:,0],uv4[1][:,1],pol=pol,jonesdict=jonesdict)) 
-        a3 = np.abs(model.sample_uv(uv4[2][:,0],uv4[2][:,1],pol=pol,jonesdict=jonesdict)) 
-        a4 = np.abs(model.sample_uv(uv4[3][:,0],uv4[3][:,1],pol=pol,jonesdict=jonesdict)) 
+        a1 = np.abs(model.sample_uv(uv4[0][:,0],uv4[0][:,1],pol=pol,jonesdict=jonesdict))
+        a2 = np.abs(model.sample_uv(uv4[1][:,0],uv4[1][:,1],pol=pol,jonesdict=jonesdict))
+        a3 = np.abs(model.sample_uv(uv4[2][:,0],uv4[2][:,1],pol=pol,jonesdict=jonesdict))
+        a4 = np.abs(model.sample_uv(uv4[3][:,0],uv4[3][:,1],pol=pol,jonesdict=jonesdict))
 
         log_clamp_samples = np.log(a1) + np.log(a2) - np.log(a3) - np.log(a4)
         log_clamp_diag_samples.append(np.dot(tform_mats[iA],log_clamp_samples))
@@ -2113,7 +2104,7 @@ def chisqgrad_logamp(model, uv, amp, sigma, pol='I', fit_pol=False, fit_cpol=Fal
 
     V_grad = model.sample_grad_uv(uv[:,0],uv[:,1],pol=pol,fit_pol=fit_pol,fit_cpol=fit_cpol,jonesdict=jonesdict)
 
-    pp = ((np.log(amp) - np.log(amp_samples))) / (logsigma**2) / i1
+    pp = (np.log(amp) - np.log(amp_samples)) / (logsigma**2) / i1
     out = (-2.0/len(amp)) * np.real(np.dot(pp, V_grad.T))
     return out
 
@@ -2141,7 +2132,7 @@ def chisq_m(model, uv, m, msigma, jonesdict=None):
 
     msamples = model.sample_uv(uv[:,0],uv[:,1],pol='P',jonesdict=jonesdict)/model.sample_uv(uv[:,0],uv[:,1],pol='I',jonesdict=jonesdict)
 
-    return np.sum(np.abs((m - msamples))**2/(msigma**2)) / (2*len(m))   
+    return np.sum(np.abs(m - msamples)**2/(msigma**2)) / (2*len(m))
 
 def chisqgrad_m(model, uv, mvis, msigma, fit_pol=False, fit_cpol=False, fit_leakage=False, jonesdict=None):
     """The gradient of the polarimetric ratio chisq
@@ -2165,7 +2156,7 @@ def chisq_fracpol(upper, lower, model, uv, m, msigma, jonesdict=None):
 
     msamples = model.sample_uv(uv[:,0],uv[:,1],pol=upper.upper(),jonesdict=jonesdict)/model.sample_uv(uv[:,0],uv[:,1],pol=lower.upper(),jonesdict=jonesdict)
 
-    return np.sum(np.abs((m - msamples))**2/(msigma**2)) / (2*len(m))   
+    return np.sum(np.abs(m - msamples)**2/(msigma**2)) / (2*len(m))
 
 def chisqgrad_fracpol(upper, lower, model, uv, mvis, msigma, fit_pol=False, fit_cpol=False, fit_leakage=False, jonesdict=None):
     """The gradient of the polarimetric ratio chisq
@@ -2193,7 +2184,7 @@ def chisq_polclosure(model, uv, vis, sigma, jonesdict=None):
     LL = model.sample_uv(uv[:,0],uv[:,1],pol='LL',jonesdict=jonesdict)
     samples = (RL * LR)/(RR * LL)
 
-    return np.sum(np.abs((vis - samples))**2/(sigma**2)) / (2*len(vis))   
+    return np.sum(np.abs(vis - samples)**2/(sigma**2)) / (2*len(vis))
 
 def chisqgrad_polclosure(model, uv, vis, sigma, fit_pol=False, fit_cpol=False, fit_leakage=False, jonesdict=None):
     """The gradient of the polarimetric ratio chisq
@@ -2308,7 +2299,7 @@ def make_jonesdict(Obsdata, data_arr):
     DR2 = np.array([Obsdata.tarr[Obsdata.tkey[o['t2']]]['dr'] for o in data_arr])
     DL2 = np.array([Obsdata.tarr[Obsdata.tkey[o['t2']]]['dl'] for o in data_arr])
 
-    return {'fr1':fr1,'fr2':fr2,'t1':t1,'t2':t2, 
+    return {'fr1':fr1,'fr2':fr2,'t1':t1,'t2':t2,
             'DR1':DR1, 'DR2':DR2, 'DL1':DL1, 'DL2':DL2}
 
 def chisqdata_vis(Obsdata, pol='I', **kwargs):
@@ -2355,7 +2346,7 @@ def chisqdata_amp(Obsdata, pol='I',**kwargs):
     # data weighting
     if weighting=='uniform':
         sigma = np.median(sigma) * np.ones(len(sigma))
-        
+
     jonesdict = make_jonesdict(Obsdata, data_arr)
 
     return (amp, sigma, uv, jonesdict)
@@ -2452,7 +2443,7 @@ def chisqdata_cphase_diag(Obsdata, pol='I',**kwargs):
         # get diagonalized closure phases and errors
         clphase_diag.append(cl[0]['cphase'])
         sigma_diag.append(cl[0]['sigmacp'])
-        
+
         # get uv arrays
         u1 = cl[2][:,0].astype('float')
         v1 = cl[3][:,0].astype('float')
@@ -2623,7 +2614,7 @@ def chisqdata_fracpol(Obsdata, pol_upper,pol_lower,**kwargs):
     upper_amp = data_arr[pol_upper + 'amp']
     lower_amp = data_arr[pol_lower + 'amp']
     upper_sig = data_arr[pol_upper + 'sigma']
-    lower_sig = data_arr[pol_lower + 'sigma']    
+    lower_sig = data_arr[pol_lower + 'sigma']
 
     sig = ((upper_sig/lower_amp)**2 + (lower_sig*upper_amp/lower_amp**2)**2)**0.5
 

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -185,16 +185,7 @@ class Obsdata(object):
         if self.tstop < self.tstart:
             self.tstop += 24.0
 
-        # Saved closure quantity arrays
-        self.amp = None
-        self.bispec = None
-        self.cphase = None
-        self.cphase_diag = None
-        self.camp = None
-        self.logcamp = None
-        self.logcamp_diag = None
-
-    @property 
+    @property
     def tarr(self):
         return self._tarr
         
@@ -1301,328 +1292,6 @@ class Obsdata(object):
 
         return out
 
-    def add_amp(self, avg_time=0, scan_avg=False, debias=True, err_type='predicted',
-                return_type='rec', round_s=0.1, snrcut=0.):
-        """Adds attribute self.amp: aan amplitude table with incoherently averaged amplitudes
-
-           Args:
-               avg_time (float): incoherent integration time in seconds
-               scan_avg (bool): if True, average over scans in self.scans instead of intime
-               debias (bool): if True then apply debiasing
-               err_type (str): 'predicted' or 'measured'
-               return_type: data frame ('df') or recarray ('rec')
-               round_s (float): accuracy of datetime object in seconds
-               snrcut (float): flag amplitudes with snr lower than this
-
-        """
-
-        # Get the spacing between datapoints in seconds
-        if len(set([x[0] for x in list(self.unpack('time'))])) > 1:
-            tint0 = np.min(np.diff(np.asarray(sorted(list(set(
-                           [x[0] for x in list(self.unpack('time'))])))))) * 3600.
-        else:
-            tint0 = 0.0
-
-        if avg_time <= tint0:
-            adf = ehdf.make_amp(self, debias=debias, round_s=round_s)
-            if return_type == 'rec':
-                adf = ehdf.df_to_rec(adf, 'amp')
-            print("Updated self.amp: no averaging")
-        else:
-            adf = ehdf.incoh_avg_vis(self, dt=avg_time, debias=debias, scan_avg=scan_avg,
-                                     return_type=return_type, rec_type='amp', err_type=err_type)
-
-        # snr cut
-        adf = adf[adf['amp'] / adf['sigma'] > snrcut]
-        self.amp = adf
-        print("Updated self.amp: avg_time %f s\n" % avg_time)
-
-        return
-
-    def add_bispec(self, avg_time=0, return_type='rec', count='max', snrcut=0.,
-                   err_type='predicted', num_samples=1000, round_s=0.1, uv_min=False):
-        """Adds attribute self.bispec: bispectra table with bispectra averaged for dt
-
-           Args:
-               avg_time (float): bispectrum averaging timescale
-               return_type: data frame ('df') or recarray ('rec')
-               count (str): If 'min', return minimal set of bispectra,
-                            if 'max' return all bispectra up to reordering
-               err_type (str): 'predicted' or 'measured'
-               num_samples: number of bootstrap (re)samples if measuring error
-               round_s (float): accuracy of datetime object in seconds
-               snrcut (float): flag bispectra with snr lower than this
-
-        """
-
-        # Get spacing between datapoints in seconds
-        if len(set([x[0] for x in list(self.unpack('time'))])) > 1:
-            tint0 = np.min(np.diff(np.asarray(sorted(list(set(
-                           [x[0] for x in list(self.unpack('time'))])))))) * 3600.
-        else:
-            tint0 = 0
-
-        if avg_time > tint0:
-            cdf = ehdf.make_bsp_df(self, mode='all', round_s=round_s, count=count,
-                                   snrcut=0., uv_min=uv_min)
-            cdf = ehdf.average_bispectra(cdf, avg_time, return_type=return_type,
-                                         num_samples=num_samples, snrcut=snrcut)
-        else:
-            cdf = ehdf.make_bsp_df(self, mode='all', round_s=round_s, count=count,
-                                   snrcut=snrcut, uv_min=uv_min)
-            print("Updated self.bispec: no averaging")
-            if return_type == 'rec':
-                cdf = ehdf.df_to_rec(cdf, 'bispec')
-
-        self.bispec = cdf
-        print("Updated self.bispec: avg_time %f s\n" % avg_time)
-
-        return
-
-    def add_cphase(self, avg_time=0, return_type='rec', count='max', snrcut=0.,
-                   err_type='predicted', num_samples=1000, round_s=0.1, uv_min=False):
-        """Adds attribute self.cphase: cphase table averaged for dt
-
-           Args:
-               avg_time (float): closure phase averaging timescale
-               return_type: data frame ('df') or recarray ('rec')
-               count (str): If 'min', return minimal set of phases,
-                            if 'max' return all closure phases up to reordering
-               err_type (str): 'predicted' or 'measured'
-               num_samples: number of bootstrap (re)samples if measuring error
-               round_s (float): accuracy of datetime object in seconds
-               snrcut (float): flag closure phases with snr lower than this
-
-        """
-
-        # Get spacing between datapoints in seconds
-        if len(set([x[0] for x in list(self.unpack('time'))])) > 1:
-            tint0 = np.min(np.diff(np.asarray(sorted(list(set(
-                           [x[0] for x in list(self.unpack('time'))])))))) * 3600.
-        else:
-            tint0 = 0
-
-        if avg_time > tint0:
-            cdf = ehdf.make_cphase_df(self, mode='all', round_s=round_s, count=count,
-                                      snrcut=0., uv_min=uv_min)
-            cdf = ehdf.average_cphases(cdf, avg_time, return_type=return_type, err_type=err_type,
-                                       num_samples=num_samples, snrcut=snrcut)
-        else:
-            cdf = ehdf.make_cphase_df(self, mode='all', round_s=round_s, count=count,
-                                      snrcut=snrcut, uv_min=uv_min)
-            if return_type == 'rec':
-                cdf = ehdf.df_to_rec(cdf, 'cphase')
-            print("Updated self.cphase: no averaging")
-
-        self.cphase = cdf
-        print("updated self.cphase: avg_time %f s\n" % avg_time)
-
-        return
-
-    def add_cphase_diag(self, avg_time=0, return_type='rec', vtype='vis', count='min', snrcut=0.,
-                        err_type='predicted', num_samples=1000, round_s=0.1, uv_min=False):
-        """Adds attribute self.cphase_diag: cphase_diag table averaged for dt
-
-           Args:
-               avg_time (float): closure phase averaging timescale
-               return_type: data frame ('df') or recarray ('rec')
-               vtype (str): Visibility type (e.g., 'vis', 'llvis', 'rrvis', etc.)
-               count (str): If 'min', return minimal set of phases,
-                            If 'max' return all closure phases up to reordering
-               err_type (str): 'predicted' or 'measured'
-               num_samples: number of bootstrap (re)samples if measuring error
-               round_s (float): accuracy of datetime object in seconds
-               snrcut (float): flag closure phases with snr lower than this
-
-        """
-
-        # Get spacing between datapoints in seconds
-        if len(set([x[0] for x in list(self.unpack('time'))])) > 1:
-            tint0 = np.min(np.diff(np.asarray(sorted(list(set(
-                           [x[0] for x in list(self.unpack('time'))]))))))
-            tint0 *= 3600
-        else:
-            tint0 = 0
-
-        # Dom TODO: implement averaging during diagonal closure phase creation
-        if avg_time > tint0:
-            print("Averaging while creating diagonal closure phases is not yet implemented!")
-            print("Proceeding for now without averaging.")
-            cdf = ehdf.make_cphase_diag_df(self, vtype=vtype, round_s=round_s,
-                                           count=count, snrcut=snrcut, uv_min=uv_min)
-        else:
-            cdf = ehdf.make_cphase_diag_df(self, vtype=vtype, round_s=round_s,
-                                           count=count, snrcut=snrcut, uv_min=uv_min)
-            if return_type == 'rec':
-                cdf = ehdf.df_to_rec(cdf, 'cphase_diag')
-            print("Updated self.cphase_diag: no averaging")
-
-        self.cphase_diag = cdf
-        print("updated self.cphase_diag: avg_time %f s\n" % avg_time)
-
-        return
-
-    def add_camp(self, avg_time=0, return_type='rec', ctype='camp',
-                 count='max', debias=True, snrcut=0.,
-                 err_type='predicted', num_samples=1000, round_s=0.1):
-        """Adds attribute self.camp or self.logcamp: closure amplitudes table
-
-           Args:
-               avg_time (float): closure amplitude averaging timescale
-               return_type: data frame ('df') or recarray ('rec')
-               ctype (str): The closure amplitude type ('camp' or 'logcamp')
-               debias (bool): If True, debias the closure amplitude
-               count (str): If 'min', return minimal set of amplitudes,
-                            if 'max' return all closure amplitudes up to inverses
-               err_type (str): 'predicted' or 'measured'
-               num_samples: number of bootstrap (re)samples if measuring error
-               round_s (float): accuracy of datetime object in seconds
-               snrcut (float): flag closure amplitudes with snr lower than this
-        """
-
-        # Get spacing between datapoints in seconds
-        if len(set([x[0] for x in list(self.unpack('time'))])) > 1:
-            tint0 = np.min(np.diff(np.asarray(sorted(list(set(
-                           [x[0] for x in list(self.unpack('time'))]))))))
-            tint0 *= 3600
-        else:
-            tint0 = 0
-
-        if avg_time > tint0:
-            foo = self.avg_incoherent(avg_time, debias=debias, err_type=err_type)
-        else:
-            foo = self
-        cdf = ehdf.make_camp_df(foo, ctype=ctype, debias=False,
-                                count=count, round_s=round_s, snrcut=snrcut)
-
-        if ctype == 'logcamp':
-            print("updated self.lcamp: no averaging")
-        elif ctype == 'camp':
-            print("updated self.camp: no averaging")
-        if return_type == 'rec':
-            cdf = ehdf.df_to_rec(cdf, 'camp')
-
-        if ctype == 'logcamp':
-            self.logcamp = cdf
-            print("updated self.logcamp: avg_time %f s\n" % avg_time)
-        elif ctype == 'camp':
-            self.camp = cdf
-            print("updated self.camp: avg_time %f s\n" % avg_time)
-
-        return
-
-    def add_logcamp(self, avg_time=0, return_type='rec', ctype='camp',
-                    count='max', debias=True, snrcut=0.,
-                    err_type='predicted', num_samples=1000, round_s=0.1):
-        """Adds attribute self.logcamp: closure amplitudes table
-
-           Args:
-               avg_time (float): closure amplitude averaging timescale
-               return_type: data frame ('df') or recarray ('rec')
-               ctype (str): The closure amplitude type ('camp' or 'logcamp')
-               debias (bool): If True, debias the closure amplitude
-               count (str): If 'min', return minimal set of amplitudes,
-                            if 'max' return all closure amplitudes up to inverses
-               err_type (str): 'predicted' or 'measured'
-               num_samples: number of bootstrap (re)samples if measuring error
-               round_s (float): accuracy of datetime object in seconds
-               snrcut (float): flag closure amplitudes with snr lower than this
-
-        """
-
-        self.add_camp(return_type=return_type, ctype='logcamp',
-                      count=count, debias=debias, snrcut=snrcut,
-                      avg_time=avg_time, err_type=err_type,
-                      num_samples=num_samples, round_s=round_s)
-
-        return
-
-    def add_logcamp_diag(self, avg_time=0, return_type='rec', count='min', snrcut=0.,
-                         debias=True, err_type='predicted', num_samples=1000, round_s=0.1):
-        """Adds attribute self.logcamp_diag: logcamp_diag table averaged for dt
-
-           Args:
-               avg_time (float): diagonal log closure amplitude averaging timescale
-               return_type: data frame ('df') or recarray ('rec')
-               debias (bool): If True, debias the diagonal log closure amplitude
-               count (str): If 'min', return minimal set of amplitudes,
-                            If 'max' return all diagonal log closure amplitudes up to inverses
-               err_type (str): 'predicted' or 'measured'
-               num_samples: number of bootstrap (re)samples if measuring error
-               round_s (float): accuracy of datetime object in seconds
-               snrcut (float): flag diagonal log closure amplitudes with snr lower than this
-
-        """
-
-        # Get spacing between datapoints in seconds
-        if len(set([x[0] for x in list(self.unpack('time'))])) > 1:
-            tint0 = np.min(np.diff(np.asarray(sorted(list(set(
-                           [x[0] for x in list(self.unpack('time'))]))))))
-            tint0 *= 3600
-        else:
-            tint0 = 0
-
-        if avg_time > tint0:
-            foo = self.avg_incoherent(avg_time, debias=debias, err_type=err_type)
-            cdf = ehdf.make_logcamp_diag_df(foo, debias='False', count=count,
-                                            round_s=round_s, snrcut=snrcut)
-        else:
-            foo = self
-            cdf = ehdf.make_logcamp_diag_df(foo, debias=debias, count=count,
-                                            round_s=round_s, snrcut=snrcut)
-
-        if return_type == 'rec':
-            cdf = ehdf.df_to_rec(cdf, 'logcamp_diag')
-
-        self.logcamp_diag = cdf
-        print("updated self.logcamp_diag: avg_time %f s\n" % avg_time)
-
-        return
-
-    def add_all(self, avg_time=0, return_type='rec',
-                count='max', debias=True, snrcut=0.,
-                err_type='predicted', num_samples=1000, round_s=0.1):
-        """Adds tables of all all averaged derived quantities
-           self.amp,self.bispec,self.cphase,self.camp,self.logcamp
-
-           Args:
-               avg_time (float): closure amplitude averaging timescale
-               return_type: data frame ('df') or recarray ('rec')
-               debias (bool): If True, debias the closure amplitude
-               count (str): If 'min', return minimal set of closure quantities,
-                            if 'max' return all closure quantities
-               err_type (str): 'predicted' or 'measured'
-               num_samples: number of bootstrap (re)samples if measuring error
-               round_s (float): accuracy of datetime object in seconds
-               snrcut (float): flag closure amplitudes with snr lower than this
-
-        """
-
-        self.add_amp(return_type=return_type, avg_time=avg_time, debias=debias, err_type=err_type)
-        self.add_bispec(return_type=return_type, count=count,
-                        avg_time=avg_time, snrcut=snrcut, err_type=err_type,
-                        num_samples=num_samples, round_s=round_s)
-        self.add_cphase(return_type=return_type, count=count,
-                        avg_time=avg_time, snrcut=snrcut, err_type=err_type,
-                        num_samples=num_samples, round_s=round_s)
-        self.add_cphase_diag(return_type=return_type, count='min',
-                             avg_time=avg_time, snrcut=snrcut, err_type=err_type,
-                             num_samples=num_samples, round_s=round_s)
-        self.add_camp(return_type=return_type, ctype='camp',
-                      count=count, debias=debias, snrcut=snrcut,
-                      avg_time=avg_time, err_type=err_type,
-                      num_samples=num_samples, round_s=round_s)
-        self.add_camp(return_type=return_type, ctype='logcamp',
-                      count=count, debias=debias, snrcut=snrcut,
-                      avg_time=avg_time, err_type=err_type,
-                      num_samples=num_samples, round_s=round_s)
-        self.add_logcamp_diag(return_type=return_type, count='min',
-                              debias=debias, avg_time=avg_time,
-                              snrcut=snrcut, err_type=err_type,
-                              num_samples=num_samples, round_s=round_s)
-
-        return
-
     def add_scans(self, info='self', filepath='', dt=0.0165, margin=0.0001,split_subarray=False):
         """Compute scans and add self.scans to Obsdata object.
 
@@ -1878,9 +1547,8 @@ class Obsdata(object):
 
         # estimate the original total flux
         obs_zerobl = self.flag_uvdist(uv_max=uv_max)
-        obs_zerobl.add_amp(debias=True)
-        orig_totflux = np.sum(obs_zerobl.amp['amp'] * (1 / obs_zerobl.amp['sigma']**2))
-        orig_totflux /= np.sum(1 / obs_zerobl.amp['sigma']**2)
+        amps = obs_zerobl.unpack(['amp', 'sigma'], debias=debias)
+        orig_totflux = np.sum(amps['amp'] / amps['sigma']**2) / np.sum(1 / amps['sigma']**2)
 
         print('Rescaling zero baseline by ' + str(orig_totflux - totflux) + ' Jy' +
               ' to ' + str(totflux) + ' Jy')
@@ -3113,9 +2781,9 @@ class Obsdata(object):
         print("\n")
         return out
 
-    def bispectra_tri(self, site1, site2, site3, 
-                      vtype='vis', timetype=False, snrcut=0., method='from_maxset', 
-                      bs=[], force_recompute=False):
+    def bispectra_tri(self, site1, site2, site3,
+                      vtype='vis', timetype=False, snrcut=0., method='from_maxset',
+                      bs=[]):
 
         """Return complex bispectrum  over time on a triangle (1-2-3).
 
@@ -3131,7 +2799,6 @@ class Obsdata(object):
 
                method (str): 'from_maxset' (old, default), 'from_vis' (new, more robust)
                bs (list): optionally pass in the precomputed, time-sorted bispectra
-               force_recompute (bool): if True, recompute bispectra instead of using saved data
 
            Returns:
                (numpy.recarry): A recarray of the bispectra on this triangle with datatype DTBIS
@@ -3151,10 +2818,7 @@ class Obsdata(object):
         # TODO: verify consistency/performance of from_vis, and delete this method
         if method=='from_maxset':
 
-            if ((len(bs) == 0) and not (self.bispec is None) and not (len(self.bispec) == 0) and
-                    not force_recompute):
-                bs = self.bispec
-            elif (len(bs) == 0) or force_recompute:
+            if len(bs) == 0:
                 bs = self.bispectra(mode='all', count='max', vtype=vtype,
                                     timetype=timetype, snrcut=snrcut)
 
@@ -3290,8 +2954,8 @@ class Obsdata(object):
         return outdata
 
     def cphase_tri(self, site1, site2, site3, vtype='vis', ang_unit='deg',
-                   timetype=False, snrcut=0., method='from_maxset', 
-                   cphases=[], force_recompute=False):
+                   timetype=False, snrcut=0., method='from_maxset',
+                   cphases=[]):
         """Return closure phase  over time on a triangle (1-2-3).
 
            Args:
@@ -3307,7 +2971,6 @@ class Obsdata(object):
 
                method (str): 'from_maxset' (old, default), 'from_vis' (new, more robust)
                cphases (list): optionally pass in the precomputed time-sorted cphases
-               force_recompute (bool): if True, do not use save closure phase tables
 
            Returns:
                (numpy.recarry): A recarray of the closure phases with datatype DTCPHASE
@@ -3327,13 +2990,9 @@ class Obsdata(object):
         # get selected closure phases from the maximal set
         # TODO: verify consistency/performance of from_vis, and delete this method
         if method=='from_maxset':
-                
-            # Get closure phases (maximal set)
-            if ((len(cphases) == 0) and not (self.cphase is None) and not (len(self.cphase) == 0) and
-                    not force_recompute):
-                cphases = self.cphase
 
-            elif (len(cphases) == 0) or force_recompute:
+            # Get closure phases (maximal set)
+            if len(cphases) == 0:
                 cphases = self.c_phases(mode='all', count='max', vtype=vtype, ang_unit=ang_unit,
                                         timetype=timetype, snrcut=snrcut)
 
@@ -3747,10 +3406,10 @@ class Obsdata(object):
         print("\n")
         return out
 
-    def camp_quad(self, site1, site2, site3, site4, 
+    def camp_quad(self, site1, site2, site3, site4,
                   vtype='vis', ctype='camp', debias=True, timetype=False, snrcut=0.,
                   method='from_maxset',
-                  camps=[], force_recompute=False):
+                  camps=[]):
         """Return closure phase over time on a quadrange (1-2)(3-4)/(1-4)(2-3).
 
            Args:
@@ -3768,7 +3427,6 @@ class Obsdata(object):
 
                method (str): 'from_maxset' (old, default), 'from_vis' (new, more robust)
                camps (list): optionally pass in the time-sorted, precomputed camps
-               force_recompute (bool): if True, do not use save closure amplitude data
 
            Returns:
                (numpy.recarry): A recarray of the closure amplitudes with datatype DTCAMP
@@ -3789,13 +3447,7 @@ class Obsdata(object):
         # get selected closure amplitudes from the maximal set
         # TODO: verify consistency/performance of from_vis, and delete this method
         if method=='from_maxset':
-            if (((ctype == 'camp') and (len(camps) == 0)) and not (self.camp is None) and
-                    not (len(self.camp) == 0) and not force_recompute):
-                camps = self.camp
-            elif (((ctype == 'logcamp') and (len(camps) == 0)) and not (self.logcamp is None) and
-                  not (len(self.logcamp) == 0) and not force_recompute):
-                camps = self.logcamp
-            elif (len(camps) == 0) or force_recompute:
+            if len(camps) == 0:
                 camps = self.c_amplitudes(mode='all', count='max', vtype=vtype, ctype=ctype,
                                           debias=debias, timetype=timetype, snrcut=snrcut)
 
@@ -4051,9 +3703,6 @@ class Obsdata(object):
         if (field1 not in ehc.FIELDS) and (field2 not in ehc.FIELDS):
             raise Exception("valid fields are " + ' '.join(ehc.FIELDS))
 
-        if 'amp' in [field1, field2] and not (self.amp is None):
-            print("Warning: plotall is not using amplitudes in Obsdata.amp array!")
-
         # Label individual baselines
         # ANDREW TODO this is way too slow, make  it faster??
         if tag_bl:
@@ -4277,9 +3926,6 @@ class Obsdata(object):
             timetype = self.timetype
 
         field = field.lower()
-        if field == 'amp' and not (self.amp is None):
-            print("Warning: plot_bl is not using amplitudes in Obsdata.amp array!")
-
         if label is None:
             label = str(self.source)
         else:
@@ -4372,7 +4018,7 @@ class Obsdata(object):
         return x
 
     def plot_cphase(self, site1, site2, site3,
-                    vtype='vis', cphases=[], force_recompute=False,
+                    vtype='vis', cphases=[],
                     ang_unit='deg', timetype=False, snrcut=0.,
                     axis=False, rangex=False, rangey=False,
                     color=ehc.SCOLORS[0], marker='o', markersize=ehc.MARKERSIZE, label=None,
@@ -4388,7 +4034,6 @@ class Obsdata(object):
                vtype (str): The visibilty type from which to assemble closure phases
                             ('vis','qvis','uvis','vvis','pvis')
                cphases (list): optionally pass in the prcomputed, time-sorted closure phases
-               force_recompute (bool): if True, do not use stored closure phase able
                snrcut (float): flag closure amplitudes with snr lower than this
 
                ang_unit (str): phase unit 'deg' or 'rad'
@@ -4426,12 +4071,8 @@ class Obsdata(object):
         else:
             label = str(label)
 
-        # Get closure phases (maximal set)
-        if (len(cphases) == 0) and (self.cphase is not None) and not force_recompute:
-            cphases = self.cphase
-
         cpdata = self.cphase_tri(site1, site2, site3, vtype=vtype, timetype=timetype,
-                                 cphases=cphases, force_recompute=force_recompute, snrcut=snrcut)
+                                 cphases=cphases, snrcut=snrcut)
         plotdata = np.array([[obs['time'], obs['cphase'] * angle, obs['sigmacp']]
                              for obs in cpdata])
 
@@ -4498,7 +4139,7 @@ class Obsdata(object):
         return x
 
     def plot_camp(self, site1, site2, site3, site4,
-                  vtype='vis', ctype='camp', camps=[], force_recompute=False,
+                  vtype='vis', ctype='camp', camps=[],
                   debias=False, timetype=False, snrcut=0.,
                   axis=False, rangex=False, rangey=False,
                   color=ehc.SCOLORS[0], marker='o', markersize=ehc.MARKERSIZE, label=None,
@@ -4516,7 +4157,6 @@ class Obsdata(object):
                             ('vis','qvis','uvis','vvis','pvis')
                ctype (str): The closure amplitude type ('camp' or 'logcamp')
                camps (list): optionally pass in camps so they don't have to be recomputed
-               force_recompute (bool): if True, recompute camps instead of using stored data
                snrcut (float): flag closure amplitudes with snr lower than this
 
                debias (bool): If True, debias the closure amplitude
@@ -4551,18 +4191,10 @@ class Obsdata(object):
             label = str(label)
 
         # Get closure amplitudes (maximal set)
-        if ((ctype == 'camp') and (len(camps) == 0) and (self.camp is not None) and
-                not (len(self.camp) == 0) and not force_recompute):
-            camps = self.camp
-        elif ((ctype == 'logcamp') and (len(camps) == 0) and (self.logcamp is not None) and
-              not (len(self.logcamp) == 0) and not force_recompute):
-            camps = self.logcamp
-
-        # Get closure amplitudes (maximal set)
         cpdata = self.camp_quad(site1, site2, site3, site4,
                                 vtype=vtype, ctype=ctype, snrcut=snrcut,
                                 debias=debias, timetype=timetype,
-                                camps=camps, force_recompute=force_recompute)
+                                camps=camps)
 
         if len(cpdata) == 0:
             print('No closure amplitudes on this triangle!')

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -17,22 +17,17 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
-
-import string
 import copy
+import itertools as it
+import string
+import sys
+
+import matplotlib.pyplot as plt
 import numpy as np
 import numpy.lib.recfunctions as rec
-import matplotlib.pyplot as plt
 import scipy.optimize as opt
 import scipy.spatial as spatial
-import itertools as it
-import sys
 
 try:
     import pandas as pd
@@ -41,14 +36,15 @@ except ImportError:
     print("Please install pandas to use statistics package!")
 
 
-import ehtim.image
-import ehtim.io.save
-import ehtim.io.load
+import warnings
+
 import ehtim.const_def as ehc
+import ehtim.image
+import ehtim.io.load
+import ehtim.io.save
 import ehtim.observing.obs_helpers as obsh
 import ehtim.statistics.dataframes as ehdf
 
-import warnings
 warnings.filterwarnings("ignore",
                         message="Casting complex values to real discards the imaginary part")
 
@@ -64,7 +60,7 @@ TARRPOS = 5
 ##################################################################################################
 
 
-class Obsdata(object):
+class Obsdata:
 
     """A polarimetric VLBI observation of visibility amplitudes and phases (in Jy).
 
@@ -133,7 +129,7 @@ class Obsdata(object):
 
         if len(datatable) == 0:
             raise Exception("No data in input table!")
-        if not (datatable.dtype in [ehc.DTPOL_STOKES, ehc.DTPOL_CIRC]):
+        if datatable.dtype not in [ehc.DTPOL_STOKES, ehc.DTPOL_CIRC]:
             raise Exception("Data table dtype should be DTPOL_STOKES or DTPOL_CIRC")
 
         # Polarization Representation
@@ -173,7 +169,7 @@ class Obsdata(object):
         self.tkey = {self.tarr[i]['site']: i for i in range(len(self.tarr))}
         if np.any(self.tarr['sefdr'] != 0) or np.any(self.tarr['sefdl'] != 0):
             self.reorder_tarr_sefd(reorder_baselines=False)
-            
+
         # reorder baselines to uvfits convention
         self.reorder_baselines(trial_speedups=trial_speedups)
 
@@ -188,12 +184,12 @@ class Obsdata(object):
     @property
     def tarr(self):
         return self._tarr
-        
-    @tarr.setter 
+
+    @tarr.setter
     def tarr(self, tarr):
         self._tarr = tarr
         self.tkey = {tarr[i]['site']: i for i in range(len(tarr))}
-        
+
     def obsdata_args(self):
         """"Copy arguments for making a new Obsdata into a list and dictonary
         """
@@ -335,9 +331,9 @@ class Obsdata(object):
         """
         if trial_speedups:
             self.reorder_baselines_trial_speedups()
-        
+
         else: # original code
-        
+
             # Time partition the datatable
             datatable = self.data.copy()
             datalist = []
@@ -351,7 +347,7 @@ class Obsdata(object):
                 blpairs = []
                 for dat in tlist:
                     # Remove conjugate baselines
-                    if not (set((dat['t1'], dat['t2']))) in blpairs:         
+                    if (set((dat['t1'], dat['t2']))) not in blpairs:
 
                         # Reverse the baseline in the right order for uvfits:
                         if(self.tkey[dat['t2']] < self.tkey[dat['t1']]):
@@ -374,7 +370,7 @@ class Obsdata(object):
                                 lr = dat['lrvis'].copy()
                                 dat['rlvis'] = np.conj(lr)
                                 dat['lrvis'] = np.conj(rl)
-                                
+
                                 # You also have to switch the errors for the coherency!
                                 rlerr = dat['rlsigma'].copy()
                                 lrerr = dat['lrsigma'].copy()
@@ -403,33 +399,33 @@ class Obsdata(object):
         """
 
         dat = self.data.copy()
-              
+
         ############ Ensure correct baseline order
-        # TODO can these be faster? 
-        t1nums = np.fromiter([self.tkey[t] for t in dat['t1']],int) 
-        t2nums = np.fromiter([self.tkey[t] for t in dat['t2']],int) 
-        
+        # TODO can these be faster?
+        t1nums = np.fromiter([self.tkey[t] for t in dat['t1']],int)
+        t2nums = np.fromiter([self.tkey[t] for t in dat['t2']],int)
+
         # which entries are in the wrong telescope order?
         ordermask = t2nums < t1nums
-        
+
         # flip the order of these entries
         t1 = dat['t1'].copy()
         t2 = dat['t2'].copy()
         tau1 = dat['tau1'].copy()
-        tau2 = dat['tau2'].copy()     
-          
+        tau2 = dat['tau2'].copy()
+
         dat['t1'][ordermask] = t2[ordermask]
         dat['t2'][ordermask] = t1[ordermask]
         dat['tau1'][ordermask] = tau2[ordermask]
         dat['tau2'][ordermask] = tau1[ordermask]
         dat['u'][ordermask] *= -1
         dat['v'][ordermask] *= -1
-                    
+
         if self.polrep=='stokes':
             dat['vis'][ordermask]  = np.conj(dat['vis'][ordermask])
             dat['qvis'][ordermask] = np.conj(dat['qvis'][ordermask])
             dat['uvis'][ordermask] = np.conj(dat['uvis'][ordermask])
-            dat['vvis'][ordermask] = np.conj(dat['vvis'][ordermask])                         
+            dat['vvis'][ordermask] = np.conj(dat['vvis'][ordermask])
 
         elif self.polrep == 'circ':
             dat['rrvis'][ordermask] = np.conj(dat['rrvis'][ordermask])
@@ -450,10 +446,10 @@ class Obsdata(object):
 
         # Remove duplicate or conjugate entries at any timestep
         # Since telescope order has been sorted conjugates should appear as duplicates
-        timeblcombos = np.vstack((dat['time'],t1nums,t2nums)).T        
+        timeblcombos = np.vstack((dat['time'],t1nums,t2nums)).T
         uniqdat, uniqdatinv = np.unique(timeblcombos,axis=0, return_inverse=True)
-        
-        if len(uniqdat) != len(dat): 
+
+        if len(uniqdat) != len(dat):
             print("WARNING: removing duplicate/conjuagte points in reorder_baselines!")
             deletemask = np.ones(len(dat)).astype(bool)
 
@@ -461,10 +457,10 @@ class Obsdata(object):
                 idxs = np.argwhere(uniqdatinv==j)[:,0]
                 for idx in idxs[1:]: # delete all but first occurance
                     deletemask[idx] = False
-            
-            # remove duplicates   
-            dat_unique = dat[deletemask]                 
-                  
+
+            # remove duplicates
+            dat_unique = dat[deletemask]
+
         # sort data
         dat = dat[np.argsort(dat, order=['time', 't1'])]
 
@@ -549,7 +545,7 @@ class Obsdata(object):
                     elif f == 'lrvis':
                         data[f] = np.hstack((self.data['lrvis'], np.conj(self.data['rlvis'])))
 
-                    # ALSO SWITCH THE ERRORS!                    
+                    # ALSO SWITCH THE ERRORS!
                 else:
                     raise Exception("polrep must be either 'stokes' or 'circ'")
             # The conjugate baselines need the transpose error terms.
@@ -596,7 +592,7 @@ class Obsdata(object):
                 datalist.append(np.array([obs for obs in group]))
         else:
             # Group measurements by scan
-            if ((self.scans is None) or 
+            if ((self.scans is None) or
                  np.any([scan is None for scan in self.scans]) or
                  len(self.scans) == 0):
                 print("No scan table in observation. Adding scan table before gathering...")
@@ -657,8 +653,8 @@ class Obsdata(object):
         for s, s_obs in enumerate(splitObs):
             dt = abs(s_obs.tstart - time)
             if dt < delta_t:
-                delta_t = dt 
-                closest_index = s 
+                delta_t = dt
+                closest_index = s
 
         print(f"Using scan with time {splitObs[closest_index].tstart}.")
         return splitObs[closest_index]
@@ -686,7 +682,7 @@ class Obsdata(object):
             datalist.append(np.array([obs for obs in group]))
 
         return np.array(datalist, dtype=object)
-        
+
     def unpack_bl(self, site1, site2, fields, ang_unit='deg', debias=False, timetype=False):
         """Unpack the data over time on the selected baseline site1-site2.
 
@@ -727,9 +723,9 @@ class Obsdata(object):
                                           debias=debias, timetype=timetype)
 
                     allout.append(out)
-        
+
         return np.array(allout)
-        
+
     def unpack(self, fields, mode='all', ang_unit='deg', debias=False, conj=False, timetype=False):
         """Unpack the data for the whole observation .
 
@@ -959,7 +955,7 @@ class Obsdata(object):
                                   + np.abs(data['llsigma'] * data['rrvis'] / data['llvis'])**2)
 
             else:
-                raise Exception("%s is not a valid field \n" % field +
+                raise Exception(f"{field} is not a valid field \n" +
                                 "valid field values are: " + ' '.join(ehc.FIELDS))
 
             if field in ["time_utc"] and self.timetype == 'GMST':
@@ -1087,7 +1083,7 @@ class Obsdata(object):
         """
         if dtype not in ['vis', 'bs', 'amp', 'cphase',
                          'cphase_diag', 'camp', 'logcamp', 'logcamp_diag', 'm']:
-            raise Exception("%s is not a supported dterms!" % dtype)
+            raise Exception(f"{dtype} is not a supported dterms!")
 
         # TODO -- should import this at top, but the circular dependencies create a mess...
         import ehtim.imaging.imager_utils as iu
@@ -1125,7 +1121,7 @@ class Obsdata(object):
             chisq = np.sum(np.array(num_list) * np.array(chisq_list)) / np.sum(num_list)
 
         # Model -- single chi^2
-        elif hasattr(im_or_mov,'N_models'):            
+        elif hasattr(im_or_mov,'N_models'):
             (data, sigma, uv, jonesdict) = mu.chisqdata(self, dtype, pol, **kwargs)
             chisq = mu.chisq(im_or_mov, uv, data, sigma, dtype, jonesdict)
 
@@ -1188,8 +1184,8 @@ class Obsdata(object):
 
         ivec = imstokes.imvec
         rhovec = np.sqrt(imstokes.qvec**2 + imstokes.uvec**2 + imstokes.vvec**2) / ivec
-        phivec = np.angle(imstokes.qvec + 1j * imstokes.uvec) 
-        psivec = np.arcsin(vvec/ivec)
+        phivec = np.angle(imstokes.qvec + 1j * imstokes.uvec)
+        psivec = np.arcsin(imstokes.vvec/ivec)
         if len(mask) > 0 and np.any(np.invert(mask)):
             ivec = ivec[mask]
             rhovec = rhovec[mask]
@@ -1217,8 +1213,7 @@ class Obsdata(object):
         site1 = self.data['t1']
         site2 = self.data['t2']
         arr = ehtim.array.Array(self.tarr)
-        print("Recomputing U,V Points using MJD %d \n RA %e \n DEC %e \n RF %e GHz"
-              % (self.mjd, self.ra, self.dec, self.rf / 1.e9))
+        print(f"Recomputing U,V Points using MJD {self.mjd:d} \n RA {self.ra:e} \n DEC {self.dec:e} \n RF {self.rf / 1.e9:e} GHz")
 
         (timesout, uout, vout) = obsh.compute_uv_coordinates(arr, site1, site2, times,
                                                              self.mjd, self.ra, self.dec, self.rf,
@@ -1706,7 +1701,7 @@ class Obsdata(object):
             for cphase in scan:
                 all_triangles.append((cphase[1], cphase[2], cphase[3]))
         std_list = []
-        print("Estimating noise rescaling factor from %d triangles...\n" % len(set(all_triangles)))
+        print(f"Estimating noise rescaling factor from {len(set(all_triangles))} triangles...\n")
 
         # Now determine the differences of adjacent samples on each triangle,
         # relative to the expected thermal noise
@@ -1714,8 +1709,7 @@ class Obsdata(object):
         for tri in set(all_triangles):
             i_count = i_count + 1
             if print_std:
-                sys.stdout.write('\rGetting noise for triangles %i/%i ' %
-                                 (i_count, len(set(all_triangles))))
+                sys.stdout.write(f'\rGetting noise for triangles {i_count}/{len(set(all_triangles))} ')
                 sys.stdout.flush()
             all_tri = np.array([[]])
             for scan in c_phases:
@@ -1730,8 +1724,7 @@ class Obsdata(object):
             # See whether the triangle has sufficient SNR
             if np.median(np.abs(all_tri[:, 1] / all_tri[:, 2])) < median_snr_cut:
                 if print_std:
-                    print(tri, 'median snr too low (%6.4f)' %
-                          np.median(np.abs(all_tri[:, 1] / all_tri[:, 2])))
+                    print(tri, f'median snr too low ({np.median(np.abs(all_tri[:, 1] / all_tri[:, 2])):6.4f})')
                 continue
 
             # Now go through and find studentized differences of adjacent points
@@ -1747,11 +1740,10 @@ class Obsdata(object):
             if len(s_list) > min_num:
                 std_list.append(np.std(s_list))
                 if print_std:
-                    print(tri, '%6.4f [%d differences]' % (np.std(s_list), len(s_list)))
+                    print(tri, f'{np.std(s_list):6.4f} [{len(s_list)} differences]')
             else:
                 if print_std and len(all_tri) > 0:
-                    print(tri, '%d cphases found [%d differences < min_num = %d]' %
-                          (len(all_tri), len(s_list), min_num))
+                    print(tri, f'{len(all_tri)} cphases found [{len(s_list)} differences < min_num = {min_num}]')
 
         if len(std_list) == 0:
             print("No suitable closure phase differences! Try using a larger max_diff_sec.")
@@ -1782,7 +1774,7 @@ class Obsdata(object):
 
         datatable_kept = datatable_kept[mask]
         datatable_flagged = datatable_flagged[np.invert(mask)]
-        print('Flagged %d/%d visibilities' % (len(datatable_flagged), len(self.data)))
+        print(f'Flagged {len(datatable_flagged)}/{len(self.data)} visibilities')
 
         obs_kept = self.copy()
         obs_flagged = self.copy()
@@ -1815,7 +1807,7 @@ class Obsdata(object):
 
         datatable_kept = datatable_kept[mask]
         datatable_flagged = datatable_flagged[np.invert(mask)]
-        print('Flagged %d/%d visibilities' % (len(datatable_flagged), len(self.data)))
+        print(f'Flagged {len(datatable_flagged)}/{len(self.data)} visibilities')
 
         obs_kept = self.copy()
         obs_flagged = self.copy()
@@ -1848,7 +1840,7 @@ class Obsdata(object):
 
         datatable_kept = datatable_kept[mask]
         datatable_flagged = datatable_flagged[np.invert(mask)]
-        print('U-V flagged %d/%d visibilities' % (len(datatable_flagged), len(self.data)))
+        print(f'U-V flagged {len(datatable_flagged)}/{len(self.data)} visibilities')
 
         obs_kept = self.copy()
         obs_flagged = self.copy()
@@ -1885,7 +1877,7 @@ class Obsdata(object):
 
         datatable_kept = datatable_kept[mask]
         datatable_flagged = datatable_flagged[np.invert(mask)]
-        print('Flagged %d/%d visibilities' % (len(datatable_flagged), len(self.data)))
+        print(f'Flagged {len(datatable_flagged)}/{len(self.data)} visibilities')
 
         obs_kept = self.copy()
         obs_flagged = self.copy()
@@ -1922,7 +1914,7 @@ class Obsdata(object):
 
         datatable_kept = datatable_kept[mask]
         datatable_flagged = datatable_flagged[np.invert(mask)]
-        print('Flagged %d/%d visibilities' % (len(datatable_flagged), len(self.data)))
+        print(f'Flagged {len(datatable_flagged)}/{len(self.data)} visibilities')
 
         obs_kept = self.copy()
         obs_flagged = self.copy()
@@ -1954,7 +1946,7 @@ class Obsdata(object):
 
         datatable_kept = datatable_kept[mask]
         datatable_flagged = datatable_flagged[np.invert(mask)]
-        print('snr flagged %d/%d visibilities' % (len(datatable_flagged), len(self.data)))
+        print(f'snr flagged {len(datatable_flagged)}/{len(self.data)} visibilities')
 
         obs_kept = self.copy()
         obs_flagged = self.copy()
@@ -1987,7 +1979,7 @@ class Obsdata(object):
 
         datatable_kept = datatable_kept[mask]
         datatable_flagged = datatable_flagged[np.invert(mask)]
-        print('sigma flagged %d/%d visibilities' % (len(datatable_flagged), len(self.data)))
+        print(f'sigma flagged {len(datatable_flagged)}/{len(self.data)} visibilities')
 
         obs_kept = self.copy()
         obs_flagged = self.copy()
@@ -2042,7 +2034,7 @@ class Obsdata(object):
 
         datatable_kept = datatable_kept[mask]
         datatable_flagged = datatable_flagged[np.invert(mask)]
-        print('time flagged %d/%d visibilities' % (len(datatable_flagged), len(self.data)))
+        print(f'time flagged {len(datatable_flagged)}/{len(self.data)} visibilities')
 
         obs_kept = self.copy()
         obs_flagged = self.copy()
@@ -2129,8 +2121,7 @@ class Obsdata(object):
 
         datatable_kept = datatable_kept[mask]
         datatable_flagged = datatable_flagged[np.invert(mask)]
-        print('anomalous %s flagged %d/%d visibilities' %
-              (field, len(datatable_flagged), len(self.data)))
+        print(f'anomalous {field} flagged {len(datatable_flagged)}/{len(self.data)} visibilities')
 
         # Make new observations with all data first to avoid problems with empty arrays
         obs_kept = self.copy()
@@ -2209,8 +2200,7 @@ class Obsdata(object):
                 zip(df_filtered.scan_id, df_filtered.datetime))))]
 
             remaining_points = np.shape(df_filtered2)[0]
-            print('Flagged out {} of {} datapoints'.format(
-                tot_points - remaining_points, tot_points))
+            print(f'Flagged out {tot_points - remaining_points} of {tot_points} datapoints')
             if return_type == 'rec':
                 out_vis = ehdf.df_to_rec(df_filtered2, 'vis')
 
@@ -2617,7 +2607,7 @@ class Obsdata(object):
                     continue
                 bi.dtype.names = cpnames
                 bi['sigmacp'] = np.real(bi['sigmacp'] / np.abs(bi['cphase']) / angle)
-                bi['cphase'] = np.real((np.angle(bi['cphase']) / angle))
+                bi['cphase'] = np.real(np.angle(bi['cphase']) / angle)
                 cps.append(bi.astype(np.dtype(ehc.DTCPHASE)))
 
             if mode == 'time' and len(cps) > 0:
@@ -2707,8 +2697,7 @@ class Obsdata(object):
         # loop over the timestamps
         for kk, t in enumerate(T_cps):
 
-            sys.stdout.write('\rDiagonalizing closure phases:: type %s, count %s, scan %i/%i ' %
-                             (vtype, count, kk + 1, len(T_cps)))
+            sys.stdout.write(f'\rDiagonalizing closure phases:: type {vtype}, count {count}, scan {kk + 1}/{len(T_cps)} ')
             sys.stdout.flush()
 
             # index masks for this timestamp
@@ -2807,7 +2796,7 @@ class Obsdata(object):
             timetype = self.timetype
 
         if method=='from_maxset' and (vtype in ['lrvis','pvis','rlvis']):
-            print ("Warning! method='from_maxset' default in bispectra_tri() inconsistent with vtype=%s" % vtype)
+            print (f"Warning! method='from_maxset' default in bispectra_tri() inconsistent with vtype={vtype}")
             print ("Switching to method='from_vis'")
             method = 'from_vis'
 
@@ -2944,7 +2933,7 @@ class Obsdata(object):
                                          l1['u'], l1['v'],
                                          l2['u'], l2['v'],
                                          l3['u'], l3['v'],
-                                         bi, 
+                                         bi,
                                          bisig),
                                dtype=ehc.DTBIS))
         else:
@@ -2980,7 +2969,7 @@ class Obsdata(object):
             timetype = self.timetype
 
         if method=='from_maxset' and (vtype in ['lrvis','pvis','rlvis']):
-            print ("Warning! method='from_maxset' default in cphase_tri() is inconsistent with vtype=%s" % vtype)
+            print (f"Warning! method='from_maxset' default in cphase_tri() is inconsistent with vtype={vtype}")
             print ("Switching to method='from_vis'")
             method = 'from_vis'
 
@@ -3082,8 +3071,10 @@ class Obsdata(object):
         # get selected closure phases from the visibilities directly
         # taken from bispectra() method
         elif method=='from_vis':
-            if ang_unit == 'deg': angle = ehc.DEGREE
-            else: angle = 1.0
+            if ang_unit == 'deg':
+                angle = ehc.DEGREE
+            else:
+                angle = 1.0
 
             # get all equal-time data, and loop  over to construct closure phase
             tlist = self.tlist(conj=True)
@@ -3159,7 +3150,7 @@ class Obsdata(object):
         if vtype not in ('vis', 'qvis', 'uvis', 'vvis', 'rrvis', 'lrvis', 'rlvis', 'llvis'):
             raise Exception("possible options for vtype are " +
                             "'vis', 'qvis', 'uvis','vvis','rrvis','lrvis','rlvis','llvis'")
-        if not (ctype in ['camp', 'logcamp']):
+        if ctype not in ['camp', 'logcamp']:
             raise Exception("closure amplitude type must be 'camp' or 'logcamp'!")
         if timetype not in ['GMST', 'UTC', 'gmst', 'utc']:
             raise Exception("timetype should be 'GMST' or 'UTC'!")
@@ -3329,8 +3320,7 @@ class Obsdata(object):
         # loop over the timestamps
         for kk, t in enumerate(T_lcas):
 
-            printstr = ('\rDiagonalizing log closure amplitudes:: type %s, count %s, scan %i/%i ' %
-                        (vtype, count, kk + 1, len(T_lcas)))
+            printstr = f'\rDiagonalizing log closure amplitudes:: type {vtype}, count {count}, scan {kk + 1}/{len(T_lcas)} '
             sys.stdout.write(printstr)
             sys.stdout.flush()
 
@@ -3437,7 +3427,7 @@ class Obsdata(object):
 
 
         if method=='from_maxset' and (vtype in ['lrvis','pvis','rlvis']):
-            print ("Warning! method='from_maxset' default in camp_quad() is inconsistent with vtype=%s" % vtype)
+            print (f"Warning! method='from_maxset' default in camp_quad() is inconsistent with vtype={vtype}")
             print ("Switching to method='from_vis'")
             method = 'from_vis'
 
@@ -3670,9 +3660,9 @@ class Obsdata(object):
                timetype (str): 'GMST' or 'UTC'
 
                axis (matplotlib.axes.Axes): add plot to this axis
-               xscale (str): 'linear' or 'log' y-axis scale               
+               xscale (str): 'linear' or 'log' y-axis scale
                yscale (str): 'linear' or 'log' y-axis scale
-               
+
                rangex (list): [xmin, xmax] x-axis limits
                rangey (list): [ymin, ymax] y-axis limits
 
@@ -3825,7 +3815,7 @@ class Obsdata(object):
             tolerance = len(data[field2])
 
             if label is None:
-                labelstr = "%s-%s" % ((str(bl[0]), str(bl[1])))
+                labelstr = f"{str(bl[0])}-{str(bl[1])}"
 
             else:
                 labelstr = str(label)
@@ -3840,7 +3830,7 @@ class Obsdata(object):
         # axis scales
         x.set_xscale(xscale)
         x.set_yscale(yscale)
-        
+
         # Data ranges
         if not rangex:
             rangex = [np.min(xmins) - 0.2 * np.abs(np.min(xmins)),
@@ -4001,7 +3991,7 @@ class Obsdata(object):
                 x.set_ylabel(ehc.FIELD_LABELS[field])
             except KeyError:
                 x.set_ylabel(field.capitalize())
-            x.set_title('%s - %s' % (site1, site2))
+            x.set_title(f'{site1} - {site2}')
 
         if grid:
             x.grid()
@@ -4080,7 +4070,7 @@ class Obsdata(object):
         plotdata = plotdata[~nan_mask]
 
         if len(plotdata) == 0:
-            print("%s %s %s : No closure phases on this triangle!" % (site1, site2, site3))
+            print(f"{site1} {site2} {site3} : No closure phases on this triangle!")
             return
 
         # Plot the data
@@ -4121,7 +4111,7 @@ class Obsdata(object):
             else:
                 x.set_ylabel(r'Closure Phase (radian)')
 
-        x.set_title('%s - %s - %s' % (site1, site2, site3))
+        x.set_title(f'{site1} - {site2} - {site3}')
 
         if grid:
             x.grid()
@@ -4251,8 +4241,7 @@ class Obsdata(object):
                 x.set_ylabel('Closure Amplitude')
             elif ctype == 'logcamp':
                 x.set_ylabel('Log Closure Amplitude')
-            x.set_title('(%s - %s)(%s - %s)/(%s - %s)(%s - %s)' % (site1, site2, site3, site4,
-                                                                   site1, site4, site2, site3))
+            x.set_title(f'({site1} - {site2})({site3} - {site4})/({site1} - {site4})({site2} - {site3})')
         if grid:
             x.grid()
         if legend:
@@ -4424,7 +4413,7 @@ def load_uvfits(fname, flipbl=False, remove_nan=False, force_singlepol=None,
            channel (list): list of channels to average in the import. channel=all averages all
            IF (list): list of IFs to  average in  the import. IF=all averages all IFS
            remove_nan (bool): whether or not to remove entries with nan data
-           ignore_pzero_date (bool): if True, ignore the offset parameters in DATE field 
+           ignore_pzero_date (bool): if True, ignore the offset parameters in DATE field
                                      TODO: what is the correct behavior per AIPS memo 117?
            trial_speedups (bool): if True, use faster array/telescope handling paths
            invvar_channel_avg (bool): if True, average IFs/channels with inverse-variance
@@ -4468,23 +4457,23 @@ def load_maps(arrfile, obsspec, ifile, qfile=0, ufile=0, vfile=0,
                                        src=src, mjd=mjd, ampcal=ampcal, phasecal=phasecal)
 
 def load_obs(
-                fname,                  
-                polrep='stokes',        
-                flipbl=False,               
-                remove_nan=False, 
-                force_singlepol=None, 
-                channel=all, 
-                IF=all, 
+                fname,
+                polrep='stokes',
+                flipbl=False,
+                remove_nan=False,
+                force_singlepol=None,
+                channel=all,
+                IF=all,
                 allow_singlepol=True,
                 flux=1.0,
-                obsspec=None, 
-                ifile=None, 
-                qfile=None, 
-                ufile=None, 
+                obsspec=None,
+                ifile=None,
+                qfile=None,
+                ufile=None,
                 vfile=None,
-                src=ehc.SOURCE_DEFAULT, 
-                mjd=ehc.MJD_DEFAULT, 
-                ampcal=False, 
+                src=ehc.SOURCE_DEFAULT,
+                mjd=ehc.MJD_DEFAULT,
+                ampcal=False,
                 phasecal=False
     ):
     """Smart obs read-in, detects file type and loads appropriately.
@@ -4528,10 +4517,10 @@ def load_obs(
     else:
         if obsspec is not None and ifile is None:
             print("You have provided a value for <obsspec> but no value for <ifile>")
-            return 
+            return
         elif obsspec is None and ifile is not None:
             print("You have provided a value for <ifile> but no value for <obsspec>")
-            return 
+            return
 
         elif obsspec is not None and ifile is not None:
             return load_maps(fname, obsspec, ifile, qfile=qfile, ufile=ufile, vfile=vfile,

--- a/ehtim/plotting/comp_plots.py
+++ b/ehtim/plotting/comp_plots.py
@@ -16,21 +16,16 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
+import copy
+import itertools as it
 
+import matplotlib.pyplot as plt
 import numpy as np
 import numpy.matlib as matlib
-import matplotlib.pyplot as plt
-import itertools as it
-import copy
 
-from ehtim.obsdata import merge_obs
 import ehtim.const_def as ehc
+from ehtim.obsdata import merge_obs
 
 COLORLIST = ehc.SCOLORS
 
@@ -725,14 +720,13 @@ def plotall_obs_im_cphases(obs, imlist,
     nplot = 0
     for c in range(0, len(uniqueclosure_tri)):
         cphases_obs_tri = obs.cphase_tri(uniqueclosure_tri[c][0],
-                                         uniqueclosure_tri[cs][1],
+                                         uniqueclosure_tri[c][1],
                                          uniqueclosure_tri[c][2],
                                          vtype=vtype, ang_unit='deg', cphases=cphases_obs)
 
         if len(cphases_obs_tri) > 0:
             if print_chisqs:
-                printstr = "%s %s %s :" % (
-                    uniqueclosure_tri[c][0], uniqueclosure_tri[c][1], uniqueclosure_tri[c][2])
+                printstr = f"{uniqueclosure_tri[c][0]} {uniqueclosure_tri[c][1]} {uniqueclosure_tri[c][2]} :"
                 for i in range(1, len(obs_all)):
                     cphases_model_tri = obs_all[i].cphase_tri(uniqueclosure_tri[c][0],
                                                               uniqueclosure_tri[c][1],
@@ -743,7 +737,7 @@ def plotall_obs_im_cphases(obs, imlist,
                     chisq_tri = np.sum((1.0 - np.cos(resids)) /
                                        ((cphases_obs_tri['sigmacp']*ehc.DEGREE)**2))
                     chisq_tri *= (2.0/len(cphases_obs_tri))
-                    printstr += " chisq%i: %0.2f" % (i, chisq_tri)
+                    printstr += f" chisq{i}: {chisq_tri:0.2f}"
                 print(printstr)
 
             if display_mode == 'individual':
@@ -795,7 +789,7 @@ def prep_plot_lists(obslist, imlist, clist=ehc.SCOLORS, legendlabels=None,
     if not((len(imlist) == len(obslist)) or len(imlist) <= 1 or len(obslist) <= 1):
         raise Exception("imlist and obslist must be the same length, or either must have length 1")
 
-    if not (legendlabels is None) and (len(legendlabels) != max(len(imlist), len(obslist))):
+    if legendlabels is not None and (len(legendlabels) != max(len(imlist), len(obslist))):
         raise Exception("legendlabels should be the same length of the longer of imlist, obslist!")
 
     if legendlabels is None:

--- a/ehtim/plotting/comp_plots.py
+++ b/ehtim/plotting/comp_plots.py
@@ -174,7 +174,7 @@ def plot_bl_compare(obslist, imlist, site1, site2, field,
 
 
 def plot_cphase_compare(obslist, imlist, site1, site2, site3,
-                        vtype='vis', cphases=[], force_recompute=False,
+                        vtype='vis', cphases=[],
                         ang_unit='deg', timetype='UTC', ttype='nfft',
                         axis=False, rangex=False, rangey=False, snrcut=0.,
                         clist=COLORLIST, legendlabels=None, markersize=ehc.MARKERSIZE,
@@ -191,7 +191,6 @@ def plot_cphase_compare(obslist, imlist, site1, site2, site3,
 
            vtype (str): The visibilty type ('vis','qvis','uvis','vvis','pvis')
            cphases (list): optionally pass in a list of cphases so they don't have to be recomputed
-           force_recompute (bool): if True, recompute closure phases instead of using stored data
 
            ang_unit (str): phase unit 'deg' or 'rad'
            timetype (str): 'GMST' or 'UTC'
@@ -226,28 +225,19 @@ def plot_cphase_compare(obslist, imlist, site1, site2, site3,
     if len(cphases) != len(obslist):
         raise Exception("cphases list must be same length as obslist!")
 
-    cphases_back = []
-    for i in range(len(obslist)):
-        cphases_back.append(obslist[i].cphase)
-        obslist[i].cphase = cphases[i]
-
     prepdata = prep_plot_lists(obslist, imlist, clist=clist, legendlabels=legendlabels,
                                sgrscat=False, ttype=ttype)
     (obslist_plot, clist_plot, legendlabels_plot, markers) = prepdata
     for i in range(len(obslist_plot)):
         obs = obslist_plot[i]
         axis = obs.plot_cphase(site1, site2, site3,
-                               vtype=vtype, force_recompute=force_recompute,
+                               vtype=vtype, cphases=cphases[i],
                                ang_unit=ang_unit, timetype=timetype,
                                axis=axis, rangex=rangex, rangey=rangey,
                                grid=grid, ebar=ebar, axislabels=axislabels,
                                show=False, legend=False, snrcut=snrcut,
                                label=legendlabels_plot[i], color=clist_plot[i % len(clist_plot)],
                                marker=markers[i], markersize=markersize)
-
-    # return to original cphase attribute
-    for i in range(len(obslist)):
-        obslist[i].cphase = cphases_back[i]
 
     if legend:
         plt.legend()
@@ -263,7 +253,7 @@ def plot_cphase_compare(obslist, imlist, site1, site2, site3,
 
 
 def plot_camp_compare(obslist, imlist, site1, site2, site3, site4,
-                      vtype='vis', ctype='camp', camps=[], force_recompute=False,
+                      vtype='vis', ctype='camp', camps=[],
                       debias=False, sgrscat=False, timetype='UTC', ttype='nfft',
                       axis=False, rangex=False, rangey=False, snrcut=0.,
                       clist=COLORLIST, legendlabels=None, markersize=ehc.MARKERSIZE,
@@ -282,7 +272,6 @@ def plot_camp_compare(obslist, imlist, site1, site2, site3, site4,
            vtype (str): The visibilty type ('vis','qvis','uvis','vvis','pvis')
            ctype (str): The closure amplitude type ('camp' or 'logcamp')
            camps (list): optionally pass in a list of camp so they don't have to be recomputed
-           force_recompute (bool): if True, recompute closure phases instead of using stored data
 
            debias (bool): If True, debias amplitudes.
            sgrscat (bool): if True, the visibilites will be blurred by the Sgr A* scattering kernel
@@ -320,15 +309,6 @@ def plot_camp_compare(obslist, imlist, site1, site2, site3, site4,
     if len(camps) != len(obslist):
         raise Exception("camps list must be same length as obslist!")
 
-    camps_back = []
-    for i in range(len(obslist)):
-        if ctype == 'camp':
-            camps_back.append(obslist[i].camp)
-            obslist[i].camp = camps[i]
-        elif ctype == 'logcamp':
-            camps_back.append(obslist[i].logcamp)
-            obslist[i].logcamp = camps[i]
-
     prepdata = prep_plot_lists(obslist, imlist, clist=clist, legendlabels=legendlabels,
                                sgrscat=sgrscat, ttype=ttype)
     (obslist_plot, clist_plot, legendlabels_plot, markers) = prepdata
@@ -336,19 +316,13 @@ def plot_camp_compare(obslist, imlist, site1, site2, site3, site4,
     for i in range(len(obslist_plot)):
         obs = obslist_plot[i]
         axis = obs.plot_camp(site1, site2, site3, site4,
-                             vtype=vtype, ctype=ctype, force_recompute=force_recompute,
+                             vtype=vtype, ctype=ctype, camps=camps[i],
                              debias=debias, timetype=timetype,
                              axis=axis, rangex=rangex, rangey=rangey,
                              grid=grid, ebar=ebar, axislabels=axislabels,
                              show=False, legend=False, snrcut=0.,
                              label=legendlabels_plot[i], color=clist_plot[i % len(clist_plot)],
                              marker=markers[i], markersize=markersize)
-
-    for i in range(len(obslist)):
-        if ctype == 'camp':
-            obslist[i].camp = camps_back[i]
-        elif ctype == 'logcamp':
-            obslist[i].logcamp = camps_back[i]
 
     if legend:
         plt.legend()
@@ -525,7 +499,6 @@ def plot_cphase_obs_compare(obslist,  site1, site2, site3, **kwargs):
 
            vtype (str): The visibilty type ('vis','qvis','uvis','vvis','pvis')
            cphases (list): optionally pass in a list of cphases so they don't have to be recomputed
-           force_recompute (bool): if True, recompute closure phases instead of using stored data
 
            ang_unit (str): phase unit 'deg' or 'rad'
            timetype (str): 'GMST' or 'UTC'
@@ -565,7 +538,6 @@ def plot_cphase_obs_im_compare(obslist, imlist, site1, site2, site3, **kwargs):
 
            vtype (str): The visibilty type ('vis','qvis','uvis','vvis','pvis')
            cphases (list): optionally pass in a list of cphases so they don't have to be recomputed
-           force_recompute (bool): if True, recompute closure phases instead of using stored data
 
            ang_unit (str): phase unit 'deg' or 'rad'
            timetype (str): 'GMST' or 'UTC'
@@ -606,7 +578,6 @@ def plot_camp_obs_compare(obslist,  site1, site2, site3, site4, **kwargs):
            vtype (str): The visibilty type ('vis','qvis','uvis','vvis','pvis')
            ctype (str): The closure amplitude type ('camp' or 'logcamp')
            camps (list): optionally pass in a list of camps so they don't have to be recomputed
-           force_recompute (bool): if True, recompute closure phases instead of using stored data
 
            debias (bool): If True, debias amplitudes.
            sgrscat (bool): if True, the visibilites will be blurred by the Sgr A* scattering kernel
@@ -650,7 +621,6 @@ def plot_camp_obs_im_compare(obslist,  imlist, site1, site2, site3, site4, **kwa
            vtype (str): The visibilty type ('vis','qvis','uvis','vvis','pvis')
            ctype (str): The closure amplitude type ('camp' or 'logcamp')
            camps (list): optionally pass in a list of camps so they don't have to be recomputed
-           force_recompute (bool): if True, recompute closure phases instead of using stored data
 
            debias (bool): If True, debias amplitudes.
            sgrscat (bool): if True, the visibilites will be blurred by the Sgr A* scattering kernel

--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -1,5 +1,6 @@
 # Michael Johnson, 2/15/2017
 # See http://adsabs.harvard.edu/abs/2016ApJ...833...74J for details about this module
+# TODO >> remove ruff exceptions in pyproject.toml after cleaning up this file
 
 from __future__ import print_function
 from builtins import range

--- a/examples/example_im_closure.py
+++ b/examples/example_im_closure.py
@@ -26,7 +26,7 @@ im.display()
 # bw_hz is the  bandwidth in Hz
 # sgrscat=True blurs the visibilities with the Sgr A* scattering kernel for the appropriate image frequency
 # ampcal and phasecal determine if gain variations and phase errors are included
-tint_sec = 5
+tint_sec = 30
 tadv_sec = 30
 tstart_hr = 0
 tstop_hr = 24
@@ -55,15 +55,7 @@ gaussprior = emptyprior.add_gauss(zbl, (prior_fwhm, prior_fwhm, 0, 0, 0))
 gaussprior = gaussprior.add_const_pol(.1, np.pi/3, 0, 1)
 gausspriorc = gaussprior.switch_polrep('circ')
 
-# Average the closure quantities and add them to the obsdata object
-avg_time = 600
-#obs.add_bispec(avg_time=avg_time)
-obs.add_amp(avg_time=avg_time)
-obs.add_cphase(avg_time=avg_time)
-obs.add_camp(avg_time=avg_time)
-obs.add_logcamp(avg_time=avg_time)
-
-# Image directly with these averaged data
+# Image directly with the unaveraged averaged data
 flux = zbl
 imgr  = eh.imager.Imager(obs, gaussprior, gaussprior, flux,
                           data_term={'amp':50, 'cphase':100},

--- a/examples/example_im_closure.py
+++ b/examples/example_im_closure.py
@@ -4,13 +4,11 @@
 # Note: must import ehtim outside the ehtim directory
 # either in parent eht-imaging directory or after installing with setuptools
 
-from __future__ import division
-from __future__ import print_function
 
-import matplotlib.pyplot as plt
 import numpy as np
+
 import ehtim as eh
-from   ehtim.calibrating import self_cal as sc
+
 #from  ehtim.plotting import self_cal as sc
 
 # Load the image and the array

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,10 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["F841"]
+# modeling_utils.py + stochastic_optics.py have deferred cleanup (see CLAUDE.md);
+# silence legacy-style noise until the dedicated cleanup PR.
+"ehtim/modeling/modeling_utils.py" = ["E701", "E721", "E722", "F403", "F405", "UP031"]
+"ehtim/scattering/stochastic_optics.py" = ["E701", "E721", "E722", "F403", "F405", "UP031"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["ehtim"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["F841"]
-# modeling_utils.py + stochastic_optics.py have deferred cleanup (see CLAUDE.md);
+# modeling_utils.py + stochastic_optics.py have deferred cleanup
 # silence legacy-style noise until the dedicated cleanup PR.
 "ehtim/modeling/modeling_utils.py" = ["E701", "E721", "E722", "F403", "F405", "UP031"]
 "ehtim/scattering/stochastic_optics.py" = ["E701", "E721", "E722", "F403", "F405", "UP031"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,6 +120,15 @@ def obs_noisy(gauss_im, eht_array):
 
 
 @pytest.fixture(scope="session")
+def obs_pol_direct(gauss_im_pol, eht_array):
+    """Noise-free observation of the polarized Gaussian image using direct FT."""
+    return gauss_im_pol.observe(
+        eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
+        ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+    )
+
+
+@pytest.fixture(scope="session")
 def gauss_prior(gauss_im):
     """A blurred copy of the Gaussian image suitable for use as a prior."""
     return gauss_im.blur_circ(30 * eh.RADPERUAS)

--- a/tests/test_obsdata.py
+++ b/tests/test_obsdata.py
@@ -8,7 +8,6 @@ recomputes from scratch, so they must be deterministic.
 import numpy as np
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Closure-quantity idempotence (Phase 0)
 # ---------------------------------------------------------------------------

--- a/tests/test_obsdata.py
+++ b/tests/test_obsdata.py
@@ -1,0 +1,56 @@
+"""Tests for Obsdata methods.
+
+The first batch is Phase 0 of the obsdata cleanup: with the closure-table
+cache gone, every call to bispectra() / c_phases() / c_amplitudes() now
+recomputes from scratch, so they must be deterministic.
+"""
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Closure-quantity idempotence (Phase 0)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("vtype", ["vis", "qvis", "uvis", "vvis"])
+def test_bispectra_idempotent_stokes(obs_pol_direct, vtype):
+    a = obs_pol_direct.bispectra(mode="all", count="max", vtype=vtype)
+    b = obs_pol_direct.bispectra(mode="all", count="max", vtype=vtype)
+    assert a.dtype == b.dtype
+    assert len(a) == len(b)
+    for field in a.dtype.names:
+        np.testing.assert_array_equal(a[field], b[field], err_msg=f"field={field}")
+
+
+@pytest.mark.parametrize("vtype", ["rrvis", "llvis", "rlvis", "lrvis"])
+def test_bispectra_idempotent_circ(obs_pol_direct, vtype):
+    obs_circ = obs_pol_direct.switch_polrep("circ")
+    a = obs_circ.bispectra(mode="all", count="max", vtype=vtype)
+    b = obs_circ.bispectra(mode="all", count="max", vtype=vtype)
+    assert a.dtype == b.dtype
+    assert len(a) == len(b)
+    for field in a.dtype.names:
+        np.testing.assert_array_equal(a[field], b[field], err_msg=f"field={field}")
+
+
+@pytest.mark.parametrize("vtype", ["vis", "qvis", "uvis", "vvis"])
+def test_c_phases_idempotent(obs_pol_direct, vtype):
+    a = obs_pol_direct.c_phases(mode="all", count="max", vtype=vtype)
+    b = obs_pol_direct.c_phases(mode="all", count="max", vtype=vtype)
+    assert a.dtype == b.dtype
+    assert len(a) == len(b)
+    for field in a.dtype.names:
+        np.testing.assert_array_equal(a[field], b[field], err_msg=f"field={field}")
+
+
+@pytest.mark.parametrize("ctype", ["camp", "logcamp"])
+@pytest.mark.parametrize("vtype", ["vis", "qvis", "uvis", "vvis"])
+def test_c_amplitudes_idempotent(obs_pol_direct, vtype, ctype):
+    a = obs_pol_direct.c_amplitudes(mode="all", count="max", vtype=vtype, ctype=ctype)
+    b = obs_pol_direct.c_amplitudes(mode="all", count="max", vtype=vtype, ctype=ctype)
+    assert a.dtype == b.dtype
+    assert len(a) == len(b)
+    for field in a.dtype.names:
+        np.testing.assert_array_equal(a[field], b[field], err_msg=f"field={field}")

--- a/tests/test_obsdata.py
+++ b/tests/test_obsdata.py
@@ -53,3 +53,35 @@ def test_c_amplitudes_idempotent(obs_pol_direct, vtype, ctype):
     assert len(a) == len(b)
     for field in a.dtype.names:
         np.testing.assert_array_equal(a[field], b[field], err_msg=f"field={field}")
+
+@pytest.mark.parametrize("vtype", ["vis", "qvis", "uvis", "vvis"])
+def test_bispectra_tri_idempotent(obs_pol_direct, vtype):
+    sites = list(obs_pol_direct.tarr['site'][:3])
+    a = obs_pol_direct.bispectra_tri(*sites, vtype=vtype)
+    b = obs_pol_direct.bispectra_tri(*sites, vtype=vtype)
+    np.testing.assert_array_equal(a, b)
+
+@pytest.mark.parametrize("vtype", ["vis", "qvis", "uvis", "vvis"])
+def test_cphase_tri_idempotent(obs_pol_direct, vtype):
+    sites = list(obs_pol_direct.tarr['site'][:3])
+    a = obs_pol_direct.cphase_tri(*sites, vtype=vtype)
+    b = obs_pol_direct.cphase_tri(*sites, vtype=vtype)
+    np.testing.assert_array_equal(a, b)
+
+@pytest.mark.parametrize("ctype", ["camp", "logcamp"])
+@pytest.mark.parametrize("vtype", ["vis", "qvis", "uvis", "vvis"])
+def test_camp_quad_idempotent(obs_pol_direct, vtype):
+    sites = list(obs_pol_direct.tarr['site'][:4])
+    a = obs_pol_direct.camp_quad(*sites, vtype=vtype, ctype=ctype)
+    b = obs_pol_direct.camp_quad(*sites, vtype=vtype, ctype=ctype)
+    np.testing.assert_array_equal(a, b)
+
+def test_save_load_cphase_roundtrip(tmp_path, obs_pol_direct):
+    from ehtim.io.save import save_dtype_txt
+    from ehtim.io.load import load_dtype_txt
+    cph = obs_pol_direct.c_phases(mode='all', count='max', vtype='vis')
+    fname = str(tmp_path / "cph.txt")
+    save_dtype_txt(obs_pol_direct, fname, data=cph, dtype='cphase')
+    loaded = load_dtype_txt(fname, dtype='cphase')
+    assert loaded.dtype == cph.dtype
+    np.testing.assert_array_almost_equal(loaded['cphase'], cph['cphase'])

--- a/tests/test_obsdata.py
+++ b/tests/test_obsdata.py
@@ -70,7 +70,7 @@ def test_cphase_tri_idempotent(obs_pol_direct, vtype):
 
 @pytest.mark.parametrize("ctype", ["camp", "logcamp"])
 @pytest.mark.parametrize("vtype", ["vis", "qvis", "uvis", "vvis"])
-def test_camp_quad_idempotent(obs_pol_direct, vtype):
+def test_camp_quad_idempotent(obs_pol_direct, vtype, ctype):
     sites = list(obs_pol_direct.tarr['site'][:4])
     a = obs_pol_direct.camp_quad(*sites, vtype=vtype, ctype=ctype)
     b = obs_pol_direct.camp_quad(*sites, vtype=vtype, ctype=ctype)


### PR DESCRIPTION
Removes the cached closure-table state on `Obsdata` (`amp`, `bispec`, `cphase`, `cphase_diag`, `camp`, `logcamp`, `logcamp_diag`) and the machinery that kept it in sync. Part of [#212](https://github.com/achael/eht-imaging/issues/212).

## What changed

- **`obsdata.py`** — drop the 7 cache slots, 8 `add_*` methods, and `force_recompute` kwargs from `bispectra_tri` / `cphase_tri` / `camp_quad` / `plot_cphase` / `plot_camp` (only existed to bypass the cache).
- **`imager_utils.py` + `modeling_utils.py` `chisqdata_*`** — all 15 amp/bs/cphase/camp/logcamp variants (DFT/FFT/NFFT) had an `if Obsdata.<table> is None: compute else: use cached` branch. Collapses to the unconditional compute path.
- **`applycal` / `self_cal`** — drop `copy_closure_tables`.
- **`comp_plots.py`** — `plot_cphase_compare` / `plot_camp_compare` used to monkey-patch `obs.cphase` / `obs.camp`. Now pass closure data through the existing `Obsdata.plot_cphase` / `plot_camp` kwargs.
- **`image.py:pad_image_to_imageobs`** — inline `obs.unpack(['amp','sigma'], debias=...)` instead of the `add_amp()` side-effect pattern.
- **`io/save.py`, `io/load.py`** — `save_dtype_txt(obs, fname, data, dtype=...)` and `load_dtype_txt(filename, dtype=...) -> np.recarray`. Data flows explicitly instead of via the cache.
- **`examples/example_im_closure.py`** — drop the four pre-imaging `obs.add_*` calls (dead weight now).
- **`tests/test_obsdata.py`** (new) — idempotence on `bispectra()` / `c_phases()` / `c_amplitudes()` across all standard `vtype`s and both `ctype`s. New `obs_pol_direct` conftest fixture.


## Design decisions to flag

1. `save_dtype_txt(obs, fname, data, dtype=...)` is the only user-visible API break — `data` is now a required positional. Old form pulled `obs.<table>` implicitly.
2. `load_dtype_txt` returns the recarray instead of writing it back to `obs.<table>`.
3. The eight `add_*` methods are removed outright (callers see `AttributeError`). Worth deprecation shims pointing at `obs.bispectra()` / `obs.c_phases()` / `obs.c_amplitudes()` / `obs.unpack(['amp','sigma'])` instead?