### PR TITLE
Fix three latent bugs in Obsdata

### DIFF
--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -20,7 +20,6 @@
 
 import copy
 import itertools as it
-import string
 import sys
 
 import matplotlib.pyplot as plt
@@ -453,7 +452,7 @@ class Obsdata:
             print("WARNING: removing duplicate/conjuagte points in reorder_baselines!")
             deletemask = np.ones(len(dat)).astype(bool)
 
-            for j in len(uniqdat):
+            for j in range(len(uniqdat)):
                 idxs = np.argwhere(uniqdatinv==j)[:,0]
                 for idx in idxs[1:]: # delete all but first occurance
                     deletemask[idx] = False
@@ -2317,7 +2316,7 @@ class Obsdata:
             ker = obsh.sgra_kernel_uv(self.rf, u[i], v[i])
             vis1[i] = vis1[i] / ker
             vis2[i] = vis2[i] / ker
-            vis2[i] = vis3[i] / ker
+            vis3[i] = vis3[i] / ker
             vis4[i] = vis4[i] / ker
             sigma1[i] = sigma1[i] / ker
             sigma2[i] = sigma2[i] / ker
@@ -3923,7 +3922,7 @@ class Obsdata:
 
         # Determine if fields are valid
         if field not in ehc.FIELDS:
-            raise Exception("valid fields are " + string.join(ehc.FIELDS))
+            raise Exception("valid fields are " + ' '.join(ehc.FIELDS))
 
         plotdata = self.unpack_bl(site1, site2, field, ang_unit=ang_unit,
                                   debias=debias, timetype=timetype)


### PR DESCRIPTION
Three independent one-line bugs in [ehtim/obsdata.py](ehtim/obsdata.py), found while doing a method-by-method read in preparation for the mixed-pol Phase 1 test coverage (next PR). 

- **`reorder_baselines_trial_speedups`** ([obsdata.py:469](ehtim/obsdata.py#L469)) — `for j in len(uniqdat):` iterates over an `int`, raising `TypeError`. Should be `range(len(uniqdat))`. The branch only runs when duplicate `(time, t1, t2)` rows exist
- **`deblur`** ([obsdata.py:2662](ehtim/obsdata.py#L2662)) — `vis2[i] = vis3[i] / ker` overwrites the second visibility slot with the (divided) third instead of dividing the third in place. The result is silent corruption of slot 3 (`uvis` on stokes, `rlvis` on circ) whenever anyone called `obs.deblur()`. Fixed to `vis3[i] = vis3[i] / ker`.
- **`plot_bl`** ([obsdata.py:4290](ehtim/obsdata.py#L4290)) — the invalid-field error path called `string.join(ehc.FIELDS)`, but `string` is not imported anywhere in the file (it's a Python 2 idiom).  Changed to `' '.join(ehc.FIELDS)`, matching the sibling code path in `plotall` ([obsdata.py:4052](ehtim/obsdata.py#L4052)).

## Test plan

- [x] Full pytest suite green: `688 passed, 91 skipped, 186 warnings` (no test changes; this is a regression check that the fixes don't break anything).
- [x] Andrew/Rohan: visual scan of the three lines — there's no behavioural test to add because none of these branches are reachable on a clean call path. Coverage for the surrounding methods (`reorder_baselines_trial_speedups`, `deblur`, `plot_bl`) lands in the follow-up `feature/obsdata-method-tests` PR.