### PR TITLE
Fix polchisq psi parametrization and gmst_to_utc inverse

### DIFF
--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -1196,8 +1196,8 @@ class Obsdata:
         ivec = imstokes.imvec
         rhovec = np.sqrt(imstokes.qvec**2 + imstokes.uvec**2 + imstokes.vvec**2) / ivec
         phivec = np.angle(imstokes.qvec + 1j * imstokes.uvec)
-        # V = I*rho*sin(psi) per pol_imager_utils.make_v_image, not V = I*sin(psi).
-        psivec = np.arcsin(imstokes.vvec / (ivec * rhovec))
+        psivec = np.where(rhovec > 0, np.arcsin(np.clip(imstokes.vvec / (ivec * rhovec), -1, 1)), 0.0)
+
         if len(mask) > 0 and np.any(np.invert(mask)):
             ivec = ivec[mask]
             rhovec = rhovec[mask]

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -234,6 +234,18 @@ class Obsdata:
         if timetype_out == 'UTC':
             out.data['time'] = obsh.gmst_to_utc(out.data['time'], out.mjd)
         if timetype_out == 'GMST':
+            # GMST values from astropy wrap into [0, 24), so any obs spanning
+            # longer than one sidereal day aliases here -- and the aliasing
+            # cannot be detected once we are already in GMST, so warn now.
+            span = float(out.data['time'].max() - out.data['time'].min())
+            if span > 23.9345:
+                warnings.warn(
+                    f"Obsdata spans {span:.3f} hours, more than one sidereal "
+                    "day (~23.9345 h); UTC->GMST conversion will alias and "
+                    "cannot be uniquely inverted. Split the obs by day before "
+                    "converting timetype.",
+                    stacklevel=2,
+                )
             out.data['time'] = obsh.utc_to_gmst(out.data['time'], out.mjd)
 
         out.timetype = timetype_out
@@ -1184,7 +1196,8 @@ class Obsdata:
         ivec = imstokes.imvec
         rhovec = np.sqrt(imstokes.qvec**2 + imstokes.uvec**2 + imstokes.vvec**2) / ivec
         phivec = np.angle(imstokes.qvec + 1j * imstokes.uvec)
-        psivec = np.arcsin(imstokes.vvec/ivec)
+        # V = I*rho*sin(psi) per pol_imager_utils.make_v_image, not V = I*sin(psi).
+        psivec = np.arcsin(imstokes.vvec / (ivec * rhovec))
         if len(mask) > 0 and np.any(np.invert(mask)):
             ivec = ivec[mask]
             rhovec = rhovec[mask]

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -974,13 +974,28 @@ def gmtstring(gmt):
 
 
 def gmst_to_utc(gmst, mjd):
-    """Convert gmst times in hours to utc hours using astropy
+    """Convert gmst times in hours to utc hours using astropy.
+
+    Inverse of :func:`utc_to_gmst` on the canonical solar day of ``mjd``:
+    returns UTC in [0, 24). The local sidereal rate is sampled directly
+    from astropy across that day (mean GMST is polynomial in UT, so
+    within a day it's linear to ~1e-14 hours -- no iteration needed).
+
+    Note: an obs that spans > ~23.93 solar hours aliases in GMST and
+    cannot be uniquely round-tripped through this inverse; callers
+    must keep their obs inside a single sidereal day.
     """
 
     mjd = int(mjd)
-    time_obj_ref = at.Time(mjd, format='mjd', scale='utc')
-    time_sidereal_ref = time_obj_ref.sidereal_time('mean', 'greenwich').hour
-    time_utc = (gmst - time_sidereal_ref) * 0.9972695601848
+    t0 = at.Time(mjd, format='mjd', scale='utc')
+    t1 = at.Time(mjd + 1, format='mjd', scale='utc')
+    s0 = t0.sidereal_time('mean', 'greenwich').hour
+    s1 = t1.sidereal_time('mean', 'greenwich').hour
+    # Sidereal hours elapsed in 24 solar hours (~24.0657)
+    sidereal_per_day = ((s1 - s0) % 24.0) + 24.0
+    # Wrap into [0, 24) sidereal so utc lands in [0, 24) of mjd
+    delta_sidereal = (gmst - s0) % 24.0
+    time_utc = delta_sidereal * 24.0 / sidereal_per_day
 
     return time_utc
 

--- a/tests/test_obsdata.py
+++ b/tests/test_obsdata.py
@@ -15,9 +15,8 @@ import pytest
 
 import ehtim as eh
 import ehtim.const_def as ehc
-
-from ehtim.io.save import save_dtype_txt
 from ehtim.io.load import load_dtype_txt
+from ehtim.io.save import save_dtype_txt
 
 # ---------------------------------------------------------------------------
 # Section 1: Construction & basic state (__init__, tarr setter, obsdata_args, copy)

--- a/tests/test_obsdata.py
+++ b/tests/test_obsdata.py
@@ -8,6 +8,8 @@ All tests use the session-scoped observation fixtures from conftest.py
 expensive `Image.observe` calls are amortised across the whole module.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -117,19 +119,38 @@ def test_switch_timetype_shifts_data_time(obs_direct):
     assert not np.allclose(out.data["time"], obs_direct.data["time"])
 
 
-@pytest.mark.xfail(
-    reason=(
-        "obs_helpers.gmst_to_utc uses a constant sidereal-rate approximation "
-        "while utc_to_gmst calls astropy per-sample, so the roundtrip drifts "
-        "by a few minutes over a 24h obs. See obs_helpers.py:976."
-    ),
-    strict=True,
-)
 def test_switch_timetype_roundtrip_utc_gmst(obs_direct):
     rt = obs_direct.switch_timetype("GMST").switch_timetype("UTC")
     diff = (rt.data["time"] - obs_direct.data["time"]) % 24.0
     diff = np.minimum(diff, 24.0 - diff)
     np.testing.assert_allclose(diff, 0.0, atol=1e-9)
+
+
+def test_switch_timetype_warns_on_multi_day_to_gmst(obs_direct):
+    """UTC->GMST on an obs spanning > 1 sidereal day must warn (aliases)."""
+    multi_day = obs_direct.copy()
+    # Stretch the obs to span ~30h by pushing later rows past 24h.
+    times = multi_day.data["time"].copy()
+    times[len(times) // 2:] += 12.0
+    multi_day.data["time"] = times
+    with pytest.warns(UserWarning, match="more than one sidereal day"):
+        multi_day.switch_timetype("GMST")
+
+
+def test_switch_timetype_no_warn_on_single_day(obs_direct):
+    """A normal <24h obs must not trigger the multi-day warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        obs_direct.switch_timetype("GMST")
+
+
+def test_switch_timetype_no_warn_on_gmst_to_utc(obs_direct):
+    """GMST->UTC has no informative span signal; must not warn even if
+    the underlying obs was originally multi-day."""
+    gmst_obs = obs_direct.switch_timetype("GMST")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        gmst_obs.switch_timetype("UTC")
 
 
 def test_switch_timetype_noop(obs_direct):
@@ -530,15 +551,6 @@ def test_polchisq_invalid_dtype_raises(obs_pol_direct, gauss_im_pol):
         obs_pol_direct.polchisq(gauss_im_pol, dtype="banana", ttype="direct")
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Obsdata.polchisq packs the (I, m, phi, psi) parametrization with "
-        "psi = arcsin(V/I), but pol_imager_utils.make_v_image defines "
-        "V = I*m*sin(psi), so psi should be arcsin(V/(I*m)). The mismatch "
-        "produces an O(1e-2) self-consistency residue. See obsdata.py:1187."
-    ),
-    strict=True,
-)
 def test_polchisq_self_consistency(obs_pol_direct, gauss_im_pol):
     chisq = obs_pol_direct.polchisq(gauss_im_pol, dtype="pvis", ttype="direct")
     assert chisq == pytest.approx(0.0, abs=1e-6)
@@ -1102,3 +1114,5 @@ def test_save_load_cphase_roundtrip(tmp_path, obs_pol_direct):
     loaded = load_dtype_txt(fname, dtype='cphase')
     assert loaded.dtype == cph.dtype
     np.testing.assert_array_almost_equal(loaded['cphase'], cph['cphase'])
+
+


### PR DESCRIPTION
## Summary

Two latent bugs in `obsdata.py` + `obs_helpers.py`, plus an explicit warning for the multi-day aliasing limit. The two `xfail(strict=True)` regression tests landed via #249/#250 are now passing and have had their decorators dropped.

### Bug 1 — `Obsdata.polchisq` psi parametrization

`obsdata.py:1188` packed `psi = arcsin(V/I)`, but `pol_imager_utils.make_v_image` defines `V = I*rho*sin(psi)`. The imager and the chisq disagreed on what `psi` meant, producing an O(1e-2) self-consistency residue when evaluated on the generating image. Fixed to `psi = arcsin(V/(I*rho))`.

### Bug 2 — `obs_helpers.gmst_to_utc` inverse

`obs_helpers.py:976` used a hardcoded constant solar/sidereal ratio (`0.99726956...`) for a linear inverse, while `utc_to_gmst` called astropy per-sample. The mismatched rate accumulated to several minutes over a 24h obs.

Replaced with astropy-derived local sidereal rate (sample at `mjd` and `mjd+1`), plus a `[0, 24)` wrap on the sidereal delta so UTC lands in the canonical solar day of `mjd`. Roundtrip is now ~1e-11 hr for any obs that fits in one sidereal day (~23.93 solar hours).

### Companion warning — multi-day aliasing

The `>23.93h` aliasing limit is fundamental: GMST mod 24 is many-to-one in solar UTC, and once data is in GMST the diagnostic signal is gone. Added a `UserWarning` in `Obsdata.switch_timetype` on the **UTC->GMST branch only** — the only direction where the unaliased span is still visible in the input. The inverse GMST->UTC has no signal to detect this, so no warning there.

## Test plan

- [x] `pytest tests/test_obsdata.py` → 169 passed, 1 skipped
- [x] `pytest tests/` (full suite, on prior unrebased commit) → 730 passed, 91 skipped
- [x] The two previously-`xfail(strict=True)` tests (`test_switch_timetype_roundtrip_utc_gmst`, `test_polchisq_self_consistency`) now pass; their decorators are removed.
- [x] Three new tests covering the multi-day warning (`test_switch_timetype_warns_on_multi_day_to_gmst`, `test_switch_timetype_no_warn_on_single_day`, `test_switch_timetype_no_warn_on_gmst_to_utc`).
- [x] Multi-day stress: verified `utc_to_gmst` handles negative / >24 / multi-day inputs; `gmst_to_utc` returns UTC in [0, 24) of `mjd` with <1e-9 hr roundtrip for any single-sidereal-day obs.