### PR TITLE
Support rectangular images for dynamical_imaging

### DIFF
--- a/ehtim/imaging/dynamical_imaging.py
+++ b/ehtim/imaging/dynamical_imaging.py
@@ -2561,9 +2561,9 @@ def Cont(imG):
 
     import matplotlib.pyplot as plt
     plt.figure()
-    Z = np.reshape(imG.imvec,(imG.xdim,imG.ydim))
-    pov = imG.xdim*imG.psize
-    pov_mas = pov/(RADPERUAS*1.e3)
+    Z = np.reshape(imG.imvec,(imG.ydim,imG.xdim))
+    pov_x_mas = imG.xdim*imG.psize/(RADPERUAS*1.e3)
+    pov_y_mas = imG.ydim*imG.psize/(RADPERUAS*1.e3)
     Zmax = np.amax(Z)
     print(Zmax)
 
@@ -2572,7 +2572,7 @@ def Cont(imG):
     CS = plt.contour(Z, levels,
                      origin='lower',
                      linewidths=2,
-                     extent=(-pov_mas/2., pov_mas/2., -pov_mas/2., pov_mas/2.))
+                     extent=(-pov_x_mas/2., pov_x_mas/2., -pov_y_mas/2., pov_y_mas/2.))
     plt.show()
 
 

--- a/ehtim/imaging/dynamical_imaging.py
+++ b/ehtim/imaging/dynamical_imaging.py
@@ -727,7 +727,7 @@ def static_regularizer(Frame_List, Prior_List, embed_mask_List, flux, psize, sty
     N_frame = Frame_List.shape[0]
     xdim = int(len(Frame_List[0].ravel())**0.5)
 
-    s = np.sum( regularizer(Frame_List[i].ravel()[embed_mask_List[i]], Prior_List[i].ravel()[embed_mask_List[i]], embed_mask_List[i], flux=flux, xdim=xdim, ydim=xdim, psize=psize, stype=stype, norm_reg=norm_reg, **kwargs) for i in range(N_frame))
+    s = sum(regularizer(Frame_List[i].ravel()[embed_mask_List[i]], Prior_List[i].ravel()[embed_mask_List[i]], embed_mask_List[i], flux=flux, xdim=xdim, ydim=xdim, psize=psize, stype=stype, norm_reg=norm_reg, **kwargs) for i in range(N_frame))
 
     return s/N_frame
 
@@ -745,7 +745,7 @@ def static_regularizer_gradient(Frame_List, Prior_List, embed_mask_List, flux, p
 ##################################################################################################
 
 def centroid(Frame_List, coord):
-    return np.sum(np.sum(im.ravel() * coord[:,0])**2 + np.sum(im.ravel() * coord[:,1])**2 for im in Frame_List)/len(Frame_List)
+    return sum(np.sum(im.ravel() * coord[:,0])**2 + np.sum(im.ravel() * coord[:,1])**2 for im in Frame_List)/len(Frame_List)
 
 def centroid_gradient(Frame_List, coord): #Includes Jacobian factor to account for the frames being written as log(frame)
     return 2.0 * np.concatenate([(np.sum(im.ravel() * coord[:,0])*coord[:,0] + np.sum(im.ravel() * coord[:,1])*coord[:,1])*im.ravel() for im in Frame_List])/len(Frame_List)

--- a/ehtim/imaging/dynamical_imaging.py
+++ b/ehtim/imaging/dynamical_imaging.py
@@ -21,34 +21,28 @@
 # Contact Michael Johnson (mjohnson@cfa.harvard.edu) with any questions
 # The methods/techniques used in this are described in http://adsabs.harvard.edu/abs/2017ApJ...850..172J
 
-import time
-import numpy as np
-
-import scipy.optimize as opt
-import scipy.ndimage.filters as filt
-import scipy.signal
-
-import matplotlib.pyplot as plt
-
-import itertools as it
-
-from ehtim.const_def import * #Note: C is m/s rather than cm/s.
-from ehtim.observing.obs_helpers import *
-import ehtim.obsdata as obsdata
-import ehtim.image as image
-import ehtim.movie as movie
-from ehtim.imaging.imager_utils import *
-
-import ehtim.scattering as so
-
-from multiprocessing import Pool
-from functools import partial
-
 #imports from the blazarFileDownloader
 import calendar
-import requests
 import os
+import time
 from html.parser import HTMLParser
+from multiprocessing import Pool
+
+import matplotlib.pyplot as plt
+import numpy as np
+import requests
+import scipy.ndimage.filters as filt
+import scipy.optimize as opt
+import scipy.signal
+
+import ehtim.image as image
+import ehtim.movie as movie
+import ehtim.obsdata as obsdata
+import ehtim.scattering as so
+from ehtim.const_def import *  #Note: C is m/s rather than cm/s.
+from ehtim.imaging.imager_utils import *
+from ehtim.observing.obs_helpers import *
+
 #from HTMLParser import HTMLParser
 
 Fast_Convolve = True # This option will not wrap the convolution around the image
@@ -137,8 +131,8 @@ def export_multipanel_movie(im_List_Set, out='movie.mp4', fps=10, dpi=120, scale
     # Example: di.export_multipanel_movie([im_List,im_List_2],scale='log',xlim=[1000,-1000],ylim=[-3000,500],dynamic_range=[1000,5000], titles = ['43 GHz (BU)','15 GHz (MOJAVE)'])
     import matplotlib
     matplotlib.use('agg')
-    import matplotlib.pyplot as plt
     import matplotlib.animation as animation
+    import matplotlib.pyplot as plt
 
     fig = plt.figure()
 
@@ -194,7 +188,7 @@ def export_multipanel_movie(im_List_Set, out='movie.mp4', fps=10, dpi=120, scale
 
     def update_img(n):
         if verbose:
-            print ("processing frame {0} of {1}".format(n, len(im_List)*pad_factor))
+            print (f"processing frame {n} of {len(im_List)*pad_factor}")
         for j in range(N_set):
             plt_im[j].set_data(im_data(j, n))
 
@@ -214,8 +208,8 @@ def export_multipanel_movie(im_List_Set, out='movie.mp4', fps=10, dpi=120, scale
 def export_movie(im_List, out='movie.mp4', fps=10, dpi=120, scale='linear', cbar_unit = 'Jy', gamma=0.5, dynamic_range=1000.0, pad_factor=1, verbose=False):
     import matplotlib
     matplotlib.use('agg')
-    import matplotlib.pyplot as plt
     import matplotlib.animation as animation
+    import matplotlib.pyplot as plt
 
     mjd_range = im_List[-1].mjd - im_List[0].mjd    
 
@@ -267,7 +261,7 @@ def export_movie(im_List, out='movie.mp4', fps=10, dpi=120, scale='linear', cbar
 
     def update_img(n):
         if verbose:
-            print ("processing frame {0} of {1}".format(n, len(im_List)*pad_factor))
+            print (f"processing frame {n} of {len(im_List)*pad_factor}")
         plt_im.set_data(im_data(n))
         if mjd_range != 0:
             fig.suptitle('MJD: ' + str(im_List[int((n-n%pad_factor)//pad_factor)].mjd))
@@ -993,7 +987,7 @@ ttype = 'nfft', fft_pad_factor=2):
                     + np.concatenate([embed(chisq_grad[i,1], embed_mask_List[i]) for i in range(N_frame)])/N_frame*alpha_d2
                     + np.concatenate([embed(chisq_grad[i,2], embed_mask_List[i]) for i in range(N_frame)])/N_frame*alpha_d3)
 
-        return (np.concatenate((s1 + s2 + (s_dynamic_grad + chisq_grad)[embed_mask_All]))*J_factor)
+        return (np.concatenate(s1 + s2 + (s_dynamic_grad + chisq_grad)[embed_mask_All])*J_factor)
 
     # Plotting function for each iteration
     global nit
@@ -1977,8 +1971,8 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
             Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_ypix, N_xpix)))
             init_i += cur_len
 
-        s1 = s2 = s_dS = s_dF = np.zeros((N_freq*N_frame*cur_len))
-        s_dynamic_grad = cm_grad = flux_grad = np.zeros((N_freq*N_frame*N_xpix*N_ypix))
+        s1 = s2 = s_dS = s_dF = np.zeros(N_freq*N_frame*cur_len)
+        s_dynamic_grad = cm_grad = flux_grad = np.zeros(N_freq*N_frame*N_xpix*N_ypix)
         s_multifreq = 0.0
 
         # Multifrequency part

--- a/ehtim/imaging/dynamical_imaging.py
+++ b/ehtim/imaging/dynamical_imaging.py
@@ -26,7 +26,7 @@ import calendar
 import os
 import time
 from html.parser import HTMLParser
-from multiprocessing import Pool
+from multiprocessing import Pool, cpu_count
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -39,11 +39,16 @@ import ehtim.image as image
 import ehtim.movie as movie
 import ehtim.obsdata as obsdata
 import ehtim.scattering as so
-from ehtim.const_def import *  #Note: C is m/s rather than cm/s.
-from ehtim.imaging.imager_utils import *
-from ehtim.observing.obs_helpers import *
-
-#from HTMLParser import HTMLParser
+from ehtim.const_def import C, RADPERAS, RADPERUAS
+from ehtim.imaging.imager_utils import (
+    chisq,
+    chisqdata,
+    chisqgrad,
+    embed,
+    regularizer,
+    regularizergrad,
+)
+from ehtim.observing.obs_helpers import ticks
 
 Fast_Convolve = True # This option will not wrap the convolution around the image
 
@@ -188,12 +193,12 @@ def export_multipanel_movie(im_List_Set, out='movie.mp4', fps=10, dpi=120, scale
 
     def update_img(n):
         if verbose:
-            print (f"processing frame {n} of {len(im_List)*pad_factor}")
+            print (f"processing frame {n} of {len(im_List_Set[0])*pad_factor}")
         for j in range(N_set):
             plt_im[j].set_data(im_data(j, n))
 
         if mjd_step > 0.1:
-            fig.suptitle('MJD: ' + str(im_List_Set[0][int((n-n%pad_factor)//pad_factor)].mjd), verticalalignment = verticalalignment)
+            fig.suptitle('MJD: ' + str(im_List_Set[0][int((n-n%pad_factor)//pad_factor)].mjd), verticalalignment='center')
         else:
             time = im_List_Set[0][int((n-n%pad_factor)//pad_factor)].time
             time_str = ("%d:%02d.%02d" % (int(time), (time*60) % 60, (time*3600) % 60))
@@ -469,38 +474,26 @@ def RdI_gradient(Frames, metric='SymKL', p=2.0, **kwargs):
         return 0.0
 
 def Rflow(Frames, Flow, metric='D2', p=2.0, **kwargs):
-    if metric == 'KL':
-        return Rflow_KL(Frames, Flow)
-    elif metric == 'SymKL':
-        return Rflow_SymKL(Frames, Flow)
-    elif metric == 'D2':
+    if metric == 'D2':
         return Rflow_D2(Frames, Flow)
-    elif metric == 'Dp':
-        return Rflow_Dp(Frames, Flow, p=p)
+    elif metric in ('KL', 'SymKL', 'Dp'):
+        raise NotImplementedError(f"Rflow metric={metric!r} is not implemented")
     else:
         return 0.0
 
 def Rflow_gradient_I(Frames, Flow, metric='D2', p=2.0, **kwargs):
-    if metric == 'KL':
-        return Rflow_KL_gradient_I(Frames, Flow)
-    elif metric == 'SymKL':
-        return Rflow_SymKL_gradient_I(Frames, Flow)
-    elif metric == 'D2':
+    if metric == 'D2':
         return Rflow_D2_gradient_I(Frames, Flow)
-    elif metric == 'Dp':
-        return Rflow_Dp_gradient_I(Frames, Flow, p=p)
+    elif metric in ('KL', 'SymKL', 'Dp'):
+        raise NotImplementedError(f"Rflow_gradient_I metric={metric!r} is not implemented")
     else:
         return 0.0
 
 def Rflow_gradient_m(Frames, Flow, metric='D2', p=2.0, **kwargs):
-    if metric == 'KL':
-        return Rflow_KL_gradient_m(Frames, Flow)
-    elif metric == 'SymKL':
-        return Rflow_SymKL_gradient_m(Frames, Flow)
-    elif metric == 'D2':
-        return Rflow_Dp_gradient_m(Frames, Flow)
-    elif metric == 'Dp':
-        return Rflow_Dp_gradient_m(Frames, Flow, p=p)
+    if metric == 'D2':
+        return Rflow_D2_gradient_m(Frames, Flow)
+    elif metric in ('KL', 'SymKL', 'Dp'):
+        raise NotImplementedError(f"Rflow_gradient_m metric={metric!r} is not implemented")
     else:
         return 0.0
 
@@ -837,8 +830,9 @@ d1='vis', d2=False, d3=False,
 alpha_d1=10, alpha_d2=10, alpha_d3=10,
 systematic_noise1=0.0, systematic_noise2=0.0, systematic_noise3=0.0,
 entropy1="tv2", entropy2="l1",
-alpha_s1=1.0, alpha_s2=1.0, norm_reg=True, alpha_A=1.0,
+alpha_s1=1.0, alpha_s2=1.0, norm_reg=True, alpha_A=1.0, alpha_flux=0.0,
 R_dt  ={'alpha':0.0, 'metric':'SymKL', 'p':2.0},
+Target_Dynamic_Range=10000.0,
 maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
 minimizer_method = 'L-BFGS-B', NHIST = 25, update_interval = 1, clipfloor=0.,
 ttype = 'nfft', fft_pad_factor=2):

--- a/ehtim/imaging/dynamical_imaging.py
+++ b/ehtim/imaging/dynamical_imaging.py
@@ -39,7 +39,7 @@ import ehtim.image as image
 import ehtim.movie as movie
 import ehtim.obsdata as obsdata
 import ehtim.scattering as so
-from ehtim.const_def import C, RADPERAS, RADPERUAS
+from ehtim.const_def import RADPERAS, RADPERUAS, C
 from ehtim.imaging.imager_utils import (
     chisq,
     chisqdata,
@@ -153,7 +153,7 @@ def export_multipanel_movie(im_List_Set, out='movie.mp4', fps=10, dpi=120, scale
     maxi   = np.zeros(N_set)
     plt_im = [None,]*N_set
 
-    if type(dynamic_range) == float or type(dynamic_range) == int:
+    if isinstance(dynamic_range, (float, int)):
         dynamic_range = np.zeros(N_set) + dynamic_range
 
     for j in range(N_set):
@@ -201,7 +201,7 @@ def export_multipanel_movie(im_List_Set, out='movie.mp4', fps=10, dpi=120, scale
             fig.suptitle('MJD: ' + str(im_List_Set[0][int((n-n%pad_factor)//pad_factor)].mjd), verticalalignment='center')
         else:
             time = im_List_Set[0][int((n-n%pad_factor)//pad_factor)].time
-            time_str = ("%d:%02d.%02d" % (int(time), (time*60) % 60, (time*3600) % 60))
+            time_str = f"{int(time)}:{(time*60) % 60:02.0f}.{(time*3600) % 60:02.0f}"
             fig.suptitle(time_str)
 
         return plt_im
@@ -272,7 +272,7 @@ def export_movie(im_List, out='movie.mp4', fps=10, dpi=120, scale='linear', cbar
             fig.suptitle('MJD: ' + str(im_List[int((n-n%pad_factor)//pad_factor)].mjd))
         else:
             time = im_List[int((n-n%pad_factor)//pad_factor)].time
-            time_str = ("%d:%02d.%02d" % (int(time), (time*60) % 60, (time*3600) % 60))
+            time_str = f"{int(time)}:{(time*60) % 60:02.0f}.{(time*3600) % 60:02.0f}"
             fig.suptitle(time_str)
 
         return plt_im
@@ -937,7 +937,8 @@ ttype = 'nfft', fft_pad_factor=2):
 
         s_dynamic = 0.0
 
-        if R_dt['alpha'] != 0.0: s_dynamic += Rdt(Frames, B_dt, **R_dt)*R_dt['alpha']
+        if R_dt['alpha'] != 0.0:
+            s_dynamic += Rdt(Frames, B_dt, **R_dt)*R_dt['alpha']
 
         chisq = np.array([get_chisq(j, Frames[j].ravel()[embed_mask_List[j]], d1, d2, d3, ttype, embed_mask_List[j]) for j in range(N_frame)])
 
@@ -966,7 +967,8 @@ ttype = 'nfft', fft_pad_factor=2):
             s2 = static_regularizer_gradient(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s2
 
         s_dynamic_grad = 0.0
-        if R_dt['alpha'] != 0.0: s_dynamic_grad += Rdt_gradient(Frames, B_dt, **R_dt)*R_dt['alpha']
+        if R_dt['alpha'] != 0.0:
+            s_dynamic_grad += Rdt_gradient(Frames, B_dt, **R_dt)*R_dt['alpha']
 
 
         chisq_grad = np.array([get_chisqgrad(j, Frames[j].ravel()[embed_mask_List[j]], d1, d2, d3, ttype, embed_mask_List[j]) for j in range(N_frame)])
@@ -991,7 +993,7 @@ ttype = 'nfft', fft_pad_factor=2):
         nit += 1
 
         if nit%update_interval == 0 or final:
-            print ("iteration %d" % nit)
+            print(f"iteration {nit}")
 
             Frames = np.zeros((N_frame, N_ypix, N_xpix))
             log_Frames = np.zeros((N_frame, N_ypix, N_xpix))
@@ -1015,7 +1017,8 @@ ttype = 'nfft', fft_pad_factor=2):
 
             s_dynamic = 0.0
 
-            if R_dt['alpha'] != 0.0: s_dynamic += Rdt(Frames, B_dt, **R_dt)*R_dt['alpha']
+            if R_dt['alpha'] != 0.0:
+                s_dynamic += Rdt(Frames, B_dt, **R_dt)*R_dt['alpha']
 
             chisq = np.array([get_chisq(j, Frames[j].ravel()[embed_mask_List[j]],
                               d1, d2, d3, ttype, embed_mask_List[j]) for j in range(N_frame)])
@@ -1029,23 +1032,37 @@ ttype = 'nfft', fft_pad_factor=2):
             chisq1_max = np.max(chisq1_List)
             chisq2_max = np.max(chisq2_List)
             chisq3_max = np.max(chisq3_List)
-            if d1: print (f"chi2_1: {chisq1:f}")
-            if d2: print (f"chi2_2: {chisq2:f}")
-            if d3: print (f"chi2_3: {chisq3:f}")
-            if d1: print ("weighted chi2_1: %f" % (chisq1 * alpha_d1))
-            if d2: print ("weighted chi2_2: %f" % (chisq2 * alpha_d2))
-            if d3: print ("weighted chi2_3: %f" % (chisq3 * alpha_d3))
-            if d1: print (f"Max Frame chi2_1: {chisq1_max:f}")
-            if d2: print (f"Max Frame chi2_2: {chisq2_max:f}")
-            if d3: print (f"Max Frame chi2_3: {chisq3_max:f}")
+            if d1:
+                print (f"chi2_1: {chisq1:f}")
+            if d2:
+                print (f"chi2_2: {chisq2:f}")
+            if d3:
+                print (f"chi2_3: {chisq3:f}")
+            if d1:
+                print ("weighted chi2_1: %f" % (chisq1 * alpha_d1))
+            if d2:
+                print ("weighted chi2_2: %f" % (chisq2 * alpha_d2))
+            if d3:
+                print ("weighted chi2_3: %f" % (chisq3 * alpha_d3))
+            if d1:
+                print (f"Max Frame chi2_1: {chisq1_max:f}")
+            if d2:
+                print (f"Max Frame chi2_2: {chisq2_max:f}")
+            if d3:
+                print (f"Max Frame chi2_3: {chisq3_max:f}")
 
             if final:
-                if d1: print ("All chisq1:",chisq1_List)
-                if d2: print ("All chisq2:",chisq2_List)
-                if d3: print ("All chisq3:",chisq3_List)
+                if d1:
+                    print ("All chisq1:",chisq1_List)
+                if d2:
+                    print ("All chisq2:",chisq2_List)
+                if d3:
+                    print ("All chisq3:",chisq3_List)
 
-            if s1 != 0.0: print (f"weighted s1: {s1:f}")
-            if s2 != 0.0: print (f"weighted s2: {s2:f}")
+            if s1 != 0.0:
+                print (f"weighted s1: {s1:f}")
+            if s2 != 0.0:
+                print (f"weighted s2: {s2:f}")
             print (f"weighted s_dynamic: {s_dynamic:f}")
 
             if nit%refresh_interval == 0:
@@ -1156,13 +1173,13 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
     global A1_List, A2_List, A3_List, data1_List, data2_List, data3_List, sigma1_List, sigma2_List, sigma3_List
 
     # Make a list of frames if a movie is passed
-    if type(init_ims) == list:
+    if isinstance(init_ims, list):
         InitIm_List = init_ims
     else:
         InitIm_List = init_ims.im_list()
 
     # Make a list of observations if a single Obsdata object is passed
-    if type(obs_input) == list:
+    if isinstance(obs_input, list):
         Obsdata_List = obs_input
     else:
         # Create one obsdata object for every frame
@@ -1178,12 +1195,12 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
             Obsdata_List[j].mjd  = InitIm_List[j].mjd
             try:
                 Obsdata_List[j].data = np.concatenate(tlist[[x == j for x in idx_list]])
-            except:
+            except Exception:
                 Obsdata_List[j].data = []
                 c = c + 1
                 pass
         if c > 0:
-            print("%d/%d frames have no data"%(c,len(frame_mjds)))
+            print(f"{c}/{len(frame_mjds)} frames have no data")
 
     N_frame = len(Obsdata_List)
     N_xpix, N_ypix = Prior.xdim, Prior.ydim  # per-frame pixel dimensions
@@ -1302,15 +1319,15 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
             # Try to create the chisqdata. These can throw errors, for instance when no closure quantities exist in a frame with data
             try:
                 (data1_List[i], sigma1_List[i], A1_List[i]) = chisqdata(Obsdata_List[i], Prior, embed_mask_List[i], d1, ttype=ttype, fft_pad_factor=fft_pad_factor, systematic_noise=systematic_noise1)
-            except:
+            except Exception:
                 pass
             try:
                 (data2_List[i], sigma2_List[i], A2_List[i]) = chisqdata(Obsdata_List[i], Prior, embed_mask_List[i], d2, ttype=ttype, fft_pad_factor=fft_pad_factor, systematic_noise=systematic_noise2)
-            except:
+            except Exception:
                 pass
             try:
                 (data3_List[i], sigma3_List[i], A3_List[i]) = chisqdata(Obsdata_List[i], Prior, embed_mask_List[i], d3, ttype=ttype, fft_pad_factor=fft_pad_factor, systematic_noise=systematic_noise3)
-            except:
+            except Exception:
                 pass
 
     # Coordinate matrix for COM constraint
@@ -1324,7 +1341,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         pool = Pool(processes=processes)
     elif processes == 0:
         processes = int(cpu_count())
-        print("Using Multiprocessing with %d Processes" % processes)
+        print(f"Using Multiprocessing with {processes} Processes")
         pool = Pool(processes=processes)
     else:
         print("Not Using Multiprocessing")
@@ -1365,15 +1382,21 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
 
         s_dynamic = cm = flux = s_dS = s_dF = 0.0
 
-        if R_dI['alpha'] != 0.0: s_dynamic += RdI(Frames, **R_dI)*R_dI['alpha']
-        if R_dt['alpha'] != 0.0: s_dynamic += Rdt(Frames, B_dt, **R_dt)*R_dt['alpha']
+        if R_dI['alpha'] != 0.0:
+            s_dynamic += RdI(Frames, **R_dI)*R_dI['alpha']
+        if R_dt['alpha'] != 0.0:
+            s_dynamic += Rdt(Frames, B_dt, **R_dt)*R_dt['alpha']
 
-        if alpha_dS1 != 0.0: s_dS += RdS(Frames, nprior_embed_List, embed_mask_List, entropy1, norm_reg, beam_size=beam_size, alpha_A=alpha_A)*alpha_dS1
-        if alpha_dS2 != 0.0: s_dS += RdS(Frames, nprior_embed_List, embed_mask_List, entropy2, norm_reg, beam_size=beam_size, alpha_A=alpha_A)*alpha_dS2
+        if alpha_dS1 != 0.0:
+            s_dS += RdS(Frames, nprior_embed_List, embed_mask_List, entropy1, norm_reg, beam_size=beam_size, alpha_A=alpha_A)*alpha_dS1
+        if alpha_dS2 != 0.0:
+            s_dS += RdS(Frames, nprior_embed_List, embed_mask_List, entropy2, norm_reg, beam_size=beam_size, alpha_A=alpha_A)*alpha_dS2
 
-        if alpha_dF != 0.0: s_dF += RdF_clip(Frames, embed_mask_List)*alpha_dF
+        if alpha_dF != 0.0:
+            s_dF += RdF_clip(Frames, embed_mask_List)*alpha_dF
 
-        if alpha_centroid != 0.0: cm = centroid(Frames, coord) * alpha_centroid
+        if alpha_centroid != 0.0:
+            cm = centroid(Frames, coord) * alpha_centroid
 
         if alpha_flux > 0.0:
             flux = alpha_flux * movie_flux_constraint(Frames, flux_List)
@@ -1440,15 +1463,21 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
             s2 = static_regularizer_gradient(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim, **kwargs)*alpha_s2
 
         s_dynamic_grad = cm_grad = flux_grad = s_dS = s_dF = 0.0
-        if R_dI['alpha'] != 0.0: s_dynamic_grad += RdI_gradient(Frames,**R_dI)*R_dI['alpha']
-        if R_dt['alpha'] != 0.0: s_dynamic_grad += Rdt_gradient(Frames, B_dt, **R_dt)*R_dt['alpha']
+        if R_dI['alpha'] != 0.0:
+            s_dynamic_grad += RdI_gradient(Frames,**R_dI)*R_dI['alpha']
+        if R_dt['alpha'] != 0.0:
+            s_dynamic_grad += Rdt_gradient(Frames, B_dt, **R_dt)*R_dt['alpha']
 
-        if alpha_dS1 != 0.0: s_dS += RdS_gradient(Frames, nprior_embed_List, embed_mask_List, entropy1, norm_reg, beam_size=beam_size, alpha_A=alpha_A)*alpha_dS1
-        if alpha_dS2 != 0.0: s_dS += RdS_gradient(Frames, nprior_embed_List, embed_mask_List, entropy2, norm_reg, beam_size=beam_size, alpha_A=alpha_A)*alpha_dS2
+        if alpha_dS1 != 0.0:
+            s_dS += RdS_gradient(Frames, nprior_embed_List, embed_mask_List, entropy1, norm_reg, beam_size=beam_size, alpha_A=alpha_A)*alpha_dS1
+        if alpha_dS2 != 0.0:
+            s_dS += RdS_gradient(Frames, nprior_embed_List, embed_mask_List, entropy2, norm_reg, beam_size=beam_size, alpha_A=alpha_A)*alpha_dS2
 
-        if alpha_dF != 0.0: s_dF += RdF_gradient_clip(Frames, embed_mask_List)*alpha_dF
+        if alpha_dF != 0.0:
+            s_dF += RdF_gradient_clip(Frames, embed_mask_List)*alpha_dF
 
-        if alpha_centroid != 0.0: cm_grad = centroid_gradient(Frames, coord) * alpha_centroid
+        if alpha_centroid != 0.0:
+            cm_grad = centroid_gradient(Frames, coord) * alpha_centroid
 
         if alpha_flux > 0.0:
             flux_grad = alpha_flux * movie_flux_constraint_grad(Frames, flux_List)
@@ -1592,7 +1621,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         nit += 1
 
         if nit%update_interval == 0 or final:
-            print ("iteration %d" % nit)
+            print(f"iteration {nit}")
 
             Frames = np.zeros((N_frame, N_ypix, N_xpix))
             log_Frames = np.zeros((N_frame, N_ypix, N_xpix))
@@ -1630,15 +1659,21 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
 
             s_dynamic = cm = s_dS = s_dF = 0.0
 
-            if R_dI['alpha'] != 0.0: s_dynamic += RdI(Frames, **R_dI)*R_dI['alpha']
-            if R_dt['alpha'] != 0.0: s_dynamic += Rdt(Frames, B_dt, **R_dt)*R_dt['alpha']
+            if R_dI['alpha'] != 0.0:
+                s_dynamic += RdI(Frames, **R_dI)*R_dI['alpha']
+            if R_dt['alpha'] != 0.0:
+                s_dynamic += Rdt(Frames, B_dt, **R_dt)*R_dt['alpha']
 
-            if alpha_dS1 != 0.0: s_dS += RdS(Frames, nprior_embed_List, embed_mask_List, entropy1, norm_reg, beam_size=beam_size, alpha_A=alpha_A, **kwargs)*alpha_dS1
-            if alpha_dS2 != 0.0: s_dS += RdS(Frames, nprior_embed_List, embed_mask_List, entropy2, norm_reg, beam_size=beam_size, alpha_A=alpha_A, **kwargs)*alpha_dS2
+            if alpha_dS1 != 0.0:
+                s_dS += RdS(Frames, nprior_embed_List, embed_mask_List, entropy1, norm_reg, beam_size=beam_size, alpha_A=alpha_A, **kwargs)*alpha_dS1
+            if alpha_dS2 != 0.0:
+                s_dS += RdS(Frames, nprior_embed_List, embed_mask_List, entropy2, norm_reg, beam_size=beam_size, alpha_A=alpha_A, **kwargs)*alpha_dS2
 
-            if alpha_dF != 0.0: s_dF += RdF_clip(Frames, embed_mask_List)*alpha_dF
+            if alpha_dF != 0.0:
+                s_dF += RdF_clip(Frames, embed_mask_List)*alpha_dF
 
-            if alpha_centroid != 0.0: cm = centroid(Frames, coord) * alpha_centroid
+            if alpha_centroid != 0.0:
+                cm = centroid(Frames, coord) * alpha_centroid
 
             if not stochastic_optics:
                 if processes > 0:
@@ -1665,20 +1700,32 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
             chisq1_max = np.max(chisq1_List)
             chisq2_max = np.max(chisq2_List)
             chisq3_max = np.max(chisq3_List)
-            if d1: print (f"chi2_1: {chisq1:f}")
-            if d2: print (f"chi2_2: {chisq2:f}")
-            if d3: print (f"chi2_3: {chisq3:f}")
-            if d1: print ("weighted chi2_1: %f" % (chisq1 * alpha_d1))
-            if d2: print ("weighted chi2_2: %f" % (chisq2 * alpha_d2))
-            if d3: print ("weighted chi2_3: %f" % (chisq3 * alpha_d3))
-            if d1: print (f"Max Frame chi2_1: {chisq1_max:f}")
-            if d2: print (f"Max Frame chi2_2: {chisq2_max:f}")
-            if d3: print (f"Max Frame chi2_3: {chisq3_max:f}")
+            if d1:
+                print (f"chi2_1: {chisq1:f}")
+            if d2:
+                print (f"chi2_2: {chisq2:f}")
+            if d3:
+                print (f"chi2_3: {chisq3:f}")
+            if d1:
+                print ("weighted chi2_1: %f" % (chisq1 * alpha_d1))
+            if d2:
+                print ("weighted chi2_2: %f" % (chisq2 * alpha_d2))
+            if d3:
+                print ("weighted chi2_3: %f" % (chisq3 * alpha_d3))
+            if d1:
+                print (f"Max Frame chi2_1: {chisq1_max:f}")
+            if d2:
+                print (f"Max Frame chi2_2: {chisq2_max:f}")
+            if d3:
+                print (f"Max Frame chi2_3: {chisq3_max:f}")
 
             if final:
-                if d1: print ("All chisq1:",chisq1_List)
-                if d2: print ("All chisq2:",chisq2_List)
-                if d3: print ("All chisq3:",chisq3_List)
+                if d1:
+                    print ("All chisq1:",chisq1_List)
+                if d2:
+                    print ("All chisq2:",chisq2_List)
+                if d3:
+                    print ("All chisq3:",chisq3_List)
 
             # Now deal with the a flow, if necessary
             if R_flow['alpha'] != 0.0:
@@ -1688,12 +1735,17 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
                 s_dynamic += Rflow(Frames, Flow, **R_flow)*R_flow['alpha']
                 print ("Weighted R_Flow: %f" % (Rflow(Frames, Flow, **R_flow)*R_flow['alpha']))
 
-            if s1 != 0.0: print (f"weighted s1: {s1:f}")
-            if s2 != 0.0: print (f"weighted s2: {s2:f}")
-            if s_dF != 0.0: print (f"weighted s_dF: {s_dF:f}")
-            if s_dS != 0.0: print (f"weighted s_dS: {s_dS:f}")
+            if s1 != 0.0:
+                print (f"weighted s1: {s1:f}")
+            if s2 != 0.0:
+                print (f"weighted s2: {s2:f}")
+            if s_dF != 0.0:
+                print (f"weighted s_dF: {s_dF:f}")
+            if s_dS != 0.0:
+                print (f"weighted s_dS: {s_dS:f}")
             print (f"weighted s_dynamic: {s_dynamic:f}")
-            if alpha_centroid > 0.0: print (f"weighted COM: {cm:f}")
+            if alpha_centroid > 0.0:
+                print (f"weighted COM: {cm:f}")
 
             if alpha_flux > 0.0:
                 print ("weighted flux constraint: %f" % (alpha_flux * movie_flux_constraint(Frames, flux_List)))
@@ -1773,7 +1825,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
                          Prior.ra, Prior.dec, rf=Obsdata_List[i].rf, source=Prior.source,
                          mjd=InitIm_List[i].mjd, time=InitIm_List[i].time, pulse=Prior.pulse) for i in range(N_frame)]
 
-    if type(init_ims) == list:
+    if isinstance(init_ims, list):
         pass
     else:
         outim = movie.merge_im_list(outim)
@@ -1933,15 +1985,21 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
             if alpha_s2 != 0.0:
                 s2 += static_regularizer(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s2
 
-            if R_dI['alpha'] != 0.0: s_dynamic += RdI(Frames[i1:i2], **R_dI)*R_dI['alpha']
-            if R_dt['alpha'] != 0.0: s_dynamic += Rdt(Frames[i1:i2], B_dt, **R_dt)*R_dt['alpha']
+            if R_dI['alpha'] != 0.0:
+                s_dynamic += RdI(Frames[i1:i2], **R_dI)*R_dI['alpha']
+            if R_dt['alpha'] != 0.0:
+                s_dynamic += Rdt(Frames[i1:i2], B_dt, **R_dt)*R_dt['alpha']
 
-            if alpha_dS1 != 0.0: s_dS += RdS(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], entropy1, norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_dS1
-            if alpha_dS2 != 0.0: s_dS += RdS(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], entropy2, norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_dS2
+            if alpha_dS1 != 0.0:
+                s_dS += RdS(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], entropy1, norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_dS1
+            if alpha_dS2 != 0.0:
+                s_dS += RdS(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], entropy2, norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_dS2
 
-            if alpha_dF != 0.0: s_dF += RdF_clip(Frames[i1:i2], embed_mask_List[i1:i2])*alpha_dF
+            if alpha_dF != 0.0:
+                s_dF += RdF_clip(Frames[i1:i2], embed_mask_List[i1:i2])*alpha_dF
 
-        if alpha_centroid != 0.0: cm = centroid(Frames, coord) * alpha_centroid
+        if alpha_centroid != 0.0:
+            cm = centroid(Frames, coord) * alpha_centroid
 
         if alpha_flux > 0.0:
             flux = alpha_flux * movie_flux_constraint(Frames, flux_List)
@@ -1991,15 +2049,21 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
             if alpha_s2 != 0.0:
                 s2[mf1:mf2] = static_regularizer_gradient(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s2
 
-            if R_dI['alpha'] != 0.0: s_dynamic_grad[f1:f2] += RdI_gradient(Frames[i1:i2],**R_dI)*R_dI['alpha']
-            if R_dt['alpha'] != 0.0: s_dynamic_grad[f1:f2] += Rdt_gradient(Frames[i1:i2], B_dt, **R_dt)*R_dt['alpha']
+            if R_dI['alpha'] != 0.0:
+                s_dynamic_grad[f1:f2] += RdI_gradient(Frames[i1:i2],**R_dI)*R_dI['alpha']
+            if R_dt['alpha'] != 0.0:
+                s_dynamic_grad[f1:f2] += Rdt_gradient(Frames[i1:i2], B_dt, **R_dt)*R_dt['alpha']
 
-            if alpha_dS1 != 0.0: s_dS[mf1:mf2] += RdS_gradient(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], entropy1, norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_dS1
-            if alpha_dS2 != 0.0: s_dS[mf1:mf2] += RdS_gradient(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], entropy2, norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_dS2
+            if alpha_dS1 != 0.0:
+                s_dS[mf1:mf2] += RdS_gradient(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], entropy1, norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_dS1
+            if alpha_dS2 != 0.0:
+                s_dS[mf1:mf2] += RdS_gradient(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], entropy2, norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_dS2
 
-            if alpha_dF != 0.0: s_dF[mf1:mf2] += RdF_gradient_clip(Frames[i1:i2], embed_mask_List[i1:i2])*alpha_dF
+            if alpha_dF != 0.0:
+                s_dF[mf1:mf2] += RdF_gradient_clip(Frames[i1:i2], embed_mask_List[i1:i2])*alpha_dF
 
-        if alpha_centroid != 0.0: cm_grad = centroid_gradient(Frames, coord) * alpha_centroid
+        if alpha_centroid != 0.0:
+            cm_grad = centroid_gradient(Frames, coord) * alpha_centroid
 
         if alpha_flux > 0.0:
             flux_grad = alpha_flux * movie_flux_constraint_grad(Frames, flux_List)
@@ -2030,7 +2094,7 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
         nit += 1
 
         if nit%update_interval == 0 or final:
-            print ("iteration %d" % nit)
+            print(f"iteration {nit}")
 
             Frames = np.zeros((N_freq*N_frame, N_ypix, N_xpix))
             log_Frames = np.zeros((N_freq*N_frame, N_ypix, N_xpix))
@@ -2059,15 +2123,21 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
                 if alpha_s2 != 0.0:
                     s2 += static_regularizer(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s2
 
-                if R_dI['alpha'] != 0.0: s_dynamic += RdI(Frames[i1:i2], **R_dI)*R_dI['alpha']
-                if R_dt['alpha'] != 0.0: s_dynamic += Rdt(Frames[i1:i2], B_dt, **R_dt)*R_dt['alpha']
+                if R_dI['alpha'] != 0.0:
+                    s_dynamic += RdI(Frames[i1:i2], **R_dI)*R_dI['alpha']
+                if R_dt['alpha'] != 0.0:
+                    s_dynamic += Rdt(Frames[i1:i2], B_dt, **R_dt)*R_dt['alpha']
 
-                if alpha_dS1 != 0.0: s_dS += RdS(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], entropy1, norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_dS1
-                if alpha_dS2 != 0.0: s_dS += RdS(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], entropy2, norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_dS2
+                if alpha_dS1 != 0.0:
+                    s_dS += RdS(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], entropy1, norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_dS1
+                if alpha_dS2 != 0.0:
+                    s_dS += RdS(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], entropy2, norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_dS2
 
-                if alpha_dF != 0.0: s_dF += RdF_clip(Frames[i1:i2], embed_mask_List[i1:i2])*alpha_dF
+                if alpha_dF != 0.0:
+                    s_dF += RdF_clip(Frames[i1:i2], embed_mask_List[i1:i2])*alpha_dF
 
-            if alpha_centroid != 0.0: cm = centroid(Frames, coord) * alpha_centroid
+            if alpha_centroid != 0.0:
+                cm = centroid(Frames, coord) * alpha_centroid
 
             chisq = np.array([get_chisq(j, Frames[j].ravel()[embed_mask_List[j]],
                                   d1, d2, d3, ttype, embed_mask_List[j]) for j in range(N_freq*N_frame)])
@@ -2081,28 +2151,45 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
             chisq1_max = np.max(chisq1_List)
             chisq2_max = np.max(chisq2_List)
             chisq3_max = np.max(chisq3_List)
-            if d1: print (f"chi2_1: {chisq1:f}")
-            if d2: print (f"chi2_2: {chisq2:f}")
-            if d3: print (f"chi2_3: {chisq3:f}")
-            if d1: print ("weighted chi2_1: %f" % (chisq1 * alpha_d1))
-            if d2: print ("weighted chi2_2: %f" % (chisq2 * alpha_d2))
-            if d3: print ("weighted chi2_3: %f" % (chisq3 * alpha_d3))
-            if d1: print (f"Max Frame chi2_1: {chisq1_max:f}")
-            if d2: print (f"Max Frame chi2_2: {chisq2_max:f}")
-            if d3: print (f"Max Frame chi2_3: {chisq3_max:f}")
+            if d1:
+                print (f"chi2_1: {chisq1:f}")
+            if d2:
+                print (f"chi2_2: {chisq2:f}")
+            if d3:
+                print (f"chi2_3: {chisq3:f}")
+            if d1:
+                print ("weighted chi2_1: %f" % (chisq1 * alpha_d1))
+            if d2:
+                print ("weighted chi2_2: %f" % (chisq2 * alpha_d2))
+            if d3:
+                print ("weighted chi2_3: %f" % (chisq3 * alpha_d3))
+            if d1:
+                print (f"Max Frame chi2_1: {chisq1_max:f}")
+            if d2:
+                print (f"Max Frame chi2_2: {chisq2_max:f}")
+            if d3:
+                print (f"Max Frame chi2_3: {chisq3_max:f}")
 
             if final:
-                if d1: print ("All chisq1:",chisq1_List)
-                if d2: print ("All chisq2:",chisq2_List)
-                if d3: print ("All chisq3:",chisq3_List)
+                if d1:
+                    print ("All chisq1:",chisq1_List)
+                if d2:
+                    print ("All chisq2:",chisq2_List)
+                if d3:
+                    print ("All chisq3:",chisq3_List)
 
-            if s1 != 0.0: print (f"weighted s1: {s1:f}")
-            if s2 != 0.0: print (f"weighted s2: {s2:f}")
-            if s_dF != 0.0: print (f"weighted s_dF: {s_dF:f}")
-            if s_dS != 0.0: print (f"weighted s_dS: {s_dS:f}")
+            if s1 != 0.0:
+                print (f"weighted s1: {s1:f}")
+            if s2 != 0.0:
+                print (f"weighted s2: {s2:f}")
+            if s_dF != 0.0:
+                print (f"weighted s_dF: {s_dF:f}")
+            if s_dS != 0.0:
+                print (f"weighted s_dS: {s_dS:f}")
             print (f"weighted s_dynamic: {s_dynamic:f}")
             print (f"weighted s_multifreq: {s_multifreq:f}")
-            if alpha_centroid > 0.0: print (f"weighted COM: {cm:f}")
+            if alpha_centroid > 0.0:
+                print (f"weighted COM: {cm:f}")
 
             if alpha_flux > 0.0:
                 print ("weighted flux constraint: %f" % (alpha_flux * movie_flux_constraint(Frames, flux_List)))
@@ -2233,7 +2320,7 @@ def plot_i_dynamic(im_List, Prior, nit, chi2, s, s_dynamic, ipynb=False):
     if i == 0:
         plt.xlabel(r'Relative RA ($\mu$as)')
         plt.ylabel(r'Relative Dec ($\mu$as)')
-        plt.title(r"step: %i  $\chi^2$: %f  $s$: %f  $s_{t}$: %f" % (nit, chi2, s, s_dynamic), fontsize=20)
+        plt.title(rf"step: {nit}  $\chi^2$: {chi2:f}  $s$: {s:f}  $s_{{t}}$: {s_dynamic:f}", fontsize=20)
     else:
         plt.xlabel('')
         plt.ylabel('')

--- a/ehtim/imaging/dynamical_imaging.py
+++ b/ehtim/imaging/dynamical_imaging.py
@@ -113,13 +113,13 @@ def align_left(im,min_frac=0.1,opposite_frac_thresh=0.05):
         if projected_flux[j] > thresh:  #or projected_flux[j] > opposite_thresh
             break
 
-    im_rotate.imvec = np.roll(im.imvec.reshape((im.ydim,im.xdim)), center[0] - j, (1)).flatten()
+    im_rotate.imvec = np.roll(im.imvec.reshape((im.ydim,im.xdim)), center[1] - j, (1)).flatten()
     if len(im.qvec):
-        im_rotate.qvec = np.roll(im.qvec.reshape((im.ydim,im.xdim)), center[0] - j, (1)).flatten()
+        im_rotate.qvec = np.roll(im.qvec.reshape((im.ydim,im.xdim)), center[1] - j, (1)).flatten()
     if len(im.uvec):
-        im_rotate.uvec = np.roll(im.uvec.reshape((im.ydim,im.xdim)), center[0] - j, (1)).flatten()
+        im_rotate.uvec = np.roll(im.uvec.reshape((im.ydim,im.xdim)), center[1] - j, (1)).flatten()
     if len(im.vvec):
-        im_rotate.vvec = np.roll(im.vvec.reshape((im.ydim,im.xdim)), center[0] - j, (1)).flatten()
+        im_rotate.vvec = np.roll(im.vvec.reshape((im.ydim,im.xdim)), center[1] - j, (1)).flatten()
 
     return im_rotate
 

--- a/ehtim/imaging/dynamical_imaging.py
+++ b/ehtim/imaging/dynamical_imaging.py
@@ -823,7 +823,7 @@ ttype = 'nfft', fft_pad_factor=2):
     global A1_List, A2_List, A3_List, data1_List, data2_List, data3_List, sigma1_List, sigma2_List, sigma3_List
 
     N_frame = len(Obsdata_List)
-    N_pixel = Prior.xdim #pixel dimension
+    N_xpix, N_ypix = Prior.xdim, Prior.ydim  # per-frame pixel dimensions
 
     # Determine the appropriate final resolution
     all_res = []
@@ -901,14 +901,14 @@ ttype = 'nfft', fft_pad_factor=2):
     # Define the objective function and gradient
     def objfunc(x):
         # Frames is a list of the *unscattered* frames
-        Frames = np.zeros((N_frame, N_pixel, N_pixel))
-        log_Frames = np.zeros((N_frame, N_pixel, N_pixel))
+        Frames = np.zeros((N_frame, N_ypix, N_xpix))
+        log_Frames = np.zeros((N_frame, N_ypix, N_xpix))
 
         init_i = 0
         for i in range(N_frame):
             cur_len = np.sum(embed_mask_List[i])
-            log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_pixel, N_pixel))
-            Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_pixel, N_pixel)))
+            log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_ypix, N_xpix))
+            Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_ypix, N_xpix)))
             init_i += cur_len
 
         s1 = s2 = 0.0
@@ -931,14 +931,14 @@ ttype = 'nfft', fft_pad_factor=2):
         return (s1 + s2 + s_dynamic + chisq)*J_factor
 
     def objgrad(x):
-        Frames = np.zeros((N_frame, N_pixel, N_pixel))
-        log_Frames = np.zeros((N_frame, N_pixel, N_pixel))
+        Frames = np.zeros((N_frame, N_ypix, N_xpix))
+        log_Frames = np.zeros((N_frame, N_ypix, N_xpix))
 
         init_i = 0
         for i in range(N_frame):
             cur_len = np.sum(embed_mask_List[i])
-            log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_pixel, N_pixel))
-            Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_pixel, N_pixel)))
+            log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_ypix, N_xpix))
+            Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_ypix, N_xpix)))
             init_i += cur_len
 
         s1 = s2 = 0.0
@@ -976,14 +976,14 @@ ttype = 'nfft', fft_pad_factor=2):
         if nit%update_interval == 0 or final == True:
             print ("iteration %d" % nit)
 
-            Frames = np.zeros((N_frame, N_pixel, N_pixel))
-            log_Frames = np.zeros((N_frame, N_pixel, N_pixel))
+            Frames = np.zeros((N_frame, N_ypix, N_xpix))
+            log_Frames = np.zeros((N_frame, N_ypix, N_xpix))
 
             init_i = 0
             for i in range(N_frame):
                 cur_len = np.sum(embed_mask_List[i])
-                log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_pixel, N_pixel))
-                Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_pixel, N_pixel)))
+                log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_ypix, N_xpix))
+                Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_ypix, N_xpix)))
                 init_i += cur_len
 
             s1 = s2 = 0.0
@@ -1037,7 +1037,7 @@ ttype = 'nfft', fft_pad_factor=2):
     loginit = np.hstack(loginit_List).flatten()
     x0 = loginit
 
-    print ("Total Pixel #: ",(N_pixel*N_pixel*N_frame))
+    print ("Total Pixel #: ",(N_xpix*N_ypix*N_frame))
     print ("Clipped Pixel #: ",(len(loginit)))
 
     print ("Initial Values:")
@@ -1049,15 +1049,15 @@ ttype = 'nfft', fft_pad_factor=2):
     res = opt.minimize(objfunc, x0, method=minimizer_method, jac=objgrad, options=optdict, callback=plotcur)
     tstop = time.time()
 
-    Frames = np.zeros((N_frame, N_pixel, N_pixel))
-    log_Frames = np.zeros((N_frame, N_pixel, N_pixel))
+    Frames = np.zeros((N_frame, N_ypix, N_xpix))
+    log_Frames = np.zeros((N_frame, N_ypix, N_xpix))
 
     init_i = 0
     for i in range(N_frame):
         cur_len = np.sum(embed_mask_List[i])
-        log_Frames[i] = embed(res.x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_pixel, N_pixel))
+        log_Frames[i] = embed(res.x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_ypix, N_xpix))
         #Impose the prior mask in linear space for the output
-        Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_pixel, N_pixel)))
+        Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_ypix, N_xpix)))
         init_i += cur_len
 
     plotcur(res.x, final=True)
@@ -1169,7 +1169,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
             print("%d/%d frames have no data"%(c,len(frame_mjds)))
 
     N_frame = len(Obsdata_List)
-    N_pixel = Prior.xdim #pixel dimension
+    N_xpix, N_ypix = Prior.xdim, Prior.ydim  # per-frame pixel dimensions
 
     # Determine the appropriate final resolution
     all_res = []
@@ -1315,21 +1315,21 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
     # Define the objective function and gradient
     def objfunc(x):
         # Frames is a list of the *unscattered* frames
-        Frames = np.zeros((N_frame, N_pixel, N_pixel))
-        log_Frames = np.zeros((N_frame, N_pixel, N_pixel))
+        Frames = np.zeros((N_frame, N_ypix, N_xpix))
+        log_Frames = np.zeros((N_frame, N_ypix, N_xpix))
 
         init_i = 0
         for i in range(N_frame):
             cur_len = np.sum(embed_mask_List[i])
-            log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_pixel, N_pixel))
-            Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_pixel, N_pixel)))
+            log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_ypix, N_xpix))
+            Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_ypix, N_xpix)))
             init_i += cur_len
 
         if R_flow['alpha'] != 0.0:
             cur_len = np.sum(embed_mask_List[0]) #assumes all the priors have the same embedding
-            Flow_x = embed(x[init_i:(init_i+2*cur_len-1):2],   embed_mask_List[i]).reshape((N_pixel, N_pixel))
-            Flow_y = embed(x[(init_i+1):(init_i+2*cur_len):2], embed_mask_List[i]).reshape((N_pixel, N_pixel))
-            Flow = np.transpose([Flow_x.ravel(),Flow_y.ravel()]).reshape((N_pixel, N_pixel,2))
+            Flow_x = embed(x[init_i:(init_i+2*cur_len-1):2],   embed_mask_List[i]).reshape((N_ypix, N_xpix))
+            Flow_y = embed(x[(init_i+1):(init_i+2*cur_len):2], embed_mask_List[i]).reshape((N_ypix, N_xpix))
+            Flow = np.transpose([Flow_x.ravel(),Flow_y.ravel()]).reshape((N_ypix, N_xpix,2))
             init_i += 2*cur_len
 
         if stochastic_optics == True:
@@ -1390,21 +1390,21 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         return (s1 + s2 + s_dF + s_dS + s_dynamic + chisq + cm + flux + regterm_scattering)*J_factor
 
     def objgrad(x):
-        Frames = np.zeros((N_frame, N_pixel, N_pixel))
-        log_Frames = np.zeros((N_frame, N_pixel, N_pixel))
+        Frames = np.zeros((N_frame, N_ypix, N_xpix))
+        log_Frames = np.zeros((N_frame, N_ypix, N_xpix))
 
         init_i = 0
         for i in range(N_frame):
             cur_len = np.sum(embed_mask_List[i])
-            log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_pixel, N_pixel))
-            Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_pixel, N_pixel)))
+            log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_ypix, N_xpix))
+            Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_ypix, N_xpix)))
             init_i += cur_len
 
         if R_flow['alpha'] != 0.0:
             cur_len = np.sum(embed_mask_List[0]) #assumes all the priors have the same embedding
-            Flow_x = embed(x[init_i:(init_i+2*cur_len-1):2],   embed_mask_List[i]).reshape((N_pixel, N_pixel))
-            Flow_y = embed(x[(init_i+1):(init_i+2*cur_len):2], embed_mask_List[i]).reshape((N_pixel, N_pixel))
-            Flow = np.transpose([Flow_x.ravel(),Flow_y.ravel()]).reshape((N_pixel, N_pixel,2))
+            Flow_x = embed(x[init_i:(init_i+2*cur_len-1):2],   embed_mask_List[i]).reshape((N_ypix, N_xpix))
+            Flow_y = embed(x[(init_i+1):(init_i+2*cur_len):2], embed_mask_List[i]).reshape((N_ypix, N_xpix))
+            Flow = np.transpose([Flow_x.ravel(),Flow_y.ravel()]).reshape((N_ypix, N_xpix,2))
             init_i += 2*cur_len
 
         if stochastic_optics == True:
@@ -1547,9 +1547,9 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         flow_grad = np.array([])
         if R_flow['alpha'] != 0.0:
             cur_len = np.sum(embed_mask_List[0])
-            Flow_x = embed(x[init_i:(init_i+2*cur_len-1):2],   embed_mask_List[i]).reshape((N_pixel, N_pixel))
-            Flow_y = embed(x[(init_i+1):(init_i+2*cur_len):2], embed_mask_List[i]).reshape((N_pixel, N_pixel))
-            Flow = np.transpose([Flow_x.ravel(),Flow_y.ravel()]).reshape((N_pixel, N_pixel,2))
+            Flow_x = embed(x[init_i:(init_i+2*cur_len-1):2],   embed_mask_List[i]).reshape((N_ypix, N_xpix))
+            Flow_y = embed(x[(init_i+1):(init_i+2*cur_len):2], embed_mask_List[i]).reshape((N_ypix, N_xpix))
+            Flow = np.transpose([Flow_x.ravel(),Flow_y.ravel()]).reshape((N_ypix, N_xpix,2))
             flow_tv_grad = squared_gradient_flow_grad(Flow)
             s_dynamic_grad_Frames = s_dynamic_grad_Flow = 0.0
             s_dynamic_grad_Frames = Rflow_gradient_I(Frames, Flow, R_flow)
@@ -1577,21 +1577,21 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         if nit%update_interval == 0 or final == True:
             print ("iteration %d" % nit)
 
-            Frames = np.zeros((N_frame, N_pixel, N_pixel))
-            log_Frames = np.zeros((N_frame, N_pixel, N_pixel))
+            Frames = np.zeros((N_frame, N_ypix, N_xpix))
+            log_Frames = np.zeros((N_frame, N_ypix, N_xpix))
 
             init_i = 0
             for i in range(N_frame):
                 cur_len = np.sum(embed_mask_List[i])
-                log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_pixel, N_pixel))
-                Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_pixel, N_pixel)))
+                log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_ypix, N_xpix))
+                Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_ypix, N_xpix)))
                 init_i += cur_len
 
             if R_flow['alpha'] != 0.0:
                 cur_len = np.sum(embed_mask_List[0]) #assumes all the priors have the same embedding
-                Flow_x = embed(x[init_i:(init_i+2*cur_len-1):2],   embed_mask_List[i]).reshape((N_pixel, N_pixel))
-                Flow_y = embed(x[(init_i+1):(init_i+2*cur_len):2], embed_mask_List[i]).reshape((N_pixel, N_pixel))
-                Flow = np.transpose([Flow_x.ravel(),Flow_y.ravel()]).reshape((N_pixel, N_pixel,2))
+                Flow_x = embed(x[init_i:(init_i+2*cur_len-1):2],   embed_mask_List[i]).reshape((N_ypix, N_xpix))
+                Flow_y = embed(x[(init_i+1):(init_i+2*cur_len):2], embed_mask_List[i]).reshape((N_ypix, N_xpix))
+                Flow = np.transpose([Flow_x.ravel(),Flow_y.ravel()]).reshape((N_ypix, N_xpix,2))
                 init_i += 2*cur_len
 
             if stochastic_optics == True:
@@ -1702,7 +1702,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         x0 = np.concatenate((x0,np.zeros(N**2-1)))
 
 
-    print ("Total Pixel #: ",(N_pixel*N_pixel*N_frame))
+    print ("Total Pixel #: ",(N_xpix*N_ypix*N_frame))
     print ("Clipped Pixel #: ",(len(loginit)))
 
     print ("Initial Values:")
@@ -1714,15 +1714,15 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
     res = opt.minimize(objfunc, x0, method=minimizer_method, jac=objgrad, options=optdict, callback=plotcur)
     tstop = time.time()
 
-    Frames = np.zeros((N_frame, N_pixel, N_pixel))
-    log_Frames = np.zeros((N_frame, N_pixel, N_pixel))
+    Frames = np.zeros((N_frame, N_ypix, N_xpix))
+    log_Frames = np.zeros((N_frame, N_ypix, N_xpix))
 
     init_i = 0
     for i in range(N_frame):
         cur_len = np.sum(embed_mask_List[i])
-        log_Frames[i] = embed(res.x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_pixel, N_pixel))
+        log_Frames[i] = embed(res.x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_ypix, N_xpix))
         #Impose the prior mask in linear space for the output
-        Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_pixel, N_pixel)))
+        Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_ypix, N_xpix)))
         init_i += cur_len
 
     Flow = EpsilonList = False
@@ -1730,9 +1730,9 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
     if R_flow['alpha'] != 0.0:
         print ("Collecting Flow...")
         cur_len = np.sum(embed_mask_List[0])
-        Flow_x = embed(res.x[init_i:(init_i+2*cur_len-1):2],   embed_mask_List[i]).reshape((N_pixel, N_pixel))
-        Flow_y = embed(res.x[(init_i+1):(init_i+2*cur_len):2], embed_mask_List[i]).reshape((N_pixel, N_pixel))
-        Flow = np.transpose([Flow_x.ravel(),Flow_y.ravel()]).reshape((N_pixel, N_pixel,2))
+        Flow_x = embed(res.x[init_i:(init_i+2*cur_len-1):2],   embed_mask_List[i]).reshape((N_ypix, N_xpix))
+        Flow_y = embed(res.x[(init_i+1):(init_i+2*cur_len):2], embed_mask_List[i]).reshape((N_ypix, N_xpix))
+        Flow = np.transpose([Flow_x.ravel(),Flow_y.ravel()]).reshape((N_ypix, N_xpix,2))
         init_i += 2*cur_len
 
     if stochastic_optics == True:
@@ -1790,7 +1790,7 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
 
     N_freq  = len(Obsdata_Multifreq_List)
     N_frame = len(Obsdata_Multifreq_List[0])
-    N_pixel = Prior.xdim #pixel dimension
+    N_xpix, N_ypix = Prior.xdim, Prior.ydim  # per-frame pixel dimensions
 
     # Flatten the input lists
     flux_List    = [x for y in flux_Multifreq_List    for x in y]
@@ -1889,14 +1889,14 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
 
     # Define the objective function and gradient
     def objfunc(x):
-        Frames = np.zeros((N_freq*N_frame, N_pixel, N_pixel))
-        log_Frames = np.zeros((N_freq*N_frame, N_pixel, N_pixel))
+        Frames = np.zeros((N_freq*N_frame, N_ypix, N_xpix))
+        log_Frames = np.zeros((N_freq*N_frame, N_ypix, N_xpix))
 
         init_i = 0
         for i in range(N_freq*N_frame):
             cur_len = np.sum(embed_mask_List[i])
-            log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_pixel, N_pixel))
-            Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_pixel, N_pixel)))
+            log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_ypix, N_xpix))
+            Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_ypix, N_xpix)))
             init_i += cur_len
 
         s1 = s2 = s_multifreq = s_dynamic = cm = flux = s_dS = s_dF = 0.0
@@ -1938,33 +1938,33 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
         return (s1 + s2 + s_dF + s_dS + s_multifreq + s_dynamic + chisq + cm + flux)*J_factor
 
     def objgrad(x):
-        Frames = np.zeros((N_freq*N_frame, N_pixel, N_pixel))
-        log_Frames = np.zeros((N_freq*N_frame, N_pixel, N_pixel))
+        Frames = np.zeros((N_freq*N_frame, N_ypix, N_xpix))
+        log_Frames = np.zeros((N_freq*N_frame, N_ypix, N_xpix))
 
         init_i = 0
         for i in range(N_freq*N_frame):
             cur_len = np.sum(embed_mask_List[i])
-            log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_pixel, N_pixel))
-            Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_pixel, N_pixel)))
+            log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_ypix, N_xpix))
+            Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_ypix, N_xpix)))
             init_i += cur_len
 
         s1 = s2 = s_dS = s_dF = np.zeros((N_freq*N_frame*cur_len))
-        s_dynamic_grad = cm_grad = flux_grad = np.zeros((N_freq*N_frame*N_pixel*N_pixel))
+        s_dynamic_grad = cm_grad = flux_grad = np.zeros((N_freq*N_frame*N_xpix*N_ypix))
         s_multifreq = 0.0
 
         # Multifrequency part
         if R_dt_multifreq['alpha'] != 0.0:
-            s_multifreq = np.zeros((N_freq*N_frame, N_pixel*N_pixel))
+            s_multifreq = np.zeros((N_freq*N_frame, N_xpix*N_ypix))
             for j in range(N_frame):
-                s_multifreq[j::N_frame] += Rdt_gradient(Frames[j::N_frame], B_dt_multifreq, **R_dt_multifreq).reshape((N_freq,N_pixel*N_pixel))*R_dt_multifreq['alpha']
-            s_multifreq = s_multifreq.reshape(N_freq*N_frame*N_pixel*N_pixel)
+                s_multifreq[j::N_frame] += Rdt_gradient(Frames[j::N_frame], B_dt_multifreq, **R_dt_multifreq).reshape((N_freq,N_xpix*N_ypix))*R_dt_multifreq['alpha']
+            s_multifreq = s_multifreq.reshape(N_freq*N_frame*N_xpix*N_ypix)
 
         # Individual frequencies
         for j in range(N_freq):
             i1 = j*N_frame
             i2 = (j+1)*N_frame
-            f1 = j*N_frame*N_pixel*N_pixel 
-            f2 = (j+1)*N_frame*N_pixel*N_pixel
+            f1 = j*N_frame*N_xpix*N_ypix 
+            f2 = (j+1)*N_frame*N_xpix*N_ypix
             mf1 = j*N_frame*cur_len # Note: This assumes that all priors have the same number of masked pixels!
             mf2 = (j+1)*N_frame*cur_len
 
@@ -2015,14 +2015,14 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
         if nit%update_interval == 0 or final == True:
             print ("iteration %d" % nit)
 
-            Frames = np.zeros((N_freq*N_frame, N_pixel, N_pixel))
-            log_Frames = np.zeros((N_freq*N_frame, N_pixel, N_pixel))
+            Frames = np.zeros((N_freq*N_frame, N_ypix, N_xpix))
+            log_Frames = np.zeros((N_freq*N_frame, N_ypix, N_xpix))
 
             init_i = 0
             for i in range(N_freq*N_frame):
                 cur_len = np.sum(embed_mask_List[i])
-                log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_pixel, N_pixel))
-                Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_pixel, N_pixel)))
+                log_Frames[i] = embed(x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_ypix, N_xpix))
+                Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_ypix, N_xpix)))
                 init_i += cur_len
 
             s1 = s2 = s_multifreq = s_dynamic = cm = s_dS = s_dF = 0.0
@@ -2097,7 +2097,7 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
 
     x0 = loginit
 
-    print ("Total Pixel #: ",(N_pixel*N_pixel*N_frame*N_freq))
+    print ("Total Pixel #: ",(N_xpix*N_ypix*N_frame*N_freq))
     print ("Clipped Pixel #: ",(len(loginit)))
 
     print ("Initial Values:")
@@ -2109,15 +2109,15 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
     res = opt.minimize(objfunc, x0, method=minimizer_method, jac=objgrad, options=optdict, callback=plotcur)
     tstop = time.time()
 
-    Frames = np.zeros((N_freq*N_frame, N_pixel, N_pixel))
-    log_Frames = np.zeros((N_freq*N_frame, N_pixel, N_pixel))
+    Frames = np.zeros((N_freq*N_frame, N_ypix, N_xpix))
+    log_Frames = np.zeros((N_freq*N_frame, N_ypix, N_xpix))
 
     init_i = 0
     for i in range(N_freq*N_frame):
         cur_len = np.sum(embed_mask_List[i])
-        log_Frames[i] = embed(res.x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_pixel, N_pixel))
+        log_Frames[i] = embed(res.x[init_i:(init_i+cur_len)], embed_mask_List[i]).reshape((N_ypix, N_xpix))
         #Impose the prior mask in linear space for the output
-        Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_pixel, N_pixel)))
+        Frames[i] = np.exp(log_Frames[i])*(embed_mask_List[i].reshape((N_ypix, N_xpix)))
         init_i += cur_len
 
     plotcur(res.x, final=True)

--- a/ehtim/imaging/dynamical_imaging.py
+++ b/ehtim/imaging/dynamical_imaging.py
@@ -98,7 +98,7 @@ def center_core(im, blur_size_uas=100):
         im_rotate.uvec = np.roll(im.uvec.reshape((im.ydim,im.xdim)), center - core_pos, (0,1)).flatten()
     if len(im.vvec):
         im_rotate.vvec = np.roll(im.vvec.reshape((im.ydim,im.xdim)), center - core_pos, (0,1)).flatten()
-    
+
     return im_rotate
 
 def align_left(im,min_frac=0.1,opposite_frac_thresh=0.05):
@@ -166,9 +166,9 @@ def export_multipanel_movie(im_List_Set, out='movie.mp4', fps=10, dpi=120, scale
         ax = plt.subplot(1, N_set, j+1)
         plt_im[j] = plt.imshow(im_data(j, 0), extent=extent[j], cmap=plt.get_cmap('afmhot'), interpolation='gaussian')
 
-        if xlim != None:
+        if xlim is not None:
             ax.set_xlim(xlim)
-        if ylim != None:
+        if ylim is not None:
             ax.set_ylim(ylim)
 
         if scale == 'linear':
@@ -177,8 +177,8 @@ def export_multipanel_movie(im_List_Set, out='movie.mp4', fps=10, dpi=120, scale
             plt_im[j].set_clim([np.log(maxi[j]/dynamic_range[j]),np.log(maxi[j])])
 
         if j == 0:
-            plt.xlabel('Relative RA ($\mu$as)')
-            plt.ylabel('Relative Dec ($\mu$as)')
+            plt.xlabel(r'Relative RA ($\mu$as)')
+            plt.ylabel(r'Relative Dec ($\mu$as)')
 
         if len(titles) > 0:
             ax.set_title(titles[j])
@@ -211,7 +211,7 @@ def export_movie(im_List, out='movie.mp4', fps=10, dpi=120, scale='linear', cbar
     import matplotlib.animation as animation
     import matplotlib.pyplot as plt
 
-    mjd_range = im_List[-1].mjd - im_List[0].mjd    
+    mjd_range = im_List[-1].mjd - im_List[0].mjd
 
     fig = plt.figure()
 
@@ -253,8 +253,8 @@ def export_movie(im_List, out='movie.mp4', fps=10, dpi=120, scale='linear', cbar
     elif scale == 'gamma':
         plt_im.set_clim([(maxi/dynamic_range)**gamma,(maxi)**(gamma)])
 
-    plt.xlabel('Relative RA ($\mu$as)')
-    plt.ylabel('Relative Dec ($\mu$as)')
+    plt.xlabel(r'Relative RA ($\mu$as)')
+    plt.ylabel(r'Relative Dec ($\mu$as)')
 
     fig.set_size_inches([5,5])
     plt.tight_layout()
@@ -348,7 +348,7 @@ def Wrapped_Convolve(sig,ker):
 
     N = sig.shape[0]
 
-    if Fast_Convolve == False:
+    if not Fast_Convolve:
         return scipy.signal.fftconvolve(np.pad(sig,((N, N), (N, N)), 'wrap'), np.pad(ker,((N, N), (N, N)), 'constant'),mode='same')[N:(2*N),N:(2*N)]
     else:
         return scipy.signal.fftconvolve(sig, ker,mode='same')
@@ -792,14 +792,14 @@ def get_chisq(i, imvec_embed, d1, d2, d3, ttype, mask):
     global A1_List, A2_List, A3_List, data1_List, data2_List, data3_List, sigma1_List, sigma2_List, sigma3_List
     chisq1 = chisq2 = chisq3 = 1.0
 
-    if d1 != False and len(data1_List[i])>0:
+    if d1 and len(data1_List[i])>0:
 
         chisq1 = chisq(imvec_embed, A1_List[i], data1_List[i], sigma1_List[i], d1, ttype=ttype, mask=mask)
 
-    if d2 != False and len(data2_List[i])>0:
+    if d2 and len(data2_List[i])>0:
         chisq2 = chisq(imvec_embed, A2_List[i], data2_List[i], sigma2_List[i], d2, ttype=ttype, mask=mask)
 
-    if d3 != False and len(data3_List[i])>0:
+    if d3 and len(data3_List[i])>0:
         chisq3 = chisq(imvec_embed, A3_List[i], data3_List[i], sigma3_List[i], d3, ttype=ttype, mask=mask)
 
     return [chisq1, chisq2, chisq3]
@@ -812,14 +812,14 @@ def get_chisqgrad(i, imvec_embed, d1, d2, d3, ttype, mask):
     global A1_List, A2_List, A3_List, data1_List, data2_List, data3_List, sigma1_List, sigma2_List, sigma3_List
     chisqgrad1 = chisqgrad2 = chisqgrad3 = 0.0*imvec_embed
 
-    if d1 != False and len(data1_List[i])>0:
+    if d1 and len(data1_List[i])>0:
 
         chisqgrad1 = chisqgrad(imvec_embed, A1_List[i], data1_List[i], sigma1_List[i], d1, ttype=ttype, mask=mask) #This *does not* include the Jacobian factor
 
-    if d2 != False and len(data2_List[i])>0:
+    if d2 and len(data2_List[i])>0:
         chisqgrad2 = chisqgrad(imvec_embed, A2_List[i], data2_List[i], sigma2_List[i], d2, ttype=ttype, mask=mask) #This *does not* include the Jacobian factor
 
-    if d3 != False and len(data3_List[i])>0:
+    if d3 and len(data3_List[i])>0:
         chisqgrad3 = chisqgrad(imvec_embed, A3_List[i], data3_List[i], sigma3_List[i], d3, ttype=ttype, mask=mask) #This *does not* include the Jacobian factor
 
     return [chisqgrad1, chisqgrad2, chisqgrad3]
@@ -839,8 +839,8 @@ systematic_noise1=0.0, systematic_noise2=0.0, systematic_noise3=0.0,
 entropy1="tv2", entropy2="l1",
 alpha_s1=1.0, alpha_s2=1.0, norm_reg=True, alpha_A=1.0,
 R_dt  ={'alpha':0.0, 'metric':'SymKL', 'p':2.0},
-maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000, 
-minimizer_method = 'L-BFGS-B', NHIST = 25, update_interval = 1, clipfloor=0., 
+maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
+minimizer_method = 'L-BFGS-B', NHIST = 25, update_interval = 1, clipfloor=0.,
 ttype = 'nfft', fft_pad_factor=2):
 
     global A1_List, A2_List, A3_List, data1_List, data2_List, data3_List, sigma1_List, sigma2_List, sigma3_List
@@ -996,7 +996,7 @@ ttype = 'nfft', fft_pad_factor=2):
         global nit
         nit += 1
 
-        if nit%update_interval == 0 or final == True:
+        if nit%update_interval == 0 or final:
             print ("iteration %d" % nit)
 
             Frames = np.zeros((N_frame, N_ypix, N_xpix))
@@ -1035,24 +1035,24 @@ ttype = 'nfft', fft_pad_factor=2):
             chisq1_max = np.max(chisq1_List)
             chisq2_max = np.max(chisq2_List)
             chisq3_max = np.max(chisq3_List)
-            if d1 != False: print ("chi2_1: %f" % chisq1)
-            if d2 != False: print ("chi2_2: %f" % chisq2)
-            if d3 != False: print ("chi2_3: %f" % chisq3)
-            if d1 != False: print ("weighted chi2_1: %f" % (chisq1 * alpha_d1))
-            if d2 != False: print ("weighted chi2_2: %f" % (chisq2 * alpha_d2))
-            if d3 != False: print ("weighted chi2_3: %f" % (chisq3 * alpha_d3))
-            if d1 != False: print ("Max Frame chi2_1: %f" % chisq1_max)
-            if d2 != False: print ("Max Frame chi2_2: %f" % chisq2_max)
-            if d3 != False: print ("Max Frame chi2_3: %f" % chisq3_max)
+            if d1: print (f"chi2_1: {chisq1:f}")
+            if d2: print (f"chi2_2: {chisq2:f}")
+            if d3: print (f"chi2_3: {chisq3:f}")
+            if d1: print ("weighted chi2_1: %f" % (chisq1 * alpha_d1))
+            if d2: print ("weighted chi2_2: %f" % (chisq2 * alpha_d2))
+            if d3: print ("weighted chi2_3: %f" % (chisq3 * alpha_d3))
+            if d1: print (f"Max Frame chi2_1: {chisq1_max:f}")
+            if d2: print (f"Max Frame chi2_2: {chisq2_max:f}")
+            if d3: print (f"Max Frame chi2_3: {chisq3_max:f}")
 
-            if final == True:
-                if d1 != False: print ("All chisq1:",chisq1_List)
-                if d2 != False: print ("All chisq2:",chisq2_List)
-                if d3 != False: print ("All chisq3:",chisq3_List)
+            if final:
+                if d1: print ("All chisq1:",chisq1_List)
+                if d2: print ("All chisq2:",chisq2_List)
+                if d3: print ("All chisq3:",chisq3_List)
 
-            if s1 != 0.0: print ("weighted s1: %f" % (s1))
-            if s2 != 0.0: print ("weighted s2: %f" % (s2))
-            print ("weighted s_dynamic: %f" % (s_dynamic))
+            if s1 != 0.0: print (f"weighted s1: {s1:f}")
+            if s2 != 0.0: print (f"weighted s2: {s2:f}")
+            print (f"weighted s_dynamic: {s_dynamic:f}")
 
             if nit%refresh_interval == 0:
                 print ("Plotting Functionality Temporarily Disabled...")
@@ -1087,7 +1087,7 @@ ttype = 'nfft', fft_pad_factor=2):
 
     # Print stats
     print ("time: %f s" % (tstop - tstart))
-    print ("J: %f" % res.fun)
+    print (f"J: {res.fun:f}")
     print (res.message)
 
     outim = [image.Image(Frames[i].reshape(Prior.ydim, Prior.xdim), Prior.psize,
@@ -1109,8 +1109,8 @@ R_flow={'alpha':0.0, 'metric':'SymKL', 'p':2.0, 'alpha_flow_tv':50.0},
 alpha_centroid=0.0, alpha_flux=0.0, alpha_dF=0.0, alpha_dS1=0.0, alpha_dS2=0.0, #other regularizers
 stochastic_optics=False, scattering_model=False, alpha_phi = 1.e4, #options for scattering
 Target_Dynamic_Range = 10000.0,
-maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000, 
-minimizer_method = 'L-BFGS-B', NHIST = 25, update_interval = 1, clipfloor=0., processes = -1, 
+maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
+minimizer_method = 'L-BFGS-B', NHIST = 25, update_interval = 1, clipfloor=0., processes = -1,
 recalculate_chisqdata = True,  ttype = 'nfft', fft_pad_factor=2, **kwargs):
 
     """Run dynamical imaging.
@@ -1118,8 +1118,8 @@ recalculate_chisqdata = True,  ttype = 'nfft', fft_pad_factor=2, **kwargs):
        Args:
            obs_input (List or Obsdata): Observation. Form can be either:
                                      1. List of Obsdata objects, one per reconstructed frame. Some can have empty data arrays.
-                                     2. Single Obsdata object. 
-           init_ims (List or Movie): List of initial images. List can be either:    
+                                     2. Single Obsdata object.
+           init_ims (List or Movie): List of initial images. List can be either:
                                      1. Each an Image object, one per reconstructed frame.
                                      2. A Movie object, where the frames will be used
            Prior (Image): The Image object with the prior image
@@ -1150,8 +1150,8 @@ recalculate_chisqdata = True,  ttype = 'nfft', fft_pad_factor=2, **kwargs):
            norm_reg (bool): If True, normalizes regularizer terms
            ttype (str): The Fourier transform type; options are 'fast', 'direct', 'nfft'
 
-           stochastic_optics (bool): If True, stochastic optics imaging is used. 
-           scattering_model (ScatteringModel): Optional specification of the ScatteringModel object. 
+           stochastic_optics (bool): If True, stochastic optics imaging is used.
+           scattering_model (ScatteringModel): Optional specification of the ScatteringModel object.
            alpha_phi (float): Weighting for screen phase regularization in stochastic optics.
 minimizer_method = 'L-BFGS-B', update_interval = 1
 
@@ -1182,9 +1182,9 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         c = 0
         for j in range(len(frame_mjds)):
             Obsdata_List[j].mjd  = InitIm_List[j].mjd
-            try: 
+            try:
                 Obsdata_List[j].data = np.concatenate(tlist[[x == j for x in idx_list]])
-            except: 
+            except:
                 Obsdata_List[j].data = []
                 c = c + 1
                 pass
@@ -1217,11 +1217,11 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         raise Exception("Number of elements in the list of total flux densities does not match the number of frames!")
 
     # If using stochastic optics, do some preliminary calculations
-    if stochastic_optics == True:
+    if stochastic_optics:
         # Doesn't yet work with clipping
         clipfloor = -1.0
 
-        if scattering_model == False:
+        if not scattering_model:
             print("No scattering model specified. Assuming the default scattering for Sgr A*.")
             scattering_model = so.ScatteringModel()
 
@@ -1274,7 +1274,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
     ninit_embed_List = [InitIm_List[i].imvec for i in range(N_frame)]
     ninit_List = [ninit_embed_List[i][embed_mask_List[i]] for i in range(N_frame)]
 
-    if (recalculate_chisqdata == True and ttype == 'direct') or ttype != 'direct':
+    if (recalculate_chisqdata and ttype == 'direct') or ttype != 'direct':
         print ("Calculating lists/matrices for chi-squared terms...")
         A1_List = [None for _ in range(N_frame)]
         A2_List = [None for _ in range(N_frame)]
@@ -1304,9 +1304,9 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         if len(Obsdata_List[i].data) == 0:  #This allows the algorithm to create frames for periods with no data
             continue
 
-        if (recalculate_chisqdata == True and ttype == 'direct') or ttype != 'direct':
+        if (recalculate_chisqdata and ttype == 'direct') or ttype != 'direct':
             # Try to create the chisqdata. These can throw errors, for instance when no closure quantities exist in a frame with data
-            try: 
+            try:
                 (data1_List[i], sigma1_List[i], A1_List[i]) = chisqdata(Obsdata_List[i], Prior, embed_mask_List[i], d1, ttype=ttype, fft_pad_factor=fft_pad_factor, systematic_noise=systematic_noise1)
             except:
                 pass
@@ -1355,7 +1355,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
             Flow = np.transpose([Flow_x.ravel(),Flow_y.ravel()]).reshape((N_ypix, N_xpix,2))
             init_i += 2*cur_len
 
-        if stochastic_optics == True:
+        if stochastic_optics:
             EpsilonList = x[init_i:(init_i + N**2-1)]
             im_List = [image.Image(Frames[j], Prior.psize, Prior.ra, Prior.dec, rf=Obsdata_List[j].rf, source=Prior.source, mjd=Prior.mjd) for j in range(N_frame)]
             #the list of scattered image vectors
@@ -1384,7 +1384,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         if alpha_flux > 0.0:
             flux = alpha_flux * movie_flux_constraint(Frames, flux_List)
 
-        if stochastic_optics == False:
+        if not stochastic_optics:
             if processes > 0:
                 chisq = np.array(pool.map(get_chisq_wrap, [[j, Frames[j].ravel()[embed_mask_List[j]], d1, d2, d3, ttype, embed_mask_List[j]] for j in range(N_frame)]))
             else:
@@ -1406,7 +1406,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
 
         # Scattering screen regularization term
         regterm_scattering = 0.0
-        if stochastic_optics == True:
+        if stochastic_optics:
             chisq_epsilon = sum(EpsilonList*EpsilonList)/((N*N-1.0)/2.0)
             regterm_scattering = alpha_phi * (chisq_epsilon - 1.0)
 
@@ -1430,7 +1430,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
             Flow = np.transpose([Flow_x.ravel(),Flow_y.ravel()]).reshape((N_ypix, N_xpix,2))
             init_i += 2*cur_len
 
-        if stochastic_optics == True:
+        if stochastic_optics:
             EpsilonList = x[init_i:(init_i + N**2-1)]
             Epsilon_Screen = so.MakeEpsilonScreenFromList(EpsilonList, N)
             im_List = [image.Image(Frames[j], Prior.psize, Prior.ra, Prior.dec, rf=Obsdata_List[j].rf, source=Prior.source, mjd=Prior.mjd) for j in range(N_frame)]
@@ -1463,7 +1463,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
 
 
         # Michael -- can we do something about this
-        if stochastic_optics == False:
+        if not stochastic_optics:
             if processes > 0:
                 chisq_grad = np.array(pool.map(get_chisqgrad_wrap, [[j, Frames[j].ravel()[embed_mask_List[j]], d1, d2, d3, ttype, embed_mask_List[j]] for j in range(N_frame)]))
             else:
@@ -1510,7 +1510,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
 
         # Gradient of the data chi^2 wrt to the epsilon screen -- this is the really difficult one
         chisq_grad_epsilon = np.array([])
-        if stochastic_optics == True:
+        if stochastic_optics:
             #Preliminary Definitions
             chisq_grad_epsilon = np.zeros(N**2-1)
             ell_mat = np.zeros((N,N))
@@ -1585,7 +1585,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
 
         # Gradient of the chi^2 regularization term for the epsilon screen
         chisq_epsilon_grad = np.array([])
-        if stochastic_optics == True:
+        if stochastic_optics:
             chisq_epsilon_grad = alpha_phi * 2.0*EpsilonList/((N*N-1)/2.0)
 
         return (np.concatenate((s1 + s2 + s_dF + s_dS + (s_dynamic_grad + chisq_grad + cm_grad + cm_grad + flux_grad)[embed_mask_All], flow_grad, chisq_grad_epsilon + chisq_epsilon_grad))*J_factor)
@@ -1597,7 +1597,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         global nit
         nit += 1
 
-        if nit%update_interval == 0 or final == True:
+        if nit%update_interval == 0 or final:
             print ("iteration %d" % nit)
 
             Frames = np.zeros((N_frame, N_ypix, N_xpix))
@@ -1617,7 +1617,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
                 Flow = np.transpose([Flow_x.ravel(),Flow_y.ravel()]).reshape((N_ypix, N_xpix,2))
                 init_i += 2*cur_len
 
-            if stochastic_optics == True:
+            if stochastic_optics:
                 EpsilonList = x[init_i:(init_i + N**2-1)]
                 im_List = [image.Image(Frames[j], Prior.psize, Prior.ra, Prior.dec, rf=Obsdata_List[j].rf, source=Prior.source, mjd=Prior.mjd) for j in range(N_frame)]
 
@@ -1646,7 +1646,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
 
             if alpha_centroid != 0.0: cm = centroid(Frames, coord) * alpha_centroid
 
-            if stochastic_optics == False:
+            if not stochastic_optics:
                 if processes > 0:
 
                     chisq = np.array(pool.map(get_chisq_wrap, [[j, Frames[j].ravel()[embed_mask_List[j]],
@@ -1671,20 +1671,20 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
             chisq1_max = np.max(chisq1_List)
             chisq2_max = np.max(chisq2_List)
             chisq3_max = np.max(chisq3_List)
-            if d1 != False: print ("chi2_1: %f" % chisq1)
-            if d2 != False: print ("chi2_2: %f" % chisq2)
-            if d3 != False: print ("chi2_3: %f" % chisq3)
-            if d1 != False: print ("weighted chi2_1: %f" % (chisq1 * alpha_d1))
-            if d2 != False: print ("weighted chi2_2: %f" % (chisq2 * alpha_d2))
-            if d3 != False: print ("weighted chi2_3: %f" % (chisq3 * alpha_d3))
-            if d1 != False: print ("Max Frame chi2_1: %f" % chisq1_max)
-            if d2 != False: print ("Max Frame chi2_2: %f" % chisq2_max)
-            if d3 != False: print ("Max Frame chi2_3: %f" % chisq3_max)
+            if d1: print (f"chi2_1: {chisq1:f}")
+            if d2: print (f"chi2_2: {chisq2:f}")
+            if d3: print (f"chi2_3: {chisq3:f}")
+            if d1: print ("weighted chi2_1: %f" % (chisq1 * alpha_d1))
+            if d2: print ("weighted chi2_2: %f" % (chisq2 * alpha_d2))
+            if d3: print ("weighted chi2_3: %f" % (chisq3 * alpha_d3))
+            if d1: print (f"Max Frame chi2_1: {chisq1_max:f}")
+            if d2: print (f"Max Frame chi2_2: {chisq2_max:f}")
+            if d3: print (f"Max Frame chi2_3: {chisq3_max:f}")
 
-            if final == True:
-                if d1 != False: print ("All chisq1:",chisq1_List)
-                if d2 != False: print ("All chisq2:",chisq2_List)
-                if d3 != False: print ("All chisq3:",chisq3_List)
+            if final:
+                if d1: print ("All chisq1:",chisq1_List)
+                if d2: print ("All chisq2:",chisq2_List)
+                if d3: print ("All chisq3:",chisq3_List)
 
             # Now deal with the a flow, if necessary
             if R_flow['alpha'] != 0.0:
@@ -1694,22 +1694,22 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
                 s_dynamic += Rflow(Frames, Flow, **R_flow)*R_flow['alpha']
                 print ("Weighted R_Flow: %f" % (Rflow(Frames, Flow, **R_flow)*R_flow['alpha']))
 
-            if s1 != 0.0: print ("weighted s1: %f" % (s1))
-            if s2 != 0.0: print ("weighted s2: %f" % (s2))
-            if s_dF != 0.0: print ("weighted s_dF: %f" % (s_dF))
-            if s_dS != 0.0: print ("weighted s_dS: %f" % (s_dS))
-            print ("weighted s_dynamic: %f" % (s_dynamic))
-            if alpha_centroid > 0.0: print ("weighted COM: %f" % cm)
+            if s1 != 0.0: print (f"weighted s1: {s1:f}")
+            if s2 != 0.0: print (f"weighted s2: {s2:f}")
+            if s_dF != 0.0: print (f"weighted s_dF: {s_dF:f}")
+            if s_dS != 0.0: print (f"weighted s_dS: {s_dS:f}")
+            print (f"weighted s_dynamic: {s_dynamic:f}")
+            if alpha_centroid > 0.0: print (f"weighted COM: {cm:f}")
 
             if alpha_flux > 0.0:
                 print ("weighted flux constraint: %f" % (alpha_flux * movie_flux_constraint(Frames, flux_List)))
 
-            if stochastic_optics == True:
+            if stochastic_optics:
                 chisq_epsilon = sum(EpsilonList*EpsilonList)/((N*N-1.0)/2.0)
                 regterm_scattering = alpha_phi * (chisq_epsilon - 1.0)
-                print("Epsilon chi^2 : %0.2f " % (chisq_epsilon))
-                print("Weighted Epsilon chi^2 : %0.2f " % (regterm_scattering))
-                print("Max |Epsilon| : %0.2f " % (max(abs(EpsilonList))))
+                print(f"Epsilon chi^2 : {chisq_epsilon:0.2f} ")
+                print(f"Weighted Epsilon chi^2 : {regterm_scattering:0.2f} ")
+                print(f"Max |Epsilon| : {max(abs(EpsilonList)):0.2f} ")
 
             if nit%refresh_interval == 0:
                 print ("Plotting Functionality Temporarily Disabled...")
@@ -1721,7 +1721,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         Flow_Init_embed = np.transpose([Flow_Init.ravel()[::2][embed_mask_List[0]],Flow_Init.ravel()[1::2][embed_mask_List[0]]]).ravel()
         x0 = np.concatenate( (loginit, Flow_Init_embed) )
 
-    if stochastic_optics == True:
+    if stochastic_optics:
         x0 = np.concatenate((x0,np.zeros(N**2-1)))
 
 
@@ -1758,7 +1758,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         Flow = np.transpose([Flow_x.ravel(),Flow_y.ravel()]).reshape((N_ypix, N_xpix,2))
         init_i += 2*cur_len
 
-    if stochastic_optics == True:
+    if stochastic_optics:
         EpsilonList = res.x[init_i:(init_i + N**2-1)]
         init_i += len(EpsilonList)
 
@@ -1767,7 +1767,7 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
 
     # Print stats
     print ("time: %f s" % (tstop - tstart))
-    print ("J: %f" % res.fun)
+    print (f"J: {res.fun:f}")
     print (res.message)
 
     #Note: the global variables are *not* released to avoid recalculation
@@ -1781,10 +1781,10 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
 
     if type(init_ims) == list:
         pass
-    else: 
+    else:
         outim = movie.merge_im_list(outim)
 
-    if R_flow['alpha'] == 0.0 and stochastic_optics == False:
+    if R_flow['alpha'] == 0.0 and not stochastic_optics:
         return outim
     else:
         return {'Movie':outim, 'Frames':outim, 'Flow':Flow, 'EpsilonList':EpsilonList }
@@ -1872,7 +1872,7 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
     ninit_embed_List = [InitIm_List[i].imvec for i in range(N_freq * N_frame)]
     ninit_List = [ninit_embed_List[i][embed_mask_List[i]] for i in range(N_freq * N_frame)]
 
-    if (recalculate_chisqdata == True and ttype == 'direct') or ttype != 'direct':
+    if (recalculate_chisqdata and ttype == 'direct') or ttype != 'direct':
         print ("Calculating lists/matrices for chi-squared terms...")
         A1_List = [None,] * N_freq * N_frame
         A2_List = [None,] * N_freq * N_frame
@@ -1900,7 +1900,7 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
         if len(Obsdata_List[i].data) == 0:  #This allows the algorithm to create frames for periods with no data
             continue
 
-        if (recalculate_chisqdata == True and ttype == 'direct') or ttype != 'direct':
+        if (recalculate_chisqdata and ttype == 'direct') or ttype != 'direct':
             (data1_List[i], sigma1_List[i], A1_List[i]) = chisqdata(Obsdata_List[i], Prior, embed_mask_List[i], d1, ttype=ttype, fft_pad_factor=fft_pad_factor, systematic_noise=systematic_noise1)
             (data2_List[i], sigma2_List[i], A2_List[i]) = chisqdata(Obsdata_List[i], Prior, embed_mask_List[i], d2, ttype=ttype, fft_pad_factor=fft_pad_factor, systematic_noise=systematic_noise2)
             (data3_List[i], sigma3_List[i], A3_List[i]) = chisqdata(Obsdata_List[i], Prior, embed_mask_List[i], d3, ttype=ttype, fft_pad_factor=fft_pad_factor, systematic_noise=systematic_noise3)
@@ -1925,7 +1925,7 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
         s1 = s2 = s_multifreq = s_dynamic = cm = flux = s_dS = s_dF = 0.0
 
         # Multifrequency part
-        if R_dt_multifreq['alpha'] != 0.0: 
+        if R_dt_multifreq['alpha'] != 0.0:
             for j in range(N_frame):
                 s_multifreq += Rdt(Frames[j::N_frame], B_dt_multifreq, **R_dt_multifreq)*R_dt_multifreq['alpha']
 
@@ -1986,7 +1986,7 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
         for j in range(N_freq):
             i1 = j*N_frame
             i2 = (j+1)*N_frame
-            f1 = j*N_frame*N_xpix*N_ypix 
+            f1 = j*N_frame*N_xpix*N_ypix
             f2 = (j+1)*N_frame*N_xpix*N_ypix
             mf1 = j*N_frame*cur_len # Note: This assumes that all priors have the same number of masked pixels!
             mf2 = (j+1)*N_frame*cur_len
@@ -2035,7 +2035,7 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
         global nit
         nit += 1
 
-        if nit%update_interval == 0 or final == True:
+        if nit%update_interval == 0 or final:
             print ("iteration %d" % nit)
 
             Frames = np.zeros((N_freq*N_frame, N_ypix, N_xpix))
@@ -2051,7 +2051,7 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
             s1 = s2 = s_multifreq = s_dynamic = cm = s_dS = s_dF = 0.0
 
             # Multifrequency part
-            if R_dt_multifreq['alpha'] != 0.0: 
+            if R_dt_multifreq['alpha'] != 0.0:
                 for j in range(N_frame):
                     s_multifreq += Rdt(Frames[j::N_frame], B_dt_multifreq, **R_dt_multifreq)*R_dt_multifreq['alpha']
 
@@ -2087,28 +2087,28 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
             chisq1_max = np.max(chisq1_List)
             chisq2_max = np.max(chisq2_List)
             chisq3_max = np.max(chisq3_List)
-            if d1 != False: print ("chi2_1: %f" % chisq1)
-            if d2 != False: print ("chi2_2: %f" % chisq2)
-            if d3 != False: print ("chi2_3: %f" % chisq3)
-            if d1 != False: print ("weighted chi2_1: %f" % (chisq1 * alpha_d1))
-            if d2 != False: print ("weighted chi2_2: %f" % (chisq2 * alpha_d2))
-            if d3 != False: print ("weighted chi2_3: %f" % (chisq3 * alpha_d3))
-            if d1 != False: print ("Max Frame chi2_1: %f" % chisq1_max)
-            if d2 != False: print ("Max Frame chi2_2: %f" % chisq2_max)
-            if d3 != False: print ("Max Frame chi2_3: %f" % chisq3_max)
+            if d1: print (f"chi2_1: {chisq1:f}")
+            if d2: print (f"chi2_2: {chisq2:f}")
+            if d3: print (f"chi2_3: {chisq3:f}")
+            if d1: print ("weighted chi2_1: %f" % (chisq1 * alpha_d1))
+            if d2: print ("weighted chi2_2: %f" % (chisq2 * alpha_d2))
+            if d3: print ("weighted chi2_3: %f" % (chisq3 * alpha_d3))
+            if d1: print (f"Max Frame chi2_1: {chisq1_max:f}")
+            if d2: print (f"Max Frame chi2_2: {chisq2_max:f}")
+            if d3: print (f"Max Frame chi2_3: {chisq3_max:f}")
 
-            if final == True:
-                if d1 != False: print ("All chisq1:",chisq1_List)
-                if d2 != False: print ("All chisq2:",chisq2_List)
-                if d3 != False: print ("All chisq3:",chisq3_List)
+            if final:
+                if d1: print ("All chisq1:",chisq1_List)
+                if d2: print ("All chisq2:",chisq2_List)
+                if d3: print ("All chisq3:",chisq3_List)
 
-            if s1 != 0.0: print ("weighted s1: %f" % (s1))
-            if s2 != 0.0: print ("weighted s2: %f" % (s2))
-            if s_dF != 0.0: print ("weighted s_dF: %f" % (s_dF))
-            if s_dS != 0.0: print ("weighted s_dS: %f" % (s_dS))
-            print ("weighted s_dynamic: %f" % (s_dynamic))
-            print ("weighted s_multifreq: %f" % (s_multifreq))
-            if alpha_centroid > 0.0: print ("weighted COM: %f" % cm)
+            if s1 != 0.0: print (f"weighted s1: {s1:f}")
+            if s2 != 0.0: print (f"weighted s2: {s2:f}")
+            if s_dF != 0.0: print (f"weighted s_dF: {s_dF:f}")
+            if s_dS != 0.0: print (f"weighted s_dS: {s_dS:f}")
+            print (f"weighted s_dynamic: {s_dynamic:f}")
+            print (f"weighted s_multifreq: {s_multifreq:f}")
+            if alpha_centroid > 0.0: print (f"weighted COM: {cm:f}")
 
             if alpha_flux > 0.0:
                 print ("weighted flux constraint: %f" % (alpha_flux * movie_flux_constraint(Frames, flux_List)))
@@ -2147,7 +2147,7 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
 
     # Print stats
     print ("time: %f s" % (tstop - tstart))
-    print ("J: %f" % res.fun)
+    print (f"J: {res.fun:f}")
     print (res.message)
 
     #Return Frames
@@ -2178,7 +2178,7 @@ def plot_im_List_Set(im_List_List, plot_log_amplitude=False, ipynb=False):
     for i in range(xnum*ynum):
         plt.subplot(ynum, xnum, i+1)
         im = im_List_List[(i-i%xnum)//xnum][i%xnum]
-        if plot_log_amplitude == False:
+        if not plot_log_amplitude:
             plt.imshow(im.imvec.reshape(im.ydim,im.xdim), cmap=plt.get_cmap('afmhot'), interpolation='gaussian')
         else:
             plt.imshow(np.log(im.imvec.reshape(im.ydim,im.xdim)), cmap=plt.get_cmap('afmhot'), interpolation='gaussian')
@@ -2187,8 +2187,8 @@ def plot_im_List_Set(im_List_List, plot_log_amplitude=False, ipynb=False):
         plt.xticks(xticks[0], xticks[1])
         plt.yticks(yticks[0], yticks[1])
         if i == 0:
-            plt.xlabel('Relative RA ($\mu$as)')
-            plt.ylabel('Relative Dec ($\mu$as)')
+            plt.xlabel(r'Relative RA ($\mu$as)')
+            plt.ylabel(r'Relative Dec ($\mu$as)')
         else:
             plt.xlabel('')
             plt.ylabel('')
@@ -2205,7 +2205,7 @@ def plot_im_List(im_List, plot_log_amplitude=False, ipynb=False):
 
     for i in range(len(im_List)):
         plt.subplot(1, len(im_List), i+1)
-        if plot_log_amplitude == False:
+        if not plot_log_amplitude:
             plt.imshow(im_List[i].imvec.reshape(Prior.ydim,Prior.xdim), cmap=plt.get_cmap('afmhot'), interpolation='gaussian')
         else:
             plt.imshow(np.log(im_List[i].imvec.reshape(Prior.ydim,Prior.xdim)), cmap=plt.get_cmap('afmhot'), interpolation='gaussian')
@@ -2214,8 +2214,8 @@ def plot_im_List(im_List, plot_log_amplitude=False, ipynb=False):
         plt.xticks(xticks[0], xticks[1])
         plt.yticks(yticks[0], yticks[1])
         if i == 0:
-            plt.xlabel('Relative RA ($\mu$as)')
-            plt.ylabel('Relative Dec ($\mu$as)')
+            plt.xlabel(r'Relative RA ($\mu$as)')
+            plt.ylabel(r'Relative Dec ($\mu$as)')
         else:
             plt.xlabel('')
             plt.ylabel('')
@@ -2237,9 +2237,9 @@ def plot_i_dynamic(im_List, Prior, nit, chi2, s, s_dynamic, ipynb=False):
         plt.xticks(xticks[0], xticks[1])
         plt.yticks(yticks[0], yticks[1])
     if i == 0:
-        plt.xlabel('Relative RA ($\mu$as)')
-        plt.ylabel('Relative Dec ($\mu$as)')
-        plt.title("step: %i  $\chi^2$: %f  $s$: %f  $s_{t}$: %f" % (nit, chi2, s, s_dynamic), fontsize=20)
+        plt.xlabel(r'Relative RA ($\mu$as)')
+        plt.ylabel(r'Relative Dec ($\mu$as)')
+        plt.title(r"step: %i  $\chi^2$: %f  $s$: %f  $s_{t}$: %f" % (nit, chi2, s, s_dynamic), fontsize=20)
     else:
         plt.xlabel('')
         plt.ylabel('')
@@ -2396,7 +2396,7 @@ def downloadMOJAVEfiles(url, path = './'):
         UVurl = baseurl+UVbuFileName
         CLEANurl = baseurl + CLEANbuFileName
         # If it doesn't already exist, download the UV file
-        if os.path.isfile(UVpath+'/'+date+'_'+ sn+".uvf") == False:
+        if not os.path.isfile(UVpath+'/'+date+'_'+ sn+".uvf"):
             print ("Downloading " + (UVpath+'/'+date+'_'+ sn+".uvf"))
             response = requests.get(UVurl, stream=True)
             with open(UVpath+'/'+date+'_'+ sn+".uvf",'wb') as handle:
@@ -2405,7 +2405,7 @@ def downloadMOJAVEfiles(url, path = './'):
             print ("Already Downloaded " + (UVpath+'/'+date+'_'+ sn+".uvf"))
 
         # If it doesn't already exist, download the CLEAN file
-        if os.path.isfile(CLEANpath+'/'+date+'_'+sn+".icn.fits.gz") == False:
+        if not os.path.isfile(CLEANpath+'/'+date+'_'+sn+".icn.fits.gz"):
             print ("Downloading " + (CLEANpath+'/'+date+'_'+sn+".icn.fits.gz"))
             response = requests.get(CLEANurl, stream=True)
             with open(CLEANpath+'/'+date+'_'+sn+".icn.fits.gz",'wb') as handle:
@@ -2448,7 +2448,7 @@ def downloadCLEANfiles(url, path = './'):
         UVurl = baseurl+UVbuFileName
         CLEANurl = baseurl + CLEANbuFileName
         # If it doesn't already exist, download the UV file
-        if os.path.isfile(UVpath+'/'+date+'_'+ sn+"_UV.UVP.gz") == False:
+        if not os.path.isfile(UVpath+'/'+date+'_'+ sn+"_UV.UVP.gz"):
             print ("Downloading " + (UVpath+'/'+date+'_'+ sn+"_UV.UVP.gz"))
             response = requests.get(UVurl, stream=True)
             with open(UVpath+'/'+date+'_'+ sn+"_UV.UVP.gz",'wb') as handle:
@@ -2457,7 +2457,7 @@ def downloadCLEANfiles(url, path = './'):
             print ("Already Downloaded " + (UVpath+'/'+date+'_'+ sn+"_UV.UVP.gz"))
 
         # If it doesn't already exist, download the CLEAN file
-        if os.path.isfile(CLEANpath+'/'+date+'_'+sn+"_CLEAN.mod") == False:
+        if not os.path.isfile(CLEANpath+'/'+date+'_'+sn+"_CLEAN.mod"):
             print ("Downloading " + (CLEANpath+'/'+date+'_'+sn+"_CLEAN.mod"))
             response = requests.get(CLEANurl, stream=True)
             with open(CLEANpath+'/'+date+'_'+sn+"_CLEAN.mod",'wb') as handle:

--- a/ehtim/imaging/dynamical_imaging.py
+++ b/ehtim/imaging/dynamical_imaging.py
@@ -723,22 +723,51 @@ def squared_gradient_flow_grad(flow):
 
 ###### Static Regularizer Master Functions #######
 
-def static_regularizer(Frame_List, Prior_List, embed_mask_List, flux, psize, stype="simple", norm_reg=True, **kwargs):
+def static_regularizer(Frame_List, Prior_List, embed_mask_List, flux, psize,
+                       stype="simple", norm_reg=True, xdim=None, ydim=None,
+                       **kwargs):
+    """Per-frame mean of ``regularizer`` over a stack of frames.
+
+    Pass ``xdim`` and ``ydim`` explicitly to support rectangular frames; if
+    either is omitted, both default to ``sqrt(npix)`` (square frames).
+    """
     N_frame = Frame_List.shape[0]
-    xdim = int(len(Frame_List[0].ravel())**0.5)
+    if xdim is None or ydim is None:
+        xdim = ydim = int(len(Frame_List[0].ravel())**0.5)
 
-    s = sum(regularizer(Frame_List[i].ravel()[embed_mask_List[i]], Prior_List[i].ravel()[embed_mask_List[i]], embed_mask_List[i], flux=flux, xdim=xdim, ydim=xdim, psize=psize, stype=stype, norm_reg=norm_reg, **kwargs) for i in range(N_frame))
+    s = sum(regularizer(Frame_List[i].ravel()[embed_mask_List[i]],
+                        Prior_List[i].ravel()[embed_mask_List[i]],
+                        embed_mask_List[i],
+                        flux=flux, xdim=xdim, ydim=ydim, psize=psize,
+                        stype=stype, norm_reg=norm_reg, **kwargs)
+            for i in range(N_frame))
 
-    return s/N_frame
+    return s / N_frame
 
-def static_regularizer_gradient(Frame_List, Prior_List, embed_mask_List, flux, psize, stype="simple", norm_reg=True, **kwargs):
-    # Note: this function includes Jacobian factor to account for the frames being written as log(frame)
+
+def static_regularizer_gradient(Frame_List, Prior_List, embed_mask_List, flux,
+                                psize, stype="simple", norm_reg=True,
+                                xdim=None, ydim=None, **kwargs):
+    """Per-frame mean of ``regularizergrad`` with the log-frame Jacobian factor.
+
+    Pass ``xdim``/``ydim`` explicitly for rectangular frames; otherwise both
+    default to ``sqrt(npix)`` (square frames).
+    """
     N_frame = Frame_List.shape[0]
-    xdim = int(len(Frame_List[0].ravel())**0.5)
+    if xdim is None or ydim is None:
+        xdim = ydim = int(len(Frame_List[0].ravel())**0.5)
 
-    s = np.concatenate([regularizergrad((Frame_List[i].ravel())[embed_mask_List[i]], Prior_List[i].ravel()[embed_mask_List[i]], embed_mask_List[i], flux=flux, xdim=xdim, ydim=xdim, psize=psize, stype=stype, norm_reg=norm_reg, **kwargs)*(Frame_List[i].ravel())[embed_mask_List[i]] for i in range(N_frame)])
+    s = np.concatenate([
+        regularizergrad((Frame_List[i].ravel())[embed_mask_List[i]],
+                        Prior_List[i].ravel()[embed_mask_List[i]],
+                        embed_mask_List[i],
+                        flux=flux, xdim=xdim, ydim=ydim, psize=psize,
+                        stype=stype, norm_reg=norm_reg, **kwargs)
+        * (Frame_List[i].ravel())[embed_mask_List[i]]
+        for i in range(N_frame)
+    ])
 
-    return s/N_frame
+    return s / N_frame
 
 ##################################################################################################
 # Other Regularization Functions
@@ -914,9 +943,9 @@ ttype = 'nfft', fft_pad_factor=2):
         s1 = s2 = 0.0
 
         if alpha_s1 != 0.0:
-            s1 = static_regularizer(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A)*alpha_s1
+            s1 = static_regularizer(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s1
         if alpha_s2 != 0.0:
-            s2 = static_regularizer(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A)*alpha_s2
+            s2 = static_regularizer(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s2
 
         s_dynamic = 0.0
 
@@ -944,9 +973,9 @@ ttype = 'nfft', fft_pad_factor=2):
         s1 = s2 = 0.0
 
         if alpha_s1 != 0.0:
-            s1 = static_regularizer_gradient(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A)*alpha_s1
+            s1 = static_regularizer_gradient(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s1
         if alpha_s2 != 0.0:
-            s2 = static_regularizer_gradient(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A)*alpha_s2
+            s2 = static_regularizer_gradient(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s2
 
         s_dynamic_grad = 0.0
         if R_dt['alpha'] != 0.0: s_dynamic_grad += Rdt_gradient(Frames, B_dt, **R_dt)*R_dt['alpha']
@@ -991,10 +1020,10 @@ ttype = 'nfft', fft_pad_factor=2):
             if alpha_s1 != 0.0:
 
                 s1 = static_regularizer(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(),
-                                        Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A)*alpha_s1
+                                        Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s1
             if alpha_s2 != 0.0:
                 s2 = static_regularizer(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(),
-                                        Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A)*alpha_s2
+                                        Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s2
 
             s_dynamic = 0.0
 
@@ -1342,9 +1371,9 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         s1 = s2 = 0.0
 
         if alpha_s1 != 0.0:
-            s1 = static_regularizer(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, **kwargs)*alpha_s1
+            s1 = static_regularizer(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim, **kwargs)*alpha_s1
         if alpha_s2 != 0.0:
-            s2 = static_regularizer(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, **kwargs)*alpha_s2
+            s2 = static_regularizer(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim, **kwargs)*alpha_s2
 
         s_dynamic = cm = flux = s_dS = s_dF = 0.0
 
@@ -1418,9 +1447,9 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
         s1 = s2 = 0.0
 
         if alpha_s1 != 0.0:
-            s1 = static_regularizer_gradient(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, **kwargs)*alpha_s1
+            s1 = static_regularizer_gradient(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim, **kwargs)*alpha_s1
         if alpha_s2 != 0.0:
-            s2 = static_regularizer_gradient(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, **kwargs)*alpha_s2
+            s2 = static_regularizer_gradient(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim, **kwargs)*alpha_s2
 
         s_dynamic_grad = cm_grad = flux_grad = s_dS = s_dF = 0.0
         if R_dI['alpha'] != 0.0: s_dynamic_grad += RdI_gradient(Frames,**R_dI)*R_dI['alpha']
@@ -1606,10 +1635,10 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
             if alpha_s1 != 0.0:
 
                 s1 = static_regularizer(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(),
-                                        Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, **kwargs)*alpha_s1
+                                        Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim, **kwargs)*alpha_s1
             if alpha_s2 != 0.0:
                 s2 = static_regularizer(Frames, nprior_embed_List, embed_mask_List, Prior.total_flux(),
-                                        Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, **kwargs)*alpha_s2
+                                        Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size, alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim, **kwargs)*alpha_s2
 
             s_dynamic = cm = s_dS = s_dF = 0.0
 
@@ -1912,9 +1941,9 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
             i2 = (j+1)*N_frame
 
             if alpha_s1 != 0.0:
-                s1 += static_regularizer(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_s1
+                s1 += static_regularizer(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s1
             if alpha_s2 != 0.0:
-                s2 += static_regularizer(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_s2
+                s2 += static_regularizer(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s2
 
             if R_dI['alpha'] != 0.0: s_dynamic += RdI(Frames[i1:i2], **R_dI)*R_dI['alpha']
             if R_dt['alpha'] != 0.0: s_dynamic += Rdt(Frames[i1:i2], B_dt, **R_dt)*R_dt['alpha']
@@ -1970,9 +1999,9 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
 
 
             if alpha_s1 != 0.0:
-                s1[mf1:mf2] = static_regularizer_gradient(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_s1
+                s1[mf1:mf2] = static_regularizer_gradient(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s1
             if alpha_s2 != 0.0:
-                s2[mf1:mf2] = static_regularizer_gradient(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_s2
+                s2[mf1:mf2] = static_regularizer_gradient(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s2
 
             if R_dI['alpha'] != 0.0: s_dynamic_grad[f1:f2] += RdI_gradient(Frames[i1:i2],**R_dI)*R_dI['alpha']
             if R_dt['alpha'] != 0.0: s_dynamic_grad[f1:f2] += Rdt_gradient(Frames[i1:i2], B_dt, **R_dt)*R_dt['alpha']
@@ -2038,9 +2067,9 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
                 i2 = (j+1)*N_frame
 
                 if alpha_s1 != 0.0:
-                    s1 += static_regularizer(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_s1
+                    s1 += static_regularizer(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy1, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s1
                 if alpha_s2 != 0.0:
-                    s2 += static_regularizer(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A)*alpha_s2
+                    s2 += static_regularizer(Frames[i1:i2], nprior_embed_List[i1:i2], embed_mask_List[i1:i2], Prior.total_flux(), Prior.psize, entropy2, norm_reg=norm_reg, beam_size=beam_size[j], alpha_A=alpha_A, xdim=Prior.xdim, ydim=Prior.ydim)*alpha_s2
 
                 if R_dI['alpha'] != 0.0: s_dynamic += RdI(Frames[i1:i2], **R_dI)*R_dI['alpha']
                 if R_dt['alpha'] != 0.0: s_dynamic += Rdt(Frames[i1:i2], B_dt, **R_dt)*R_dt['alpha']

--- a/ehtim/imaging/dynamical_imaging.py
+++ b/ehtim/imaging/dynamical_imaging.py
@@ -1331,6 +1331,8 @@ minimizer_method = 'L-BFGS-B', update_interval = 1
                 pass
 
     # Coordinate matrix for COM constraint
+    # Inner loop over x, outer over y -> ravel order matches imvec (row-major).
+    # Flat index i corresponds to pixel (y=i//xdim, x=i%xdim).
     coord = np.array([[[x,y] for x in np.linspace(Prior.xdim/2,-Prior.xdim/2,Prior.xdim)]
                              for y in np.linspace(Prior.ydim/2,-Prior.ydim/2,Prior.ydim)])
     coord = coord.reshape(Prior.ydim*Prior.xdim, 2)
@@ -1952,6 +1954,8 @@ maxit=200, J_factor = 0.001, stop=1.0e-10, ipynb=False, refresh_interval = 1000,
             (data3_List[i], sigma3_List[i], A3_List[i]) = chisqdata(Obsdata_List[i], Prior, embed_mask_List[i], d3, ttype=ttype, fft_pad_factor=fft_pad_factor, systematic_noise=systematic_noise3)
 
     # Coordinate matrix for COM constraint
+    # Inner loop over x, outer over y -> ravel order matches imvec (row-major).
+    # Flat index i corresponds to pixel (y=i//xdim, x=i%xdim).
     coord = np.array([[[x,y] for x in np.linspace(Prior.xdim/2,-Prior.xdim/2,Prior.xdim)]
                                            for y in np.linspace(Prior.ydim/2,-Prior.ydim/2,Prior.ydim)])
     coord = coord.reshape(Prior.ydim*Prior.xdim, 2)

--- a/tests/test_dynamical_imaging.py
+++ b/tests/test_dynamical_imaging.py
@@ -127,6 +127,24 @@ class TestStaticRegularizer:
         assert grad.shape == im.imvec.shape
         assert np.all(np.isfinite(grad))
 
+    def test_rect_call_without_xdim_ydim_falls_back_to_square_and_raises(
+        self, make_rect_image,
+    ):
+        """Omitting xdim/ydim defaults to the sqrt(npix) square inference.
+
+        Codifies the API contract: rect callers must opt in by passing both
+        ``xdim`` and ``ydim``. On a rectangular frame the silent square
+        fallback raises ``ValueError`` inside the leaf regularizer (because
+        the inferred square shape does not match the actual pixel count).
+        """
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        frames, priors, masks, flux, psize = self._single_frame_inputs(im)
+        with pytest.raises(ValueError):
+            di.static_regularizer(frames, priors, masks, flux, psize, stype="tv")
+        with pytest.raises(ValueError):
+            di.static_regularizer_gradient(frames, priors, masks, flux, psize,
+                                           stype="tv")
+
 
 class TestContPlotter:
     """Cont contour-plotter axis ordering and extent on rectangular frames."""

--- a/tests/test_dynamical_imaging.py
+++ b/tests/test_dynamical_imaging.py
@@ -44,6 +44,26 @@ class TestImageOperations:
         assert aligned.imvec.shape == im.imvec.shape
         assert aligned.total_flux() == pytest.approx(im.total_flux(), rel=1e-10)
 
+    def test_align_left_rolls_to_x_axis_center_on_rect(self, make_rect_image):
+        """A single bright column at x=0 lands at the x-axis centre after align.
+
+        Catches the bug where the roll amount uses the y-centre instead of
+        the x-centre, which is silent on square images but visibly wrong on
+        rectangular ones.
+        """
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        arr = np.zeros((im.ydim, im.xdim))
+        arr[:, 0] = 1.0
+        arr /= arr.sum()
+        bright = im.copy()
+        bright.imvec = arr.flatten()
+
+        aligned = di.align_left(bright, min_frac=0.1)
+
+        new_arr = aligned.imvec.reshape(aligned.ydim, aligned.xdim)
+        col_with_bright = int(np.argmax(new_arr.sum(axis=0)))
+        assert col_with_bright == (aligned.xdim - 1) // 2
+
 
 class TestAveraging:
     """Frame-list averaging and Gaussian blurring on rectangular frames."""

--- a/tests/test_dynamical_imaging.py
+++ b/tests/test_dynamical_imaging.py
@@ -7,6 +7,7 @@ loudly instead of silently corrupting movie frames.
 import numpy as np
 import pytest
 
+import ehtim as eh
 import ehtim.imaging.dynamical_imaging as di
 
 
@@ -63,3 +64,84 @@ class TestAveraging:
             assert frame.total_flux() == pytest.approx(
                 im.total_flux(), rel=1e-2,
             )
+
+
+class TestStaticRegularizer:
+    """static_regularizer + static_regularizer_gradient on rectangular frames.
+
+    Exercises the explicit xdim/ydim kwargs that prevent silent square-image
+    dimension inference from corrupting regularizer values on rect grids.
+    """
+
+    @staticmethod
+    def _single_frame_inputs(im):
+        """Pack an Image into the (1, ydim, xdim) frame stack the helpers expect."""
+        frame = im.imvec.reshape(im.ydim, im.xdim)
+        mask = np.ones(im.xdim * im.ydim, dtype=bool)
+        return (
+            np.array([frame]),
+            np.array([frame]),
+            np.array([mask]),
+            im.total_flux(),
+            im.psize,
+        )
+
+    def test_tv_value_is_finite_on_rect_frame(self, make_rect_image):
+        """Total-variation regularizer on a rect frame returns a finite scalar."""
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        frames, priors, masks, flux, psize = self._single_frame_inputs(im)
+        value = di.static_regularizer(
+            frames, priors, masks, flux, psize,
+            stype="tv", xdim=im.xdim, ydim=im.ydim,
+        )
+        assert np.isfinite(value)
+
+    def test_tv_gradient_shape_matches_image_on_rect_frame(self, make_rect_image):
+        """TV-regularizer gradient on a rect frame returns the full-pixel vector."""
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        frames, priors, masks, flux, psize = self._single_frame_inputs(im)
+        grad = di.static_regularizer_gradient(
+            frames, priors, masks, flux, psize,
+            stype="tv", xdim=im.xdim, ydim=im.ydim,
+        )
+        assert grad.shape == im.imvec.shape
+        assert np.all(np.isfinite(grad))
+
+
+class TestContPlotter:
+    """Cont contour-plotter axis ordering and extent on rectangular frames."""
+
+    @staticmethod
+    def _spy_contour(monkeypatch):
+        """Return (captured_dict, side-effect-free fake) for plt.contour / plt.show."""
+        import matplotlib.pyplot as plt
+        captured = {}
+
+        def fake_contour(Z, *args, **kwargs):
+            captured["Z_shape"] = Z.shape
+            captured["extent"] = kwargs.get("extent")
+            return None
+
+        monkeypatch.setattr(plt, "contour", fake_contour)
+        monkeypatch.setattr(plt, "show", lambda: None)
+        return captured
+
+    def test_reshapes_rect_image_to_ydim_xdim_grid(self, make_rect_image,
+                                                   monkeypatch):
+        """Cont's internal 2D grid follows the (ydim, xdim) row-major convention."""
+        captured = self._spy_contour(monkeypatch)
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        di.Cont(im)
+        assert captured["Z_shape"] == (im.ydim, im.xdim)
+
+    def test_extent_uses_separate_x_and_y_field_of_view(self, make_rect_image,
+                                                        monkeypatch):
+        """Contour extent is (-povx/2, povx/2, -povy/2, povy/2) with separate axes."""
+        captured = self._spy_contour(monkeypatch)
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        di.Cont(im)
+        pov_x_mas = im.xdim * im.psize / (eh.RADPERUAS * 1.e3)
+        pov_y_mas = im.ydim * im.psize / (eh.RADPERUAS * 1.e3)
+        expected = (-pov_x_mas / 2., pov_x_mas / 2.,
+                    -pov_y_mas / 2., pov_y_mas / 2.)
+        assert captured["extent"] == pytest.approx(expected, rel=1e-12)

--- a/tests/test_dynamical_imaging.py
+++ b/tests/test_dynamical_imaging.py
@@ -37,11 +37,30 @@ class TestImageOperations:
         assert rotated.total_flux() == pytest.approx(im.total_flux(), rel=1e-10)
 
     def test_align_left_preserves_shape_and_flux(self, make_rect_image):
-        """Horizontal alignment is a pure roll: vector length and flux unchanged."""
+        """Off-center Gaussian: align is a flux-preserving roll whose post-shift peak matches the documented formula."""
         im = make_rect_image(RECT_XDIM, RECT_YDIM)
-        aligned = di.align_left(im)
-        assert aligned.imvec.shape == im.imvec.shape
-        assert aligned.total_flux() == pytest.approx(im.total_flux(), rel=1e-10)
+        # Shift the centered Gaussian xdim/4 columns to the left so align has a
+        # non-trivial roll to perform (the centered case is near a no-op and
+        # cannot distinguish a y-vs-x roll bug from the correct fix).
+        arr = im.imvec.reshape(im.ydim, im.xdim)
+        shifted = np.roll(arr, -im.xdim // 4, axis=1)
+        offcenter = im.copy()
+        offcenter.imvec = shifted.flatten()
+
+        aligned = di.align_left(offcenter)
+
+        # Pure roll: shape + total flux preserved.
+        assert aligned.imvec.shape == offcenter.imvec.shape
+        assert aligned.total_flux() == pytest.approx(offcenter.total_flux(), rel=1e-10)
+        # Predict the post-align peak column from the documented algorithm:
+        # the leftmost above-threshold column j_first rolls to (xdim-1)//2.
+        projected = shifted.sum(axis=0)
+        j_first = int(np.argmax(projected > projected.max() * 0.1))
+        roll = (im.xdim - 1) // 2 - j_first
+        old_peak = int(np.argmax(projected))
+        expected_peak = (old_peak + roll) % im.xdim
+        new_arr = aligned.imvec.reshape(aligned.ydim, aligned.xdim)
+        assert int(np.argmax(new_arr.sum(axis=0))) == expected_peak
 
     def test_align_left_rolls_to_x_axis_center_on_rect(self, make_rect_image):
         """A single bright column at x=0 lands at the x-axis centre after align.

--- a/tests/test_dynamical_imaging.py
+++ b/tests/test_dynamical_imaging.py
@@ -10,7 +10,6 @@ import pytest
 import ehtim as eh
 import ehtim.imaging.dynamical_imaging as di
 
-
 RECT_XDIM = 32
 RECT_YDIM = 48
 

--- a/tests/test_dynamical_imaging.py
+++ b/tests/test_dynamical_imaging.py
@@ -1,0 +1,65 @@
+"""Rectangular-image (xdim != ydim) regression tests for dynamical_imaging.
+
+Locks in the (ydim, xdim) reshape contract on the public image-operation
+and averaging entry points so future shape-sensitive changes regress
+loudly instead of silently corrupting movie frames.
+"""
+import numpy as np
+import pytest
+
+import ehtim.imaging.dynamical_imaging as di
+
+
+RECT_XDIM = 32
+RECT_YDIM = 48
+
+
+class TestImageOperations:
+    """Image-shape sanity checks for KLS, core position, centering, alignment."""
+
+    def test_kls_identical_images_is_zero(self, make_rect_image):
+        """Symmetric KL divergence between an image and itself is exactly zero."""
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        assert di.get_KLS(im, im) == pytest.approx(0.0, abs=1e-12)
+
+    def test_core_position_is_centered(self, make_rect_image):
+        """A centered Gaussian source on a rect grid peaks at the pixel-grid centre."""
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        ypix, xpix = di.get_core_position(im)
+        assert abs(ypix - im.ydim // 2) <= 1
+        assert abs(xpix - im.xdim // 2) <= 1
+
+    def test_center_core_preserves_shape_and_flux(self, make_rect_image):
+        """Rotating a centered source about its core preserves vector length and flux."""
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        rotated = di.center_core(im)
+        assert rotated.imvec.shape == im.imvec.shape
+        assert rotated.total_flux() == pytest.approx(im.total_flux(), rel=1e-10)
+
+    def test_align_left_preserves_shape_and_flux(self, make_rect_image):
+        """Horizontal alignment is a pure roll: vector length and flux unchanged."""
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        aligned = di.align_left(im)
+        assert aligned.imvec.shape == im.imvec.shape
+        assert aligned.total_flux() == pytest.approx(im.total_flux(), rel=1e-10)
+
+
+class TestAveraging:
+    """Frame-list averaging and Gaussian blurring on rectangular frames."""
+
+    def test_average_of_identical_images_recovers_input(self, make_rect_image):
+        """Averaging N copies of the same frame returns that frame bit-for-bit."""
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        avg = di.average_im_list([im, im, im])
+        np.testing.assert_allclose(avg.imvec, im.imvec, rtol=1e-12)
+
+    def test_blur_im_list_preserves_shape_and_total_flux(self, make_rect_image):
+        """Gaussian (space + time) blur keeps the per-frame shape and approximate flux."""
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        blurred = di.blur_im_list([im, im, im], fwhm_x=2 * im.psize, fwhm_t=1.0)
+        assert len(blurred) == 3
+        for frame in blurred:
+            assert frame.imvec.shape == im.imvec.shape
+            assert frame.total_flux() == pytest.approx(
+                im.total_flux(), rel=1e-2,
+            )


### PR DESCRIPTION
Adds the first unit tests for `dynamical_imaging.py` and supports `xdim != ydim` inputs. Part of #212 tasks.

- `static_regularizer` + `static_regularizer_gradient` accept new `xdim`/`ydim` kwargs; default to `sqrt(npix)` square inference for back-compat. In-function call sites updated to pass `Prior.xdim` / `Prior.ydim`.
- `N_pixel` → `(N_xpix, N_ypix)` mechanical refactor across the 3 outer functions
- `Cont` contour plotter: reshape axis + separate `pov_x_mas` / `pov_y_mas` + extent uses both axes.
- `align_left`: roll amount used y-centre instead of x-centre 
- `np.sum(generator)` → `sum(generator)` in `static_regularizer` and `centroid` for NumPy 2.x compatibility.

## Out-of-scope bugs

- `dynamical_imaging_minimal:847` — undefined `alpha_flux` NameError.
- `RdS` / `RdS_gradient` pass `entropy=entropy` to `static_regularizer`, which expects `stype`; the regularizer choice is always ignored
- `Wrapped_Convolve` `Fast_Convolve=False` branch is rect-broken (default-True branch is rect-safe)..