### PR TITLE
Phase 1: mixed-pol schema additions and warnings module

### DIFF
--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -53,7 +53,7 @@ class Array(object):
     """
 
     def __init__(self, tarr, ephem={}):
-        self.tarr = tarr
+        self.tarr = ehc.upgrade_tarr(tarr)
         self.ephem = ephem
 
         # check to see if ephemeris is correct
@@ -70,11 +70,19 @@ class Array(object):
         # Dictionary of array indices for site names
         self.tkey = {self.tarr[i]['site']: i for i in range(len(self.tarr))}
 
-    @property 
+    def __setstate__(self, state):
+        # Silently upgrade legacy pickles to the current mixedpol schema.
+        if 'tarr' in state:
+            state['tarr'] = ehc.upgrade_tarr(state['tarr'])
+        if '_tarr' in state:
+            state['_tarr'] = ehc.upgrade_tarr(state['_tarr'])
+        self.__dict__.update(state)
+
+    @property
     def tarr(self):
         return self._tarr
-        
-    @tarr.setter 
+
+    @tarr.setter
     def tarr(self, tarr):
         self._tarr = tarr
         self.tkey = {tarr[i]['site']: i for i in range(len(tarr))}
@@ -215,21 +223,24 @@ class Array(object):
 
         return axes
 
-    def add_site(self, site, coords, sefd=10000, 
-                 fr_par=0, fr_elev=0, fr_off=0, 
+    def add_site(self, site, coords, sefd=10000,
+                 fr_par=0, fr_elev=0, fr_off=0,
                  dr=0.+0.j, dl=0.+0.j):
-    
+
         """Add a ground station to the array
-             
+
+           TODO (Phase 2 mixed-pol): extend signature with `feed_type='rl'` and
+           per-feed sefd/d-term kwargs (sefd_p1/sefd_p2/d_p1/d_p2). Phase 1
+           hardcodes feed_type='rl' so legacy circular workflows are unchanged.
         """
         tarr_old = self.tarr.copy()
         ephem_old = self.ephem.copy()
-        
-        
-        tarr_newline = np.array((str(site), float(coords[0]), float(coords[1]), float(coords[2]), 
-                                 float(sefd), float(sefd), 
-                                 dr, dl, 
-                                 float(fr_par), float(fr_elev), float(fr_off)), dtype=ehc.DTARR)
+
+
+        tarr_newline = np.array((str(site), float(coords[0]), float(coords[1]), float(coords[2]),
+                                 float(sefd), float(sefd),
+                                 dr, dl,
+                                 float(fr_par), float(fr_elev), float(fr_off), 'rl'), dtype=ehc.DTARR)
         tarr_new = np.append(tarr_old, tarr_newline)
         
         arr_out = Array(tarr_new, ephem_old)
@@ -256,18 +267,20 @@ class Array(object):
     def add_satellite_tle(self, tlelist, sefd=10000):
     
         """Add an earth-orbiting satellite to the array from a TLE
-        
-           Args: 
+
+           Args:
              tlearr (str) : 3 element list with [name, tle line 1, tle line 2] as strings
-             sefd (float) : assumed sefd for the array file (assumes sefdl = sefdr)     
+             sefd (float) : assumed sefd for the array file (assumes sefdl = sefdr)
+
+           TODO (Phase 2 mixed-pol): extend signature with feed_type kwarg.
         """
         satname = tlearr[0]
         tarr_new = self.tarr.copy()
         ephem_new = self.ephem.copy()
-        
+
         tarr_newline = np.array((str(satname), 0., 0., 0.,
-                                 float(sefd), float(sefd), 
-                                 0., 0., 0., 0., 0.), dtype=ehc.DTARR)
+                                 float(sefd), float(sefd),
+                                 0., 0., 0., 0., 0., 'rl'), dtype=ehc.DTARR)
         tarr_new = np.append(tarr_new, tarr_newline)
         ephem_new[satname] = tlearr
         arr_out = Array(tarr_new, ephem_new)
@@ -281,19 +294,21 @@ class Array(object):
                                sefd=10000):
         """Add an earth-orbiting satellite to the array from simple keplerian elements
            perfect keplerian orbit is assumed, no derivatives
-                   
-           Args: 
+
+           Args:
                perigee time given in mjd
                period given in days
                inclination, arg_perigee, long_ascending given in degrees
+
+           TODO (Phase 2 mixed-pol): extend signature with feed_type kwarg.
         """
 
         tarr_new = self.tarr.copy()
         ephem_new = self.ephem.copy()
-        
+
         tarr_newline = np.array((str(satname), 0., 0., 0.,
-                                 float(sefd), float(sefd), 
-                                 0., 0., 0., 0., 0.), dtype=ehc.DTARR)
+                                 float(sefd), float(sefd),
+                                 0., 0., 0., 0., 0., 'rl'), dtype=ehc.DTARR)
         tarr_new = np.append(tarr_new, tarr_newline)
         
         ephem_new[satname] = [perigee_mjd, period_days, eccentricity, inclination, arg_perigee, long_ascending]

--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -18,7 +18,6 @@
 
 
 import copy
-from builtins import range, str
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -59,9 +58,9 @@ class Array:
                 try:
                     elen = len(ephem[sitename])
                 except NameError:
-                    raise Exception('no ephemeris for site %s !' % sitename)
+                    raise Exception(f'no ephemeris for site {sitename} !')
                 if elen != 3:
-                    raise Exception('wrong ephemeris format for site %s !' % sitename)
+                    raise Exception(f'wrong ephemeris format for site {sitename} !')
 
         # Dictionary of array indices for site names
         self.tkey = {self.tarr[i]['site']: i for i in range(len(self.tarr))}
@@ -136,7 +135,7 @@ class Array:
                no_elevcut_space (bool): if True, do not apply elevation cut to orbiters
                tau (float): the base opacity at all sites, or a dict giving one opacity per site
                fix_theta_GMST (bool): if True, stops earth rotation to sample fixed u,v points
-               
+
            Returns:
                Obsdata: an observation object with no data
 
@@ -191,13 +190,13 @@ class Array:
                label (str) : title for plot
                legend (bool) : add telescope legend or not
                clist (list) : list of colors for different stations
-               rangex (list) : lower and upper x-axis limits  
-               rangey (list) : lower and upper y-axis limits 
+               rangex (list) : lower and upper x-axis limits
+               rangey (list) : lower and upper y-axis limits
                markersize (float) : marker size
                show (bool) : display the plot or not
                grid (bool) : add a grid to the plot or not
-               export_pdf (str) : save a pdf file to this path 
-               
+               export_pdf (str) : save a pdf file to this path
+
            Returns:
                matplotlib.axes
         """
@@ -244,7 +243,7 @@ class Array:
 
     def remove_site(self, site):
         """Remove a site from the array
-           
+
         """
         tarr_old = self.tarr.copy()
         ephem_old = self.ephem.copy()
@@ -255,7 +254,7 @@ class Array:
             if site in ephem_old.keys():
                 ephem_new.pop(site)
         except:
-            raise Exception("could not find site %s to delete from Array!"%site)
+            raise Exception(f"could not find site {site} to delete from Array!")
 
         arr_out = Array(tarr_new, ephem_new)
         return arr_out
@@ -335,7 +334,7 @@ class Array:
                 sat = obsh.sat_skyfield_from_elements(satellite, tstart_mjd,
                                                       elements[0],elements[1],elements[2],elements[3],elements[4],elements[5])
             else:
-                raise Exception("ephemeris format not recognized for %s"%satellite)
+                raise Exception(f"ephemeris format not recognized for {satellite}")
 
             # get GCRS positions
             fracmjds = np.linspace(tstart_mjd, tstop_mjd, npoints)

--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -16,32 +16,28 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
-
-import numpy as np
 import copy
-from astropy.time import Time
-import matplotlib.pyplot as plt
-import matplotlib
-import ehtim.observing.obs_simulate as simobs
-import ehtim.observing.obs_helpers as obsh
-import ehtim.io.save
-import ehtim.io.load
-import ehtim.const_def as ehc
-from ehtim.caltable import plot_tarr_dterms
+from builtins import range, str
 
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+from astropy.time import Time
+
+import ehtim.const_def as ehc
+import ehtim.io.load
+import ehtim.io.save
+import ehtim.observing.obs_helpers as obsh
+import ehtim.observing.obs_simulate as simobs
+from ehtim.caltable import plot_tarr_dterms
 
 ###################################################################################################
 # Array object
 ###################################################################################################
 
 
-class Array(object):
+class Array:
 
     """A VLBI array of telescopes with site locations, SEFDs, and other data.
 
@@ -99,7 +95,7 @@ class Array(object):
         newarr = copy.deepcopy(self)
         return newarr
 
-       
+
     def listbls(self):
         """List all baselines.
 
@@ -111,7 +107,7 @@ class Array(object):
         bls = []
         for i1 in sorted(self.tarr['site']):
             for i2 in sorted(self.tarr['site']):
-                if not ([i1, i2] in bls) and not ([i2, i1] in bls) and i1 != i2:
+                if [i1, i2] not in bls and [i2, i1] not in bls and i1 != i2:
                     bls.append([i1, i2])
         bls = np.array(bls)
 
@@ -149,7 +145,7 @@ class Array(object):
         obsarr = simobs.make_uvpoints(self, ra, dec, rf, bw,
                                       tint, tadv, tstart, tstop,
                                       mjd=mjd, polrep=polrep, tau=tau,
-                                      elevmin=elevmin, elevmax=elevmax, 
+                                      elevmin=elevmin, elevmax=elevmax,
                                       no_elevcut_space=no_elevcut_space,
                                       timetype=timetype, fix_theta_GMST=fix_theta_GMST)
 
@@ -214,7 +210,7 @@ class Array(object):
 
         if len(sites)==0:
             sites = list(self.tkey.keys())
-                    
+
         keys = [self.tkey[site] for site in sites]
 
         axes = plot_tarr_dterms(self.tarr, keys=keys, label=label, legend=legend, clist=clist,
@@ -242,10 +238,10 @@ class Array(object):
                                  dr, dl,
                                  float(fr_par), float(fr_elev), float(fr_off), 'rl'), dtype=ehc.DTARR)
         tarr_new = np.append(tarr_old, tarr_newline)
-        
+
         arr_out = Array(tarr_new, ephem_old)
         return arr_out
-            
+
     def remove_site(self, site):
         """Remove a site from the array
            
@@ -253,19 +249,19 @@ class Array(object):
         tarr_old = self.tarr.copy()
         ephem_old = self.ephem.copy()
         ephem_new = ephem_old.copy()
-        
+
         try:
             tarr_new = np.delete(tarr_old.copy(), self.tkey[site])
             if site in ephem_old.keys():
-                ephem_new.pop(site) 
+                ephem_new.pop(site)
         except:
             raise Exception("could not find site %s to delete from Array!"%site)
-        
+
         arr_out = Array(tarr_new, ephem_new)
         return arr_out
 
     def add_satellite_tle(self, tlelist, sefd=10000):
-    
+
         """Add an earth-orbiting satellite to the array from a TLE
 
            Args:
@@ -284,13 +280,13 @@ class Array(object):
         tarr_new = np.append(tarr_new, tarr_newline)
         ephem_new[satname] = tlearr
         arr_out = Array(tarr_new, ephem_new)
-        
+
         return arr_out
 
-    def add_satellite_elements(self, satname, 
-                               perigee_mjd=Time.now().mjd, 
+    def add_satellite_elements(self, satname,
+                               perigee_mjd=Time.now().mjd,
                                period_days=1., eccentricity=0.,
-                               inclination=0., arg_perigee=0., long_ascending=0., 
+                               inclination=0., arg_perigee=0., long_ascending=0.,
                                sefd=10000):
         """Add an earth-orbiting satellite to the array from simple keplerian elements
            perfect keplerian orbit is assumed, no derivatives
@@ -310,44 +306,44 @@ class Array(object):
                                  float(sefd), float(sefd),
                                  0., 0., 0., 0., 0., 'rl'), dtype=ehc.DTARR)
         tarr_new = np.append(tarr_new, tarr_newline)
-        
+
         ephem_new[satname] = [perigee_mjd, period_days, eccentricity, inclination, arg_perigee, long_ascending]
         arr_out = Array(tarr_new, ephem_new)
-                
+
         return arr_out
-        
+
     def plot_satellite_orbits(self, tstart_mjd=Time.now().mjd, tstop_mjd=Time.now().mjd+1, npoints=1000):
         earth_radius_polar = 6357. #km
         earth_radius_eq = 6378.
-    
+
         fig = plt.figure(figsize=(18,6))
         gs = matplotlib.gridspec.GridSpec(1,3,width_ratios=[1,1,1])
-        
+
         satellites = self.ephem.keys()
         for i,satellite in enumerate(satellites):
-        
+
             if i==0: color='k'
             else: color=ehc.SCOLORS[i-1]
-            
+
             # get skyfield satelllite object
             if len(self.ephem[satellite])==3: # TLE
                 line1 = self.ephem[satellite][1]
-                line2 = self.ephem[satellite][2]            
+                line2 = self.ephem[satellite][2]
                 sat = obsh.sat_skyfield_from_tle(satellite, line1, line2)
             elif len(self.ephem[satellite])==6: #keplerian elements
                 elements = self.ephem[satellite]
                 sat = obsh.sat_skyfield_from_elements(satellite, tstart_mjd,
                                                       elements[0],elements[1],elements[2],elements[3],elements[4],elements[5])
             else:
-                raise Exception("ephemeris format not recognized for %s"%satellite)    
-        
+                raise Exception("ephemeris format not recognized for %s"%satellite)
+
             # get GCRS positions
             fracmjds = np.linspace(tstart_mjd, tstop_mjd, npoints)
             positions = obsh.orbit_skyfield(sat, fracmjds, whichout='gcrs')
             positions *= 1.e-3 # convert to km
             distances = np.sqrt(positions[0]**2 + positions[1]**2 + positions[2]**2)
             maxdist = np.max(distances)
-            
+
             ax1 = fig.add_subplot(gs[0])
             ax1.set_aspect(1)
             plt.plot(positions[0], positions[1], color=color, marker='.',ls='None')
@@ -368,8 +364,8 @@ class Array(object):
             plt.ylabel('z (km)')
             plt.xlim(-1.1*maxdist, 1.1*maxdist)
             plt.ylim(-1.1*maxdist, 1.1*maxdist)
-            plt.grid()  
-            
+            plt.grid()
+
             ax3 = fig.add_subplot(gs[2])
             ax3.set_aspect(1)
             plt.plot(positions[0], positions[2], color=color, marker='.',ls='None', label=satellite)
@@ -383,9 +379,9 @@ class Array(object):
             plt.grid()
 
         plt.subplots_adjust(wspace=1)
-        ehc.show_noblock()            
+        ehc.show_noblock()
         return
-                                 
+
 ##########################################################################
 # Array creation functions
 ##########################################################################

--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -251,15 +251,19 @@ class Array:
 
         try:
             tarr_new = np.delete(tarr_old.copy(), self.tkey[site])
-            if site in ephem_old.keys():
+        except IndexError:
+            raise Exception(f"could not find site {site} to delete from Array.tarr!")
+
+        if site in ephem_old.keys():
+            try:
                 ephem_new.pop(site)
-        except:
-            raise Exception(f"could not find site {site} to delete from Array!")
+            except KeyError:
+                raise Exception(f"could not find ephemeris for site {site} to delete from Array.ephem!")
 
         arr_out = Array(tarr_new, ephem_new)
         return arr_out
 
-    def add_satellite_tle(self, tlelist, sefd=10000):
+    def add_satellite_tle(self, tlearr, sefd=10000):
 
         """Add an earth-orbiting satellite to the array from a TLE
 
@@ -321,8 +325,10 @@ class Array:
         satellites = self.ephem.keys()
         for i,satellite in enumerate(satellites):
 
-            if i==0: color='k'
-            else: color=ehc.SCOLORS[i-1]
+            if i==0:
+                color='k'
+            else:
+                color=ehc.SCOLORS[i-1]
 
             # get skyfield satelllite object
             if len(self.ephem[satellite])==3: # TLE

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -87,11 +87,24 @@ class Caltable:
         self.timetype = timetype
 
         # Dictionary of array indices for site names
-        self.tarr = tarr
+        self.tarr = ehc.upgrade_tarr(tarr)
         self.tkey = {self.tarr[i]['site']: i for i in range(len(self.tarr))}
 
-        # Save the data
-        self.data = datadict
+        # Save the data (upgrade per-site DTCAL recarrays as needed)
+        if isinstance(datadict, dict):
+            self.data = {site: ehc.upgrade_dtcal_circ(d)
+                         for site, d in datadict.items()}
+        else:
+            self.data = datadict
+
+    def __setstate__(self, state):
+        # Silently upgrade legacy pickles to the current mixedpol schema.
+        if 'tarr' in state:
+            state['tarr'] = ehc.upgrade_tarr(state['tarr'])
+        if 'data' in state and isinstance(state['data'], dict):
+            state['data'] = {site: ehc.upgrade_dtcal_circ(d)
+                             for site, d in state['data'].items()}
+        self.__dict__.update(state)
 
     def copy(self):
         """Copy the observation object.

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -23,6 +23,8 @@ from builtins import str
 from builtins import range
 from builtins import object
 
+import functools
+
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 from packaging import version
@@ -79,9 +81,14 @@ FFT_PAD_DEFAULT = 2
 FFT_INTERP_DEFAULT = 3
 
 # Observation recarray datatypes
+# DTARR uses generic names primary because it is a single shared dtype across
+# all stations; legacy names are title aliases. Per-Obsdata/Caltable dtypes
+# (DTPOL_*, DTCAL_*) invert this — physical names primary, generic alias.
 DTARR = [('site', 'U32'), ('x', 'f8'), ('y', 'f8'), ('z', 'f8'),
-         ('sefdr', 'f8'), ('sefdl', 'f8'), ('dr', 'c16'), ('dl', 'c16'),
-         ('fr_par', 'f8'), ('fr_elev', 'f8'), ('fr_off', 'f8')]
+         (('sefdr', 'sefd_p1'), 'f8'), (('sefdl', 'sefd_p2'), 'f8'),
+         (('dr', 'd_p1'), 'c16'), (('dl', 'd_p2'), 'c16'),
+         ('fr_par', 'f8'), ('fr_elev', 'f8'), ('fr_off', 'f8'),
+         ('feed_type', 'U2')]
 
 DTPOL_STOKES = [('time', 'f8'), ('tint', 'f8'),
                 ('t1', 'U32'), ('t2', 'U32'),
@@ -94,8 +101,29 @@ DTPOL_CIRC = [('time', 'f8'), ('tint', 'f8'),
               ('t1', 'U32'), ('t2', 'U32'),
               ('tau1', 'f8'), ('tau2', 'f8'),
               ('u', 'f8'), ('v', 'f8'),
-              ('rrvis', 'c16'), ('llvis', 'c16'), ('rlvis', 'c16'), ('lrvis', 'c16'),
-              ('rrsigma', 'f8'), ('llsigma', 'f8'), ('rlsigma', 'f8'), ('lrsigma', 'f8')]
+              (('p1p1vis', 'rrvis'), 'c16'), (('p2p2vis', 'llvis'), 'c16'),
+              (('p1p2vis', 'rlvis'), 'c16'), (('p2p1vis', 'lrvis'), 'c16'),
+              (('p1p1sigma', 'rrsigma'), 'f8'), (('p2p2sigma', 'llsigma'), 'f8'),
+              (('p1p2sigma', 'rlsigma'), 'f8'), (('p2p1sigma', 'lrsigma'), 'f8')]
+
+DTPOL_LIN = [('time', 'f8'), ('tint', 'f8'),
+             ('t1', 'U32'), ('t2', 'U32'),
+             ('tau1', 'f8'), ('tau2', 'f8'),
+             ('u', 'f8'), ('v', 'f8'),
+             (('p1p1vis', 'xxvis'), 'c16'), (('p2p2vis', 'yyvis'), 'c16'),
+             (('p1p2vis', 'xyvis'), 'c16'), (('p2p1vis', 'yxvis'), 'c16'),
+             (('p1p1sigma', 'xxsigma'), 'f8'), (('p2p2sigma', 'yysigma'), 'f8'),
+             (('p1p2sigma', 'xysigma'), 'f8'), (('p2p1sigma', 'yxsigma'), 'f8')]
+
+DTPOL_MIXED = [('time', 'f8'), ('tint', 'f8'),
+               ('t1', 'U32'), ('t2', 'U32'),
+               ('tau1', 'f8'), ('tau2', 'f8'),
+               ('u', 'f8'), ('v', 'f8'),
+               ('p1p1vis', 'c16'), ('p2p2vis', 'c16'),
+               ('p1p2vis', 'c16'), ('p2p1vis', 'c16'),
+               ('p1p1sigma', 'f8'), ('p2p2sigma', 'f8'),
+               ('p1p2sigma', 'f8'), ('p2p1sigma', 'f8'),
+               ('polbasis', 'U2')]
 
 DTAMP = [('time', 'f8'), ('tint', 'f8'),
          ('t1', 'U32'), ('t2', 'U32'),
@@ -121,15 +149,120 @@ DTCPHASEDIAG = [('time', 'f8'), ('cphase', 'f8'), ('sigmacp', 'f8'),
 DTLOGCAMPDIAG = [('time', 'f8'), ('camp', 'f8'), ('sigmaca', 'f8'),
                  ('quadrangles', 'O'), ('u', 'O'), ('v', 'O'), ('tform_matrix', 'O')]
 
-DTCAL = [('time', 'f8'), ('rscale', 'c16'), ('lscale', 'c16')]
+DTCAL_CIRC = [('time', 'f8'),
+              (('p1scale', 'rscale'), 'c16'), (('p2scale', 'lscale'), 'c16'),
+              (('d_p1', 'dr'), 'c16'), (('d_p2', 'dl'), 'c16')]
+
+DTCAL_LIN = [('time', 'f8'),
+             (('p1scale', 'xscale'), 'c16'), (('p2scale', 'yscale'), 'c16'),
+             ('d_p1', 'c16'), ('d_p2', 'c16')]
+
+DTCAL = DTCAL_CIRC  # legacy alias
 
 DTSCANS = [('time', 'f8'), ('interval', 'f8'), ('startvis', 'f8'), ('endvis', 'f8')]
+
+
+# TODO (Phase 3b): the feed_dtype_for_polrep / feed_poldict / upgrade_*
+# helpers below should migrate to ehtim/observing/pol_conventions.py when
+# that module is created.
+
+def feed_dtype_for_polrep(polrep):
+    """Return the DTPOL_* field-spec list for a given polrep."""
+    try:
+        return {'stokes': DTPOL_STOKES, 'circ': DTPOL_CIRC,
+                'lin': DTPOL_LIN, 'mixed': DTPOL_MIXED}[polrep]
+    except KeyError:
+        raise ValueError("polrep must be one of "
+                         "{'stokes', 'circ', 'lin', 'mixed'}, got %r" % polrep)
+
+
+def upgrade_tarr(tarr):
+    """Upgrade a legacy DTARR recarray (no feed_type) to the current DTARR.
+
+    Idempotent. Fills feed_type='rl' for legacy data. Used by Array,
+    Obsdata, and Caltable constructors / __setstate__ to keep backwards
+    compatibility with pickled or user-supplied recarrays.
+    """
+    import numpy as _np
+    if tarr is None:
+        return tarr
+    if tarr.dtype.names is not None and 'feed_type' in tarr.dtype.names:
+        return tarr
+    new = _np.zeros(len(tarr), dtype=DTARR)
+    for name in ('site', 'x', 'y', 'z',
+                 'sefdr', 'sefdl', 'dr', 'dl',
+                 'fr_par', 'fr_elev', 'fr_off'):
+        new[name] = tarr[name]
+    new['feed_type'] = 'rl'
+    return new
+
+
+def upgrade_dtpol_circ(data):
+    """Zero-copy view-cast of a legacy DTPOL_CIRC recarray to add title aliases.
+
+    Idempotent. Bytes are identical between legacy and new layouts; only
+    the dtype object adds the generic p1p1vis/... aliases. Returns the
+    input unchanged for non-CIRC dtypes.
+    """
+    import numpy as _np
+    target = _np.dtype(DTPOL_CIRC)
+    if data.dtype == target:
+        return data
+    if data.dtype.itemsize == target.itemsize and data.dtype.names == target.names:
+        return data.view(target)
+    return data
+
+
+def upgrade_dtcal_circ(data):
+    """Upgrade a legacy DTCAL recarray (time, rscale, lscale) to DTCAL_CIRC.
+
+    Legacy DTCAL has no D-term fields; the upgrade allocates a new recarray
+    and zero-fills dr/dl. Idempotent.
+    """
+    import numpy as _np
+    target = _np.dtype(DTCAL_CIRC)
+    if data.dtype == target:
+        return data
+    names = data.dtype.names or ()
+    if 'rscale' in names and 'dr' not in names:
+        new = _np.zeros(len(data), dtype=target)
+        for name in ('time', 'rscale', 'lscale'):
+            new[name] = data[name]
+        return new
+    return data
+
+
+@functools.lru_cache(maxsize=16)
+def feed_poldict(t1_feed, t2_feed):
+    """Return the four field names for a baseline with given feed types.
+
+    Slot convention: vis1 = (p1 of t1) x (p1 of t2), vis2 = p2 x p2,
+    vis3 = p1 x p2, vis4 = p2 x p1. Returns the *physical* slot labels
+    (e.g. 'rrvis' for ('rl','rl'); 'rxvis' for ('rl','xy')). Used at
+    construction time; '??' raises rather than silently defaulting.
+    """
+    if t1_feed == '??' or t2_feed == '??':
+        raise ValueError("feed_poldict: unknown feed_type '??' "
+                         "(t1=%r, t2=%r)" % (t1_feed, t2_feed))
+    p1a, p2a = t1_feed[0], t1_feed[1]
+    p1b, p2b = t2_feed[0], t2_feed[1]
+    return {'vis1': '%s%svis' % (p1a, p1b),
+            'vis2': '%s%svis' % (p2a, p2b),
+            'vis3': '%s%svis' % (p1a, p2b),
+            'vis4': '%s%svis' % (p2a, p1b),
+            'sigma1': '%s%ssigma' % (p1a, p1b),
+            'sigma2': '%s%ssigma' % (p2a, p2b),
+            'sigma3': '%s%ssigma' % (p1a, p2b),
+            'sigma4': '%s%ssigma' % (p2a, p1b)}
+
 
 # Dictionaries for keeping track of polarization fields
 POLDICT_STOKES = {'vis1': 'vis', 'vis2': 'qvis', 'vis3': 'uvis', 'vis4': 'vvis',
                   'sigma1': 'sigma', 'sigma2': 'qsigma', 'sigma3': 'usigma', 'sigma4': 'vsigma'}
 POLDICT_CIRC = {'vis1': 'rrvis', 'vis2': 'llvis', 'vis3': 'rlvis', 'vis4': 'lrvis',
                 'sigma1': 'rrsigma', 'sigma2': 'llsigma', 'sigma3': 'rlsigma', 'sigma4': 'lrsigma'}
+POLDICT_LIN = {'vis1': 'xxvis', 'vis2': 'yyvis', 'vis3': 'xyvis', 'vis4': 'yxvis',
+               'sigma1': 'xxsigma', 'sigma2': 'yysigma', 'sigma3': 'xysigma', 'sigma4': 'yxsigma'}
 vis_poldict = {'I': 'vis', 'Q': 'qvis', 'U': 'uvis', 'V': 'vvis',
                'RR': 'rrvis', 'LL': 'llvis', 'RL': 'rlvis', 'LR': 'lrvis'}
 amp_poldict = {'I': 'amp', 'Q': 'qamp', 'U': 'uamp', 'V': 'vamp',

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -168,7 +168,7 @@ def feed_dtype_for_polrep(polrep):
                 'lin': DTPOL_LIN, 'mixed': DTPOL_MIXED}[polrep]
     except KeyError:
         raise ValueError("polrep must be one of "
-                         "{'stokes', 'circ', 'lin', 'mixed'}, got %r" % polrep)
+                         f"{{'stokes', 'circ', 'lin', 'mixed'}}, got {polrep!r}")
 
 
 def upgrade_tarr(tarr):
@@ -238,17 +238,17 @@ def feed_poldict(t1_feed, t2_feed):
     """
     if t1_feed == '??' or t2_feed == '??':
         raise ValueError("feed_poldict: unknown feed_type '??' "
-                         "(t1=%r, t2=%r)" % (t1_feed, t2_feed))
+                         f"(t1={t1_feed!r}, t2={t2_feed!r})")
     p1a, p2a = t1_feed[0], t1_feed[1]
     p1b, p2b = t2_feed[0], t2_feed[1]
-    return {'vis1': '%s%svis' % (p1a, p1b),
-            'vis2': '%s%svis' % (p2a, p2b),
-            'vis3': '%s%svis' % (p1a, p2b),
-            'vis4': '%s%svis' % (p2a, p1b),
-            'sigma1': '%s%ssigma' % (p1a, p1b),
-            'sigma2': '%s%ssigma' % (p2a, p2b),
-            'sigma3': '%s%ssigma' % (p1a, p2b),
-            'sigma4': '%s%ssigma' % (p2a, p1b)}
+    return {'vis1': f'{p1a}{p1b}vis',
+            'vis2': f'{p2a}{p2b}vis',
+            'vis3': f'{p1a}{p2b}vis',
+            'vis4': f'{p2a}{p1b}vis',
+            'sigma1': f'{p1a}{p1b}sigma',
+            'sigma2': f'{p2a}{p2b}sigma',
+            'sigma3': f'{p1a}{p2b}sigma',
+            'sigma4': f'{p2a}{p1b}sigma'}
 
 
 # Dictionaries for keeping track of polarization fields

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -16,12 +16,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
 
 import functools
 
@@ -319,7 +314,7 @@ def show_noblock(pause=0.001):
         plt.pause(pause)
         plt.draw()
         plt.pause(pause)
-                
+
 FIELD_LABELS = {'time': 'Time',
                 'time_utc': 'Time (UTC)',
                 'time_gmst': 'Time (GMST)',

--- a/ehtim/io/load.py
+++ b/ehtim/io/load.py
@@ -827,21 +827,26 @@ def load_array_txt(filename, ephemdir='ephemeris'):
     path = os.path.dirname(filename)
 
     tdataout = []
-    if (tdata.shape[1] != 5 and tdata.shape[1] != 13):
+    if (tdata.shape[1] not in (5, 13, 14)):
         raise Exception("Array file should have format: " +
                         "(name, x, y, z, SEFDR, SEFDL " +
                         "FR_PAR_ANGLE FR_ELEV_ANGLE FR_OFFSET" +
-                        "DR_RE   DR_IM   DL_RE    DL_IM )")
+                        "DR_RE   DR_IM   DL_RE    DL_IM   [FEED_TYPE])")
 
     elif tdata.shape[1] == 5:
         tdataout = [np.array((x[0], float(x[1]), float(x[2]), float(x[3]), float(x[4]), float(x[4]),
                               0.0, 0.0,
-                              0.0, 0.0, 0.0),
+                              0.0, 0.0, 0.0, 'rl'),
                              dtype=ehc.DTARR) for x in tdata]
     elif tdata.shape[1] == 13:
         tdataout = [np.array((x[0], float(x[1]), float(x[2]), float(x[3]), float(x[4]), float(x[5]),
                               float(x[9]) + 1j * float(x[10]), float(x[11]) + 1j * float(x[12]),
-                              float(x[6]), float(x[7]), float(x[8])),
+                              float(x[6]), float(x[7]), float(x[8]), 'rl'),
+                             dtype=ehc.DTARR) for x in tdata]
+    elif tdata.shape[1] == 14:
+        tdataout = [np.array((x[0], float(x[1]), float(x[2]), float(x[3]), float(x[4]), float(x[5]),
+                              float(x[9]) + 1j * float(x[10]), float(x[11]) + 1j * float(x[12]),
+                              float(x[6]), float(x[7]), float(x[8]), str(x[13])),
                              dtype=ehc.DTARR) for x in tdata]
 
     # load spacecraft
@@ -922,12 +927,17 @@ def load_obs_txt(filename, polrep='stokes'):
     while line[1][0] != "-":
         if len(line) == 6:
             tarr.append(np.array((line[1], line[2], line[3], line[4], line[5], line[5],
-                                  0, 0, 0, 0, 0), dtype=ehc.DTARR))
+                                  0, 0, 0, 0, 0, 'rl'), dtype=ehc.DTARR))
         elif len(line) == 14:
             tarr.append(np.array((line[1], line[2], line[3], line[4], line[5], line[6],
                                   float(line[10]) + 1j * float(line[11]),
                                   float(line[12]) + 1j * float(line[13]),
-                                  line[7], line[8], line[9]), dtype=ehc.DTARR))
+                                  line[7], line[8], line[9], 'rl'), dtype=ehc.DTARR))
+        elif len(line) == 15:
+            tarr.append(np.array((line[1], line[2], line[3], line[4], line[5], line[6],
+                                  float(line[10]) + 1j * float(line[11]),
+                                  float(line[12]) + 1j * float(line[13]),
+                                  line[7], line[8], line[9], str(line[14])), dtype=ehc.DTARR))
         else:
             raise Exception("Telescope header doesn't have the right number of fields!")
         line = file.readline().split()
@@ -1075,10 +1085,12 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
     dr = np.zeros(len(tnames)) + 1j * np.zeros(len(tnames))
     dl = np.zeros(len(tnames)) + 1j * np.zeros(len(tnames))
 
+    # TODO (Phase 3c/6 mixed-pol): read POLTYA/POLTYB from the AIPS AN table
+    # to populate per-station feed_type. Until then, assume circular feeds.
     tarr = [np.array((
             str(tnames[i]), xyz[i][0], xyz[i][1], xyz[i][2],
             sefdr[i], sefdl[i], dr[i], dl[i],
-            fr_par[i], fr_el[i], fr_off[i]),
+            fr_par[i], fr_el[i], fr_off[i], 'rl'),
         dtype=ehc.DTARR) for i in range(len(tnames))]
 
     tarr = np.array(tarr)
@@ -1542,7 +1554,7 @@ def load_obs_maps(arrfile, obsspec, ifile, qfile=0, ufile=0, vfile=0,
     # Read telescope parameters from the array file
     tdata = np.loadtxt(arrfile, dtype=bytes).astype(str)
     tdata = [np.array((x[0], float(x[1]), float(x[2]), float(x[3]),
-                       float(x[-1]), float(x[-1]), 0., 0., 0., 0., 0.),
+                       float(x[-1]), float(x[-1]), 0., 0., 0., 0., 0., 'rl'),
                       dtype=ehc.DTARR) for x in tdata]
     tdata = np.array(tdata)
 

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -128,6 +128,9 @@ class Obsdata:
 
         if len(datatable) == 0:
             raise Exception("No data in input table!")
+        # Silently upgrade legacy DTPOL_CIRC (no title aliases) to the
+        # current dtype; zero-copy view-cast when applicable.
+        datatable = ehc.upgrade_dtpol_circ(datatable)
         if datatable.dtype not in [ehc.DTPOL_STOKES, ehc.DTPOL_CIRC]:
             raise Exception("Data table dtype should be DTPOL_STOKES or DTPOL_CIRC")
 
@@ -164,7 +167,7 @@ class Obsdata:
         self.scans = scantable
 
         # Telescope array: default ordering is by sefd
-        self.tarr = tarr
+        self.tarr = ehc.upgrade_tarr(tarr)
         self.tkey = {self.tarr[i]['site']: i for i in range(len(self.tarr))}
         if np.any(self.tarr['sefdr'] != 0) or np.any(self.tarr['sefdl'] != 0):
             self.reorder_tarr_sefd(reorder_baselines=False)
@@ -188,6 +191,16 @@ class Obsdata:
     def tarr(self, tarr):
         self._tarr = tarr
         self.tkey = {tarr[i]['site']: i for i in range(len(tarr))}
+
+    def __setstate__(self, state):
+        # Silently upgrade legacy pickles to the current mixedpol schema.
+        if '_tarr' in state:
+            state['_tarr'] = ehc.upgrade_tarr(state['_tarr'])
+        if 'tarr' in state:
+            state['tarr'] = ehc.upgrade_tarr(state['tarr'])
+        if 'data' in state and state['data'] is not None:
+            state['data'] = ehc.upgrade_dtpol_circ(state['data'])
+        self.__dict__.update(state)
 
     def obsdata_args(self):
         """"Copy arguments for making a new Obsdata into a list and dictonary
@@ -274,8 +287,7 @@ class Obsdata:
             rrmask = np.isnan(self.data['rrvis'])
             llmask = np.isnan(self.data['llvis'])
 
-            for f in ehc.DTPOL_STOKES:
-                f = f[0]
+            for f in np.dtype(ehc.DTPOL_STOKES).names:
                 if f in ['time', 'tint', 't1', 't2', 'tau1', 'tau2', 'u', 'v']:
                     data[f] = self.data[f]
                 elif f == 'vis':
@@ -304,8 +316,7 @@ class Obsdata:
             data = np.empty(len(self.data), dtype=ehc.DTPOL_CIRC)
             Vmask = np.isnan(self.data['vvis'])
 
-            for f in ehc.DTPOL_CIRC:
-                f = f[0]
+            for f in np.dtype(ehc.DTPOL_CIRC).names:
                 if f in ['time', 'tint', 't1', 't2', 'tau1', 'tau2', 'u', 'v']:
                     data[f] = self.data[f]
                 elif f == 'rrvis':
@@ -532,8 +543,7 @@ class Obsdata:
         data = np.empty(2 * len(self.data), dtype=self.poltype)
 
         # Add the conjugate baseline data
-        for f in self.poltype:
-            f = f[0]
+        for f in self.data.dtype.names:
             if f in ['t1', 't2', 'tau1', 'tau2']:
                 if f[-1] == '1':
                     f2 = f[:-1] + '2'

--- a/ehtim/vex.py
+++ b/ehtim/vex.py
@@ -17,18 +17,14 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
+import os
+import re
 from builtins import range
-from builtins import object
 
 import numpy as np
-import re
-
 from astropy.time import Time
-import os
+
 import ehtim.array
 import ehtim.const_def as ehc
 
@@ -37,7 +33,7 @@ import ehtim.const_def as ehc
 ###################################################################################################
 
 
-class Vex(object):
+class Vex:
     """Read in observing schedule data from .vex files.
        Assumes there is only 1 MODE in vex file
 

--- a/ehtim/vex.py
+++ b/ehtim/vex.py
@@ -172,7 +172,7 @@ class Vex(object):
         # mimic the function "load_array(filename)"
         # TODO this does not store d-term and pol cal. information!
         tdataout = [np.array((x[0], float(x[1]), float(x[2]), float(x[3]), float(x[4]), float(x[4]),
-                              0.0, 0.0, 0.0, 0.0, 0.0),
+                              0.0, 0.0, 0.0, 0.0, 0.0, 'rl'),
                              dtype=ehc.DTARR) for x in sites]
 
         tdataout = np.array(tdataout)

--- a/ehtim/vex.py
+++ b/ehtim/vex.py
@@ -20,7 +20,6 @@
 
 import os
 import re
-from builtins import range
 
 import numpy as np
 from astropy.time import Time
@@ -230,7 +229,7 @@ class Vex:
         for i in range(len(self.metalist)):
             if sname in self.metalist[i][0]:
                 return self.metalist[i]
-        print('No sector named %s' % sname)
+        print(f'No sector named {sname}')
         return False
 
     # Function to get a value of 'vname' in a line which has format of
@@ -283,7 +282,7 @@ class Vex:
         for i in range(len(sites)):
             if sites[i].split()[0] == station:
                 return float(re.findall(r"[-+]?\d+[\.]?\d*", sites[i])[3])
-        print('No station named %s' % station)
+        print(f'No station named {station}')
         return 10000.  # some arbitrary value
 
     # Find the time that any station starts observing the source in MJD.
@@ -320,7 +319,7 @@ def vexdate_to_MJD_hr(vexdate):
     time = re.findall(r"[-+]?\d+[\.]?\d*", vexdate)
     year = int(time[0])
     date = int(time[1])
-    yeardatetime = ("%04i" % year) + ':' + ("%03i" % date) + ":00:00:00.000"
+    yeardatetime = "{:04d}".format(year) + ':' + "{:03d}".format(date) + ":00:00:00.000"
     t = Time(yeardatetime, format='yday')
     mjd = t.mjd
     hour = int(time[2]) + float(time[3]) / 60. + float(time[4]) / 60. / 60.

--- a/ehtim/vex.py
+++ b/ehtim/vex.py
@@ -319,7 +319,7 @@ def vexdate_to_MJD_hr(vexdate):
     time = re.findall(r"[-+]?\d+[\.]?\d*", vexdate)
     year = int(time[0])
     date = int(time[1])
-    yeardatetime = "{:04d}".format(year) + ':' + "{:03d}".format(date) + ":00:00:00.000"
+    yeardatetime = f"{year:04d}" + ':' + f"{date:03d}" + ":00:00:00.000"
     t = Time(yeardatetime, format='yday')
     mjd = t.mjd
     hour = int(time[2]) + float(time[3]) / 60. + float(time[4]) / 60. / 60.

--- a/ehtim/warnings.py
+++ b/ehtim/warnings.py
@@ -1,0 +1,38 @@
+"""Custom warning classes for ehtim.
+
+Centralized home for ehtim-specific warning categories. New warning classes
+should be added here so users can suppress categories via the standard
+warnings machinery:
+
+    import warnings
+    import ehtim.warnings as ehw
+    warnings.filterwarnings('ignore', category=ehw.MixedPolConventionWarning)
+"""
+
+
+class MixedPolConventionWarning(UserWarning):
+    """Emitted on first non-trivial polrep conversion or Jones application
+    each session.
+
+    Notes the polarization-basis convention currently in use (defined in
+    ``ehtim/observing/pol_conventions.py``) and the ideal-feed (D = 0)
+    assumption underlying most basis transforms. Suppressible:
+
+        warnings.filterwarnings(
+            'ignore', category=ehtim.warnings.MixedPolConventionWarning
+        )
+    """
+
+
+class MixedPolClosureSkipWarning(UserWarning):
+    """Emitted when closure quantities skip triangles or quadrangles whose
+    feed-type combination makes the closure unphysical.
+
+    A bispectrum requires three visibilities of the same correlation around
+    a triangle, and a closure amplitude requires four visibilities of the
+    same correlation around a quadrangle. RR closure phases on a triangle
+    that includes a non-circular-feed station, or RR closure amplitudes on
+    a quadrangle that includes one, do not physically exist without
+    Jones-level conversion. The warning summarizes, per call, how many
+    triangles or quadrangles were skipped and why.
+    """

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -15,7 +15,6 @@ import ehtim.const_def as ehc
 import ehtim.obsdata as eo
 import ehtim.warnings as ehw
 
-
 # Legacy (pre-Phase-1) dtypes — used to verify upgrade plumbing.
 _LEGACY_DTARR = [('site', 'U32'), ('x', 'f8'), ('y', 'f8'), ('z', 'f8'),
                  ('sefdr', 'f8'), ('sefdl', 'f8'), ('dr', 'c16'), ('dl', 'c16'),

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -1,0 +1,334 @@
+"""Tests for the mixed-polarization data infrastructure.
+
+Tests are grouped by the phase of obsdata_mixedpol_plan_v2.md they cover.
+Subsequent phases (2, 2.5, 3, ...) should append their tests to this file
+under matching headers.
+"""
+import pickle
+
+import numpy as np
+import pytest
+
+import ehtim.array as ea
+import ehtim.caltable as ec
+import ehtim.const_def as ehc
+import ehtim.obsdata as eo
+import ehtim.warnings as ehw
+
+
+# Legacy (pre-Phase-1) dtypes — used to verify upgrade plumbing.
+_LEGACY_DTARR = [('site', 'U32'), ('x', 'f8'), ('y', 'f8'), ('z', 'f8'),
+                 ('sefdr', 'f8'), ('sefdl', 'f8'), ('dr', 'c16'), ('dl', 'c16'),
+                 ('fr_par', 'f8'), ('fr_elev', 'f8'), ('fr_off', 'f8')]
+
+_LEGACY_DTPOL_CIRC = [('time', 'f8'), ('tint', 'f8'),
+                     ('t1', 'U32'), ('t2', 'U32'),
+                     ('tau1', 'f8'), ('tau2', 'f8'),
+                     ('u', 'f8'), ('v', 'f8'),
+                     ('rrvis', 'c16'), ('llvis', 'c16'),
+                     ('rlvis', 'c16'), ('lrvis', 'c16'),
+                     ('rrsigma', 'f8'), ('llsigma', 'f8'),
+                     ('rlsigma', 'f8'), ('lrsigma', 'f8')]
+
+_LEGACY_DTCAL = [('time', 'f8'), ('rscale', 'c16'), ('lscale', 'c16')]
+
+
+def _legacy_tarr():
+    ot = np.zeros(2, dtype=_LEGACY_DTARR)
+    ot['site'] = ['A', 'B']
+    ot['sefdr'] = [1000., 2000.]
+    ot['sefdl'] = [1100., 2100.]
+    return ot
+
+
+def _legacy_circ_datatable():
+    od = np.zeros(2, dtype=_LEGACY_DTPOL_CIRC)
+    od['time'] = [0.0, 0.5]
+    od['t1'] = ['A', 'A']
+    od['t2'] = ['B', 'B']
+    od['rrvis'] = [1 + 0j, 2 + 0j]
+    od['rrsigma'] = [0.1, 0.2]
+    return od
+
+
+# ============================================================================
+# Phase 1 — Schema additions and warnings module
+# ============================================================================
+#
+# Plan reference: obsdata_mixedpol_plan_v2.md, "Phase 1".
+# Scope:
+#   - ehtim/warnings.py module + warning classes
+#   - DTARR migration to 12 fields with feed_type
+#   - DTPOL_CIRC / DTPOL_LIN / DTPOL_MIXED / DTCAL_CIRC / DTCAL_LIN dtypes
+#   - feed_dtype_for_polrep, feed_poldict helpers
+#   - Silent schema upgrade on __init__ and __setstate__ for Array,
+#     Obsdata, and Caltable.
+#
+# These tests guard the backwards-compatibility commitment: legacy
+# circular-feed data must keep producing numerically bit-identical
+# numerical values, with the dtype object expanding only by additive
+# columns and title aliases.
+
+# ----- Warnings module -----------------------------------------------------
+
+def test_phase1_warning_classes_are_user_warning_subclasses():
+    assert issubclass(ehw.MixedPolConventionWarning, UserWarning)
+    assert issubclass(ehw.MixedPolClosureSkipWarning, UserWarning)
+
+
+# ----- DTARR ---------------------------------------------------------------
+
+def test_phase1_dtarr_alias_equivalence():
+    a = np.zeros(2, dtype=ehc.DTARR)
+    a['sefd_p1'] = [1000., 2000.]
+    assert np.array_equal(a['sefdr'], a['sefd_p1'])
+    a['d_p1'] = [0.1 + 0.2j, 0.3 + 0.4j]
+    assert np.array_equal(a['dr'], a['d_p1'])
+
+
+def test_phase1_dtarr_primary_names_are_generic():
+    names = np.dtype(ehc.DTARR).names
+    assert 'sefd_p1' in names and 'sefd_p2' in names
+    assert 'd_p1' in names and 'd_p2' in names
+    assert 'feed_type' in names
+    # legacy names not in dtype.names (they are title aliases)
+    assert 'sefdr' not in names
+    assert 'sefdl' not in names
+
+
+def test_phase1_dtarr_default_feed_type_is_empty_until_filled():
+    a = np.zeros(1, dtype=ehc.DTARR)
+    # np.zeros gives an empty unicode string; ehtim's constructors fill 'rl'.
+    assert a['feed_type'][0] == ''
+
+
+# ----- DTPOL_CIRC ----------------------------------------------------------
+
+def test_phase1_dtpol_circ_alias_equivalence():
+    d = np.zeros(2, dtype=ehc.DTPOL_CIRC)
+    d['rrvis'] = [1 + 0j, 2 + 0j]
+    assert np.array_equal(d['p1p1vis'], d['rrvis'])
+    d['rlvis'] = [3 + 1j, 4 - 1j]
+    assert np.array_equal(d['p1p2vis'], d['rlvis'])
+    d['rrsigma'] = [0.1, 0.2]
+    assert np.array_equal(d['p1p1sigma'], d['rrsigma'])
+
+
+def test_phase1_dtpol_circ_primary_names_are_physical():
+    names = np.dtype(ehc.DTPOL_CIRC).names
+    assert 'rrvis' in names and 'lrvis' in names
+    assert 'p1p1vis' not in names  # generic is a title alias, not primary
+
+
+def test_phase1_dtpol_circ_wrong_feed_access_raises():
+    d = np.zeros(1, dtype=ehc.DTPOL_CIRC)
+    with pytest.raises((ValueError, KeyError)):
+        d['xxvis']
+
+
+# ----- DTPOL_LIN -----------------------------------------------------------
+
+def test_phase1_dtpol_lin_alias_equivalence():
+    d = np.zeros(2, dtype=ehc.DTPOL_LIN)
+    d['xxvis'] = [1 + 0j, 2 + 0j]
+    assert np.array_equal(d['p1p1vis'], d['xxvis'])
+    d['yxvis'] = [3 + 0j, 4 + 0j]
+    assert np.array_equal(d['p2p1vis'], d['yxvis'])
+
+
+def test_phase1_dtpol_lin_wrong_feed_access_raises():
+    d = np.zeros(1, dtype=ehc.DTPOL_LIN)
+    with pytest.raises((ValueError, KeyError)):
+        d['rrvis']
+
+
+# ----- DTPOL_MIXED ---------------------------------------------------------
+
+def test_phase1_dtpol_mixed_has_only_generic_names_and_polbasis():
+    names = np.dtype(ehc.DTPOL_MIXED).names
+    assert 'p1p1vis' in names and 'p2p2vis' in names
+    assert 'p1p2vis' in names and 'p2p1vis' in names
+    assert 'polbasis' in names
+    for n in ('rrvis', 'llvis', 'xxvis', 'yyvis'):
+        assert n not in names
+
+
+# ----- DTCAL ---------------------------------------------------------------
+
+def test_phase1_dtcal_circ_alias_equivalence():
+    c = np.zeros(2, dtype=ehc.DTCAL_CIRC)
+    c['rscale'] = [1 + 0j, 2 + 0j]
+    assert np.array_equal(c['p1scale'], c['rscale'])
+    c['dr'] = [0.01 + 0.02j, 0.03 - 0.01j]
+    assert np.array_equal(c['d_p1'], c['dr'])
+
+
+def test_phase1_dtcal_lin_alias_equivalence():
+    c = np.zeros(2, dtype=ehc.DTCAL_LIN)
+    c['xscale'] = [1 + 0j, 2 + 0j]
+    assert np.array_equal(c['p1scale'], c['xscale'])
+
+
+def test_phase1_dtcal_legacy_alias_is_dtcal_circ():
+    assert ehc.DTCAL is ehc.DTCAL_CIRC
+
+
+# ----- Polrep / feed dispatch helpers --------------------------------------
+
+def test_phase1_feed_dtype_for_polrep():
+    assert ehc.feed_dtype_for_polrep('stokes') is ehc.DTPOL_STOKES
+    assert ehc.feed_dtype_for_polrep('circ') is ehc.DTPOL_CIRC
+    assert ehc.feed_dtype_for_polrep('lin') is ehc.DTPOL_LIN
+    assert ehc.feed_dtype_for_polrep('mixed') is ehc.DTPOL_MIXED
+    with pytest.raises(ValueError):
+        ehc.feed_dtype_for_polrep('bogus')
+
+
+def test_phase1_feed_poldict_circular_pair():
+    d = ehc.feed_poldict('rl', 'rl')
+    assert d['vis1'] == 'rrvis'
+    assert d['vis2'] == 'llvis'
+    assert d['vis3'] == 'rlvis'
+    assert d['vis4'] == 'lrvis'
+
+
+def test_phase1_feed_poldict_linear_pair():
+    d = ehc.feed_poldict('xy', 'xy')
+    assert d['vis1'] == 'xxvis'
+    assert d['vis2'] == 'yyvis'
+    assert d['vis3'] == 'xyvis'
+    assert d['vis4'] == 'yxvis'
+
+
+def test_phase1_feed_poldict_mixed_pair():
+    d = ehc.feed_poldict('rl', 'xy')
+    assert d['vis1'] == 'rxvis'
+    assert d['vis2'] == 'lyvis'
+    assert d['vis3'] == 'ryvis'
+    assert d['vis4'] == 'lxvis'
+
+
+def test_phase1_feed_poldict_unknown_raises():
+    with pytest.raises(ValueError):
+        ehc.feed_poldict('rl', '??')
+    with pytest.raises(ValueError):
+        ehc.feed_poldict('??', 'rl')
+
+
+# ----- Schema upgrade helpers ---------------------------------------------
+
+def test_phase1_upgrade_tarr_from_legacy():
+    ot = np.zeros(2, dtype=_LEGACY_DTARR)
+    ot['site'] = ['A', 'B']
+    ot['sefdr'] = [1000., 2000.]
+    ot['sefdl'] = [1100., 2100.]
+    ot['dr'] = [0.01 + 0.02j, 0.03 + 0.04j]
+    nt = ehc.upgrade_tarr(ot)
+    assert 'feed_type' in nt.dtype.names
+    assert np.array_equal(nt['feed_type'], np.array(['rl', 'rl']))
+    # numerically bit-identical for the legacy columns
+    assert np.array_equal(nt['sefd_p1'], ot['sefdr'])
+    assert np.array_equal(nt['sefd_p2'], ot['sefdl'])
+    assert np.array_equal(nt['d_p1'], ot['dr'])
+
+
+def test_phase1_upgrade_tarr_idempotent():
+    a = np.zeros(1, dtype=ehc.DTARR)
+    a['feed_type'] = 'rl'
+    assert ehc.upgrade_tarr(a) is a
+
+
+def test_phase1_upgrade_dtpol_circ_zero_copy_view():
+    od = np.zeros(3, dtype=_LEGACY_DTPOL_CIRC)
+    od['rrvis'] = [1 + 0j, 2 + 0j, 3 + 0j]
+    nd = ehc.upgrade_dtpol_circ(od)
+    # view-cast: same underlying buffer
+    assert nd.base is od
+    # both legacy and generic accessors work
+    assert np.array_equal(nd['rrvis'], od['rrvis'])
+    assert np.array_equal(nd['p1p1vis'], od['rrvis'])
+
+
+def test_phase1_upgrade_dtpol_circ_idempotent():
+    d = np.zeros(1, dtype=ehc.DTPOL_CIRC)
+    out = ehc.upgrade_dtpol_circ(d)
+    assert out.dtype == d.dtype
+
+
+def test_phase1_upgrade_dtcal_circ_from_legacy_adds_dterm_fields():
+    oc = np.zeros(2, dtype=_LEGACY_DTCAL)
+    oc['rscale'] = [1 + 0j, 2 + 0j]
+    nc = ehc.upgrade_dtcal_circ(oc)
+    assert nc.dtype.names == ('time', 'rscale', 'lscale', 'dr', 'dl')
+    assert np.array_equal(nc['rscale'], oc['rscale'])
+    # dr/dl default to 0
+    assert np.all(nc['dr'] == 0)
+    assert np.all(nc['dl'] == 0)
+
+
+# ----- End-to-end: Array / Obsdata / Caltable upgrade through __init__ ----
+
+def test_phase1_array_upgrades_legacy_tarr():
+    arr = ea.Array(_legacy_tarr())
+    assert 'feed_type' in arr.tarr.dtype.names
+    assert np.all(arr.tarr['feed_type'] == 'rl')
+
+
+def test_phase1_array_pickle_roundtrip_from_new():
+    arr = ea.Array(_legacy_tarr())
+    arr2 = pickle.loads(pickle.dumps(arr))
+    assert np.all(arr2.tarr['feed_type'] == 'rl')
+    assert np.array_equal(arr2.tarr['sefd_p1'], arr.tarr['sefd_p1'])
+
+
+def test_phase1_array_setstate_upgrades_legacy_pickle():
+    # Simulate a pickle made before the schema migration:
+    legacy_state = {'_tarr': _legacy_tarr(), 'ephem': {},
+                    'tkey': {'A': 0, 'B': 1}}
+    arr = ea.Array.__new__(ea.Array)
+    arr.__setstate__(legacy_state)
+    assert 'feed_type' in arr.tarr.dtype.names
+    assert np.all(arr.tarr['feed_type'] == 'rl')
+
+
+def test_phase1_obsdata_upgrades_legacy_datatable_and_tarr():
+    obs = eo.Obsdata(ra=0., dec=0., rf=230e9, bw=1e9,
+                     datatable=_legacy_circ_datatable(),
+                     tarr=_legacy_tarr(), polrep='circ')
+    assert obs.polrep == 'circ'
+    assert 'feed_type' in obs.tarr.dtype.names
+    assert np.all(obs.tarr['feed_type'] == 'rl')
+    # Generic accessor works on upgraded data
+    assert np.array_equal(obs.data['p1p1vis'], obs.data['rrvis'])
+
+
+def test_phase1_obsdata_pickle_roundtrip_legacy_recarrays():
+    obs = eo.Obsdata(ra=0., dec=0., rf=230e9, bw=1e9,
+                     datatable=_legacy_circ_datatable(),
+                     tarr=_legacy_tarr(), polrep='circ')
+    obs2 = pickle.loads(pickle.dumps(obs))
+    assert np.all(obs2.tarr['feed_type'] == 'rl')
+    assert np.array_equal(obs2.data['p1p1vis'], obs.data['rrvis'])
+
+
+def test_phase1_caltable_upgrades_legacy_dtcal():
+    oc = np.zeros(2, dtype=_LEGACY_DTCAL)
+    oc['rscale'] = [1 + 0j, 1.1 + 0j]
+    caltab = ec.Caltable(ra=0., dec=0., rf=230e9, bw=1e9,
+                         datadict={'A': oc.copy(), 'B': oc.copy()},
+                         tarr=_legacy_tarr())
+    for site in ('A', 'B'):
+        assert 'dr' in caltab.data[site].dtype.names
+        assert 'd_p1' in caltab.data[site].dtype.fields  # title alias
+        assert np.all(caltab.data[site]['dr'] == 0)
+
+
+def test_phase1_caltable_pickle_roundtrip_legacy_dtcal():
+    oc = np.zeros(2, dtype=_LEGACY_DTCAL)
+    oc['rscale'] = [1 + 0j, 1.1 + 0j]
+    caltab = ec.Caltable(ra=0., dec=0., rf=230e9, bw=1e9,
+                         datadict={'A': oc.copy()}, tarr=_legacy_tarr())
+    caltab2 = pickle.loads(pickle.dumps(caltab))
+    assert 'dr' in caltab2.data['A'].dtype.names
+    assert np.array_equal(caltab2.data['A']['rscale'],
+                          caltab.data['A']['rscale'])


### PR DESCRIPTION
## Summary

Implements Phase 1 of [`obsdata_mixedpol_plan_v2.md`](../obsdata_mixedpol_plan_v2.md): schema layer only. Behavior on circular-feed inputs is **numerically bit-identical** to pre-Phase-1.

- **`ehtim/warnings.py`** (new): `MixedPolConventionWarning`, `MixedPolClosureSkipWarning`. No emission sites yet — wired up in later phases.
- **`ehtim/const_def.py`**:
  - **DTARR**: 12 fields, with generic names primary (`sefd_p1`, `sefd_p2`, `d_p1`, `d_p2`) and legacy names as title aliases. New `feed_type` field (`'U2'`). Generic-primary inversion is deliberate — DTARR is a single dtype shared across all stations, so the title-alias mitigation alone isn't enough on heterogeneous arrays.
  - **DTPOL_CIRC**: gains title aliases (`p1p1vis ↔ rrvis`, etc.). Physical names remain primary so existing code (e.g. `obs.data.dtype.names[-4:]`) is unchanged.
  - **DTPOL_LIN, DTPOL_MIXED**: new. `DTPOL_MIXED` carries a per-row `polbasis` field (populated in Phase 3a).
  - **DTCAL_CIRC, DTCAL_LIN**: new, with D-term fields (Phase 4 reads `data[site]['d_p1']`). Legacy `DTCAL` kept as an alias of `DTCAL_CIRC`.
  - **Helpers**: `feed_poldict`, `feed_dtype_for_polrep`, plus `upgrade_tarr` / `upgrade_dtpol_circ` / `upgrade_dtcal_circ` for silent schema migration. TODO note marks these for migration to `pol_conventions.py` when that module lands in Phase 3b.
- **Schema-upgrade plumbing** in `Array.__init__/__setstate__`, `Obsdata.__init__/__setstate__`, `Caltable.__init__/__setstate__`: legacy recarrays are upgraded silently. DTPOL_CIRC upgrade is a zero-copy view-cast; DTARR and DTCAL are allocate-and-copy (new fields).
- **Positional DTARR constructions** in `add_site`, `add_satellite_tle`, `add_satellite_elements`, `load_array_txt`, `load_obs_txt`, `load_uvfits`, `load_obs_oifits`, `vex.py`: minimal `feed_type='rl'` fill so import + tests keep working. Each `add_*` docstring marks the full `feed_type` kwarg as Phase 2 work.
- **`load_array_txt` and `load_obs_txt`** also accept the new column count (14 / 15 respectively) carrying an explicit `feed_type` token. Versioned-header parsing lands in Phase 2 per the plan.
- **Bugfix incidentally needed for the title-alias migration**: three sites in `obsdata.py` had `for f in <dtype-list>: f = f[0]`. After the migration `f[0]` is a `(title, name)` tuple, not a string. Switched to iterating `dtype.names`, which always gives clean field names.

## Backwards-compatibility

- All 857 pre-existing tests pass with no modification.
- Pickles built before the migration round-trip cleanly via `__setstate__`.
- Legacy field access (`obs.data['rrvis']`, `caltab.data[site]['rscale']`, `tarr['sefdr']`) all keep working unchanged.

## Test plan

- [x] 30 new tests in `tests/test_mixedpol.py` covering: alias equivalence on each new dtype, wrong-feed access raising, primary-name conventions, helper dispatch, upgrade idempotence + zero-copy view-cast verification, end-to-end construction from legacy recarrays through `__init__`, pickle round-trip through `__setstate__`.
- [x] Existing test suite (857 passed, 92 skipped — unchanged from pre-Phase-1).
- [x] CI on this PR.

## Checkpoint 1 (per plan)

`import ehtim` succeeds; full test suite green; circular Obsdata + Caltable + Array using only legacy field names → numerically bit-identical results.

## Audit

`vis_poldict`/`amp_poldict`/`sig_poldict` data-layer callers: one site at [obsdata.py:1548](https://github.com/achael/eht-imaging/blob/feature/mixedpol-phase1-schema/ehtim/obsdata.py#L1548) (`dirtyimage`, reverses `vis_poldict`). Only reachable on STOKES/CIRC obs in Phase 1 since LIN/MIXED polreps don't yet exist. Phase 3a will extend the polrep enum and update this path. Calibration and imager callers (out of Phase 1 scope) are touched in Phase 4 / Follow-up B / Alex's Phase 4 imaging project.

## Out of scope (deferred to later phases per the plan)

- `Array.tarr` `TarrView` wrapper (Phase 2)
- `add_site` full `feed_type` kwarg + per-feed sefd/d-term args (Phase 2)
- `Array.is_homogeneous_feeds`, `sefd_for_feed`, `dterm_for_feed` (Phase 2)
- `Image`/`Movie`/`Model` `'lin'` polrep widening (Phase 2.5)
- `Obsdata` `'lin'`/`'mixed'` polrep support, `switch_polrep` extensions (Phase 3)
- `pol_conventions.py` module — the `upgrade_*` helpers will move there in Phase 3b
- `Caltable.applycal` full-Jones rewrite (Phase 4)
- `obs_simulate.py` per-feed SEFD generalization (Phase 5)
- `POLTYA`/`POLTYB` parsing in uvfits IO (Phase 3c/6)