### PR TITLE
Add pandas-free ehtim.statistics.averaging + fix inverse-variance time-averaging

### DIFF
--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -1247,13 +1247,16 @@ class Obsdata:
 
         return out
 
-    def avg_coherent(self, inttime, scan_avg=False, moving=False):
+    def avg_coherent(self, inttime, scan_avg=False, moving=False, invvar_avg=True):
         """Coherently average data along u,v tracks in chunks of length inttime (sec)
 
            Args:
                 inttime (float): coherent integration time in seconds
                 scan_avg (bool): if True, average over scans in self.scans instead of intime
                 moving (bool): averaging with moving window (boxcar width in seconds)
+                invvar_avg (bool): if True (default), combine visibilities and sigmas with
+                    inverse-variance weights; if False, use the legacy unweighted mean and
+                    sqrt(sum sig^2)/N sigma
            Returns:
                 (Obsdata): Obsdata object containing averaged data
         """
@@ -1267,10 +1270,10 @@ class Obsdata:
             return self.copy()
 
         if moving:
-            vis_avg = ehavg.coh_moving_avg_vis(self, dt=inttime)
+            vis_avg = ehavg.coh_moving_avg_vis(self, dt=inttime, invvar_avg=invvar_avg)
         else:
-            vis_avg = ehavg.coh_avg_vis(self, dt=inttime,
-                                        err_type='predicted', scan_avg=scan_avg)
+            vis_avg = ehavg.coh_avg_vis(self, dt=inttime, err_type='predicted',
+                                        scan_avg=scan_avg, invvar_avg=invvar_avg)
 
         arglist, argdict = self.obsdata_args()
         arglist[DATPOS] = vis_avg
@@ -1278,7 +1281,8 @@ class Obsdata:
 
         return out
 
-    def avg_incoherent(self, inttime, scan_avg=False, debias=True, err_type='predicted'):
+    def avg_incoherent(self, inttime, scan_avg=False, debias=True, err_type='predicted',
+                       invvar_avg=True):
         """Incoherently average data along u,v tracks in chunks of length inttime (sec)
 
            Args:
@@ -1286,6 +1290,9 @@ class Obsdata:
                 scan_avg (bool): if True, average over scans in self.scans instead of intime
                 debias (bool): if True, debias the averaged amplitudes
                 err_type (str): 'predicted' or 'measured'
+                invvar_avg (bool): if True (default) and err_type='predicted', use the
+                    inverse-variance weighted amplitude + sigma; if False, the legacy
+                    deb_amp + inc_sig pair. No effect when err_type='measured'.
 
            Returns:
                 (Obsdata): Obsdata object containing averaged data
@@ -1293,7 +1300,7 @@ class Obsdata:
 
         print('Incoherently averaging data, putting phases to zero!')
         amp_rec = ehavg.incoh_avg_vis(self, dt=inttime, debias=debias, scan_avg=scan_avg,
-                                      rec_type='vis', err_type=err_type)
+                                      rec_type='vis', err_type=err_type, invvar_avg=invvar_avg)
         arglist, argdict = self.obsdata_args()
         arglist[DATPOS] = amp_rec
         out = Obsdata(*arglist, **argdict)

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -42,6 +42,7 @@ import ehtim.image
 import ehtim.io.load
 import ehtim.io.save
 import ehtim.observing.obs_helpers as obsh
+import ehtim.statistics.averaging as ehavg
 import ehtim.statistics.dataframes as ehdf
 
 warnings.filterwarnings("ignore",
@@ -1266,10 +1267,10 @@ class Obsdata:
             return self.copy()
 
         if moving:
-            vis_avg = ehdf.coh_moving_avg_vis(self, dt=inttime, return_type='rec')
+            vis_avg = ehavg.coh_moving_avg_vis(self, dt=inttime, return_type='rec')
         else:
-            vis_avg = ehdf.coh_avg_vis(self, dt=inttime, return_type='rec',
-                                       err_type='predicted', scan_avg=scan_avg)
+            vis_avg = ehavg.coh_avg_vis(self, dt=inttime, return_type='rec',
+                                        err_type='predicted', scan_avg=scan_avg)
 
         arglist, argdict = self.obsdata_args()
         arglist[DATPOS] = vis_avg
@@ -1291,8 +1292,8 @@ class Obsdata:
         """
 
         print('Incoherently averaging data, putting phases to zero!')
-        amp_rec = ehdf.incoh_avg_vis(self, dt=inttime, debias=debias, scan_avg=scan_avg,
-                                     return_type='rec', rec_type='vis', err_type=err_type)
+        amp_rec = ehavg.incoh_avg_vis(self, dt=inttime, debias=debias, scan_avg=scan_avg,
+                                      return_type='rec', rec_type='vis', err_type=err_type)
         arglist, argdict = self.obsdata_args()
         arglist[DATPOS] = amp_rec
         out = Obsdata(*arglist, **argdict)

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -1267,9 +1267,9 @@ class Obsdata:
             return self.copy()
 
         if moving:
-            vis_avg = ehavg.coh_moving_avg_vis(self, dt=inttime, return_type='rec')
+            vis_avg = ehavg.coh_moving_avg_vis(self, dt=inttime)
         else:
-            vis_avg = ehavg.coh_avg_vis(self, dt=inttime, return_type='rec',
+            vis_avg = ehavg.coh_avg_vis(self, dt=inttime,
                                         err_type='predicted', scan_avg=scan_avg)
 
         arglist, argdict = self.obsdata_args()
@@ -1293,7 +1293,7 @@ class Obsdata:
 
         print('Incoherently averaging data, putting phases to zero!')
         amp_rec = ehavg.incoh_avg_vis(self, dt=inttime, debias=debias, scan_avg=scan_avg,
-                                      return_type='rec', rec_type='vis', err_type=err_type)
+                                      rec_type='vis', err_type=err_type)
         arglist, argdict = self.obsdata_args()
         arglist[DATPOS] = amp_rec
         out = Obsdata(*arglist, **argdict)

--- a/ehtim/statistics/averaging.py
+++ b/ehtim/statistics/averaging.py
@@ -1,0 +1,409 @@
+"""Visibility time-averaging.
+
+Pure-NumPy implementations of the three averaging routines historically
+provided by ``ehtim.statistics.dataframes``:
+
+- :func:`coh_avg_vis` — coherent (complex) averaging into fixed time bins
+  or per scan.
+- :func:`coh_moving_avg_vis` — coherent moving-window averaging.
+- :func:`incoh_avg_vis` — incoherent (amplitude) averaging with Rice
+  debiasing.
+
+All three propagate visibility errors via the inverse-variance combination
+
+.. math:: \\sigma_{\\rm avg} = 1 / \\sqrt{\\sum_i 1/\\sigma_i^2}.
+
+This matches the channel/IF averaging in :func:`ehtim.io.load.load_obs_uvfits`
+(see PR #230) and replaces the historical ``sqrt(mean(sigma_i**2))`` formula in
+``dataframes.py`` which underestimated errors and inflated SNRs.
+"""
+
+import numpy as np
+
+import ehtim.const_def as ehc
+from ehtim.statistics.stats import bootstrap, mean_incoh_avg
+
+__all__ = ["coh_avg_vis", "coh_moving_avg_vis", "incoh_avg_vis"]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _polrep_fields(polrep):
+    """Return (vis_fields, sig_fields, out_dtype) for a given polrep."""
+    if polrep == "stokes":
+        return (
+            ("vis", "qvis", "uvis", "vvis"),
+            ("sigma", "qsigma", "usigma", "vsigma"),
+            ehc.DTPOL_STOKES,
+        )
+    if polrep == "circ":
+        return (
+            ("rrvis", "llvis", "rlvis", "lrvis"),
+            ("rrsigma", "llsigma", "rlsigma", "lrsigma"),
+            ehc.DTPOL_CIRC,
+        )
+    raise ValueError(f"unsupported polrep {polrep!r}")
+
+
+def _assign_scan_bin(times_hr, scans):
+    """Assign each row in `times_hr` to a scan index (or -1 if outside)."""
+    out = np.full(len(times_hr), -1, dtype=np.int64)
+    for idx, scan in enumerate(scans):
+        tstart, tstop = scan[0], scan[1]
+        out[(times_hr >= tstart) & (times_hr <= tstop)] = idx
+    return out
+
+
+def _group_ids(*keys):
+    """Map a row's tuple of key values to a contiguous group index.
+
+    Returns ``(gids, n_groups)`` where ``gids[i]`` is the group index of row i.
+    """
+    n = len(keys[0])
+    if n == 0:
+        return np.empty(0, dtype=np.int64), 0
+    dtype = [(f"k{i}", k.dtype) for i, k in enumerate(keys)]
+    rec = np.empty(n, dtype=dtype)
+    for i, k in enumerate(keys):
+        rec[f"k{i}"] = k
+    _, gids = np.unique(rec, return_inverse=True)
+    gids = gids.astype(np.int64, copy=False)
+    return gids, int(gids.max()) + 1
+
+
+def _first_index_per_group(gids, n_groups):
+    """Return an array of length n_groups giving one representative row index
+    (the first occurrence) for each group."""
+    out = np.full(n_groups, -1, dtype=np.int64)
+    for i, g in enumerate(gids):
+        if out[g] == -1:
+            out[g] = i
+    return out
+
+
+def _inverse_variance_sigma(sig_per_row, gids, n_groups):
+    """Reduce a per-row sigma array to per-group inverse-variance sigma.
+
+    For each group g, the result is ``1 / sqrt(sum_i 1/sigma_i**2)`` over rows
+    i in group g with finite, positive sigma.  Groups with no valid rows get
+    ``NaN``.
+    """
+    finite = np.isfinite(sig_per_row) & (sig_per_row > 0)
+    inv_var = np.zeros_like(sig_per_row, dtype=np.float64)
+    inv_var[finite] = 1.0 / sig_per_row[finite] ** 2
+    sums = np.bincount(gids, weights=inv_var, minlength=n_groups)
+    out = np.full(n_groups, np.nan)
+    out[sums > 0] = 1.0 / np.sqrt(sums[sums > 0])
+    return out
+
+
+def _mean_complex(vis_per_row, gids, n_groups):
+    """Reduce a per-row complex visibility array to per-group complex mean.
+
+    Skips NaN entries.  Groups with no finite rows get ``NaN + NaN*1j``.
+    """
+    finite = np.isfinite(vis_per_row.real) & np.isfinite(vis_per_row.imag)
+    re = np.where(finite, vis_per_row.real, 0.0)
+    im = np.where(finite, vis_per_row.imag, 0.0)
+    sums_re = np.bincount(gids, weights=re, minlength=n_groups)
+    sums_im = np.bincount(gids, weights=im, minlength=n_groups)
+    counts = np.bincount(gids, weights=finite.astype(np.float64), minlength=n_groups)
+    out = np.full(n_groups, np.nan + 1j * np.nan, dtype=np.complex128)
+    valid = counts > 0
+    out.real[valid] = sums_re[valid] / counts[valid]
+    out.imag[valid] = sums_im[valid] / counts[valid]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def coh_avg_vis(obs, dt=0, scan_avg=False, return_type="rec",
+                err_type="predicted", num_samples=int(1e3)):
+    """Coherently average visibilities into fixed time bins or per scan.
+
+    Parameters
+    ----------
+    obs : ehtim.obsdata.Obsdata
+    dt : float
+        Bin width in seconds.  Ignored when ``scan_avg=True``.
+    scan_avg : bool
+        If True, average each scan into a single bin.  Requires ``obs.scans``.
+    return_type : {'rec'}
+        Output format.  Only 'rec' is supported here; the legacy 'df' route
+        is gone.
+    err_type : {'predicted', 'measured'}
+        'predicted' propagates the per-row sigmas via inverse variance.
+        'measured' bootstraps the dispersion of the visibility samples.
+    num_samples : int
+        Bootstrap resample size when ``err_type='measured'``.
+
+    Returns
+    -------
+    np.recarray of dtype DTPOL_STOKES or DTPOL_CIRC matching ``obs.polrep``.
+    """
+    if return_type != "rec":
+        raise ValueError("only return_type='rec' is supported")
+    if err_type not in ("predicted", "measured"):
+        raise ValueError(f"err_type must be 'predicted' or 'measured', got {err_type!r}")
+    if dt <= 0 and not scan_avg:
+        return obs.data
+
+    vis_fields, sig_fields, out_dtype = _polrep_fields(obs.polrep)
+    data = obs.data
+
+    # Bin assignment.
+    if scan_avg:
+        if obs.scans is None or len(obs.scans) == 0:
+            raise ValueError("scan_avg=True but obs has no scan table; call add_scans() first")
+        bin_id = _assign_scan_bin(data["time"], obs.scans)
+        keep = bin_id >= 0
+        data = data[keep]
+        bin_id = bin_id[keep]
+    else:
+        # obs.data['time'] is in hours since mjd start; dt is seconds.
+        bin_id = np.floor(data["time"] * 3600.0 / dt).astype(np.int64)
+
+    if len(data) == 0:
+        return np.empty(0, dtype=out_dtype)
+
+    keys = (data["t1"], data["t2"], data["tau1"], data["tau2"], bin_id)
+    gids, n_groups = _group_ids(*keys)
+    first = _first_index_per_group(gids, n_groups)
+
+    out = np.empty(n_groups, dtype=out_dtype)
+    out["t1"] = data["t1"][first]
+    out["t2"] = data["t2"][first]
+    out["tau1"] = data["tau1"][first]
+    out["tau2"] = data["tau2"][first]
+    out["tint"] = np.bincount(gids, weights=data["tint"], minlength=n_groups)
+    counts = np.bincount(gids, minlength=n_groups).astype(np.float64)
+    out["u"] = np.bincount(gids, weights=data["u"], minlength=n_groups) / counts
+    out["v"] = np.bincount(gids, weights=data["v"], minlength=n_groups) / counts
+
+    # Time of the bin: midpoint for fixed-dt, scan min for scan_avg.
+    if scan_avg:
+        time_min = np.full(n_groups, np.inf)
+        np.minimum.at(time_min, gids, data["time"])
+        out["time"] = time_min
+    else:
+        bin_id_per_group = bin_id[first]
+        out["time"] = (bin_id_per_group * dt + dt / 2.0) / 3600.0
+
+    # Visibilities (complex mean) and sigmas (inverse-variance).
+    for vf in vis_fields:
+        out[vf] = _mean_complex(data[vf], gids, n_groups)
+
+    if err_type == "predicted":
+        for sf in sig_fields:
+            out[sf] = _inverse_variance_sigma(data[sf], gids, n_groups)
+    else:  # 'measured': bootstrap the visibility-amplitude dispersion per group.
+        for vf, sf in zip(vis_fields, sig_fields):
+            sig_out = np.full(n_groups, np.nan)
+            for g in range(n_groups):
+                rows = data[vf][gids == g]
+                rows = rows[np.isfinite(rows)]
+                if len(rows) >= 2:
+                    lo, hi = bootstrap(np.abs(rows), np.mean,
+                                       num_samples=num_samples, wrapping_variable=False)[1]
+                    sig_out[g] = 0.5 * (hi - lo)
+            out[sf] = sig_out
+
+    return out
+
+
+def coh_moving_avg_vis(obs, dt=50, return_type="rec"):
+    """Coherent moving-window average over time, per baseline.
+
+    For each row at time ``t``, average over rows in the same baseline whose
+    times fall in ``[t - dt/2, t + dt/2]``.  Output preserves the input rows
+    one-for-one; only the visibility values are replaced.
+
+    Parameters
+    ----------
+    obs : ehtim.obsdata.Obsdata
+    dt : float
+        Window full-width in seconds.
+    return_type : {'rec'}
+        Output format.  Only 'rec' is supported.
+
+    Returns
+    -------
+    np.recarray of dtype DTPOL_STOKES or DTPOL_CIRC matching ``obs.polrep``.
+    """
+    if return_type != "rec":
+        raise ValueError("only return_type='rec' is supported")
+    if dt <= 0:
+        raise ValueError("dt must be positive")
+
+    vis_fields, sig_fields, out_dtype = _polrep_fields(obs.polrep)
+    data = obs.data
+    n = len(data)
+    if n == 0:
+        return np.empty(0, dtype=out_dtype)
+
+    half = dt / 2.0 / 3600.0  # half-width in hours
+    out = data.copy()
+
+    # Group rows by baseline (t1, t2).
+    bl_keys = (data["t1"], data["t2"])
+    bl_ids, _ = _group_ids(*bl_keys)
+
+    for bl in np.unique(bl_ids):
+        rows = np.where(bl_ids == bl)[0]
+        times = data["time"][rows]
+        order = np.argsort(times, kind="stable")
+        sorted_rows = rows[order]
+        sorted_times = times[order]
+
+        # For each row, the inclusive window [t - half, t + half]
+        # corresponds to indices [left, right) in the sorted-time array.
+        left = np.searchsorted(sorted_times, sorted_times - half, side="left")
+        right = np.searchsorted(sorted_times, sorted_times + half, side="right")
+
+        for vf in vis_fields:
+            vals = data[vf][sorted_rows]
+            re_cs = np.concatenate(([0.0], np.cumsum(np.where(np.isfinite(vals), vals.real, 0.0))))
+            im_cs = np.concatenate(([0.0], np.cumsum(np.where(np.isfinite(vals), vals.imag, 0.0))))
+            cnt_cs = np.concatenate(([0.0], np.cumsum(np.isfinite(vals).astype(np.float64))))
+            cnt = cnt_cs[right] - cnt_cs[left]
+            re_mean = np.where(cnt > 0, (re_cs[right] - re_cs[left]) / np.maximum(cnt, 1.0), np.nan)
+            im_mean = np.where(cnt > 0, (im_cs[right] - im_cs[left]) / np.maximum(cnt, 1.0), np.nan)
+            out[vf][sorted_rows] = re_mean + 1j * im_mean
+
+        for sf in sig_fields:
+            vals = data[sf][sorted_rows]
+            finite = np.isfinite(vals) & (vals > 0)
+            inv_var = np.where(finite, 1.0 / np.maximum(vals, 1e-300) ** 2, 0.0)
+            inv_var_cs = np.concatenate(([0.0], np.cumsum(inv_var)))
+            sums = inv_var_cs[right] - inv_var_cs[left]
+            out[sf][sorted_rows] = np.where(sums > 0, 1.0 / np.sqrt(np.maximum(sums, 1e-300)), np.nan)
+
+    return out
+
+
+def incoh_avg_vis(obs, dt=0, debias=True, scan_avg=False, return_type="rec",
+                  rec_type="vis", err_type="predicted", num_samples=int(1e3)):
+    """Incoherently (amplitude) average visibilities, with optional Rice debias.
+
+    Parameters
+    ----------
+    obs : ehtim.obsdata.Obsdata
+        Must be polrep='stokes'.
+    dt : float
+        Bin width in seconds.  Ignored when ``scan_avg=True``.
+    debias : bool
+        Apply Rice debiasing to per-bin mean amplitude.
+    scan_avg : bool
+        If True, average each scan into a single bin.
+    return_type : {'rec'}
+        Output format.  Only 'rec' is supported.
+    rec_type : {'vis', 'amp'}
+        Output recarray dtype.  ``'vis'`` returns DTPOL_STOKES (the I,Q,U,V
+        amplitudes packed into the real parts of the vis fields);
+        ``'amp'`` returns DTAMP.
+    err_type : {'predicted', 'measured'}
+        Sigma propagation method.
+    num_samples : int
+        Bootstrap resample size when ``err_type='measured'``.
+
+    Returns
+    -------
+    np.recarray
+    """
+    if return_type != "rec":
+        raise ValueError("only return_type='rec' is supported")
+    if err_type not in ("predicted", "measured"):
+        raise ValueError(f"err_type must be 'predicted' or 'measured', got {err_type!r}")
+    if rec_type not in ("vis", "amp"):
+        raise ValueError(f"rec_type must be 'vis' or 'amp', got {rec_type!r}")
+    if obs.polrep != "stokes":
+        raise ValueError("incoh_avg_vis requires polrep='stokes'")
+    if dt <= 0 and not scan_avg:
+        return obs.data
+
+    data = obs.data
+
+    if scan_avg:
+        if obs.scans is None or len(obs.scans) == 0:
+            raise ValueError("scan_avg=True but obs has no scan table; call add_scans() first")
+        bin_id = _assign_scan_bin(data["time"], obs.scans)
+        keep = bin_id >= 0
+        data = data[keep]
+        bin_id = bin_id[keep]
+    else:
+        bin_id = np.floor(data["time"] * 3600.0 / dt).astype(np.int64)
+
+    if rec_type == "vis":
+        out_dtype = ehc.DTPOL_STOKES
+        amp_fields = ("vis", "qvis", "uvis", "vvis")
+        sig_fields = ("sigma", "qsigma", "usigma", "vsigma")
+    else:
+        out_dtype = ehc.DTAMP
+        amp_fields = ("vis",)
+        sig_fields = ("sigma",)
+
+    if len(data) == 0:
+        return np.empty(0, dtype=out_dtype)
+
+    keys = (data["t1"], data["t2"], data["tau1"], data["tau2"], bin_id)
+    gids, n_groups = _group_ids(*keys)
+    first = _first_index_per_group(gids, n_groups)
+
+    out = np.empty(n_groups, dtype=out_dtype)
+    out["t1"] = data["t1"][first]
+    out["t2"] = data["t2"][first]
+    out["tint"] = np.bincount(gids, weights=data["tint"], minlength=n_groups)
+    counts = np.bincount(gids, minlength=n_groups).astype(np.float64)
+    out["u"] = np.bincount(gids, weights=data["u"], minlength=n_groups) / counts
+    out["v"] = np.bincount(gids, weights=data["v"], minlength=n_groups) / counts
+
+    if scan_avg:
+        time_min = np.full(n_groups, np.inf)
+        np.minimum.at(time_min, gids, data["time"])
+        out["time"] = time_min
+    else:
+        bin_id_per_group = bin_id[first]
+        out["time"] = (bin_id_per_group * dt + dt / 2.0) / 3600.0
+
+    if "tau1" in out.dtype.names:
+        out["tau1"] = data["tau1"][first]
+        out["tau2"] = data["tau2"][first]
+
+    # Per-group amplitude + sigma via mean_incoh_avg / bootstrap.
+    for vf, sf in zip(amp_fields, sig_fields):
+        amp_out = np.full(n_groups, np.nan)
+        sig_out = np.full(n_groups, np.nan)
+        for g in range(n_groups):
+            mask = gids == g
+            pairs = list(zip(np.abs(data[vf][mask]), data[sf][mask]))
+            if not pairs:
+                continue
+            if err_type == "predicted":
+                a, s = mean_incoh_avg(pairs, debias=debias)
+                amp_out[g] = a
+                sig_out[g] = s
+            else:
+                amps = np.abs(np.asarray([y[0] for y in pairs]))
+                amps = amps[np.isfinite(amps)]
+                if len(amps) >= 2:
+                    centre, (lo, hi) = bootstrap(amps, np.mean,
+                                                 num_samples=num_samples,
+                                                 wrapping_variable=False)
+                    amp_out[g] = centre
+                    sig_out[g] = 0.5 * (hi - lo)
+                elif len(amps) == 1:
+                    amp_out[g] = amps[0]
+                    sig_out[g] = data[sf][mask][0]
+        if rec_type == "vis":
+            out[vf] = amp_out  # cast to complex implicitly via dtype
+        else:
+            out["amp"] = amp_out
+        out[sf] = sig_out
+
+    return out

--- a/ehtim/statistics/averaging.py
+++ b/ehtim/statistics/averaging.py
@@ -67,9 +67,9 @@ import ehtim.const_def as ehc
 
 # TODO: the helpers below (and the per-group amplitude reductions in this
 # module) overlap conceptually with stats.deb_amp / stats.inc_sig /
-# stats.mean_incoh_avg / stats.coh_sig. Worth consolidating into a single
-# set of vectorised reducers once the legacy stats.py call sites elsewhere
-# in the codebase are audited.
+# stats.mean_incoh_avg / stats.coh_sig / stats.invvar_coh_sig. Worth
+# consolidating into a single set of vectorised reducers once the legacy
+# stats.py call sites elsewhere in the codebase are audited.
 from ehtim.statistics.stats import bootstrap, mean_incoh_avg
 
 __all__ = ["coh_avg_vis", "coh_moving_avg_vis", "incoh_avg_vis"]

--- a/ehtim/statistics/averaging.py
+++ b/ehtim/statistics/averaging.py
@@ -8,9 +8,31 @@ Pure-NumPy implementations of three averaging routines:
 - :func:`incoh_avg_vis` — incoherent (amplitude) averaging with Rice
   debiasing.
 
-All three propagate visibility errors via the inverse-variance combination
+Sigma propagation uses the inverse-variance combination
 
 .. math:: \\sigma_{\\rm avg} = 1 / \\sqrt{\\sum_i 1/\\sigma_i^2}.
+
+With ``invvar_avg=True`` (default) visibility values are also combined with
+inverse-variance weights, ``<V> = sum_i(V_i/\\sigma_i^2) / sum_i(1/\\sigma_i^2)``.
+``invvar_avg=False`` reproduces the legacy direct (unweighted) mean.
+
+Conventions worth flagging for future readers:
+  - Fixed-dt bins set the output ``time`` to the bin midpoint; ``scan_avg``
+    uses the earliest sample time in each scan (matches the legacy code).
+  - Output ``(u, v)`` is the per-bin mean.
+  - ``err_type='measured'`` bootstraps the visibility-amplitude dispersion;
+    sigma is returned as half the 68% bootstrap interval width. Convention
+    inherited from the legacy code, not a standard estimator.
+  - For incoherent averaging with ``err_type='predicted'``, the per-bin
+    sigma comes from :func:`stats.inc_sig` (eq 9.86 of Thompson et al.,
+    Interferometry and Synthesis in Radio Astronomy). It is an analytic
+    Rician-SNR estimator that returns the noise level which would produce
+    the equivalent SNR penalty after Rice-debiased averaging — neither
+    stddev nor pure inverse variance.
+  - ``tau1`` / ``tau2`` (per-site opacities) are copied through from the
+    first row in each bin. They are not used as grouping keys: they are
+    basically always zero in practice, and using them would needlessly
+    fragment bins if a site's opacity drifted within a window.
 """
 
 import numpy as np
@@ -27,35 +49,51 @@ __all__ = ["coh_avg_vis", "coh_moving_avg_vis", "incoh_avg_vis"]
 
 
 def _polrep_fields(polrep):
-    """Return (vis_fields, sig_fields, out_dtype) for a given polrep."""
+    """Return (vis_fields, sig_fields, out_dtype) for a given polrep.
+
+    Field names are taken from ``ehc.POLDICT_STOKES`` / ``ehc.POLDICT_CIRC``
+    so a future mixed-pol basis can plug in by adding the corresponding
+    POLDICT entry in ``const_def`` rather than editing this module.
+    """
     if polrep == "stokes":
-        return (
-            ("vis", "qvis", "uvis", "vvis"),
-            ("sigma", "qsigma", "usigma", "vsigma"),
-            ehc.DTPOL_STOKES,
-        )
-    if polrep == "circ":
-        return (
-            ("rrvis", "llvis", "rlvis", "lrvis"),
-            ("rrsigma", "llsigma", "rlsigma", "lrsigma"),
-            ehc.DTPOL_CIRC,
-        )
-    raise ValueError(f"unsupported polrep {polrep!r}")
+        d = ehc.POLDICT_STOKES
+        out_dtype = ehc.DTPOL_STOKES
+    elif polrep == "circ":
+        d = ehc.POLDICT_CIRC
+        out_dtype = ehc.DTPOL_CIRC
+    else:
+        raise ValueError(f"unsupported polrep {polrep!r}")
+    vis = tuple(d[f"vis{i}"] for i in range(1, 5))
+    sig = tuple(d[f"sigma{i}"] for i in range(1, 5))
+    return vis, sig, out_dtype
 
 
 def _assign_scan_bin(times_hr, scans):
-    """Assign each row in `times_hr` to a scan index (or -1 if outside)."""
+    """Assign each row in `times_hr` to a scan index (or -1 if outside).
+
+    Matches the ``pandas.cut`` semantics used by the legacy code: scan
+    intervals are ``(tstart, tstop]`` (open on the left, closed on the
+    right) so a sample exactly on a scan boundary lands in the later scan
+    only, not both.
+    """
     out = np.full(len(times_hr), -1, dtype=np.int64)
     for idx, scan in enumerate(scans):
         tstart, tstop = scan[0], scan[1]
-        out[(times_hr >= tstart) & (times_hr <= tstop)] = idx
+        out[(times_hr > tstart) & (times_hr <= tstop)] = idx
     return out
 
 
 def _group_ids(*keys):
     """Map a row's tuple of key values to a contiguous group index.
 
-    Returns ``(gids, n_groups)`` where ``gids[i]`` is the group index of row i.
+    Given N input arrays of length n each (one per key column), return
+    ``(gids, n_groups)`` where ``gids[i]`` is a contiguous integer label
+    for the unique key-tuple at row i.
+
+    Example: with ``keys = (np.array(["a", "a", "b"]), np.array([0, 1, 0]))``
+    the unique tuples are ``("a", 0), ("a", 1), ("b", 0)`` and the result
+    is ``(array([0, 1, 2]), 3)`` (or another permutation; only the
+    grouping is defined, not the label order).
     """
     n = len(keys[0])
     if n == 0:
@@ -96,8 +134,19 @@ def _inverse_variance_sigma(sig_per_row, gids, n_groups):
 
 
 def _amplitude_per_group(amps_per_row, sigs_per_row, gids, n_groups,
-                         debias, err_type, num_samples):
-    """Reduce per-row (amplitude, sigma) pairs to per-group (mean_amp, sigma)."""
+                         debias, err_type, num_samples, invvar_avg):
+    """Reduce per-row (amplitude, sigma) pairs to per-group (mean_amp, sigma).
+
+    err_type:
+      - 'predicted': use the per-row sigmas. mean_incoh_avg applies Rice
+        debiasing to the amplitudes and returns the analytic Rician-SNR
+        sigma (see module docstring). When invvar_avg=True the per-group
+        amplitude mean is inverse-variance weighted; the returned sigma
+        still comes from inc_sig (predicted by the per-row sigmas).
+      - 'measured': bootstrap the amplitude dispersion within each group.
+        The reported sigma is half the 68% bootstrap interval width — a
+        convention inherited from the legacy code, not stddev.
+    """
     amp_out = np.full(n_groups, np.nan)
     sig_out = np.full(n_groups, np.nan)
     for g in range(n_groups):
@@ -107,6 +156,14 @@ def _amplitude_per_group(amps_per_row, sigs_per_row, gids, n_groups,
             continue
         if err_type == "predicted":
             a, s = mean_incoh_avg(pairs, debias=debias)
+            if invvar_avg:
+                amps_g = np.abs(amps_per_row[mask])
+                sigs_g = sigs_per_row[mask]
+                finite = (np.isfinite(amps_g) & np.isfinite(sigs_g)
+                          & (sigs_g > 0))
+                if np.any(finite):
+                    w = 1.0 / sigs_g[finite] ** 2
+                    a = np.sum(amps_g[finite] * w) / np.sum(w)
             amp_out[g] = a
             sig_out[g] = s
         else:
@@ -125,9 +182,9 @@ def _amplitude_per_group(amps_per_row, sigs_per_row, gids, n_groups,
 
 
 def _mean_complex(vis_per_row, gids, n_groups):
-    """Reduce a per-row complex visibility array to per-group complex mean.
+    """Per-group complex mean (direct, unweighted). NaN-safe.
 
-    Skips NaN entries.  Groups with no finite rows get ``NaN + NaN*1j``.
+    Groups with no finite rows get ``NaN + NaN*1j``.
     """
     finite = np.isfinite(vis_per_row.real) & np.isfinite(vis_per_row.imag)
     re = np.where(finite, vis_per_row.real, 0.0)
@@ -142,13 +199,35 @@ def _mean_complex(vis_per_row, gids, n_groups):
     return out
 
 
+def _invvar_mean_complex(vis_per_row, sig_per_row, gids, n_groups):
+    """Per-group inverse-variance weighted complex mean. NaN-safe.
+
+    ``<V>_g = sum_i (V_i / sigma_i^2) / sum_i (1 / sigma_i^2)`` over rows
+    i in group g with finite V and finite positive sigma. Groups with no
+    valid rows get ``NaN + NaN*1j``.
+    """
+    finite = (np.isfinite(vis_per_row.real) & np.isfinite(vis_per_row.imag)
+              & np.isfinite(sig_per_row) & (sig_per_row > 0))
+    inv_var = np.where(finite, 1.0 / np.maximum(sig_per_row, 1e-300) ** 2, 0.0)
+    re_w = np.where(finite, vis_per_row.real * inv_var, 0.0)
+    im_w = np.where(finite, vis_per_row.imag * inv_var, 0.0)
+    sums_re = np.bincount(gids, weights=re_w, minlength=n_groups)
+    sums_im = np.bincount(gids, weights=im_w, minlength=n_groups)
+    sums_w = np.bincount(gids, weights=inv_var, minlength=n_groups)
+    out = np.full(n_groups, np.nan + 1j * np.nan, dtype=np.complex128)
+    valid = sums_w > 0
+    out.real[valid] = sums_re[valid] / sums_w[valid]
+    out.imag[valid] = sums_im[valid] / sums_w[valid]
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
 
-def coh_avg_vis(obs, dt=0, scan_avg=False, return_type="rec",
-                err_type="predicted", num_samples=int(1e3)):
+def coh_avg_vis(obs, dt=0, scan_avg=False, err_type="predicted",
+                num_samples=int(1e3), invvar_avg=True):
     """Coherently average visibilities into fixed time bins or per scan.
 
     Parameters
@@ -158,21 +237,20 @@ def coh_avg_vis(obs, dt=0, scan_avg=False, return_type="rec",
         Bin width in seconds.  Ignored when ``scan_avg=True``.
     scan_avg : bool
         If True, average each scan into a single bin.  Requires ``obs.scans``.
-    return_type : {'rec'}
-        Output format.  Only 'rec' is supported here; the legacy 'df' route
-        is gone.
     err_type : {'predicted', 'measured'}
         'predicted' propagates the per-row sigmas via inverse variance.
         'measured' bootstraps the dispersion of the visibility samples.
     num_samples : int
         Bootstrap resample size when ``err_type='measured'``.
+    invvar_avg : bool
+        When True (default), combine visibilities with inverse-variance
+        weights ``<V> = sum_i(V_i/sig_i^2) / sum_i(1/sig_i^2)``. When False
+        use the legacy direct (unweighted) complex mean.
 
     Returns
     -------
     np.recarray of dtype DTPOL_STOKES or DTPOL_CIRC matching ``obs.polrep``.
     """
-    if return_type != "rec":
-        raise ValueError("only return_type='rec' is supported")
     if err_type not in ("predicted", "measured"):
         raise ValueError(f"err_type must be 'predicted' or 'measured', got {err_type!r}")
     if dt <= 0 and not scan_avg:
@@ -196,7 +274,11 @@ def coh_avg_vis(obs, dt=0, scan_avg=False, return_type="rec",
     if len(data) == 0:
         return np.empty(0, dtype=out_dtype)
 
-    keys = (data["t1"], data["t2"], data["tau1"], data["tau2"], bin_id)
+    # Group on baseline + bin only. tau1/tau2 (per-site opacities) are
+    # carried through (first-row copy) but not used as grouping keys --
+    # they are basically always zero and grouping on them would fragment
+    # bins when a site's opacity drifts within a window.
+    keys = (data["t1"], data["t2"], bin_id)
     gids, n_groups = _group_ids(*keys)
     first = _first_index_per_group(gids, n_groups)
 
@@ -207,10 +289,11 @@ def coh_avg_vis(obs, dt=0, scan_avg=False, return_type="rec",
     out["tau2"] = data["tau2"][first]
     out["tint"] = np.bincount(gids, weights=data["tint"], minlength=n_groups)
     counts = np.bincount(gids, minlength=n_groups).astype(np.float64)
+    # (u, v) are averaged within each bin.
     out["u"] = np.bincount(gids, weights=data["u"], minlength=n_groups) / counts
     out["v"] = np.bincount(gids, weights=data["v"], minlength=n_groups) / counts
 
-    # Time of the bin: midpoint for fixed-dt, scan min for scan_avg.
+    # Output time: midpoint of the dt window, or earliest sample in the scan.
     if scan_avg:
         time_min = np.full(n_groups, np.inf)
         np.minimum.at(time_min, gids, data["time"])
@@ -219,14 +302,21 @@ def coh_avg_vis(obs, dt=0, scan_avg=False, return_type="rec",
         bin_id_per_group = bin_id[first]
         out["time"] = (bin_id_per_group * dt + dt / 2.0) / 3600.0
 
-    # Visibilities (complex mean) and sigmas (inverse-variance).
-    for vf in vis_fields:
-        out[vf] = _mean_complex(data[vf], gids, n_groups)
+    # Visibilities: inverse-variance weighted (default) or direct mean.
+    for vf, sf in zip(vis_fields, sig_fields):
+        if invvar_avg:
+            out[vf] = _invvar_mean_complex(data[vf], data[sf], gids, n_groups)
+        else:
+            out[vf] = _mean_complex(data[vf], gids, n_groups)
 
+    # Sigmas.
     if err_type == "predicted":
         for sf in sig_fields:
             out[sf] = _inverse_variance_sigma(data[sf], gids, n_groups)
-    else:  # 'measured': bootstrap the visibility-amplitude dispersion per group.
+    else:
+        # 'measured': bootstrap the per-bin visibility-amplitude dispersion.
+        # The returned sigma is half the 68% bootstrap interval width --
+        # a convention from the legacy code, not stddev.
         for vf, sf in zip(vis_fields, sig_fields):
             sig_out = np.full(n_groups, np.nan)
             for g in range(n_groups):
@@ -241,7 +331,7 @@ def coh_avg_vis(obs, dt=0, scan_avg=False, return_type="rec",
     return out
 
 
-def coh_moving_avg_vis(obs, dt=50, return_type="rec"):
+def coh_moving_avg_vis(obs, dt=50, invvar_avg=True):
     """Coherent moving-window average over time, per baseline.
 
     For each row at time ``t``, average over rows in the same baseline whose
@@ -253,15 +343,15 @@ def coh_moving_avg_vis(obs, dt=50, return_type="rec"):
     obs : ehtim.obsdata.Obsdata
     dt : float
         Window full-width in seconds.
-    return_type : {'rec'}
-        Output format.  Only 'rec' is supported.
+    invvar_avg : bool
+        When True (default), combine visibilities within each window with
+        inverse-variance weights. When False use the direct (unweighted)
+        complex mean (legacy behavior).
 
     Returns
     -------
     np.recarray of dtype DTPOL_STOKES or DTPOL_CIRC matching ``obs.polrep``.
     """
-    if return_type != "rec":
-        raise ValueError("only return_type='rec' is supported")
     if dt <= 0:
         raise ValueError("dt must be positive")
 
@@ -274,7 +364,8 @@ def coh_moving_avg_vis(obs, dt=50, return_type="rec"):
     half = dt / 2.0 / 3600.0  # half-width in hours
     out = data.copy()
 
-    # Group rows by baseline (t1, t2).
+    # Group rows by baseline (t1, t2). tau1/tau2 are NOT grouped on; see
+    # the module docstring.
     bl_keys = (data["t1"], data["t2"])
     bl_ids, _ = _group_ids(*bl_keys)
 
@@ -290,15 +381,32 @@ def coh_moving_avg_vis(obs, dt=50, return_type="rec"):
         left = np.searchsorted(sorted_times, sorted_times - half, side="left")
         right = np.searchsorted(sorted_times, sorted_times + half, side="right")
 
-        for vf in vis_fields:
+        for vf, sf in zip(vis_fields, sig_fields):
             vals = data[vf][sorted_rows]
-            re_cs = np.concatenate(([0.0], np.cumsum(np.where(np.isfinite(vals), vals.real, 0.0))))
-            im_cs = np.concatenate(([0.0], np.cumsum(np.where(np.isfinite(vals), vals.imag, 0.0))))
-            cnt_cs = np.concatenate(([0.0], np.cumsum(np.isfinite(vals).astype(np.float64))))
-            cnt = cnt_cs[right] - cnt_cs[left]
-            re_mean = np.where(cnt > 0, (re_cs[right] - re_cs[left]) / np.maximum(cnt, 1.0), np.nan)
-            im_mean = np.where(cnt > 0, (im_cs[right] - im_cs[left]) / np.maximum(cnt, 1.0), np.nan)
-            out[vf][sorted_rows] = re_mean + 1j * im_mean
+            sigs = data[sf][sorted_rows]
+            if invvar_avg:
+                finite_v = np.isfinite(vals.real) & np.isfinite(vals.imag)
+                finite_s = np.isfinite(sigs) & (sigs > 0)
+                finite = finite_v & finite_s
+                inv_var = np.where(finite, 1.0 / np.maximum(sigs, 1e-300) ** 2, 0.0)
+                re_w = np.where(finite, vals.real * inv_var, 0.0)
+                im_w = np.where(finite, vals.imag * inv_var, 0.0)
+                re_cs = np.concatenate(([0.0], np.cumsum(re_w)))
+                im_cs = np.concatenate(([0.0], np.cumsum(im_w)))
+                w_cs = np.concatenate(([0.0], np.cumsum(inv_var)))
+                w = w_cs[right] - w_cs[left]
+                re_mean = np.where(w > 0, (re_cs[right] - re_cs[left]) / np.maximum(w, 1e-300), np.nan)
+                im_mean = np.where(w > 0, (im_cs[right] - im_cs[left]) / np.maximum(w, 1e-300), np.nan)
+                out[vf][sorted_rows] = re_mean + 1j * im_mean
+            else:
+                finite = np.isfinite(vals.real) & np.isfinite(vals.imag)
+                re_cs = np.concatenate(([0.0], np.cumsum(np.where(finite, vals.real, 0.0))))
+                im_cs = np.concatenate(([0.0], np.cumsum(np.where(finite, vals.imag, 0.0))))
+                cnt_cs = np.concatenate(([0.0], np.cumsum(finite.astype(np.float64))))
+                cnt = cnt_cs[right] - cnt_cs[left]
+                re_mean = np.where(cnt > 0, (re_cs[right] - re_cs[left]) / np.maximum(cnt, 1.0), np.nan)
+                im_mean = np.where(cnt > 0, (im_cs[right] - im_cs[left]) / np.maximum(cnt, 1.0), np.nan)
+                out[vf][sorted_rows] = re_mean + 1j * im_mean
 
         for sf in sig_fields:
             vals = data[sf][sorted_rows]
@@ -311,37 +419,39 @@ def coh_moving_avg_vis(obs, dt=50, return_type="rec"):
     return out
 
 
-def incoh_avg_vis(obs, dt=0, debias=True, scan_avg=False, return_type="rec",
-                  rec_type="vis", err_type="predicted", num_samples=int(1e3)):
+def incoh_avg_vis(obs, dt=0, debias=True, scan_avg=False, rec_type="vis",
+                  err_type="predicted", num_samples=int(1e3), invvar_avg=True):
     """Incoherently (amplitude) average visibilities, with optional Rice debias.
 
     Parameters
     ----------
     obs : ehtim.obsdata.Obsdata
-        Must be polrep='stokes'.
+        Must be polrep='stokes' (the rec_type='vis' / 'amp' field names below
+        and the Rice-debiasing helpers are written for Stokes I, Q, U, V).
     dt : float
         Bin width in seconds.  Ignored when ``scan_avg=True``.
     debias : bool
         Apply Rice debiasing to per-bin mean amplitude.
     scan_avg : bool
         If True, average each scan into a single bin.
-    return_type : {'rec'}
-        Output format.  Only 'rec' is supported.
     rec_type : {'vis', 'amp'}
         Output recarray dtype.  ``'vis'`` returns DTPOL_STOKES (the I,Q,U,V
         amplitudes packed into the real parts of the vis fields);
         ``'amp'`` returns DTAMP.
     err_type : {'predicted', 'measured'}
-        Sigma propagation method.
+        Sigma propagation method. See module docstring.
     num_samples : int
         Bootstrap resample size when ``err_type='measured'``.
+    invvar_avg : bool
+        When True (default) and ``err_type='predicted'``, the per-bin
+        amplitude mean is inverse-variance weighted by the per-row sigmas
+        before Rice debiasing reuses the analytic Rician-SNR estimator for
+        the output sigma. When False, falls back to the legacy direct mean.
 
     Returns
     -------
     np.recarray
     """
-    if return_type != "rec":
-        raise ValueError("only return_type='rec' is supported")
     if err_type not in ("predicted", "measured"):
         raise ValueError(f"err_type must be 'predicted' or 'measured', got {err_type!r}")
     if rec_type not in ("vis", "amp"):
@@ -363,6 +473,9 @@ def incoh_avg_vis(obs, dt=0, debias=True, scan_avg=False, return_type="rec",
     else:
         bin_id = np.floor(data["time"] * 3600.0 / dt).astype(np.int64)
 
+    # Field names: Stokes I, Q, U, V for rec_type='vis'; just the I
+    # amplitude for rec_type='amp'. obs.polrep is enforced to 'stokes'
+    # above; this list does not generalize to other bases.
     if rec_type == "vis":
         out_dtype = ehc.DTPOL_STOKES
         amp_fields = ("vis", "qvis", "uvis", "vvis")
@@ -375,7 +488,9 @@ def incoh_avg_vis(obs, dt=0, debias=True, scan_avg=False, return_type="rec",
     if len(data) == 0:
         return np.empty(0, dtype=out_dtype)
 
-    keys = (data["t1"], data["t2"], data["tau1"], data["tau2"], bin_id)
+    # Group on baseline + bin only. See coh_avg_vis / module docstring on
+    # why tau1, tau2 are carried through but not grouping keys.
+    keys = (data["t1"], data["t2"], bin_id)
     gids, n_groups = _group_ids(*keys)
     first = _first_index_per_group(gids, n_groups)
 
@@ -384,9 +499,11 @@ def incoh_avg_vis(obs, dt=0, debias=True, scan_avg=False, return_type="rec",
     out["t2"] = data["t2"][first]
     out["tint"] = np.bincount(gids, weights=data["tint"], minlength=n_groups)
     counts = np.bincount(gids, minlength=n_groups).astype(np.float64)
+    # (u, v) are averaged within each bin.
     out["u"] = np.bincount(gids, weights=data["u"], minlength=n_groups) / counts
     out["v"] = np.bincount(gids, weights=data["v"], minlength=n_groups) / counts
 
+    # Output time: bin midpoint for fixed dt, earliest sample in the scan.
     if scan_avg:
         time_min = np.full(n_groups, np.inf)
         np.minimum.at(time_min, gids, data["time"])
@@ -404,6 +521,7 @@ def incoh_avg_vis(obs, dt=0, debias=True, scan_avg=False, return_type="rec",
         amp_out, sig_out = _amplitude_per_group(
             np.abs(data[vf]), data[sf], gids, n_groups,
             debias=debias, err_type=err_type, num_samples=num_samples,
+            invvar_avg=invvar_avg,
         )
         if rec_type == "vis":
             out[vf] = amp_out  # cast to complex implicitly via dtype

--- a/ehtim/statistics/averaging.py
+++ b/ehtim/statistics/averaging.py
@@ -133,6 +133,23 @@ def _inverse_variance_sigma(sig_per_row, gids, n_groups):
     return out
 
 
+def _legacy_sigma(sig_per_row, gids, n_groups):
+    """Reduce per-row sigma to per-group ``sqrt(sum_i sigma_i^2) / N``.
+
+    The legacy formula used by ``dataframes.coh_avg_vis``. NOT inverse
+    variance; kept here only so ``invvar_avg=False`` reproduces legacy
+    output bit-for-bit. Groups with no finite rows get ``NaN``.
+    """
+    finite = np.isfinite(sig_per_row) & (sig_per_row > 0)
+    sq = np.where(finite, sig_per_row ** 2, 0.0)
+    sums = np.bincount(gids, weights=sq, minlength=n_groups)
+    counts = np.bincount(gids, weights=finite.astype(np.float64), minlength=n_groups)
+    out = np.full(n_groups, np.nan)
+    valid = counts > 0
+    out[valid] = np.sqrt(sums[valid]) / counts[valid]
+    return out
+
+
 def _amplitude_per_group(amps_per_row, sigs_per_row, gids, n_groups,
                          debias, err_type, num_samples, invvar_avg):
     """Reduce per-row (amplitude, sigma) pairs to per-group (mean_amp, sigma).
@@ -309,10 +326,13 @@ def coh_avg_vis(obs, dt=0, scan_avg=False, err_type="predicted",
         else:
             out[vf] = _mean_complex(data[vf], gids, n_groups)
 
-    # Sigmas.
+    # Sigmas. invvar_avg gates the predicted-sigma branch so
+    # invvar_avg=False reproduces the legacy sqrt(sum(sig^2))/N formula
+    # bit-for-bit. The bootstrap branch is unchanged either way.
     if err_type == "predicted":
+        sigma_fn = _inverse_variance_sigma if invvar_avg else _legacy_sigma
         for sf in sig_fields:
-            out[sf] = _inverse_variance_sigma(data[sf], gids, n_groups)
+            out[sf] = sigma_fn(data[sf], gids, n_groups)
     else:
         # 'measured': bootstrap the per-bin visibility-amplitude dispersion.
         # The returned sigma is half the 68% bootstrap interval width --
@@ -411,10 +431,23 @@ def coh_moving_avg_vis(obs, dt=50, invvar_avg=True):
         for sf in sig_fields:
             vals = data[sf][sorted_rows]
             finite = np.isfinite(vals) & (vals > 0)
-            inv_var = np.where(finite, 1.0 / np.maximum(vals, 1e-300) ** 2, 0.0)
-            inv_var_cs = np.concatenate(([0.0], np.cumsum(inv_var)))
-            sums = inv_var_cs[right] - inv_var_cs[left]
-            out[sf][sorted_rows] = np.where(sums > 0, 1.0 / np.sqrt(np.maximum(sums, 1e-300)), np.nan)
+            if invvar_avg:
+                inv_var = np.where(finite, 1.0 / np.maximum(vals, 1e-300) ** 2, 0.0)
+                inv_var_cs = np.concatenate(([0.0], np.cumsum(inv_var)))
+                sums = inv_var_cs[right] - inv_var_cs[left]
+                out[sf][sorted_rows] = np.where(
+                    sums > 0, 1.0 / np.sqrt(np.maximum(sums, 1e-300)), np.nan,
+                )
+            else:
+                # Legacy: sqrt(sum(sig_i^2)) / N within the window.
+                sq = np.where(finite, vals ** 2, 0.0)
+                sq_cs = np.concatenate(([0.0], np.cumsum(sq)))
+                cnt_cs = np.concatenate(([0.0], np.cumsum(finite.astype(np.float64))))
+                sums = sq_cs[right] - sq_cs[left]
+                cnt = cnt_cs[right] - cnt_cs[left]
+                out[sf][sorted_rows] = np.where(
+                    cnt > 0, np.sqrt(sums) / np.maximum(cnt, 1.0), np.nan,
+                )
 
     return out
 

--- a/ehtim/statistics/averaging.py
+++ b/ehtim/statistics/averaging.py
@@ -14,7 +14,7 @@ All three propagate visibility errors via the inverse-variance combination
 .. math:: \\sigma_{\\rm avg} = 1 / \\sqrt{\\sum_i 1/\\sigma_i^2}.
 
 This matches the channel/IF averaging in :func:`ehtim.io.load.load_obs_uvfits`
-(see PR #230) and replaces the historical ``sqrt(mean(sigma_i**2))`` formula in
+and replaces the historical ``sqrt(mean(sigma_i**2))`` formula in
 ``dataframes.py`` which underestimated errors and inflated SNRs.
 """
 

--- a/ehtim/statistics/averaging.py
+++ b/ehtim/statistics/averaging.py
@@ -8,13 +8,39 @@ Pure-NumPy implementations of three averaging routines:
 - :func:`incoh_avg_vis` — incoherent (amplitude) averaging with Rice
   debiasing.
 
-Sigma propagation uses the inverse-variance combination
+``invvar_avg`` selects the value+sigma estimator pair on each routine.
+Both halves are gated together so each branch is internally consistent:
 
-.. math:: \\sigma_{\\rm avg} = 1 / \\sqrt{\\sum_i 1/\\sigma_i^2}.
+  - ``invvar_avg=True`` (default) — inverse-variance weighted mean and
+    inverse-variance sigma:
 
-With ``invvar_avg=True`` (default) visibility values are also combined with
-inverse-variance weights, ``<V> = sum_i(V_i/\\sigma_i^2) / sum_i(1/\\sigma_i^2)``.
-``invvar_avg=False`` reproduces the legacy direct (unweighted) mean.
+    .. math:: \\langle V \\rangle = \\sum_i (V_i / \\sigma_i^2) / \\sum_i (1 / \\sigma_i^2)
+    .. math:: \\sigma_{\\rm avg} = 1 / \\sqrt{\\sum_i 1 / \\sigma_i^2}
+
+    For ``incoh_avg_vis`` the amplitude is computed as an inverse-variance
+    weighted Rice-debiased mean
+    ``sqrt(max(<|V|^2>_w - (2 - 1/N) <sigma^2>_w, 0))``; the sigma is the
+    same inverse-variance formula above.
+
+  - ``invvar_avg=False`` — legacy estimator formulas:
+
+    * ``coh_avg_vis``: direct (unweighted) complex mean with
+      ``sigma_avg = sqrt(sum sigma_i^2) / N``. Reproduces
+      ``dataframes.coh_avg_vis`` bit-for-bit.
+    * ``incoh_avg_vis``: ``stats.deb_amp`` amplitude with
+      ``stats.inc_sig`` Rician-SNR sigma (eq 9.86 of Thompson et al.,
+      Interferometry and Synthesis in Radio Astronomy). Reproduces
+      ``dataframes.incoh_avg_vis`` bit-for-bit.
+    * ``coh_moving_avg_vis``: the same unweighted-mean and
+      ``sqrt(sum sigma_i^2) / N`` formulas, but a *centered* window
+      ``[t - dt/2, t + dt/2]`` with original timestamps. This does NOT
+      reproduce ``dataframes.coh_moving_avg_vis`` bit-for-bit: the legacy
+      version used a trailing pandas ``.rolling(dt)`` window plus a
+      ``-dt/2`` timestamp shift. The centered window is the intended
+      convention; the divergence is deliberate.
+
+Mixing the two paths (e.g., inv-var amplitude with the Rician-SNR sigma)
+is not a coherent estimator and must be avoided.
 
 Conventions worth flagging for future readers:
   - Fixed-dt bins set the output ``time`` to the bin midpoint; ``scan_avg``
@@ -22,22 +48,28 @@ Conventions worth flagging for future readers:
   - Output ``(u, v)`` is the per-bin mean.
   - ``err_type='measured'`` bootstraps the visibility-amplitude dispersion;
     sigma is returned as half the 68% bootstrap interval width. Convention
-    inherited from the legacy code, not a standard estimator.
-  - For incoherent averaging with ``err_type='predicted'``, the per-bin
-    sigma comes from :func:`stats.inc_sig` (eq 9.86 of Thompson et al.,
-    Interferometry and Synthesis in Radio Astronomy). It is an analytic
-    Rician-SNR estimator that returns the noise level which would produce
-    the equivalent SNR penalty after Rice-debiased averaging — neither
-    stddev nor pure inverse variance.
+    inherited from the legacy code, not stddev. ``invvar_avg`` has no
+    effect on this path.
   - ``tau1`` / ``tau2`` (per-site opacities) are copied through from the
     first row in each bin. They are not used as grouping keys: they are
     basically always zero in practice, and using them would needlessly
     fragment bins if a site's opacity drifted within a window.
+  - ``_assign_scan_bin`` assumes ``obs.scans`` is pre-sorted and
+    non-overlapping (legacy invariant). The pandas-based
+    ``dataframes.get_bins_labels`` carried explicit overlap / midnight-
+    wraparound logic; that path is not exercised by current code paths
+    so it is not ported here.
 """
 
 import numpy as np
 
 import ehtim.const_def as ehc
+
+# TODO: the helpers below (and the per-group amplitude reductions in this
+# module) overlap conceptually with stats.deb_amp / stats.inc_sig /
+# stats.mean_incoh_avg / stats.coh_sig. Worth consolidating into a single
+# set of vectorised reducers once the legacy stats.py call sites elsewhere
+# in the codebase are audited.
 from ehtim.statistics.stats import bootstrap, mean_incoh_avg
 
 __all__ = ["coh_avg_vis", "coh_moving_avg_vis", "incoh_avg_vis"]
@@ -75,6 +107,28 @@ def _assign_scan_bin(times_hr, scans):
     intervals are ``(tstart, tstop]`` (open on the left, closed on the
     right) so a sample exactly on a scan boundary lands in the later scan
     only, not both.
+
+    Legacy behaviors deliberately NOT ported from
+    ``dataframes.get_bins_labels`` — flagged here in case a real dataset
+    ever needs them back:
+
+      1. **Edge padding.** The legacy default expanded each scan edge by
+         ``dt=0.00001`` hr (~36 ms) before binning. Not replicated:
+         scan-edge fuzz is a property of the scan table, not the binning
+         code; fix the table (e.g. ``obs.add_scans(...)``) rather than
+         relying on a hidden tolerance here.
+      2. **Overlap merging.** The legacy code detected overlapping
+         intervals in ``obs.scans`` and merged them via
+         ``merge_overlapping_intervals``. Not replicated: ``obs.scans``
+         is expected pre-sorted and non-overlapping. Overlapping
+         intervals here would cause earlier scans to silently shadow
+         later ones (the loop writes ``out[mask] = idx`` in order).
+      3. **Midnight wraparound.** The legacy code patched any interval
+         with ``tstop < tstart`` by adding 24 hr to ``tstop`` (so the
+         scan straddled midnight). Not replicated: a wrapping interval
+         here yields an empty mask and the rows get index ``-1`` (i.e.
+         dropped). Callers with multi-day or midnight-crossing data
+         should pre-normalise the scan table.
     """
     out = np.full(len(times_hr), -1, dtype=np.int64)
     for idx, scan in enumerate(scans):
@@ -117,52 +171,186 @@ def _first_index_per_group(gids, n_groups):
     return out
 
 
-def _inverse_variance_sigma(sig_per_row, gids, n_groups):
-    """Reduce a per-row sigma array to per-group inverse-variance sigma.
+# Shared weighting + segment-combine primitives.
+#
+# Both the fixed-bin path (``coh_avg_vis``, which reduces per-row terms into
+# disjoint groups via ``np.bincount``) and the sliding-window path
+# (``coh_moving_avg_vis``, which reduces overlapping windows via cumulative-
+# sum differences) build per-row terms, sum them per segment, then combine
+# the sums with identical arithmetic. The segment-sum mechanism differs
+# (bincount over group IDs vs cumsum over window index ranges, since windows
+# overlap and cannot be expressed as disjoint groups) but the combine
+# formulas live here once.
 
-    For each group g, the result is ``1 / sqrt(sum_i 1/sigma_i**2)`` over rows
-    i in group g with finite, positive sigma.  Groups with no valid rows get
-    ``NaN``.
+
+def _inverse_variance_weights(sig_per_row):
+    """Per-row inverse-variance weights ``1 / sigma**2``.
+
+    Returns ``(weights, finite)``. ``weights`` is zeroed on rows with
+    non-finite or non-positive sigma so they contribute nothing to a
+    weighted sum; ``finite`` is the per-row validity mask.
     """
     finite = np.isfinite(sig_per_row) & (sig_per_row > 0)
-    inv_var = np.zeros_like(sig_per_row, dtype=np.float64)
-    inv_var[finite] = 1.0 / sig_per_row[finite] ** 2
-    sums = np.bincount(gids, weights=inv_var, minlength=n_groups)
-    out = np.full(n_groups, np.nan)
-    out[sums > 0] = 1.0 / np.sqrt(sums[sums > 0])
+    weights = np.where(finite, 1.0 / np.maximum(sig_per_row, 1e-300) ** 2, 0.0)
+    return weights, finite
+
+
+def _window_sums(values, left, right):
+    """Sliding-window segment sums for half-open index ranges ``[left, right)``.
+
+    ``cs[right] - cs[left]`` over a zero-prefixed cumulative sum — the
+    overlapping-window analogue of ``np.bincount`` over disjoint groups.
+    Relies on float64 accumulation: the ``cs[right] - cs[left]``
+    subtraction loses precision if ported to float32 (catastrophic
+    cancellation when the running sum dwarfs the window sum).
+    """
+    cumsum = np.concatenate(([0.0], np.cumsum(values)))
+    return cumsum[right] - cumsum[left]
+
+
+def _combine_mean_inverse_variance(sum_re_w, sum_im_w, sum_w):
+    """Complex inverse-variance mean from segment sums.
+
+    ``<V> = (sum(Re/sigma**2) + i sum(Im/sigma**2)) / sum(1/sigma**2)``.
+    Segments with zero total weight get ``NaN + NaN*1j``.
+    """
+    out = np.full(sum_w.shape, np.nan + 1j * np.nan, dtype=np.complex128)
+    valid = sum_w > 0
+    out.real[valid] = sum_re_w[valid] / sum_w[valid]
+    out.imag[valid] = sum_im_w[valid] / sum_w[valid]
     return out
+
+
+def _combine_mean_direct(sum_re, sum_im, count):
+    """Complex direct (unweighted) mean from segment sums: ``sum(V) / N``.
+
+    Segments with no finite rows get ``NaN + NaN*1j``.
+    """
+    out = np.full(count.shape, np.nan + 1j * np.nan, dtype=np.complex128)
+    valid = count > 0
+    out.real[valid] = sum_re[valid] / count[valid]
+    out.imag[valid] = sum_im[valid] / count[valid]
+    return out
+
+
+def _combine_sigma_inverse_variance(sum_w):
+    """Inverse-variance sigma from segment sums: ``1 / sqrt(sum(1/sigma**2))``.
+
+    Segments with zero total weight get ``NaN``.
+    """
+    out = np.full(sum_w.shape, np.nan)
+    valid = sum_w > 0
+    out[valid] = 1.0 / np.sqrt(sum_w[valid])
+    return out
+
+
+def _combine_sigma_legacy(sum_sq, count):
+    """Legacy sigma from segment sums: ``sqrt(sum(sigma**2)) / N``.
+
+    The formula used by ``dataframes.coh_avg_vis`` — NOT inverse variance;
+    kept so ``invvar_avg=False`` reproduces legacy output bit-for-bit.
+    Segments with no finite rows get ``NaN``.
+    """
+    out = np.full(count.shape, np.nan)
+    valid = count > 0
+    out[valid] = np.sqrt(sum_sq[valid]) / count[valid]
+    return out
+
+
+def _inverse_variance_sigma(sig_per_row, gids, n_groups):
+    """Per-group inverse-variance sigma ``1 / sqrt(sum_i 1/sigma_i**2)``.
+
+    Groups with no valid rows get ``NaN``.
+    """
+    weights, _ = _inverse_variance_weights(sig_per_row)
+    sum_w = np.bincount(gids, weights=weights, minlength=n_groups)
+    return _combine_sigma_inverse_variance(sum_w)
 
 
 def _legacy_sigma(sig_per_row, gids, n_groups):
-    """Reduce per-row sigma to per-group ``sqrt(sum_i sigma_i^2) / N``.
+    """Per-group legacy sigma ``sqrt(sum_i sigma_i**2) / N``.
 
-    The legacy formula used by ``dataframes.coh_avg_vis``. NOT inverse
-    variance; kept here only so ``invvar_avg=False`` reproduces legacy
-    output bit-for-bit. Groups with no finite rows get ``NaN``.
+    Groups with no finite rows get ``NaN``.
     """
     finite = np.isfinite(sig_per_row) & (sig_per_row > 0)
     sq = np.where(finite, sig_per_row ** 2, 0.0)
-    sums = np.bincount(gids, weights=sq, minlength=n_groups)
-    counts = np.bincount(gids, weights=finite.astype(np.float64), minlength=n_groups)
-    out = np.full(n_groups, np.nan)
-    valid = counts > 0
-    out[valid] = np.sqrt(sums[valid]) / counts[valid]
-    return out
+    sum_sq = np.bincount(gids, weights=sq, minlength=n_groups)
+    count = np.bincount(gids, weights=finite.astype(np.float64), minlength=n_groups)
+    return _combine_sigma_legacy(sum_sq, count)
 
 
-def _amplitude_per_group(amps_per_row, sigs_per_row, gids, n_groups,
-                         debias, err_type, num_samples, invvar_avg):
-    """Reduce per-row (amplitude, sigma) pairs to per-group (mean_amp, sigma).
+def _legacy_mean_complex(vis_per_row, gids, n_groups):
+    """Per-group direct (unweighted) complex mean. NaN-safe.
 
-    err_type:
-      - 'predicted': use the per-row sigmas. mean_incoh_avg applies Rice
-        debiasing to the amplitudes and returns the analytic Rician-SNR
-        sigma (see module docstring). When invvar_avg=True the per-group
-        amplitude mean is inverse-variance weighted; the returned sigma
-        still comes from inc_sig (predicted by the per-row sigmas).
-      - 'measured': bootstrap the amplitude dispersion within each group.
-        The reported sigma is half the 68% bootstrap interval width — a
-        convention inherited from the legacy code, not stddev.
+    Groups with no finite rows get ``NaN + NaN*1j``.
+    """
+    finite = np.isfinite(vis_per_row.real) & np.isfinite(vis_per_row.imag)
+    re = np.where(finite, vis_per_row.real, 0.0)
+    im = np.where(finite, vis_per_row.imag, 0.0)
+    sum_re = np.bincount(gids, weights=re, minlength=n_groups)
+    sum_im = np.bincount(gids, weights=im, minlength=n_groups)
+    count = np.bincount(gids, weights=finite.astype(np.float64), minlength=n_groups)
+    return _combine_mean_direct(sum_re, sum_im, count)
+
+
+def _inverse_variance_mean_complex(vis_per_row, sig_per_row, gids, n_groups):
+    """Per-group inverse-variance weighted complex mean. NaN-safe.
+
+    ``<V>_g = sum_i (V_i / sigma_i^2) / sum_i (1 / sigma_i^2)`` over rows
+    i in group g with finite V and finite positive sigma. Groups with no
+    valid rows get ``NaN + NaN*1j``.
+    """
+    weights, finite_s = _inverse_variance_weights(sig_per_row)
+    finite = (finite_s & np.isfinite(vis_per_row.real)
+              & np.isfinite(vis_per_row.imag))
+    w = np.where(finite, weights, 0.0)
+    re_w = np.where(finite, vis_per_row.real, 0.0) * w
+    im_w = np.where(finite, vis_per_row.imag, 0.0) * w
+    sum_re_w = np.bincount(gids, weights=re_w, minlength=n_groups)
+    sum_im_w = np.bincount(gids, weights=im_w, minlength=n_groups)
+    sum_w = np.bincount(gids, weights=w, minlength=n_groups)
+    return _combine_mean_inverse_variance(sum_re_w, sum_im_w, sum_w)
+
+
+def _legacy_mean_amplitude_group(amps_per_row, sigs_per_row, gids, n_groups,
+                                 debias, err_type, num_samples):
+    """Per-group (amplitude, sigma) via the legacy stats helpers.
+
+    Reproduces ``ehtim.statistics.dataframes.incoh_avg_vis`` row-for-row.
+    Used on the ``invvar_avg=False`` branch of :func:`incoh_avg_vis`.
+
+    Parameters
+    ----------
+    amps_per_row : np.ndarray
+        Per-row magnitudes ``|V_i|``. ``np.abs(data[vis_field])`` at the
+        call site; need not be non-negative on input (taken as ``|.|``
+        internally where it matters).
+    sigs_per_row : np.ndarray
+        Per-row visibility sigmas. Rows with non-finite or non-positive
+        sigma are dropped from the per-group reductions.
+    gids : np.ndarray of int64
+        Length-N per-row group ID (output of :func:`_group_ids`).
+    n_groups : int
+        Number of distinct groups; sets the output length.
+    debias : bool
+        When True, the ``err_type='predicted'`` amplitude is the
+        Rice-debiased ``stats.deb_amp``; when False, it is the raw
+        ``sqrt(mean(|V_i|**2))``. Ignored on ``err_type='measured'``.
+    err_type : {'predicted', 'measured'}
+        ``'predicted'`` uses the per-row sigmas: amplitude from
+        ``stats.deb_amp`` (eq 9.86 of Thompson et al.), sigma from
+        ``stats.inc_sig`` (analytic Rician-SNR estimator). ``'measured'``
+        bootstraps the per-bin amplitude dispersion; sigma is half the
+        68% bootstrap-interval width (legacy convention, not stddev).
+    num_samples : int
+        Bootstrap resample count when ``err_type='measured'``.
+
+    Returns
+    -------
+    amp_out : np.ndarray, shape (n_groups,)
+        Per-group amplitude. ``NaN`` for empty groups.
+    sig_out : np.ndarray, shape (n_groups,)
+        Per-group sigma. ``NaN`` for empty groups.
     """
     amp_out = np.full(n_groups, np.nan)
     sig_out = np.full(n_groups, np.nan)
@@ -173,14 +361,6 @@ def _amplitude_per_group(amps_per_row, sigs_per_row, gids, n_groups,
             continue
         if err_type == "predicted":
             a, s = mean_incoh_avg(pairs, debias=debias)
-            if invvar_avg:
-                amps_g = np.abs(amps_per_row[mask])
-                sigs_g = sigs_per_row[mask]
-                finite = (np.isfinite(amps_g) & np.isfinite(sigs_g)
-                          & (sigs_g > 0))
-                if np.any(finite):
-                    w = 1.0 / sigs_g[finite] ** 2
-                    a = np.sum(amps_g[finite] * w) / np.sum(w)
             amp_out[g] = a
             sig_out[g] = s
         else:
@@ -198,44 +378,68 @@ def _amplitude_per_group(amps_per_row, sigs_per_row, gids, n_groups,
     return amp_out, sig_out
 
 
-def _mean_complex(vis_per_row, gids, n_groups):
-    """Per-group complex mean (direct, unweighted). NaN-safe.
+def _inverse_variance_mean_amplitude_group(amps_per_row, sigs_per_row, gids,
+                                           n_groups, debias):
+    """Per-group (amplitude, sigma) via the inverse-variance pair.
 
-    Groups with no finite rows get ``NaN + NaN*1j``.
+    Both halves are inverse-variance-weighted so the output is internally
+    consistent (no mixing across estimator families). Used on the
+    ``invvar_avg=True`` branch of :func:`incoh_avg_vis`. For each group
+    ``g``, with ``w_i = 1 / sigma_i**2`` over rows ``i`` with finite
+    ``amp_i`` and ``sigma_i > 0``:
+
+      amp**2 = sum_i(w_i * amp_i**2) / sum_i(w_i)            (not debias)
+             = max(<above> - (2 - 1/N) * N / sum_i(w_i), 0)  (debias)
+      sigma  = 1 / sqrt(sum_i(w_i))
+
+    The Rice debias term ``(2 - 1/N) * <sigma**2>_w`` generalises
+    ``stats.deb_amp``'s ``(2 - 1/Nc) * mean(sigma**2)`` to inverse-variance
+    weights: since ``w_i * sigma_i**2 = 1``, ``<sigma**2>_w = N / sum(w_i)``
+    and the correction simplifies to ``(2N - 1) / sum(w_i)``. In the
+    equal-sigma limit the amplitude reduces exactly to ``stats.deb_amp``;
+    the sigma does NOT reduce to ``stats.inc_sig`` — different estimator
+    families — see module docstring.
+
+    Parameters
+    ----------
+    amps_per_row : np.ndarray
+        Per-row magnitudes ``|V_i|``. Squared before reduction.
+    sigs_per_row : np.ndarray
+        Per-row visibility sigmas. Rows with non-finite or non-positive
+        sigma are dropped (zero inverse-variance weight).
+    gids : np.ndarray of int64
+        Length-N per-row group ID.
+    n_groups : int
+        Number of distinct groups.
+    debias : bool
+        Apply the inverse-variance-weighted Rice bias correction. When
+        False the amplitude is the bare inverse-variance-weighted RMS.
+
+    Returns
+    -------
+    amp_out : np.ndarray, shape (n_groups,)
+        Per-group amplitude. ``NaN`` for groups with no finite rows.
+    sig_out : np.ndarray, shape (n_groups,)
+        Per-group sigma. ``NaN`` for groups with no finite rows.
     """
-    finite = np.isfinite(vis_per_row.real) & np.isfinite(vis_per_row.imag)
-    re = np.where(finite, vis_per_row.real, 0.0)
-    im = np.where(finite, vis_per_row.imag, 0.0)
-    sums_re = np.bincount(gids, weights=re, minlength=n_groups)
-    sums_im = np.bincount(gids, weights=im, minlength=n_groups)
-    counts = np.bincount(gids, weights=finite.astype(np.float64), minlength=n_groups)
-    out = np.full(n_groups, np.nan + 1j * np.nan, dtype=np.complex128)
-    valid = counts > 0
-    out.real[valid] = sums_re[valid] / counts[valid]
-    out.imag[valid] = sums_im[valid] / counts[valid]
-    return out
-
-
-def _invvar_mean_complex(vis_per_row, sig_per_row, gids, n_groups):
-    """Per-group inverse-variance weighted complex mean. NaN-safe.
-
-    ``<V>_g = sum_i (V_i / sigma_i^2) / sum_i (1 / sigma_i^2)`` over rows
-    i in group g with finite V and finite positive sigma. Groups with no
-    valid rows get ``NaN + NaN*1j``.
-    """
-    finite = (np.isfinite(vis_per_row.real) & np.isfinite(vis_per_row.imag)
-              & np.isfinite(sig_per_row) & (sig_per_row > 0))
-    inv_var = np.where(finite, 1.0 / np.maximum(sig_per_row, 1e-300) ** 2, 0.0)
-    re_w = np.where(finite, vis_per_row.real * inv_var, 0.0)
-    im_w = np.where(finite, vis_per_row.imag * inv_var, 0.0)
-    sums_re = np.bincount(gids, weights=re_w, minlength=n_groups)
-    sums_im = np.bincount(gids, weights=im_w, minlength=n_groups)
+    amp_out = np.full(n_groups, np.nan)
+    sig_out = np.full(n_groups, np.nan)
+    weights, finite_s = _inverse_variance_weights(sigs_per_row)
+    finite = finite_s & np.isfinite(amps_per_row)
+    inv_var = np.where(finite, weights, 0.0)
+    a2_w = np.where(finite, amps_per_row ** 2, 0.0) * inv_var
     sums_w = np.bincount(gids, weights=inv_var, minlength=n_groups)
-    out = np.full(n_groups, np.nan + 1j * np.nan, dtype=np.complex128)
+    sums_a2_w = np.bincount(gids, weights=a2_w, minlength=n_groups)
+    counts = np.bincount(gids, weights=finite.astype(np.float64), minlength=n_groups)
     valid = sums_w > 0
-    out.real[valid] = sums_re[valid] / sums_w[valid]
-    out.imag[valid] = sums_im[valid] / sums_w[valid]
-    return out
+    sig_out[valid] = 1.0 / np.sqrt(sums_w[valid])
+    a2_avg = np.where(valid, sums_a2_w / np.maximum(sums_w, 1e-300), 0.0)
+    if debias:
+        bias = np.where(valid & (counts > 0),
+                        (2.0 * counts - 1.0) / np.maximum(sums_w, 1e-300), 0.0)
+        a2_avg = np.maximum(a2_avg - bias, 0.0)
+    amp_out[valid] = np.sqrt(a2_avg[valid])
+    return amp_out, sig_out
 
 
 # ---------------------------------------------------------------------------
@@ -322,9 +526,9 @@ def coh_avg_vis(obs, dt=0, scan_avg=False, err_type="predicted",
     # Visibilities: inverse-variance weighted (default) or direct mean.
     for vf, sf in zip(vis_fields, sig_fields):
         if invvar_avg:
-            out[vf] = _invvar_mean_complex(data[vf], data[sf], gids, n_groups)
+            out[vf] = _inverse_variance_mean_complex(data[vf], data[sf], gids, n_groups)
         else:
-            out[vf] = _mean_complex(data[vf], gids, n_groups)
+            out[vf] = _legacy_mean_complex(data[vf], gids, n_groups)
 
     # Sigmas. invvar_avg gates the predicted-sigma branch so
     # invvar_avg=False reproduces the legacy sqrt(sum(sig^2))/N formula
@@ -366,11 +570,24 @@ def coh_moving_avg_vis(obs, dt=50, invvar_avg=True):
     invvar_avg : bool
         When True (default), combine visibilities within each window with
         inverse-variance weights. When False use the direct (unweighted)
-        complex mean (legacy behavior).
+        complex mean. Selects only the value+sigma *formula*; the window
+        is centered either way (see Notes).
 
     Returns
     -------
     np.recarray of dtype DTPOL_STOKES or DTPOL_CIRC matching ``obs.polrep``.
+
+    Notes
+    -----
+    The window is centered: ``[t - dt/2, t + dt/2]`` with the row's
+    original timestamp preserved. This differs from the legacy
+    ``dataframes.coh_moving_avg_vis``, which used a trailing pandas
+    ``.rolling(dt)`` window ``(t - dt, t]`` followed by a ``-dt/2``
+    timestamp shift. The two conventions select different samples on
+    irregularly spaced data, so ``invvar_avg=False`` here does NOT
+    reproduce the legacy output bit-for-bit (only the unweighted-mean and
+    ``sqrt(sum sigma_i^2)/N`` formulas match). The centered window is the
+    intended convention.
     """
     if dt <= 0:
         raise ValueError("dt must be positive")
@@ -401,52 +618,46 @@ def coh_moving_avg_vis(obs, dt=50, invvar_avg=True):
         left = np.searchsorted(sorted_times, sorted_times - half, side="left")
         right = np.searchsorted(sorted_times, sorted_times + half, side="right")
 
+        # Same combine arithmetic as coh_avg_vis (the _combine_* helpers);
+        # only the per-segment sum uses _window_sums (cumsum over overlapping
+        # windows) instead of np.bincount (disjoint groups).
         for vf, sf in zip(vis_fields, sig_fields):
             vals = data[vf][sorted_rows]
             sigs = data[sf][sorted_rows]
             if invvar_avg:
-                finite_v = np.isfinite(vals.real) & np.isfinite(vals.imag)
-                finite_s = np.isfinite(sigs) & (sigs > 0)
-                finite = finite_v & finite_s
-                inv_var = np.where(finite, 1.0 / np.maximum(sigs, 1e-300) ** 2, 0.0)
-                re_w = np.where(finite, vals.real * inv_var, 0.0)
-                im_w = np.where(finite, vals.imag * inv_var, 0.0)
-                re_cs = np.concatenate(([0.0], np.cumsum(re_w)))
-                im_cs = np.concatenate(([0.0], np.cumsum(im_w)))
-                w_cs = np.concatenate(([0.0], np.cumsum(inv_var)))
-                w = w_cs[right] - w_cs[left]
-                re_mean = np.where(w > 0, (re_cs[right] - re_cs[left]) / np.maximum(w, 1e-300), np.nan)
-                im_mean = np.where(w > 0, (im_cs[right] - im_cs[left]) / np.maximum(w, 1e-300), np.nan)
-                out[vf][sorted_rows] = re_mean + 1j * im_mean
+                weights, finite_s = _inverse_variance_weights(sigs)
+                finite = finite_s & np.isfinite(vals.real) & np.isfinite(vals.imag)
+                w = np.where(finite, weights, 0.0)
+                re_w = np.where(finite, vals.real, 0.0) * w
+                im_w = np.where(finite, vals.imag, 0.0) * w
+                out[vf][sorted_rows] = _combine_mean_inverse_variance(
+                    _window_sums(re_w, left, right),
+                    _window_sums(im_w, left, right),
+                    _window_sums(w, left, right),
+                )
             else:
                 finite = np.isfinite(vals.real) & np.isfinite(vals.imag)
-                re_cs = np.concatenate(([0.0], np.cumsum(np.where(finite, vals.real, 0.0))))
-                im_cs = np.concatenate(([0.0], np.cumsum(np.where(finite, vals.imag, 0.0))))
-                cnt_cs = np.concatenate(([0.0], np.cumsum(finite.astype(np.float64))))
-                cnt = cnt_cs[right] - cnt_cs[left]
-                re_mean = np.where(cnt > 0, (re_cs[right] - re_cs[left]) / np.maximum(cnt, 1.0), np.nan)
-                im_mean = np.where(cnt > 0, (im_cs[right] - im_cs[left]) / np.maximum(cnt, 1.0), np.nan)
-                out[vf][sorted_rows] = re_mean + 1j * im_mean
+                re = np.where(finite, vals.real, 0.0)
+                im = np.where(finite, vals.imag, 0.0)
+                out[vf][sorted_rows] = _combine_mean_direct(
+                    _window_sums(re, left, right),
+                    _window_sums(im, left, right),
+                    _window_sums(finite.astype(np.float64), left, right),
+                )
 
         for sf in sig_fields:
             vals = data[sf][sorted_rows]
-            finite = np.isfinite(vals) & (vals > 0)
             if invvar_avg:
-                inv_var = np.where(finite, 1.0 / np.maximum(vals, 1e-300) ** 2, 0.0)
-                inv_var_cs = np.concatenate(([0.0], np.cumsum(inv_var)))
-                sums = inv_var_cs[right] - inv_var_cs[left]
-                out[sf][sorted_rows] = np.where(
-                    sums > 0, 1.0 / np.sqrt(np.maximum(sums, 1e-300)), np.nan,
+                weights, _ = _inverse_variance_weights(vals)
+                out[sf][sorted_rows] = _combine_sigma_inverse_variance(
+                    _window_sums(weights, left, right),
                 )
             else:
-                # Legacy: sqrt(sum(sig_i^2)) / N within the window.
+                finite = np.isfinite(vals) & (vals > 0)
                 sq = np.where(finite, vals ** 2, 0.0)
-                sq_cs = np.concatenate(([0.0], np.cumsum(sq)))
-                cnt_cs = np.concatenate(([0.0], np.cumsum(finite.astype(np.float64))))
-                sums = sq_cs[right] - sq_cs[left]
-                cnt = cnt_cs[right] - cnt_cs[left]
-                out[sf][sorted_rows] = np.where(
-                    cnt > 0, np.sqrt(sums) / np.maximum(cnt, 1.0), np.nan,
+                out[sf][sorted_rows] = _combine_sigma_legacy(
+                    _window_sums(sq, left, right),
+                    _window_sums(finite.astype(np.float64), left, right),
                 )
 
     return out
@@ -476,10 +687,19 @@ def incoh_avg_vis(obs, dt=0, debias=True, scan_avg=False, rec_type="vis",
     num_samples : int
         Bootstrap resample size when ``err_type='measured'``.
     invvar_avg : bool
-        When True (default) and ``err_type='predicted'``, the per-bin
-        amplitude mean is inverse-variance weighted by the per-row sigmas
-        before Rice debiasing reuses the analytic Rician-SNR estimator for
-        the output sigma. When False, falls back to the legacy direct mean.
+        Selects the (amplitude, sigma) estimator pair when
+        ``err_type='predicted'``. Both halves are gated together so the
+        output is internally consistent:
+
+          - True (default): inverse-variance-weighted Rice-debiased
+            amplitude paired with the inverse-variance sigma
+            ``1 / sqrt(sum_i 1/sigma_i**2)``.
+          - False: legacy ``stats.deb_amp`` amplitude paired with the
+            ``stats.inc_sig`` Rician-SNR sigma. Reproduces the legacy
+            ``ehtim.statistics.dataframes.incoh_avg_vis`` bit-for-bit.
+
+        Has no effect when ``err_type='measured'`` (bootstrap path is
+        unchanged either way).
 
     Returns
     -------
@@ -549,13 +769,26 @@ def incoh_avg_vis(obs, dt=0, debias=True, scan_avg=False, rec_type="vis",
         out["tau1"] = data["tau1"][first]
         out["tau2"] = data["tau2"][first]
 
-    # Per-group amplitude + sigma via mean_incoh_avg / bootstrap.
+    # Per-group amplitude + sigma. invvar_avg gates BOTH halves so the
+    # output is internally consistent on each branch:
+    #   - False : legacy mean_incoh_avg (deb_amp + inc_sig). Bit-for-bit
+    #     reproduces ehtim.statistics.dataframes.incoh_avg_vis.
+    #   - True  : inverse-variance-weighted Rice-debiased amplitude paired
+    #     with the inverse-variance sigma 1 / sqrt(sum 1/sigma^2). The
+    #     coupling matters: mixing an inv-var amplitude with the Rician-
+    #     SNR sigma (or vice versa) is not a coherent estimator.
+    # err_type='measured' bootstraps the dispersion independently of
+    # invvar_avg.
     for vf, sf in zip(amp_fields, sig_fields):
-        amp_out, sig_out = _amplitude_per_group(
-            np.abs(data[vf]), data[sf], gids, n_groups,
-            debias=debias, err_type=err_type, num_samples=num_samples,
-            invvar_avg=invvar_avg,
-        )
+        if err_type == "predicted" and invvar_avg:
+            amp_out, sig_out = _inverse_variance_mean_amplitude_group(
+                np.abs(data[vf]), data[sf], gids, n_groups, debias=debias,
+            )
+        else:
+            amp_out, sig_out = _legacy_mean_amplitude_group(
+                np.abs(data[vf]), data[sf], gids, n_groups,
+                debias=debias, err_type=err_type, num_samples=num_samples,
+            )
         if rec_type == "vis":
             out[vf] = amp_out  # cast to complex implicitly via dtype
         else:

--- a/ehtim/statistics/averaging.py
+++ b/ehtim/statistics/averaging.py
@@ -1,7 +1,6 @@
 """Visibility time-averaging.
 
-Pure-NumPy implementations of the three averaging routines historically
-provided by ``ehtim.statistics.dataframes``:
+Pure-NumPy implementations of three averaging routines:
 
 - :func:`coh_avg_vis` — coherent (complex) averaging into fixed time bins
   or per scan.
@@ -12,10 +11,6 @@ provided by ``ehtim.statistics.dataframes``:
 All three propagate visibility errors via the inverse-variance combination
 
 .. math:: \\sigma_{\\rm avg} = 1 / \\sqrt{\\sum_i 1/\\sigma_i^2}.
-
-This matches the channel/IF averaging in :func:`ehtim.io.load.load_obs_uvfits`
-and replaces the historical ``sqrt(mean(sigma_i**2))`` formula in
-``dataframes.py`` which underestimated errors and inflated SNRs.
 """
 
 import numpy as np
@@ -75,12 +70,12 @@ def _group_ids(*keys):
 
 
 def _first_index_per_group(gids, n_groups):
-    """Return an array of length n_groups giving one representative row index
-    (the first occurrence) for each group."""
-    out = np.full(n_groups, -1, dtype=np.int64)
-    for i, g in enumerate(gids):
-        if out[g] == -1:
-            out[g] = i
+    """Return an array of length n_groups giving the first-occurrence row
+    index for each group.  Vectorised via ``np.unique(..., return_index=True)``.
+    """
+    unique_groups, first_idx = np.unique(gids, return_index=True)
+    out = np.empty(n_groups, dtype=np.int64)
+    out[unique_groups] = first_idx
     return out
 
 
@@ -98,6 +93,35 @@ def _inverse_variance_sigma(sig_per_row, gids, n_groups):
     out = np.full(n_groups, np.nan)
     out[sums > 0] = 1.0 / np.sqrt(sums[sums > 0])
     return out
+
+
+def _amplitude_per_group(amps_per_row, sigs_per_row, gids, n_groups,
+                         debias, err_type, num_samples):
+    """Reduce per-row (amplitude, sigma) pairs to per-group (mean_amp, sigma)."""
+    amp_out = np.full(n_groups, np.nan)
+    sig_out = np.full(n_groups, np.nan)
+    for g in range(n_groups):
+        mask = gids == g
+        pairs = list(zip(amps_per_row[mask], sigs_per_row[mask]))
+        if not pairs:
+            continue
+        if err_type == "predicted":
+            a, s = mean_incoh_avg(pairs, debias=debias)
+            amp_out[g] = a
+            sig_out[g] = s
+        else:
+            amps = np.abs(np.asarray([y[0] for y in pairs]))
+            amps = amps[np.isfinite(amps)]
+            if len(amps) >= 2:
+                centre, (lo, hi) = bootstrap(amps, np.mean,
+                                             num_samples=num_samples,
+                                             wrapping_variable=False)
+                amp_out[g] = centre
+                sig_out[g] = 0.5 * (hi - lo)
+            elif len(amps) == 1:
+                amp_out[g] = amps[0]
+                sig_out[g] = sigs_per_row[mask][0]
+    return amp_out, sig_out
 
 
 def _mean_complex(vis_per_row, gids, n_groups):
@@ -377,29 +401,10 @@ def incoh_avg_vis(obs, dt=0, debias=True, scan_avg=False, return_type="rec",
 
     # Per-group amplitude + sigma via mean_incoh_avg / bootstrap.
     for vf, sf in zip(amp_fields, sig_fields):
-        amp_out = np.full(n_groups, np.nan)
-        sig_out = np.full(n_groups, np.nan)
-        for g in range(n_groups):
-            mask = gids == g
-            pairs = list(zip(np.abs(data[vf][mask]), data[sf][mask]))
-            if not pairs:
-                continue
-            if err_type == "predicted":
-                a, s = mean_incoh_avg(pairs, debias=debias)
-                amp_out[g] = a
-                sig_out[g] = s
-            else:
-                amps = np.abs(np.asarray([y[0] for y in pairs]))
-                amps = amps[np.isfinite(amps)]
-                if len(amps) >= 2:
-                    centre, (lo, hi) = bootstrap(amps, np.mean,
-                                                 num_samples=num_samples,
-                                                 wrapping_variable=False)
-                    amp_out[g] = centre
-                    sig_out[g] = 0.5 * (hi - lo)
-                elif len(amps) == 1:
-                    amp_out[g] = amps[0]
-                    sig_out[g] = data[sf][mask][0]
+        amp_out, sig_out = _amplitude_per_group(
+            np.abs(data[vf]), data[sf], gids, n_groups,
+            debias=debias, err_type=err_type, num_samples=num_samples,
+        )
         if rec_type == "vis":
             out[vf] = amp_out  # cast to complex implicitly via dtype
         else:

--- a/ehtim/statistics/dataframes.py
+++ b/ehtim/statistics/dataframes.py
@@ -22,13 +22,19 @@ from builtins import str
 from builtins import map
 from builtins import range
 
-import numpy as np 
+import numpy as np
 
+# pandas is imported lazily inside the closure-quantity functions below.  The
+# three averaging routines (`coh_avg_vis`, `coh_moving_avg_vis`,
+# `incoh_avg_vis`) historically lived here but were moved to
+# `ehtim.statistics.averaging` (pandas-free).  This module is kept only for
+# the closure-quantity `make_*_df` / `average_*` helpers that the soon-to-be-
+# removed `Obsdata.add_*` methods still depend on (see PR #246 on
+# dev-backend).  Once #246 syncs to `dev` this whole file is deleted.
 try:
     import pandas as pd
 except ImportError:
-    print("Warning: pandas not installed!")
-    print("Please install pandas to use statistics package!")
+    pd = None
 
 import datetime as datetime
 from astropy.time import Time

--- a/ehtim/statistics/dataframes.py
+++ b/ehtim/statistics/dataframes.py
@@ -46,6 +46,10 @@ except ImportError:
 
 import datetime as datetime
 from astropy.time import Time
+from ehtim.const_def import (
+    DTAMP, DTBIS, DTCAMP, DTCPHASE, DTCPHASEDIAG, DTLOGCAMPDIAG,
+    DTPOL_CIRC, DTPOL_STOKES, EP,
+)
 from ehtim.statistics.stats import *
 
 def make_df(obs,polarization='unknown',band='unknown',round_s=0.1):

--- a/ehtim/statistics/dataframes.py
+++ b/ehtim/statistics/dataframes.py
@@ -1,5 +1,5 @@
 # DataFrames.py
-# variety of statistical functions useful for 
+# variety of statistical functions useful for
 #
 #    Copyright (C) 2018 Maciek Wielgus
 #
@@ -16,13 +16,24 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
-from builtins import str
-from builtins import map
-from builtins import range
+import datetime as datetime
 
 import numpy as np
+from astropy.time import Time
+
+from ehtim.const_def import (
+    DTAMP,
+    DTBIS,
+    DTCAMP,
+    DTCPHASE,
+    DTCPHASEDIAG,
+    DTLOGCAMPDIAG,
+    DTPOL_CIRC,
+    DTPOL_STOKES,
+    EP,
+)
+from ehtim.statistics.stats import bootstrap, circular_mean, mean_incoh_avg
+
 
 # pandas is required for the closure-quantity helpers in this module but is
 # otherwise optional for ehtim — visibility averaging lives in
@@ -44,14 +55,6 @@ except ImportError:
     pd = _PandasStub()
 
 
-import datetime as datetime
-from astropy.time import Time
-from ehtim.const_def import (
-    DTAMP, DTBIS, DTCAMP, DTCPHASE, DTCPHASEDIAG, DTLOGCAMPDIAG,
-    DTPOL_CIRC, DTPOL_STOKES, EP,
-)
-from ehtim.statistics.stats import *
-
 def make_df(obs,polarization='unknown',band='unknown',round_s=0.1):
 
     """converts visibilities from obs.data to DataFrame format
@@ -71,9 +74,11 @@ def make_df(obs,polarization='unknown',band='unknown',round_s=0.1):
     telescopes = [(x[0],x[1]) for x in telescopes]
     df['baseline'] = [x[0]+'-'+x[1] for x in telescopes]
     if obs.polrep=='stokes':
-        vis1='vis'; sig1='sigma'
+        vis1 = 'vis'
+        sig1 = 'sigma'
     elif obs.polrep=='circ':
-        vis1='rrvis'; sig1='rrsigma'
+        vis1 = 'rrvis'
+        sig1 = 'rrsigma'
         df['vis']=df[vis1]
         df['sigma']=df[sig1]
         df['rramp']=np.abs(df['rrvis'])
@@ -118,7 +123,7 @@ def make_amp(obs,debias=True,polarization='unknown',band='unknown',round_s=0.1):
     telescopes = [(x[0],x[1]) for x in telescopes]
     df['baseline'] = [x[0]+'-'+x[1] for x in telescopes]
     df['amp'] = list(map(np.abs,df['vis']))
-    if debias==True:
+    if debias:
         amp2 = np.maximum(np.asarray(df['amp'])**2-np.asarray(df['sigma'])**2,np.asarray(df['sigma'])**2)
         df['amp'] = np.sqrt(amp2)
     df['phase'] = list(map(lambda x: (180./np.pi)*np.angle(x),df['vis']))
@@ -144,16 +149,16 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
     Returns:
         vis_avg: coherently averaged visibilities
     """
-    if (dt<=0)&(scan_avg==False):
+    if (dt<=0) & (not scan_avg):
         return obs.data
     else:
         vis = make_df(obs)
-        if scan_avg==False:
+        if not scan_avg:
             #TODO
             #we don't have to work on datetime products at all
             #change it to only use 'time' in mjd
-            t0 = datetime.datetime(1960,1,1) 
-            vis['round_time'] = list(map(lambda x: np.floor((x- t0).total_seconds()/float(dt)),vis.datetime))  
+            t0 = datetime.datetime(1960,1,1)
+            vis['round_time'] = list(map(lambda x: np.floor((x- t0).total_seconds()/float(dt)),vis.datetime))
             grouping=['tau1','tau2','polarization','band','baseline','t1','t2','round_time']
         else:
             bins, labs = get_bins_labels(obs.scans)
@@ -169,20 +174,23 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
             err_type='predicted'
 
         if obs.polrep=='stokes':
-            vis1='vis'; vis2='qvis'; vis3='uvis'; vis4='vvis'
-            sig1='sigma'; sig2='qsigma'; sig3='usigma'; sig4='vsigma'
+            vis1, vis2, vis3, vis4 = 'vis', 'qvis', 'uvis', 'vvis'
+            sig1, sig2, sig3, sig4 = 'sigma', 'qsigma', 'usigma', 'vsigma'
         elif obs.polrep=='circ':
-            vis1='rrvis'; vis2='llvis'; vis3='rlvis'; vis4='lrvis'
-            sig1='rrsigma'; sig2='llsigma'; sig3='rlsigma'; sig4='lrsigma'
+            vis1, vis2, vis3, vis4 = 'rrvis', 'llvis', 'rlvis', 'lrvis'
+            sig1, sig2, sig3, sig4 = 'rrsigma', 'llsigma', 'rlsigma', 'lrsigma'
 
-        #AVERAGING-------------------------------    
+        #AVERAGING-------------------------------
         if err_type=='measured':
             vis['dummy'] = vis[vis1]
             vis['qdummy'] = vis[vis2]
             vis['udummy'] = vis[vis3]
             vis['vdummy'] = vis[vis4]
-            meanF = lambda x: np.nanmean(np.asarray(x))
-            meanerrF = lambda x: bootstrap(np.abs(x), np.mean, num_samples=num_samples,wrapping_variable=False)
+            def meanF(x):
+                return np.nanmean(np.asarray(x))
+
+            def meanerrF(x):
+                return bootstrap(np.abs(x), np.mean, num_samples=num_samples, wrapping_variable=False)
             aggregated[vis1] = meanF
             aggregated[vis2] = meanF
             aggregated[vis3] = meanF
@@ -191,18 +199,21 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
             aggregated['udummy'] = meanerrF
             aggregated['vdummy'] = meanerrF
             aggregated['qdummy'] = meanerrF
-       
+
         elif err_type=='predicted':
-            meanF = lambda x: np.nanmean(np.asarray(x))
+            def meanF(x):
+                return np.nanmean(np.asarray(x))
             #meanerrF = lambda x: bootstrap(np.abs(x), np.mean, num_samples=num_samples,wrapping_variable=False)
             def meanerrF(x):
                 x = np.asarray(x)
                 x = x[x==x]
-                
-                if len(x)>0: ret = np.sqrt(np.sum(x**2)/len(x)**2)
-                else: ret = np.nan +1j*np.nan
+
+                if len(x) > 0:
+                    ret = np.sqrt(np.sum(x**2) / len(x)**2)
+                else:
+                    ret = np.nan + 1j * np.nan
                 return ret
-              
+
             aggregated[vis1] = meanF
             aggregated[vis2] = meanF
             aggregated[vis3] = meanF
@@ -214,7 +225,7 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
 
         #ACTUAL AVERAGING
         vis_avg = vis.groupby(grouping).agg(aggregated).reset_index()
-        
+
         if err_type=='measured':
             vis_avg[sig1] = [0.5*(x[1][1]-x[1][0]) for x in list(vis_avg['dummy'])]
             vis_avg[sig2] = [0.5*(x[1][1]-x[1][0]) for x in list(vis_avg['qdummy'])]
@@ -225,7 +236,7 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
         vis_avg['phase'] = list(map(lambda x: (180./np.pi)*np.angle(x),vis_avg[vis1]))
         vis_avg['snr'] = vis_avg['amp']/vis_avg[sig1]
 
-        if scan_avg==False:
+        if not scan_avg:
             #round datetime and time to the begining of the bucket and add half of a bucket time
             half_bucket = dt/2.
             vis_avg['datetime'] =  list(map(lambda x: t0 + datetime.timedelta(seconds= int(dt*x) + half_bucket), vis_avg['round_time']))
@@ -234,7 +245,7 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
             #drop values that couldn't be matched to any scan
             vis_avg.drop(list(vis_avg[vis_avg.scan<0].index.values),inplace=True)
         if err_type=='measured':
-            vis_avg.drop(labels=['udummy','vdummy','qdummy','dummy'],axis='columns',inplace=True)      
+            vis_avg.drop(labels=['udummy','vdummy','qdummy','dummy'],axis='columns',inplace=True)
         if return_type=='rec':
             if obs.polrep=='stokes':
                 return df_to_rec(vis_avg,'vis')
@@ -257,11 +268,11 @@ def coh_moving_avg_vis(obs,dt=50,return_type='rec'):
     if dt <= 0:
         raise Exception('Time dt must be positive!')
     if obs.polrep=='stokes':
-        vis1='vis'; vis2='qvis'; vis3='uvis'; vis4='vvis'
-        sig1='sigma'; sig2='qsigma'; sig3='usigma'; sig4='vsigma'
+        vis1, vis2, vis3, vis4 = 'vis', 'qvis', 'uvis', 'vvis'
+        sig1, sig2, sig3, sig4 = 'sigma', 'qsigma', 'usigma', 'vsigma'
     elif obs.polrep=='circ':
-        vis1='rrvis'; vis2='llvis'; vis3='rlvis'; vis4='lrvis'
-        sig1='rrsigma'; sig2='llsigma'; sig3='rlsigma'; sig4='lrsigma'
+        vis1, vis2, vis3, vis4 = 'rrvis', 'llvis', 'rlvis', 'lrvis'
+        sig1, sig2, sig3, sig4 = 'rrsigma', 'llsigma', 'rlsigma', 'lrsigma'
 
     vis = make_df(obs)
     vis = vis.sort_values(['baseline','datetime']).reset_index().copy()
@@ -270,11 +281,14 @@ def coh_moving_avg_vis(obs,dt=50,return_type='rec'):
     vis['roll_vis'] = list(zip(vis['total_seconds'],vis[vis1],vis[vis2],vis[vis3],vis[vis4],vis['datetime']))
     vis['roll_sig'] = list(zip(vis['total_seconds'],vis[sig1],vis[sig2],vis[sig3],vis[sig4],vis['datetime']))
 
-    roll_vis_local = lambda x: roll_vis(x,dt=str(int(dt))+'s',min_periods=min_periods)
-    roll_sig_local = lambda x: roll_sig(x,dt=str(int(dt))+'s',min_periods=min_periods)
+    def roll_vis_local(x):
+        return roll_vis(x, dt=str(int(dt)) + 's', min_periods=min_periods)
+
+    def roll_sig_local(x):
+        return roll_sig(x, dt=str(int(dt)) + 's', min_periods=min_periods)
     vis_avg_roll_vis = vis[['baseline','roll_vis']].groupby('baseline').transform(roll_vis_local)['roll_vis'].copy()
     vis_avg_roll_sig = vis[['baseline','roll_sig']].groupby('baseline').transform(roll_sig_local)['roll_sig'].copy()
-    
+
     for cou,col in enumerate([vis1,vis2,vis3,vis4]):
         vis[col] = [x[2*cou] + 1j*x[2*cou+1] for x in vis_avg_roll_vis]
     for cou,col in enumerate([sig1,sig2,sig3,sig4]):
@@ -311,7 +325,7 @@ def roll_sig(ser,dt='1s',min_periods=1):
                    index=[x[0] for x in ser])
     avg0 = foo.rolling(dt, min_periods=min_periods).mean()
     sumSq = foo.rolling(dt, min_periods=min_periods).sum()
-    avg = pd.DataFrame({},index=[x[0] for x in ser]) 
+    avg = pd.DataFrame({},index=[x[0] for x in ser])
     avg['sig1'] = (avg0['sig1']**1.0)/(sumSq['sig1']**0.5)
     avg['sig2'] = (avg0['sig2']**1.0)/(sumSq['sig2']**0.5)
     avg['sig3'] = (avg0['sig3']**1.0)/(sumSq['sig3']**0.5)
@@ -333,17 +347,17 @@ def incoh_avg_vis(obs,dt=0,debias=True,scan_avg=False,return_type='rec',rec_type
     Returns:
         vis_avg: coherently averaged visibilities
     """
-    if (dt<=0)&(scan_avg==False):
+    if (dt<=0) & (not scan_avg):
         print('Either averaging time must be positive, or scan_avg option should be selected!')
         return obs.data
     else:
         vis = make_df(obs)
-        if scan_avg==False:
+        if not scan_avg:
             #TODO
             #we don't have to work on datetime products at all
             #change it to only use 'time' in mjd
-            t0 = datetime.datetime(1960,1,1) 
-            vis['round_time'] = list(map(lambda x: np.floor((x- t0).total_seconds()/float(dt)),vis.datetime))  
+            t0 = datetime.datetime(1960,1,1)
+            vis['round_time'] = list(map(lambda x: np.floor((x- t0).total_seconds()/float(dt)),vis.datetime))
             grouping=['tau1','tau2','polarization','band','baseline','t1','t2','round_time']
         else:
             bins, labs = get_bins_labels(obs.scans)
@@ -358,7 +372,7 @@ def incoh_avg_vis(obs,dt=0,debias=True,scan_avg=False,return_type='rec',rec_type
             print("Error type can only be 'predicted' or 'measured'! Assuming 'predicted'.")
             err_type='predicted'
 
-        #AVERAGING------------------------------- 
+        #AVERAGING-------------------------------
         vis['dummy'] = list(zip(np.abs(vis['vis']),vis['sigma']))
         vis['udummy'] = list(zip(np.abs(vis['uvis']),vis['usigma']))
         vis['vdummy'] = list(zip(np.abs(vis['vvis']),vis['vsigma']))
@@ -388,7 +402,7 @@ def incoh_avg_vis(obs,dt=0,debias=True,scan_avg=False,return_type='rec',rec_type
             vis_avg['usigma'] = [x[1] for x in list(vis_avg['udummy'])]
             vis_avg['qsigma'] = [x[1] for x in list(vis_avg['qdummy'])]
             vis_avg['vsigma'] = [x[1] for x in list(vis_avg['vdummy'])]
-        
+
         elif err_type=='measured':
             vis_avg['vis'] = [x[0] for x in list(vis_avg['dummy'])]
             vis_avg['uvis'] = [x[0] for x in list(vis_avg['udummy'])]
@@ -402,7 +416,7 @@ def incoh_avg_vis(obs,dt=0,debias=True,scan_avg=False,return_type='rec',rec_type
         vis_avg['amp'] = list(map(np.abs,vis_avg['vis']))
         vis_avg['phase'] = 0
         vis_avg['snr'] = vis_avg['amp']/vis_avg['sigma']
-        if scan_avg==False:
+        if not scan_avg:
             #round datetime and time to the begining of the bucket and add half of a bucket time
             half_bucket = dt/2.
             vis_avg['datetime'] =  list(map(lambda x: t0 + datetime.timedelta(seconds= int(dt*x) + half_bucket), vis_avg['round_time']))
@@ -410,8 +424,8 @@ def incoh_avg_vis(obs,dt=0,debias=True,scan_avg=False,return_type='rec',rec_type
         else:
             #drop values that couldn't be matched to any scan
             vis_avg.drop(list(vis_avg[vis_avg.scan<0].index.values),inplace=True)
-            
-        vis_avg.drop(labels=['udummy','vdummy','qdummy','dummy'],axis='columns',inplace=True)    
+
+        vis_avg.drop(labels=['udummy','vdummy','qdummy','dummy'],axis='columns',inplace=True)
         if return_type=='rec':
             return df_to_rec(vis_avg,rec_type)
         elif return_type=='df':
@@ -422,7 +436,7 @@ def make_cphase_df(obs,band='unknown',polarization='unknown',mode='all',count='m
 
     """generate DataFrame of closure phases
 
-    Args: 
+    Args:
         obs: ObsData object
         round_s: accuracy of datetime object in seconds
 
@@ -448,7 +462,7 @@ def make_cphase_diag_df(obs,vtype='vis',band='unknown',polarization='unknown',co
 
     """generate DataFrame of diagonalized closure phases
 
-    Args: 
+    Args:
         obs: ObsData object
         round_s: accuracy of datetime object in seconds
 
@@ -510,7 +524,7 @@ def make_camp_df(obs,ctype='logcamp',debias=False,band='unknown',polarization='u
 
     """generate DataFrame of closure amplitudes
 
-    Args: 
+    Args:
         obs: ObsData object
         round_s: accuracy of datetime object in seconds
 
@@ -537,7 +551,7 @@ def make_logcamp_diag_df(obs,debias=True,band='unknown',polarization='unknown',m
 
     """generate DataFrame of closure amplitudes
 
-    Args: 
+    Args:
         obs: ObsData object
         round_s: accuracy of datetime object in seconds
 
@@ -599,7 +613,7 @@ def make_bsp_df(obs,band='unknown',polarization='unknown',mode='all',count='min'
 
     """generate DataFrame of bispectra
 
-    Args: 
+    Args:
         obs: ObsData object
         round_s: accuracy of datetime object in seconds
 
@@ -637,14 +651,14 @@ def average_cphases(cdf,dt,return_type='rec',err_type='predicted',num_samples=10
 
     cdf2 = cdf.copy()
     t0 = datetime.datetime(1960,1,1)
-    cdf2['round_time'] = list(map(lambda x: np.round((x- t0).total_seconds()/float(dt)),cdf2.datetime))  
+    cdf2['round_time'] = list(map(lambda x: np.round((x- t0).total_seconds()/float(dt)),cdf2.datetime))
     grouping=['polarization','band','triangle','t1','t2','t3','round_time']
     #column just for counting the elements
     cdf2['number'] = 1
     aggregated = {'datetime': np.min, 'time': np.mean,
     'number': lambda x: len(x), 'u1':np.mean, 'u2': np.mean, 'u3':np.mean,'v1':np.mean, 'v2': np.mean, 'v3':np.mean}
 
-    #AVERAGING-------------------------------    
+    #AVERAGING-------------------------------
     if err_type=='measured':
         cdf2['dummy'] = cdf2['cphase']
         aggregated['dummy'] = lambda x: bootstrap(x, circular_mean, num_samples=num_samples,wrapping_variable=True)
@@ -664,14 +678,14 @@ def average_cphases(cdf,dt,return_type='rec',err_type='predicted',num_samples=10
         cdf2['sigmacp'] = [0.5*(x[1][1]-x[1][0]) for x in list(cdf2['dummy'])]
 
     # snrcut
-    # CHECK 
+    # CHECK
     if snrcut==0:
         snrcut=EP
     cdf2 = cdf2[cdf2['sigmacp'] < 180./np.pi/snrcut].copy()  # TODO CHECK
 
     #round datetime
     cdf2['datetime'] =  list(map(lambda x: t0 + datetime.timedelta(seconds= int(dt*x)), cdf2['round_time']))
-    
+
     #ANDREW TODO-- this can lead to big problems!!
     #drop values averaged from less than 3 datapoints
     #cdf2.drop(cdf2[cdf2.number < 3.].index, inplace=True)
@@ -696,14 +710,14 @@ def average_bispectra(cdf,dt,return_type='rec',num_samples=int(1e3), snrcut=0.):
 
     cdf2 = cdf.copy()
     t0 = datetime.datetime(1960,1,1)
-    cdf2['round_time'] = list(map(lambda x: np.round((x- t0).total_seconds()/float(dt)),cdf2.datetime))  
+    cdf2['round_time'] = list(map(lambda x: np.round((x- t0).total_seconds()/float(dt)),cdf2.datetime))
     grouping=['polarization','band','triangle','t1','t2','t3','round_time']
     #column just for counting the elements
     cdf2['number'] = 1
     aggregated = {'datetime': np.min, 'time': np.mean,
     'number': lambda x: len(x), 'u1':np.mean, 'u2': np.mean, 'u3':np.mean,'v1':np.mean, 'v2': np.mean, 'v3':np.mean}
 
-    #AVERAGING-------------------------------    
+    #AVERAGING-------------------------------
     aggregated['bispec'] = np.mean
     aggregated['sigmab'] = lambda x: np.sqrt(np.sum(x**2)/len(x)**2)
 
@@ -715,7 +729,7 @@ def average_bispectra(cdf,dt,return_type='rec',num_samples=int(1e3), snrcut=0.):
 
     #round datetime
     cdf2['datetime'] =  list(map(lambda x: t0 + datetime.timedelta(seconds= int(dt*x)), cdf2['round_time']))
-    
+
     #ANDREW TODO -- this can lead to big problems!!
     #drop values averaged from less than 3 datapoints
     #cdf2.drop(cdf2[cdf2.number < 3.].index, inplace=True)
@@ -741,14 +755,14 @@ def average_camp(cdf,dt,return_type='rec',err_type='predicted',num_samples=int(1
 
     cdf2 = cdf.copy()
     t0 = datetime.datetime(1960,1,1)
-    cdf2['round_time'] = list(map(lambda x: np.round((x- t0).total_seconds()/float(dt)),cdf2.datetime))  
+    cdf2['round_time'] = list(map(lambda x: np.round((x- t0).total_seconds()/float(dt)),cdf2.datetime))
     grouping=['polarization','band','quadrangle','t1','t2','t3','t4','round_time']
     #column just for counting the elements
     cdf2['number'] = 1
     aggregated = {'datetime': np.min, 'time': np.mean,
     'number': lambda x: len(x), 'u1':np.mean, 'u2': np.mean, 'u3':np.mean, 'u4': np.mean, 'v1':np.mean, 'v2': np.mean, 'v3':np.mean,'v4':np.mean}
 
-    #AVERAGING-------------------------------    
+    #AVERAGING-------------------------------
     if err_type=='measured':
         cdf2['dummy'] = cdf2['camp']
         aggregated['dummy'] = lambda x: bootstrap(x, np.mean, num_samples=num_samples,wrapping_variable=False)
@@ -769,7 +783,7 @@ def average_camp(cdf,dt,return_type='rec',err_type='predicted',num_samples=int(1
 
     #round datetime
     cdf2['datetime'] =  list(map(lambda x: t0 + datetime.timedelta(seconds= int(dt*x)), cdf2['round_time']))
-    
+
     #ANDREW TODO -- this can lead to big problems!!
     #drop values averaged from less than 3 datapoints
     #cdf2.drop(cdf2[cdf2.number < 3.].index, inplace=True)
@@ -838,7 +852,7 @@ def get_bins_labels(intervals,dt=0.00001):
     Args:
         intervals:
         dt (float): time margin to add to the scan limits
-    ''' 
+    '''
 
     def fix_midnight_overlap(x):
         if x[1] < x[0]:
@@ -848,8 +862,9 @@ def get_bins_labels(intervals,dt=0.00001):
     def is_overlapping(interval0,interval1):
         if ((interval1[0]<=interval0[0])&(interval1[1]>=interval0[0]))|((interval1[0]<=interval0[1])&(interval1[1]>=interval0[1])):
             return True
-        else: return False
-    
+        else:
+            return False
+
     def merge_overlapping_intervals(intervals):
         return (np.min([x[0] for x in intervals]),np.max([x[1] for x in intervals]))
 
@@ -858,21 +873,21 @@ def get_bins_labels(intervals,dt=0.00001):
         indic_overlap=[is_overlapping(x,intervals[element_ind]) for x in intervals]
         fooarr=np.asarray(intervals)
         return sorted([tuple(x) for x in fooarr[indic_not_overlap]]+[merge_overlapping_intervals(list(fooarr[indic_overlap]))])
-    
+
     intervals = sorted(list(set(zip(intervals[:,0],intervals[:,1]))))
     intervals = [fix_midnight_overlap(x) for x in intervals]
     cou=0
-    while cou < len(intervals): 
+    while cou < len(intervals):
         intervals = replace_overlapping_intervals(intervals,cou)
         cou+=1
-        
+
     binsT=[None]*(2*np.shape(intervals)[0])
     binsT[::2] = [x[0]-dt for x in intervals]
     binsT[1::2] = [x[1]+dt for x in intervals]
     labels=[None]*(2*np.shape(intervals)[0]-1)
     labels[::2] = [cou for cou in range(1,len(intervals)+1)]
     labels[1::2] = [-cou for cou in range(1,len(intervals))]
-    
+
     return binsT, labels
 
 def common_set(obs1, obs2, tolerance = 0,uniquely=False, by_what='uvdist'):
@@ -898,7 +913,7 @@ def common_set(obs1, obs2, tolerance = 0,uniquely=False, by_what='uvdist'):
 
     if by_what=='ut':
         if tolerance>0:
-            d_mjd = tolerance/24.0/60.0/60.0      
+            d_mjd = tolerance/24.0/60.0/60.0
             df1['roundtime']=np.round(df1.mjd/d_mjd)
             df2['roundtime']=np.round(df2.mjd/d_mjd)
         else:
@@ -906,12 +921,12 @@ def common_set(obs1, obs2, tolerance = 0,uniquely=False, by_what='uvdist'):
             df2['roundtime'] = df2['time']
         #matching data
         df1,df2 = match_multiple_frames([df1.copy(),df2.copy()],['ta','tb','roundtime'],uniquely=uniquely)
-    
+
     elif by_what=='gmst':
         df1 = add_gmst(df1)
         df2 = add_gmst(df2)
         if tolerance>0:
-            d_gmst = tolerance      
+            d_gmst = tolerance
             df1['roundgmst']=np.round(df1.gmst/d_gmst)
             df2['roundgmst']=np.round(df2.gmst/d_gmst)
         else:
@@ -927,7 +942,7 @@ def common_set(obs1, obs2, tolerance = 0,uniquely=False, by_what='uvdist'):
             df1['roundv'] = np.round(df1.v/d_lambda)
             df2['roundu'] = np.round(df2.u/d_lambda)
             df2['roundv'] = np.round(df2.v/d_lambda)
-        else: 
+        else:
             df1['roundu'] = df1['u']
             df1['roundv'] = df1['v']
             df2['roundu'] = df2['u']
@@ -970,14 +985,14 @@ def common_multiple_sets(obsL, tolerance = 0,uniquely=False, by_what='uvdist'):
 
     if by_what=='ut':
         if tolerance>0:
-            d_mjd = tolerance/24.0/60.0/60.0    
+            d_mjd = tolerance/24.0/60.0/60.0
             for df in dfL:  df['roundtime']=np.round(df.mjd/d_mjd)
         else:
             for df in dfL:  df['roundtime']=df['time']
         #matching data
         dfcout = match_multiple_frames(dfL,['ta','tb','roundtime'],uniquely=uniquely)
-    
-    elif by_what=='gmst': 
+
+    elif by_what=='gmst':
         dfL = [add_gmst(df) for df in dfL]
         if tolerance>0:
             d_gmst = tolerance
@@ -987,13 +1002,13 @@ def common_multiple_sets(obsL, tolerance = 0,uniquely=False, by_what='uvdist'):
         #matching data
         dfcut = match_multiple_frames([df1.copy(),df2.copy()],['ta','tb','roundgmst'],uniquely=uniquely)
 
-    
+
     elif by_what=='uvdist':
         if tolerance>0:
             d_lambda = tolerance
             for df in dfL: df['roundu'] = np.round(df.u/d_lambda)
             for df in dfL: df['roundv'] = np.round(df.v/d_lambda)
-        else: 
+        else:
             for df in dfL: df['roundu'] = df['u']
             for df in dfL: df['roundv'] = df['v']
         #matching data
@@ -1019,10 +1034,10 @@ def match_multiple_frames(frames, what_is_same, dt = 0,uniquely=True):
         for frame in frames:
             frame['round_time'] = list(map(lambda x: np.round((x- datetime.datetime(2017,4,4)).total_seconds()/dt),frame['datetime']))
         what_is_same += ['round_time']
-    
+
     frames_common = {}
     for frame in frames:
-        frame['all_ind'] = list(zip(*[frame[x] for x in what_is_same]))   
+        frame['all_ind'] = list(zip(*[frame[x] for x in what_is_same]))
         if frames_common != {}:
             frames_common = frames_common&set(frame['all_ind'])
         else:

--- a/ehtim/statistics/dataframes.py
+++ b/ehtim/statistics/dataframes.py
@@ -24,17 +24,25 @@ from builtins import range
 
 import numpy as np
 
-# pandas is imported lazily inside the closure-quantity functions below.  The
-# three averaging routines (`coh_avg_vis`, `coh_moving_avg_vis`,
-# `incoh_avg_vis`) historically lived here but were moved to
-# `ehtim.statistics.averaging` (pandas-free).  This module is kept only for
-# the closure-quantity `make_*_df` / `average_*` helpers that the soon-to-be-
-# removed `Obsdata.add_*` methods still depend on (see PR #246 on
-# dev-backend).  Once #246 syncs to `dev` this whole file is deleted.
+# pandas is required for the closure-quantity helpers in this module but is
+# otherwise optional for ehtim — visibility averaging lives in
+# `ehtim.statistics.averaging` and is pandas-free.  Make the import lazy: on
+# ImportError, substitute a stub that raises a clear message on first use, so
+# `import ehtim` keeps working without pandas installed.
+class _PandasStub:
+    def __getattr__(self, name):
+        raise ImportError(
+            "pandas is required for closure-quantity helpers in "
+            "ehtim.statistics.dataframes; install via `pip install pandas`. "
+            "Visibility averaging routines live in ehtim.statistics.averaging "
+            "and do not need pandas.")
+
+
 try:
     import pandas as pd
 except ImportError:
-    pd = None
+    pd = _PandasStub()
+
 
 import datetime as datetime
 from astropy.time import Time

--- a/ehtim/statistics/stats.py
+++ b/ehtim/statistics/stats.py
@@ -262,7 +262,26 @@ def inc_sig(amp,sig):
     return sigma0
 
 def coh_sig(amp, sig):
-    """Inverse-variance combined sigma: 1 / sqrt(sum_i 1/sig_i^2)."""
+    """Error on the directly (unweighted) averaged visibility: sqrt(sum_i sig_i^2) / N.
+
+    Correct estimator when the visibilities are combined with the plain
+    mean. For the inverse-variance weighted mean, use ``invvar_coh_sig``.
+    """
+    amp = np.abs(np.asarray(amp))
+    sig = np.asarray(sig)
+    Nc = len(amp)
+    sigma0 = np.sqrt(np.sum(sig ** 2) / Nc ** 2)
+    return sigma0
+
+
+def invvar_coh_sig(amp, sig):
+    """Error on the inverse-variance weighted averaged visibility: 1 / sqrt(sum_i 1/sig_i^2).
+
+    Correct estimator when the visibilities are combined with
+    inverse-variance weights. For the plain unweighted mean, use
+    ``coh_sig``. Rows with non-finite or non-positive sigma are dropped;
+    returns NaN if none remain.
+    """
     sig = np.asarray(sig)
     finite = np.isfinite(sig) & (sig > 0)
     if not np.any(finite):

--- a/ehtim/statistics/stats.py
+++ b/ehtim/statistics/stats.py
@@ -265,12 +265,13 @@ def inc_sig(amp,sig):
     else: sigma0=coh_sig(amp,sig)
     return sigma0
 
-def coh_sig(amp,sig):
-    amp = np.abs(np.asarray(amp))
+def coh_sig(amp, sig):
+    """Inverse-variance combined sigma: 1 / sqrt(sum_i 1/sig_i^2)."""
     sig = np.asarray(sig)
-    Nc = len(amp)
-    sigma0 = np.sqrt(np.sum(sig**2)/Nc**2)
-    return sigma0
+    finite = np.isfinite(sig) & (sig > 0)
+    if not np.any(finite):
+        return np.nan
+    return 1.0 / np.sqrt(np.sum(1.0 / sig[finite] ** 2))
 
 
 def dicts_TV_report(obs,snr_cut=2.):
@@ -284,7 +285,7 @@ def dicts_TV_report(obs,snr_cut=2.):
             lcatv: dictionary of quadrangle mean TV
         """
     amp = obs.data
-    baselines = list(set([(x[0],x[1]) for x in lca[['t1','t2']]]))
+    baselines = list(set([(x[0],x[1]) for x in amp[['t1','t2']]]))
     amptv = {}
     for cou,quad in enumerate(baselines):
         amptv[quad] = np.mean(np.abs(np.diff(np.abs(amp[(amp['t1']==baselines[cou][0])&(amp['t2']==baselines[cou][1])]['vis']))))
@@ -317,8 +318,8 @@ def compare_TV(obs,obsref,snr_cut=2.,output=''):
             cprel / cpmed: dictionary of triangle relative differences in mean TV / median of triangle relative differences in mean TV
             lcarel / lcamed: dictionary of quadrangle relative differences in mean TV / median of quadrangle relative differences in mean TV
         """
-    amptv, cptv, lcatv = dicts_TV(obs,snr_cut=snr_cut)
-    ampref, cpref, lcaref = dicts_TV(obsref,snr_cut=snr_cut)
+    amptv, cptv, lcatv = dicts_TV_report(obs,snr_cut=snr_cut)
+    ampref, cpref, lcaref = dicts_TV_report(obsref,snr_cut=snr_cut)
     
     cprel = {key: (cptv[key] - cpref[key])/cpref[key] for key in cptv.keys() if key in set(cpref.keys())}
     amprel = {key: (amptv[key] - ampref[key])/ampref[key] for key in amptv.keys() if key in set(ampref.keys())}

--- a/ehtim/statistics/stats.py
+++ b/ehtim/statistics/stats.py
@@ -1,5 +1,5 @@
 # stats.py
-# variety of statistical functions useful for 
+# variety of statistical functions useful for
 #
 #    Copyright (C) 2018 Maciek Wielgus
 #
@@ -16,17 +16,9 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
-from builtins import str
-from builtins import map
-from builtins import range
-
 import numpy as np
 import numpy.random as npr
-import sys
 
-from ehtim.const_def import *
 
 def circular_mean(theta, unit='deg'):
     '''circular mean for averaging angular quantities
@@ -103,7 +95,7 @@ def mean_incoh_amp(amp,sigma,debias=True,err_type='predicted',num_samples=int(1e
     """
     if (not hasattr(amp, "__len__")):
         amp = [amp]
-    amp = np.asarray(amp, dtype=np.float32) 
+    amp = np.asarray(amp, dtype=np.float32)
     N = len(amp)
     if (not hasattr(sigma, "__len__")):
         sigma = sigma*np.ones(N)
@@ -117,12 +109,13 @@ def mean_incoh_amp(amp,sigma,debias=True,err_type='predicted',num_samples=int(1e
         amp_clean=amp[(amp==amp)&(sigma==sigma)&(sigma>0)&(amp>0)]
         sigma_clean=sigma[(amp==amp)&(sigma==sigma)&(sigma>0)&(amp>0)]
         #eq. 9.86 from Thompson et al.
-        if debias==True:
+        if debias:
             amp0sq = ( np.mean(amp_clean**2 - (2. - 1./N)*sigma_clean**2) )
-        else: amp0sq = np.mean(amp_clean**2)
+        else:
+            amp0sq = np.mean(amp_clean**2)
         amp0sq = np.maximum(amp0sq,0.)
         amp0 = np.sqrt(amp0sq)
-        
+
         #getting errors
         if err_type=='predicted':
             sigma0 = np.sqrt(np.sum(sigma_clean**2)/len(sigma_clean)**2)
@@ -142,7 +135,7 @@ def mean_incoh_amp_from_vis(vis,sigma,debias=True,err_type='predicted',num_sampl
     """
     if (not hasattr(vis, "__len__")):
         vis = [vis]
-    vis= np.asarray(vis) 
+    vis= np.asarray(vis)
     vis= vis[vis==vis]
     amp=np.abs(vis)
 
@@ -163,10 +156,12 @@ def mean_incoh_amp_from_vis(vis,sigma,debias=True,err_type='predicted',num_sampl
             return None, None
         else:
             #eq. 9.86 from Thompson et al.
-            if debias==True:
+            if debias:
                 amp0sq = ( np.mean(amp_clean**2 - (2. - 1./Nc)*sigma_clean**2) )
-            else: amp0sq = np.mean(amp_clean**2)
-            if (amp0sq!=amp0sq): amp0sq=0.
+            else:
+                amp0sq = np.mean(amp_clean**2)
+            if amp0sq != amp0sq:
+                amp0sq = 0.
             amp0sq = np.maximum(amp0sq,0.)
             amp0 = np.sqrt(amp0sq)
             #getting errors
@@ -204,7 +199,7 @@ def bootstrap(data, statistic, num_samples=int(1e3), alpha='1sig',wrapping_varia
         alpha=0.0027
     stat = np.zeros(num_samples)
     data = np.asarray(data)
-    if wrapping_variable==True:
+    if wrapping_variable:
         m=statistic(data)
     else:
         m=0
@@ -234,9 +229,9 @@ def mean_incoh_avg(x,debias=True):
         amp0 = amp[0]
         sig0 = sig[0]
     else:
-        if debias==True:
+        if debias:
             amp0 = deb_amp(amp,sig)
-        else: 
+        else:
             amp0= np.sqrt(np.maximum(np.mean(amp**2),0.))
         sig0 = inc_sig(amp,sig)
         #sig0 = coh_sig(amp,sig)
@@ -262,7 +257,8 @@ def inc_sig(amp,sig):
     snrA = 1./(np.sqrt(1. + 2./np.sqrt(Nc)*(1./snr0)*np.sqrt(1.+1./snr0**2)) - 1.)
     if snrA>0:
         sigma0=amp0/snrA
-    else: sigma0=coh_sig(amp,sig)
+    else:
+        sigma0=coh_sig(amp,sig)
     return sigma0
 
 def coh_sig(amp, sig):
@@ -289,7 +285,7 @@ def dicts_TV_report(obs,snr_cut=2.):
     amptv = {}
     for cou,quad in enumerate(baselines):
         amptv[quad] = np.mean(np.abs(np.diff(np.abs(amp[(amp['t1']==baselines[cou][0])&(amp['t2']==baselines[cou][1])]['vis']))))
-      
+
     cp = obs.c_phases()
     obs = obs.flag_low_snr(snr_cut=snr_cut)
     triangles = list(set([(x[0],x[1],x[2]) for x in cp[['t1','t2','t3']]]))
@@ -297,12 +293,12 @@ def dicts_TV_report(obs,snr_cut=2.):
     for cou,tri in enumerate(triangles):
         cptv[tri] = np.mean(np.abs(np.diff(cp[(cp['t1']==triangles[cou][0])&(cp['t2']==triangles[cou][1])&(cp['t3']==triangles[cou][2])]['cphase'])))
 
-    lca = obs.c_amplitudes(ctype='logcamp')   
+    lca = obs.c_amplitudes(ctype='logcamp')
     quadrangles = list(set([(x[0],x[1],x[2],x[3]) for x in lca[['t1','t2','t3','t4']]]))
     lcatv = {}
     for cou,quad in enumerate(quadrangles):
         lcatv[quad] = np.mean(np.abs(np.diff(lca[(lca['t1']==quadrangles[cou][0])&(lca['t2']==quadrangles[cou][1])&(lca['t3']==quadrangles[cou][2])&(lca['t4']==quadrangles[cou][3])]['camp'])))
-  
+
     return amptv, cptv, lcatv
 
 def compare_TV(obs,obsref,snr_cut=2.,output=''):
@@ -320,17 +316,17 @@ def compare_TV(obs,obsref,snr_cut=2.,output=''):
         """
     amptv, cptv, lcatv = dicts_TV_report(obs,snr_cut=snr_cut)
     ampref, cpref, lcaref = dicts_TV_report(obsref,snr_cut=snr_cut)
-    
+
     cprel = {key: (cptv[key] - cpref[key])/cpref[key] for key in cptv.keys() if key in set(cpref.keys())}
     amprel = {key: (amptv[key] - ampref[key])/ampref[key] for key in amptv.keys() if key in set(ampref.keys())}
     lcarel = {key: (lcatv[key] - lcaref[key])/lcaref[key] for key in lcatv.keys() if key in set(lcaref.keys())}
     amprel = {key:amprel[key] for key in amprel.keys() if amprel[key]==amprel[key]}
     cprel = {key:cprel[key] for key in cprel.keys() if cprel[key]==cprel[key]}
     lcarel = {key:lcarel[key] for key in lcarel.keys() if lcarel[key]==lcarel[key]}
-    
+
     if output=='Full':
         return amprel, cprel, lcarel
-    else: 
+    else:
         ampmed =np.median([amprel[key] for key in amprel.keys() if amprel[key]==amprel[key]])
         cpmed =np.median([cprel[key] for key in cprel.keys() if cprel[key]==cprel[key]])
         lcamed =np.median([lcarel[key] for key in lcarel.keys() if lcarel[key]==lcarel[key]])

--- a/ehtim/statistics/stats.py
+++ b/ehtim/statistics/stats.py
@@ -238,7 +238,18 @@ def mean_incoh_avg(x,debias=True):
     return amp0,sig0
 
 def deb_amp(amp,sig):
-    #eq. 9.86 from Thompson et al.
+    """Rice-debiased visibility amplitude from N noisy samples.
+
+    Implements eq. (9.86) of Thompson, Moran & Swenson (Interferometry and
+    Synthesis in Radio Astronomy, 3rd ed.):
+
+        |V|_e = [ mean(amp_i^2) - (2 - 1/N) * sigma^2 ]^(1/2)
+
+    The (2 - 1/N) coefficient (rather than the naive 2 of the squared-
+    amplitude estimator, eq. 9.81) is the second-order bias correction for
+    estimating |V| instead of |V|^2 (eqs. 9.84-9.85). Derived for equal-
+    variance samples; assumes a single sigma scale across the N samples.
+    """
     amp = np.abs(np.asarray(amp))
     sig = np.asarray(sig)
     Nc = len(amp)
@@ -248,6 +259,18 @@ def deb_amp(amp,sig):
     return amp0
 
 def inc_sig(amp,sig):
+    """Noise on the Rice-debiased amplitude (deb_amp) from N samples.
+
+    Returns the sigma that reproduces the analytic incoherent-averaging
+    SNR of eq. (9.88) of Thompson, Moran & Swenson:
+
+        R_sn = sqrt(N)/(2 sigma^2) * |V|^2 / sqrt(1 + |V|^2/sigma^2)
+
+    so that sigma_out = |V|_e * (sqrt(1 + 1/R_sn) - 1). At very low SNR
+    (snrA <= 0, where the Rician approximation breaks down) it falls back
+    to coh_sig. Like deb_amp, assumes a single sigma scale (uses the
+    median of sig).
+    """
     amp = np.abs(np.asarray(amp))
     sig = np.asarray(sig)
     Nc = len(amp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "finufft>=2.2",
     "skyfield",
     "h5py",
-    "pandas",
     "requests",
     "future",
     "networkx",
@@ -43,6 +42,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov",
     "ruff",
+    "pandas",
 ]
 
 [project.urls]

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -305,3 +305,78 @@ def test_parity_incoh_avg_vis_amplitude_matches_legacy(obs_direct, _legacy_ehdf)
     # Real parts hold the (debiased) amplitude.
     np.testing.assert_allclose(new_s["vis"].real, old_s["vis"].real,
                                rtol=1e-8, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Section 7: additional coverage — scan_avg, polrep='circ', moving-avg sigma,
+# err_type='measured'
+# ---------------------------------------------------------------------------
+
+
+def test_coh_avg_vis_scan_avg_groups_per_scan():
+    """scan_avg=True puts samples into one bin per scan; rows outside any
+    scan are dropped."""
+    # Five samples at 0, 5, 10, 60, 70 seconds.  Scans: [0, 15s] and [55s, 75s].
+    times = np.array([0.0, 5.0 / 3600.0, 10.0 / 3600.0,
+                      60.0 / 3600.0, 70.0 / 3600.0])
+    obs = _make_obs(times_hr=times)
+    obs.scans = np.array([[0.0, 15.0 / 3600.0],
+                          [55.0 / 3600.0, 75.0 / 3600.0]])
+    out = coh_avg_vis(obs, dt=0, scan_avg=True)
+    # Two scans, two output rows.
+    assert len(out) == 2
+    # tint per scan: scan 1 has 3 samples × 1s, scan 2 has 2 samples × 1s.
+    tints = sorted(out["tint"])
+    assert tints == [2.0, 3.0]
+
+
+def test_coh_avg_vis_polrep_circ():
+    """coh_avg_vis on a circular-polrep obs produces DTPOL_CIRC output."""
+    times = np.array([0.0, 5.0 / 3600.0])
+    obs = _make_obs(times_hr=times,
+                    vis_fn=lambda t, t1, t2: 1.0 + 0.0j if t == 0.0 else 3.0 + 0.0j,
+                    polrep="circ")
+    out = coh_avg_vis(obs, dt=60.0)
+    assert len(out) == 1
+    assert out.dtype == ehc.DTPOL_CIRC
+    # All four circ visibility fields receive the same complex mean.
+    for vf in ("rrvis", "llvis", "rlvis", "lrvis"):
+        assert out[vf][0] == pytest.approx(2.0 + 0.0j)
+
+
+def test_coh_moving_avg_vis_inverse_variance_sigma():
+    """Sliding-window sigma combines via inverse variance, not mean-of-squares.
+
+    Two samples within a 120 s window with sigmas (0.1, 0.2) should reduce to
+    1/sqrt(1/0.01 + 1/0.04) ≈ 0.0894 at both row positions.
+    """
+    times = np.array([0.0, 1.0 / 3600.0])  # 1 s apart
+    obs = _make_obs(times_hr=times)
+    obs.data["sigma"] = np.array([0.1, 0.2])
+    obs.data["qsigma"] = np.array([0.1, 0.2])
+    obs.data["usigma"] = np.array([0.1, 0.2])
+    obs.data["vsigma"] = np.array([0.1, 0.2])
+
+    out = coh_moving_avg_vis(obs, dt=120.0)
+    expected = 1.0 / np.sqrt(1.0 / 0.1**2 + 1.0 / 0.2**2)
+    np.testing.assert_allclose(out["sigma"], expected, rtol=1e-12)
+
+
+def test_coh_avg_vis_err_type_measured_smoke():
+    """The bootstrap err_type='measured' path runs end-to-end."""
+    rng = np.random.default_rng(42)
+    n = 8
+    times = np.linspace(0.0, 7.0 / 3600.0, n)  # 8 samples within 60 s
+    # Visibility = 1+0j with Gaussian noise of std 0.05.
+    real_noise = rng.normal(0.0, 0.05, size=n)
+    imag_noise = rng.normal(0.0, 0.05, size=n)
+
+    def vis_fn(t, t1, t2):
+        i = int(round(t * 3600.0))  # back to seconds index
+        return (1.0 + real_noise[i]) + 1j * imag_noise[i]
+
+    obs = _make_obs(times_hr=times, vis_fn=vis_fn, sigma=0.05)
+    out = coh_avg_vis(obs, dt=60.0, err_type="measured", num_samples=200)
+    assert len(out) == 1
+    # Bootstrap sigma should be a positive finite number.
+    assert np.isfinite(out["sigma"][0]) and out["sigma"][0] > 0

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -8,8 +8,12 @@ inverse-variance combination
 
     sigma_avg = 1 / sqrt(sum(1/sigma_i**2)).
 
+Visibility values are also combined with inverse-variance weights by default
+(``invvar_avg=True``); ``invvar_avg=False`` reproduces the legacy direct
+(unweighted) complex mean.
+
 This file pins both the migration (pandas-free, matching record-array
-contracts) and the inverse-variance fix.
+contracts) and the two weighting modes.
 """
 
 import numpy as np
@@ -255,8 +259,15 @@ def _legacy_ehdf():
 
 
 def test_parity_coh_avg_vis_complex_mean_matches_legacy(obs_direct, _legacy_ehdf):
-    """Averaged visibility values match the legacy pandas implementation."""
-    new = coh_avg_vis(obs_direct, dt=60.0)
+    """Direct (invvar_avg=False) complex mean matches the legacy pandas
+    implementation row-for-row, independently of how sigmas are distributed.
+
+    obs_direct has uniform sigma within each (baseline, time-bucket) bin, so
+    invvar_avg=True would also pass here by coincidence -- but invvar_avg=False
+    is the genuinely equivalent comparison. The varied-sigma case is covered
+    by test_parity_coh_avg_vis_varied_sigma below.
+    """
+    new = coh_avg_vis(obs_direct, dt=60.0, invvar_avg=False)
     old = _legacy_ehdf.coh_avg_vis(obs_direct, dt=60.0, return_type='rec')
     assert len(new) == len(old)
     # Sort both by (t1, t2, time) for an order-independent comparison.
@@ -266,6 +277,44 @@ def test_parity_coh_avg_vis_complex_mean_matches_legacy(obs_direct, _legacy_ehdf
     for vf in ("vis", "qvis", "uvis", "vvis"):
         np.testing.assert_allclose(new_s[vf], old_s[vf], rtol=1e-10, atol=1e-12,
                                    err_msg=f"vis mismatch in field {vf!r}")
+
+
+def test_parity_coh_avg_vis_varied_sigma(_legacy_ehdf):
+    """With varied intra-bin sigmas, invvar_avg=False matches the legacy
+    direct mean exactly, while invvar_avg=True diverges as expected.
+
+    Four samples in one 60 s bin on one baseline with varying vis values
+    and varying sigmas exercise the weighting branch.
+    """
+    times = np.array([0.0, 10.0 / 3600.0, 20.0 / 3600.0, 30.0 / 3600.0])
+    obs = _make_obs(times_hr=times,
+                    vis_fn=lambda t, t1, t2: 1.0 + (t * 3600.0) * 0.01)
+    obs.data["sigma"] = np.array([0.1, 0.4, 0.1, 0.4])
+    obs.data["qsigma"] = np.array([0.1, 0.4, 0.1, 0.4])
+    obs.data["usigma"] = np.array([0.1, 0.4, 0.1, 0.4])
+    obs.data["vsigma"] = np.array([0.1, 0.4, 0.1, 0.4])
+
+    new_direct = coh_avg_vis(obs, dt=60.0, invvar_avg=False)
+    new_invvar = coh_avg_vis(obs, dt=60.0, invvar_avg=True)
+    old = _legacy_ehdf.coh_avg_vis(obs, dt=60.0, return_type='rec')
+
+    # Direct mean: bit-for-bit equal to legacy.
+    np.testing.assert_allclose(
+        new_direct["vis"], old["vis"], rtol=1e-12, atol=1e-14,
+        err_msg="invvar_avg=False should match legacy on varied sigmas",
+    )
+
+    # Direct mean of vis values [1.0, 1.1, 1.2, 1.3] is 1.15.
+    assert new_direct["vis"][0].real == pytest.approx(1.15, rel=1e-12)
+
+    # Inverse-variance weighted mean: weights [100, 6.25, 100, 6.25] →
+    # <V> = (1.0*100 + 1.1*6.25 + 1.2*100 + 1.3*6.25) / 212.5 ≈ 1.1.
+    w = np.array([1/0.1**2, 1/0.4**2, 1/0.1**2, 1/0.4**2])
+    expected_invvar = np.sum(np.array([1.0, 1.1, 1.2, 1.3]) * w) / np.sum(w)
+    assert new_invvar["vis"][0].real == pytest.approx(expected_invvar, rel=1e-12)
+
+    # The two means genuinely differ on varied-sigma data.
+    assert abs(new_invvar["vis"][0] - new_direct["vis"][0]) > 1e-3
 
 
 def test_parity_coh_avg_vis_sigma_differs_by_inverse_variance(_legacy_ehdf):
@@ -295,8 +344,13 @@ def test_parity_coh_avg_vis_sigma_differs_by_inverse_variance(_legacy_ehdf):
 
 
 def test_parity_incoh_avg_vis_amplitude_matches_legacy(obs_direct, _legacy_ehdf):
-    """Incoherently-averaged amplitudes match the legacy implementation."""
-    new = incoh_avg_vis(obs_direct, dt=60.0, debias=True)
+    """Direct-mean (invvar_avg=False) incoherent amplitude matches legacy.
+
+    Same caveat as the coherent parity test: with uniform intra-bin sigmas
+    the invvar branch would also pass coincidentally. invvar_avg=False is
+    the genuine equivalence.
+    """
+    new = incoh_avg_vis(obs_direct, dt=60.0, debias=True, invvar_avg=False)
     old = _legacy_ehdf.incoh_avg_vis(obs_direct, dt=60.0, debias=True, return_type='rec')
     assert len(new) == len(old)
     new_key = np.argsort(new, order=("t1", "t2", "time"))
@@ -315,19 +369,25 @@ def test_parity_incoh_avg_vis_amplitude_matches_legacy(obs_direct, _legacy_ehdf)
 
 def test_coh_avg_vis_scan_avg_groups_per_scan():
     """scan_avg=True puts samples into one bin per scan; rows outside any
-    scan are dropped."""
-    # Five samples at 0, 5, 10, 60, 70 seconds.  Scans: [0, 15s] and [55s, 75s].
-    times = np.array([0.0, 5.0 / 3600.0, 10.0 / 3600.0,
-                      60.0 / 3600.0, 70.0 / 3600.0])
+    scan are dropped.
+
+    Scan intervals follow pandas.cut semantics: ``(tstart, tstop]`` (open on
+    the left, closed on the right), so a sample exactly on a scan boundary
+    lands in the LATER scan only, not both.
+    """
+    # Six samples at 2, 5, 10, 15, 60, 75 seconds. Scans: (0, 15s] and (55s, 75s].
+    # Sample at t=15s lands in scan 1 (right-inclusive); sample at t=75s in scan 2.
+    times = np.array([2.0 / 3600.0, 5.0 / 3600.0, 10.0 / 3600.0,
+                      15.0 / 3600.0, 60.0 / 3600.0, 75.0 / 3600.0])
     obs = _make_obs(times_hr=times)
     obs.scans = np.array([[0.0, 15.0 / 3600.0],
                           [55.0 / 3600.0, 75.0 / 3600.0]])
     out = coh_avg_vis(obs, dt=0, scan_avg=True)
     # Two scans, two output rows.
     assert len(out) == 2
-    # tint per scan: scan 1 has 3 samples × 1s, scan 2 has 2 samples × 1s.
+    # tint per scan: scan 1 has 4 samples × 1s, scan 2 has 2 samples × 1s.
     tints = sorted(out["tint"])
-    assert tints == [2.0, 3.0]
+    assert tints == [2.0, 4.0]
 
 
 def test_coh_avg_vis_polrep_circ():

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -431,6 +431,104 @@ def test_coh_moving_avg_vis_inverse_variance_sigma():
     np.testing.assert_allclose(out["sigma"], expected, rtol=1e-12)
 
 
+def test_coh_moving_avg_vis_invvar_mean_nonuniform_sigma():
+    """Sliding-window inverse-variance mean weights by 1/sigma^2.
+
+    Two samples (vis 1.0 and 3.0, sigmas 0.1 and 0.2) inside one 120 s
+    window: weights [100, 25], <V> = (1.0*100 + 3.0*25)/125 = 1.4 at both
+    row positions.
+    """
+    times = np.array([0.0, 1.0 / 3600.0])
+    obs = _make_obs(times_hr=times,
+                    vis_fn=lambda t, t1, t2: 1.0 + 0.0j if t == 0.0 else 3.0 + 0.0j)
+    obs.data["sigma"] = np.array([0.1, 0.2])
+    obs.data["qsigma"] = np.array([0.1, 0.2])
+    obs.data["usigma"] = np.array([0.1, 0.2])
+    obs.data["vsigma"] = np.array([0.1, 0.2])
+
+    out = coh_moving_avg_vis(obs, dt=120.0, invvar_avg=True)
+    w = np.array([1 / 0.1**2, 1 / 0.2**2])
+    expected = np.sum(np.array([1.0, 3.0]) * w) / np.sum(w)
+    np.testing.assert_allclose(out["vis"].real, expected, rtol=1e-12)
+
+
+def test_coh_moving_avg_vis_legacy_mean_and_sigma_nonuniform():
+    """invvar_avg=False sliding window: direct mean + legacy sigma.
+
+    Two samples (vis 1.0 and 3.0, sigmas 0.1 and 0.2) in one 120 s window:
+    direct mean = 2.0, legacy sigma = sqrt(0.1^2 + 0.2^2)/2 ≈ 0.1118 at
+    both rows.
+    """
+    times = np.array([0.0, 1.0 / 3600.0])
+    obs = _make_obs(times_hr=times,
+                    vis_fn=lambda t, t1, t2: 1.0 + 0.0j if t == 0.0 else 3.0 + 0.0j)
+    obs.data["sigma"] = np.array([0.1, 0.2])
+    obs.data["qsigma"] = np.array([0.1, 0.2])
+    obs.data["usigma"] = np.array([0.1, 0.2])
+    obs.data["vsigma"] = np.array([0.1, 0.2])
+
+    out = coh_moving_avg_vis(obs, dt=120.0, invvar_avg=False)
+    np.testing.assert_allclose(out["vis"].real, 2.0, rtol=1e-12)
+    expected_sig = np.sqrt(0.1**2 + 0.2**2) / 2.0
+    np.testing.assert_allclose(out["sigma"], expected_sig, rtol=1e-12)
+
+
+def test_coh_moving_avg_vis_full_window_matches_coh_avg_vis():
+    """A moving window wide enough to cover every sample on a baseline
+    yields, at each row, the same value coh_avg_vis produces for the bin
+    that contains all those samples. Holds for both weighting modes.
+
+    This pins that the moving-window and fixed-bin paths share identical
+    combine arithmetic — only their segment-sum mechanism (cumsum window
+    vs bincount group) differs.
+    """
+    times = np.array([0.0, 10.0 / 3600.0, 20.0 / 3600.0])
+    obs = _make_obs(times_hr=times,
+                    vis_fn=lambda t, t1, t2: 1.0 + (t * 3600.0) * 0.05)
+    obs.data["sigma"] = np.array([0.1, 0.3, 0.2])
+    obs.data["qsigma"] = np.array([0.1, 0.3, 0.2])
+    obs.data["usigma"] = np.array([0.1, 0.3, 0.2])
+    obs.data["vsigma"] = np.array([0.1, 0.3, 0.2])
+
+    for invvar in (True, False):
+        binned = coh_avg_vis(obs, dt=60.0, invvar_avg=invvar)
+        moving = coh_moving_avg_vis(obs, dt=120.0, invvar_avg=invvar)
+        assert len(binned) == 1
+        # Every moving-window row collapses to the single-bin value.
+        np.testing.assert_allclose(moving["vis"], binned["vis"][0], rtol=1e-12)
+        np.testing.assert_allclose(moving["sigma"], binned["sigma"][0], rtol=1e-12)
+
+
+def test_coh_moving_avg_vis_centered_window_differs_from_legacy(_legacy_ehdf):
+    """The window is centered ([t-dt/2, t+dt/2], original timestamps), unlike
+    the legacy dataframes.coh_moving_avg_vis trailing .rolling(dt) window +
+    -dt/2 shift. On irregular spacing the two select different samples, so
+    the outputs differ. Pinned so a silent revert to the trailing convention
+    is caught.
+    """
+    # Five samples at 0, 20, 40, 70, 130 s on one baseline; vis = 1..5.
+    sec_to_vis = {0: 1.0, 20: 2.0, 40: 3.0, 70: 4.0, 130: 5.0}
+    times = np.array(sorted(sec_to_vis)) / 3600.0
+    obs = _make_obs(times_hr=times,
+                    vis_fn=lambda t, t1, t2: sec_to_vis[int(round(t * 3600.0))] + 0.0j)
+
+    new = coh_moving_avg_vis(obs, dt=50.0, invvar_avg=False)
+    new = new[np.argsort(new["time"])]
+    # Centered window, half-width 25 s, computed by hand:
+    #   t=0   -> [-25, 25]  -> {0, 20}     -> mean(1, 2)    = 1.5
+    #   t=20  -> [-5, 45]   -> {0, 20, 40} -> mean(1, 2, 3) = 2.0
+    #   t=40  -> [15, 65]   -> {20, 40}    -> mean(2, 3)    = 2.5
+    #   t=70  -> [45, 95]   -> {70}        -> 4.0
+    #   t=130 -> [105, 155] -> {130}       -> 5.0
+    np.testing.assert_allclose(new["vis"].real, [1.5, 2.0, 2.5, 4.0, 5.0],
+                               rtol=1e-12)
+
+    # Legacy trailing window selects a different set, so the values differ.
+    old = _legacy_ehdf.coh_moving_avg_vis(obs, dt=50.0, return_type="rec")
+    old = old[np.argsort(old["time"])]
+    assert np.any(np.abs(new["vis"].real - old["vis"].real) > 1e-6)
+
+
 def test_coh_avg_vis_err_type_measured_smoke():
     """The bootstrap err_type='measured' path runs end-to-end."""
     rng = np.random.default_rng(42)
@@ -449,3 +547,147 @@ def test_coh_avg_vis_err_type_measured_smoke():
     assert len(out) == 1
     # Bootstrap sigma should be a positive finite number.
     assert np.isfinite(out["sigma"][0]) and out["sigma"][0] > 0
+
+
+# ---------------------------------------------------------------------------
+# Section 8: incoh_avg_vis — coupled (amp, sigma) estimator pairs
+#
+# invvar_avg gates BOTH the amplitude estimator and the sigma estimator
+# under err_type='predicted', so each branch produces a self-consistent
+# pair:
+#   - True : inverse-variance Rice-debiased amplitude + 1/sqrt(sum 1/sig^2)
+#   - False: stats.deb_amp + stats.inc_sig (legacy Rician-SNR pair)
+# Mixing across paths (inv-var amp with Rician sigma, or vice versa) is
+# not a valid estimator; the tests below pin the coupling.
+# ---------------------------------------------------------------------------
+
+
+def test_incoh_avg_vis_invvar_sigma_inverse_variance(_legacy_ehdf):
+    """invvar_avg=True returns the inverse-variance sigma 1/sqrt(sum 1/sig^2).
+
+    With sigmas [0.1, 0.2] the inverse-variance combination differs from
+    the Rician-SNR estimator (invvar_avg=False) by ~25%, so the formula
+    can be pinned strictly.
+    """
+    times = np.array([0.0, 1.0 / 3600.0])
+    obs = _make_obs(times_hr=times)
+    obs.data["sigma"] = np.array([0.1, 0.2])
+    obs.data["qsigma"] = np.array([0.1, 0.2])
+    obs.data["usigma"] = np.array([0.1, 0.2])
+    obs.data["vsigma"] = np.array([0.1, 0.2])
+
+    out_invvar = incoh_avg_vis(obs, dt=60.0, debias=False, invvar_avg=True)
+    expected = 1.0 / np.sqrt(1.0 / 0.1**2 + 1.0 / 0.2**2)
+    assert out_invvar["sigma"][0] == pytest.approx(expected, rel=1e-12)
+
+
+def test_incoh_avg_vis_invvar_amp_equal_sigma_matches_deb_amp():
+    """Equal-sigma limit: the inverse-variance Rice-debiased amplitude
+    reduces to stats.deb_amp.
+
+    With w_i = 1/sigma**2 the inv-var bias correction (2N-1)/sum(w)
+    becomes (2 - 1/N)*sigma**2 and matches stats.deb_amp's
+    (2 - 1/Nc)*mean(sigma**2) exactly when all sigmas are equal.
+    """
+    times = np.array([0.0, 1.0 / 3600.0, 2.0 / 3600.0])
+    sigma_val = 0.2
+
+    def vis_fn(t, t1, t2):
+        s = int(round(t * 3600.0))
+        return [1.0, 1.2, 0.8][s] + 0.0j
+
+    obs = _make_obs(times_hr=times, vis_fn=vis_fn, sigma=sigma_val)
+    out_invvar = incoh_avg_vis(obs, dt=60.0, debias=True, invvar_avg=True)
+    out_legacy = incoh_avg_vis(obs, dt=60.0, debias=True, invvar_avg=False)
+
+    np.testing.assert_allclose(out_invvar["vis"].real, out_legacy["vis"].real,
+                               rtol=1e-12, atol=1e-14)
+
+
+def test_incoh_avg_vis_invvar_debias_subtracts_bias():
+    """invvar_avg=True with debias=True must subtract the Rice bias term
+    from the inverse-variance weighted second moment.
+
+    Three samples of |V| = 1.0 with sigma = 0.5: <|V|^2>_w = 1, the bias
+    correction (2N-1)/sum(w) = 5/12 ≈ 0.417, so the debiased amplitude
+    must be strictly smaller than the undebiased one.
+    """
+    times = np.array([0.0, 1.0 / 3600.0, 2.0 / 3600.0])
+    obs = _make_obs(times_hr=times,
+                    vis_fn=lambda t, t1, t2: 1.0 + 0.0j,
+                    sigma=0.5)
+    out_no_debias = incoh_avg_vis(obs, dt=60.0, debias=False, invvar_avg=True)
+    out_debias = incoh_avg_vis(obs, dt=60.0, debias=True, invvar_avg=True)
+    assert out_debias["vis"][0].real < out_no_debias["vis"][0].real - 1e-6
+
+
+def test_incoh_avg_vis_invvar_varied_sigma_diverges_from_legacy(_legacy_ehdf):
+    """Varied intra-bin sigmas: invvar_avg=True (coupled inv-var pair)
+    differs from invvar_avg=False (legacy deb_amp + inc_sig) in BOTH
+    amplitude and sigma. Pins that the two paths are not aliases.
+    """
+    times = np.array([0.0, 10.0 / 3600.0, 20.0 / 3600.0, 30.0 / 3600.0])
+    obs = _make_obs(times_hr=times,
+                    vis_fn=lambda t, t1, t2: 1.0 + (t * 3600.0) * 0.01)
+    obs.data["sigma"] = np.array([0.1, 0.4, 0.1, 0.4])
+
+    out_invvar = incoh_avg_vis(obs, dt=60.0, debias=True, invvar_avg=True)
+    out_legacy = incoh_avg_vis(obs, dt=60.0, debias=True, invvar_avg=False)
+
+    assert abs(out_invvar["vis"][0].real - out_legacy["vis"][0].real) > 1e-4
+    assert abs(out_invvar["sigma"][0] - out_legacy["sigma"][0]) > 1e-4
+
+
+def test_parity_incoh_avg_vis_invvar_false_matches_legacy_varied_sigma(_legacy_ehdf):
+    """invvar_avg=False reproduces ehtim.statistics.dataframes.incoh_avg_vis
+    bit-for-bit on varied intra-bin sigmas (deb_amp amplitude and inc_sig
+    sigma both match).
+    """
+    times = np.array([0.0, 10.0 / 3600.0, 20.0 / 3600.0, 30.0 / 3600.0])
+    obs = _make_obs(times_hr=times,
+                    vis_fn=lambda t, t1, t2: 1.0 + (t * 3600.0) * 0.01)
+    obs.data["sigma"] = np.array([0.1, 0.4, 0.1, 0.4])
+    obs.data["qsigma"] = np.array([0.1, 0.4, 0.1, 0.4])
+    obs.data["usigma"] = np.array([0.1, 0.4, 0.1, 0.4])
+    obs.data["vsigma"] = np.array([0.1, 0.4, 0.1, 0.4])
+
+    new = incoh_avg_vis(obs, dt=60.0, debias=True, invvar_avg=False)
+    old = _legacy_ehdf.incoh_avg_vis(obs, dt=60.0, debias=True, return_type='rec')
+
+    np.testing.assert_allclose(new["vis"].real, old["vis"].real,
+                               rtol=1e-8, atol=1e-10)
+    np.testing.assert_allclose(new["sigma"], old["sigma"],
+                               rtol=1e-8, atol=1e-10)
+
+
+def test_incoh_avg_vis_invvar_on_eht2017_gaussian(obs_direct, _legacy_ehdf):
+    """End-to-end on the realistic EHT2017 Gaussian fixture (obs_direct).
+
+    Bins are chosen wide enough (dt = 2 h) to capture multiple integrations
+    per baseline so the two estimator paths actually exercise their
+    multi-sample math (single-sample bins are degenerate: both branches
+    just return the lone sigma untouched).
+
+    Pins:
+      - both branches run without error and emit the same row count,
+      - amplitudes and sigmas are finite and non-negative,
+      - sigma diverges between branches on at least some rows.
+    """
+    dt = 7200.0  # 2-hour bins — multiple 5s integrations per baseline
+    new_invvar = incoh_avg_vis(obs_direct, dt=dt, debias=True, invvar_avg=True)
+    new_legacy = incoh_avg_vis(obs_direct, dt=dt, debias=True, invvar_avg=False)
+    assert len(new_invvar) == len(new_legacy)
+    new_invvar = new_invvar[np.argsort(new_invvar, order=("t1", "t2", "time"))]
+    new_legacy = new_legacy[np.argsort(new_legacy, order=("t1", "t2", "time"))]
+
+    for branch in (new_invvar, new_legacy):
+        assert np.all(np.isfinite(branch["vis"].real))
+        assert np.all(branch["vis"].real >= 0)
+        assert np.all(np.isfinite(branch["sigma"]))
+        assert np.all(branch["sigma"] >= 0)
+
+    sigma_diff = np.abs(new_invvar["sigma"] - new_legacy["sigma"])
+    assert np.any(sigma_diff > 1e-6), (
+        "expected at least one row where the inverse-variance sigma and "
+        "the Rician-SNR sigma disagree on obs_direct"
+    )

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -1,0 +1,307 @@
+"""Tests for ehtim.statistics.averaging.
+
+The three averaging routines historically lived in
+`ehtim.statistics.dataframes` (pandas-based) and propagated visibility errors
+via `sqrt(mean(sigma_i**2))`.  The migration to a pandas-free
+`ehtim.statistics.averaging` swapped that formula for the correct
+inverse-variance combination
+
+    sigma_avg = 1 / sqrt(sum(1/sigma_i**2)).
+
+This file pins both the migration (pandas-free, matching record-array
+contracts) and the inverse-variance fix.
+"""
+
+import numpy as np
+import pytest
+
+import ehtim as eh
+import ehtim.const_def as ehc
+from ehtim.statistics.averaging import (
+    coh_avg_vis,
+    coh_moving_avg_vis,
+    incoh_avg_vis,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic Obsdata fixture
+# ---------------------------------------------------------------------------
+
+
+_STATIONS = (b"AA", b"AP", b"LM")
+
+
+def _make_obs(times_hr, baselines=None, vis_fn=None, sigma=0.1, polrep="stokes"):
+    """Build a minimal Obsdata with caller-specified times + visibility values.
+
+    `baselines` is a list of (t1, t2) pairs of bytes-strings; one row per
+    timestamp uses each baseline.  Defaults to a single baseline (AA, AP).
+    `vis_fn(t, t1, t2)` returns the complex Stokes-I (or RR) visibility for
+    each (time, baseline).  Defaults to `1+0j`.
+    """
+    if baselines is None:
+        baselines = [(b"AA", b"AP")]
+    if vis_fn is None:
+        def vis_fn(t, t1, t2):
+            return 1.0 + 0.0j
+    times_hr = np.asarray(times_hr, dtype=float)
+    n_times = len(times_hr)
+    n_bls = len(baselines)
+    n = n_times * n_bls
+
+    if polrep == "stokes":
+        dtype = ehc.DTPOL_STOKES
+        vis_fields = ("vis", "qvis", "uvis", "vvis")
+        sig_fields = ("sigma", "qsigma", "usigma", "vsigma")
+    else:
+        dtype = ehc.DTPOL_CIRC
+        vis_fields = ("rrvis", "llvis", "rlvis", "lrvis")
+        sig_fields = ("rrsigma", "llsigma", "rlsigma", "lrsigma")
+    data = np.zeros(n, dtype=dtype)
+    sigma_arr = np.broadcast_to(np.asarray(sigma, dtype=float), (n_times,))
+    idx = 0
+    for t1, t2 in baselines:
+        sl = slice(idx, idx + n_times)
+        data["time"][sl] = times_hr
+        data["tint"][sl] = 1.0
+        data["t1"][sl] = t1
+        data["t2"][sl] = t2
+        data["u"][sl] = 1e9
+        data["v"][sl] = 1e9
+        for vf in vis_fields:
+            data[vf][sl] = [vis_fn(t, t1, t2) for t in times_hr]
+        for sf in sig_fields:
+            data[sf][sl] = sigma_arr
+        idx += n_times
+
+    tarr = np.zeros(len(_STATIONS), dtype=ehc.DTARR)
+    for i, site in enumerate(_STATIONS):
+        tarr[i]["site"] = site
+        tarr[i]["sefdr"] = 1.0
+        tarr[i]["sefdl"] = 1.0
+
+    obs = eh.obsdata.Obsdata(
+        ra=17.761, dec=-29.0, rf=230e9, bw=4e9,
+        datatable=data, tarr=tarr, polrep=polrep,
+    )
+    return obs
+
+
+# ---------------------------------------------------------------------------
+# Section 1: coh_avg_vis — bin grouping + complex mean
+# ---------------------------------------------------------------------------
+
+
+def test_coh_avg_vis_dt_zero_returns_input():
+    """dt=0, scan_avg=False is a no-op (returns input data)."""
+    obs = _make_obs(times_hr=np.array([0.0, 0.01]))
+    out = coh_avg_vis(obs, dt=0, scan_avg=False)
+    assert out is obs.data
+
+
+def test_coh_avg_vis_single_bin_complex_mean():
+    """Two visibilities in the same 60s bin coherently average to their mean."""
+    times = np.array([0.0, 5.0 / 3600.0])  # 0s and 5s after start
+    obs = _make_obs(times_hr=times,
+                    vis_fn=lambda t, t1, t2: 1.0 + 0.0j if t == 0.0 else 3.0 + 0.0j)
+    out = coh_avg_vis(obs, dt=60.0)
+    assert len(out) == 1
+    assert out["vis"][0] == pytest.approx(2.0 + 0.0j)
+
+
+def test_coh_avg_vis_two_bins_separated():
+    """Two visibilities one minute apart land in different bins."""
+    times = np.array([0.0, 70.0 / 3600.0])
+    obs = _make_obs(times_hr=times,
+                    vis_fn=lambda t, t1, t2: 1.0 + 0.0j if t == 0.0 else 3.0 + 0.0j)
+    out = coh_avg_vis(obs, dt=60.0)
+    assert len(out) == 2
+
+
+def test_coh_avg_vis_tint_summed_in_bin():
+    """tint accumulates inside the bin (units stay seconds)."""
+    times = np.array([0.0, 5.0 / 3600.0, 10.0 / 3600.0])
+    obs = _make_obs(times_hr=times)
+    out = coh_avg_vis(obs, dt=60.0)
+    assert out["tint"][0] == pytest.approx(3.0)  # three 1s integrations
+
+
+# ---------------------------------------------------------------------------
+# Section 2: inverse-variance sigma — the task-2.17 regression
+# ---------------------------------------------------------------------------
+
+
+def test_coh_avg_vis_uniform_sigma_drops_by_sqrt_n():
+    """N visibilities with identical sigma s → averaged sigma = s/sqrt(N)."""
+    times = np.array([0.0, 1.0 / 3600.0, 2.0 / 3600.0, 3.0 / 3600.0])  # 4 samples
+    obs = _make_obs(times_hr=times, sigma=0.1)
+    out = coh_avg_vis(obs, dt=60.0)
+    assert out["sigma"][0] == pytest.approx(0.1 / np.sqrt(4), rel=1e-12)
+
+
+def test_coh_avg_vis_inverse_variance_sigma_nonuniform():
+    """Non-uniform sigmas combine via 1/sqrt(sum(1/sigma_i^2)), not sqrt(mean(sigma_i^2)).
+
+    The old pandas-based meanerrF in dataframes.py used the latter (wrong).  For
+    sigmas [0.1, 0.2] the correct inverse-variance combination is
+    1/sqrt(1/0.01 + 1/0.04) = 1/sqrt(125) ≈ 0.0894, vs the old (wrong) value
+    sqrt((0.01 + 0.04)/4) = 0.1118.  The 25% discrepancy makes this a strict
+    regression test.
+    """
+    times = np.array([0.0, 1.0 / 3600.0])
+    obs = _make_obs(times_hr=times)
+    # Override sigmas by patching the recarray directly.
+    obs.data["sigma"] = np.array([0.1, 0.2])
+    obs.data["qsigma"] = np.array([0.1, 0.2])
+    obs.data["usigma"] = np.array([0.1, 0.2])
+    obs.data["vsigma"] = np.array([0.1, 0.2])
+
+    out = coh_avg_vis(obs, dt=60.0)
+    expected = 1.0 / np.sqrt(1.0 / 0.1**2 + 1.0 / 0.2**2)
+    assert out["sigma"][0] == pytest.approx(expected, rel=1e-12)
+    # Sanity: should NOT equal the historical buggy formula.
+    wrong = np.sqrt((0.1**2 + 0.2**2) / 2**2)
+    assert abs(out["sigma"][0] - wrong) > 1e-4
+
+
+# ---------------------------------------------------------------------------
+# Section 3: coh_moving_avg_vis — sliding-window
+# ---------------------------------------------------------------------------
+
+
+def test_coh_moving_avg_vis_constant_input_unchanged():
+    """Moving average of a constant signal is the constant."""
+    times = np.linspace(0.0, 0.05, 50)  # 50 samples spread over 3 minutes
+    obs = _make_obs(times_hr=times)
+    out = coh_moving_avg_vis(obs, dt=30.0)
+    np.testing.assert_allclose(out["vis"], 1.0 + 0.0j, atol=1e-12)
+
+
+def test_coh_moving_avg_vis_baselines_independent():
+    """A second baseline's samples don't pollute the first baseline's window."""
+    times = np.array([0.0, 1.0 / 3600.0])
+
+    def vis_fn(t, t1, t2):
+        # Baseline (AA, AP) carries 1+0j; baseline (AA, LM) carries 99+0j.
+        return 99.0 + 0.0j if t2 == b"LM" else 1.0 + 0.0j
+
+    obs = _make_obs(times_hr=times,
+                    baselines=[(b"AA", b"AP"), (b"AA", b"LM")],
+                    vis_fn=vis_fn)
+    out = coh_moving_avg_vis(obs, dt=120.0)
+    mask_AP = (out["t1"] == b"AA") & (out["t2"] == b"AP")
+    mask_LM = (out["t1"] == b"AA") & (out["t2"] == b"LM")
+    np.testing.assert_allclose(out["vis"][mask_AP], 1.0 + 0.0j, atol=1e-12)
+    np.testing.assert_allclose(out["vis"][mask_LM], 99.0 + 0.0j, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Section 4: incoh_avg_vis — high-SNR sanity
+# ---------------------------------------------------------------------------
+
+
+def test_incoh_avg_vis_high_snr_recovers_amplitude():
+    """At very high SNR, incoherent averaging recovers the true amplitude."""
+    times = np.array([0.0, 1.0 / 3600.0, 2.0 / 3600.0])
+    obs = _make_obs(times_hr=times,
+                    vis_fn=lambda t, t1, t2: 1.0 + 0.0j,
+                    sigma=1e-6)  # very small noise
+    out = incoh_avg_vis(obs, dt=60.0, debias=True)
+    assert abs(out["vis"][0].real - 1.0) < 1e-4
+
+
+# ---------------------------------------------------------------------------
+# Section 5: end-to-end through Obsdata wrappers
+# ---------------------------------------------------------------------------
+
+
+def test_avg_coherent_through_obs_wrapper(obs_direct):
+    """obs.avg_coherent() round-trips through ehavg.coh_avg_vis."""
+    out = obs_direct.avg_coherent(60.0)
+    assert out.data.dtype == obs_direct.data.dtype
+    # Same or fewer rows than input.
+    assert len(out.data) <= len(obs_direct.data)
+
+
+def test_avg_incoherent_through_obs_wrapper(obs_direct):
+    """obs.avg_incoherent() round-trips through ehavg.incoh_avg_vis."""
+    out = obs_direct.avg_incoherent(60.0)
+    assert out.data.dtype == obs_direct.data.dtype
+    assert len(out.data) <= len(obs_direct.data)
+
+
+# ---------------------------------------------------------------------------
+# Section 6: parity vs the legacy pandas implementations in dataframes.py
+#
+# Per Andrew's suggestion: keep ehtim.statistics.dataframes around for now so
+# we can A/B test the new pandas-free averaging against the original.  Once
+# this PR has flushed through dev / dev-backend and PR #246's add_* removal
+# has propagated, dataframes.py is deleted in a follow-up PR.
+#
+# Vis values are coherently averaged the same way in both implementations
+# (complex mean) so they must match within float tolerance.  Sigmas
+# intentionally differ: the new code uses inverse-variance combination, the
+# old code used sqrt(mean(sigma_i**2)).  Both are asserted.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def _legacy_ehdf():
+    """Import the pandas-based legacy module; skip parity tests if pandas
+    isn't installed in the env."""
+    pytest.importorskip("pandas")
+    from ehtim.statistics import dataframes as legacy
+    return legacy
+
+
+def test_parity_coh_avg_vis_complex_mean_matches_legacy(obs_direct, _legacy_ehdf):
+    """Averaged visibility values match the legacy pandas implementation."""
+    new = coh_avg_vis(obs_direct, dt=60.0)
+    old = _legacy_ehdf.coh_avg_vis(obs_direct, dt=60.0, return_type='rec')
+    assert len(new) == len(old)
+    # Sort both by (t1, t2, time) for an order-independent comparison.
+    new_key = np.argsort(new, order=("t1", "t2", "time"))
+    old_key = np.argsort(old, order=("t1", "t2", "time"))
+    new_s, old_s = new[new_key], old[old_key]
+    for vf in ("vis", "qvis", "uvis", "vvis"):
+        np.testing.assert_allclose(new_s[vf], old_s[vf], rtol=1e-10, atol=1e-12,
+                                   err_msg=f"vis mismatch in field {vf!r}")
+
+
+def test_parity_coh_avg_vis_sigma_differs_by_inverse_variance(_legacy_ehdf):
+    """Sigma values intentionally differ — the new code fixes the bug.
+
+    For two equal-time-bin samples with sigmas (0.1, 0.2), the new
+    inverse-variance value is 1/sqrt(125) ≈ 0.0894; the legacy formula
+    sqrt((0.01 + 0.04)/4) ≈ 0.1118.
+    """
+    times = np.array([0.0, 1.0 / 3600.0])
+    obs = _make_obs(times_hr=times)
+    obs.data["sigma"] = np.array([0.1, 0.2])
+    obs.data["qsigma"] = np.array([0.1, 0.2])
+    obs.data["usigma"] = np.array([0.1, 0.2])
+    obs.data["vsigma"] = np.array([0.1, 0.2])
+
+    new = coh_avg_vis(obs, dt=60.0)
+    old = _legacy_ehdf.coh_avg_vis(obs, dt=60.0, return_type='rec')
+
+    expected_new = 1.0 / np.sqrt(1.0 / 0.1**2 + 1.0 / 0.2**2)
+    expected_old = np.sqrt((0.1**2 + 0.2**2) / 4)
+
+    assert new["sigma"][0] == pytest.approx(expected_new, rel=1e-12)
+    assert old["sigma"][0] == pytest.approx(expected_old, rel=1e-12)
+    # And the two formulas must genuinely disagree on non-uniform sigmas.
+    assert abs(new["sigma"][0] - old["sigma"][0]) > 1e-4
+
+
+def test_parity_incoh_avg_vis_amplitude_matches_legacy(obs_direct, _legacy_ehdf):
+    """Incoherently-averaged amplitudes match the legacy implementation."""
+    new = incoh_avg_vis(obs_direct, dt=60.0, debias=True)
+    old = _legacy_ehdf.incoh_avg_vis(obs_direct, dt=60.0, debias=True, return_type='rec')
+    assert len(new) == len(old)
+    new_key = np.argsort(new, order=("t1", "t2", "time"))
+    old_key = np.argsort(old, order=("t1", "t2", "time"))
+    new_s, old_s = new[new_key], old[old_key]
+    # Real parts hold the (debiased) amplitude.
+    np.testing.assert_allclose(new_s["vis"].real, old_s["vis"].real,
+                               rtol=1e-8, atol=1e-10)

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -317,12 +317,16 @@ def test_parity_coh_avg_vis_varied_sigma(_legacy_ehdf):
     assert abs(new_invvar["vis"][0] - new_direct["vis"][0]) > 1e-3
 
 
-def test_parity_coh_avg_vis_sigma_differs_by_inverse_variance(_legacy_ehdf):
-    """Sigma values intentionally differ — the new code fixes the bug.
+def test_parity_coh_avg_vis_sigma_invvar_vs_legacy(_legacy_ehdf):
+    """invvar_avg gates the predicted-sigma branch as well as the vis mean.
 
-    For two equal-time-bin samples with sigmas (0.1, 0.2), the new
-    inverse-variance value is 1/sqrt(125) ≈ 0.0894; the legacy formula
-    sqrt((0.01 + 0.04)/4) ≈ 0.1118.
+    - invvar_avg=False : reproduces the legacy sqrt(sum(sig_i^2))/N formula
+      bit-for-bit, so new vs legacy is a true parity check.
+    - invvar_avg=True (default): uses 1/sqrt(sum(1/sig_i^2)) — analytically
+      the correct error on the inverse-variance mean.
+
+    With sigmas [0.1, 0.2] the two formulas differ by ~25%, so the
+    divergence assertion is strict.
     """
     times = np.array([0.0, 1.0 / 3600.0])
     obs = _make_obs(times_hr=times)
@@ -331,16 +335,21 @@ def test_parity_coh_avg_vis_sigma_differs_by_inverse_variance(_legacy_ehdf):
     obs.data["usigma"] = np.array([0.1, 0.2])
     obs.data["vsigma"] = np.array([0.1, 0.2])
 
-    new = coh_avg_vis(obs, dt=60.0)
+    new_legacy = coh_avg_vis(obs, dt=60.0, invvar_avg=False)
+    new_default = coh_avg_vis(obs, dt=60.0)  # invvar_avg=True
     old = _legacy_ehdf.coh_avg_vis(obs, dt=60.0, return_type='rec')
 
-    expected_new = 1.0 / np.sqrt(1.0 / 0.1**2 + 1.0 / 0.2**2)
-    expected_old = np.sqrt((0.1**2 + 0.2**2) / 4)
+    # invvar_avg=False matches legacy on all four pol sigmas.
+    for sf in ("sigma", "qsigma", "usigma", "vsigma"):
+        assert new_legacy[sf][0] == pytest.approx(old[sf][0], rel=1e-12), \
+            f"invvar_avg=False should reproduce legacy {sf} exactly"
 
-    assert new["sigma"][0] == pytest.approx(expected_new, rel=1e-12)
-    assert old["sigma"][0] == pytest.approx(expected_old, rel=1e-12)
-    # And the two formulas must genuinely disagree on non-uniform sigmas.
-    assert abs(new["sigma"][0] - old["sigma"][0]) > 1e-4
+    # invvar_avg=True returns the analytic inverse-variance sigma.
+    expected_invvar = 1.0 / np.sqrt(1.0 / 0.1**2 + 1.0 / 0.2**2)
+    assert new_default["sigma"][0] == pytest.approx(expected_invvar, rel=1e-12)
+
+    # And the two modes genuinely disagree on non-uniform sigmas.
+    assert abs(new_default["sigma"][0] - new_legacy["sigma"][0]) > 1e-4
 
 
 def test_parity_incoh_avg_vis_amplitude_matches_legacy(obs_direct, _legacy_ehdf):

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -234,6 +234,43 @@ def test_avg_incoherent_through_obs_wrapper(obs_direct):
     assert len(out.data) <= len(obs_direct.data)
 
 
+def test_avg_coherent_wrapper_invvar_flag_forwarded():
+    """Obsdata.avg_coherent forwards invvar_avg to the backend: on varied
+    intra-bin sigmas the two modes give different averaged visibilities,
+    and invvar_avg=False matches the standalone backend call.
+    """
+    times = np.array([0.0, 10.0 / 3600.0, 20.0 / 3600.0, 30.0 / 3600.0])
+    obs = _make_obs(times_hr=times,
+                    vis_fn=lambda t, t1, t2: 1.0 + (t * 3600.0) * 0.01)
+    obs.data["sigma"] = np.array([0.1, 0.4, 0.1, 0.4])
+    obs.data["qsigma"] = np.array([0.1, 0.4, 0.1, 0.4])
+    obs.data["usigma"] = np.array([0.1, 0.4, 0.1, 0.4])
+    obs.data["vsigma"] = np.array([0.1, 0.4, 0.1, 0.4])
+
+    out_invvar = obs.avg_coherent(60.0, invvar_avg=True)
+    out_direct = obs.avg_coherent(60.0, invvar_avg=False)
+    assert abs(out_invvar.data["vis"][0] - out_direct.data["vis"][0]) > 1e-3
+
+    # invvar_avg=False through the wrapper == the standalone backend call.
+    backend = coh_avg_vis(obs, dt=60.0, invvar_avg=False)
+    np.testing.assert_allclose(out_direct.data["vis"], backend["vis"],
+                               rtol=1e-12, atol=1e-14)
+
+
+def test_avg_incoherent_wrapper_invvar_flag_forwarded():
+    """Obsdata.avg_incoherent forwards invvar_avg to the backend: the two
+    modes give different sigmas on varied intra-bin sigmas.
+    """
+    times = np.array([0.0, 10.0 / 3600.0, 20.0 / 3600.0, 30.0 / 3600.0])
+    obs = _make_obs(times_hr=times,
+                    vis_fn=lambda t, t1, t2: 1.0 + (t * 3600.0) * 0.01)
+    obs.data["sigma"] = np.array([0.1, 0.4, 0.1, 0.4])
+
+    out_invvar = obs.avg_incoherent(60.0, invvar_avg=True)
+    out_direct = obs.avg_incoherent(60.0, invvar_avg=False)
+    assert abs(out_invvar.data["sigma"][0] - out_direct.data["sigma"][0]) > 1e-4
+
+
 # ---------------------------------------------------------------------------
 # Section 6: parity vs the legacy pandas implementations in dataframes.py
 #


### PR DESCRIPTION
Moves the three visibility-averaging routines (`coh_avg_vis`, `coh_moving_avg_vis`, `incoh_avg_vis`) from `ehtim.statistics.dataframes` (pandas) to a new pandas-free `ehtim.statistics.averaging` (pure NumPy).
Bundles the inverse-variance time-averaging fix,  same class of bug as PR #230.

## What changed

- **New** `ehtim/statistics/averaging.py` — pure-NumPy implementations vectorised via `np.bincount` / cumsum + `searchsorted`.
- **Bug fix:** sigma combination switched from `sqrt(mean(sigma_i**2))` (wrong) to `1/sqrt(sum(1/sigma_i**2))` (correct inverse-variance), mirroring the channel/IF averaging in `load_obs_uvfits` (PR #230).
- **`ehtim/obsdata.py`** — `avg_coherent` / `avg_incoherent` / `add_amp` rewired to the new module.
- **`ehtim/statistics/dataframes.py`** — pandas now lazy-imported (via a  `_PandasStub` that raises a clear `ImportError` on first attribute access) so users without pandas can still `import ehtim`. Closure-quantity helpers (`make_*_df`, `average_*`) remain; they're called only by `Obsdata.add_*` methods that PR #246 removes on
  `dev-backend`.  Once #246 syncs through to `dev`, `dataframes.py` can be deleted in a follow-up PR.

## Behavior change

Inverse-variance sigmas are systematically smaller and more physical than the old formula.  Pipelines with tuned SNR cuts may need to retune; same class of behavior change as PR #230.

## API breaks

- `incoh_avg_vis(..., return_type='df')` and `coh_avg_vis(..., return_type='df')` (and the moving variant) now raise `ValueError`; the new module only emits recarrays.  `Obsdata.add_amp` raises `NotImplementedError` if a
  user requests `return_type='df'` for the averaging path.  Pre-2.0 internal break; no external pipelines should be affected.

Part of #212 — closes tasks 2.7 and 2.17.