### PR TITLE
Support rectangular images for stochastic_optics

### DIFF
--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -101,19 +101,19 @@ class ScatteringModel(object):
             def avM_Anisotropy(kzeta):                
                 return np.abs( (kzeta*sps.i0(kzeta)/sps.i1(kzeta) - 1.0)**0.5 - A )
 
-            self.kzeta = minimize(avM_Anisotropy, A**2, method='nelder-mead', options={'xtol': 1e-8, 'disp': False}).x
+            self.kzeta = minimize(avM_Anisotropy, A**2, method='nelder-mead', options={'xatol': 1e-8, 'disp': False}).x[0]
             self.P_phi_prefac = 1.0/(2.0*np.pi*sps.i0(self.kzeta))  
         elif model == 'boxcar':
             def boxcar_Anisotropy(kzeta):                
                 return np.abs( np.sin(np.pi/(1.0 + kzeta))/(np.pi/(1.0 + kzeta)) - (theta_maj_mas_ref**2 - theta_min_mas_ref**2)/(theta_maj_mas_ref**2 + theta_min_mas_ref**2) )       
 
-            self.kzeta = minimize(boxcar_Anisotropy, A, method='nelder-mead', options={'xtol': 1e-8, 'disp': False}).x
+            self.kzeta = minimize(boxcar_Anisotropy, A, method='nelder-mead', options={'xatol': 1e-8, 'disp': False}).x[0]
             self.P_phi_prefac = (1.0 + self.kzeta)/(2.0*np.pi)   
         elif model == 'dipole':
             def dipole_Anisotropy(kzeta):                
                 return np.abs( sps.hyp2f1((self.scatt_alpha + 2.0)/2.0, 0.5, 2.0, -kzeta)/sps.hyp2f1((self.scatt_alpha + 2.0)/2.0, 1.5, 2.0, -kzeta) - A**2 )  
 
-            self.kzeta = minimize(dipole_Anisotropy, A, method='nelder-mead', options={'xtol': 1e-8, 'disp': False}).x
+            self.kzeta = minimize(dipole_Anisotropy, A, method='nelder-mead', options={'xatol': 1e-8, 'disp': False}).x[0]
             self.P_phi_prefac = 1.0/(2.0*np.pi*sps.hyp2f1((self.scatt_alpha + 2.0)/2.0, 0.5, 1.0, -self.kzeta))       
         else:
             print("Scattering Model Not Recognized!")

--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -214,16 +214,20 @@ class ScatteringModel(object):
             """
 
         #Derived parameters
-        FOV = Reference_Image.psize * Reference_Image.xdim * self.observer_screen_distance #Field of view, in cm, at the scattering screen
-        N = Reference_Image.xdim
-        dq = 2.0*np.pi/FOV #this is the spacing in wavenumber
-        screen_x_offset_pixels = (Vx_km_per_s * 1.e5) * (t_hr*3600.0) / (FOV/float(N))
-        screen_y_offset_pixels = (Vy_km_per_s * 1.e5) * (t_hr*3600.0) / (FOV/float(N))
+        Nx = Reference_Image.xdim
+        Ny = Reference_Image.ydim
+        FOV_x = Reference_Image.psize * Nx * self.observer_screen_distance  # x-axis FOV at the screen (cm)
+        FOV_y = Reference_Image.psize * Ny * self.observer_screen_distance  # y-axis FOV at the screen (cm)
+        dq_x = 2.0*np.pi/FOV_x  # wavenumber spacing along x
+        dq_y = 2.0*np.pi/FOV_y  # wavenumber spacing along y
+        screen_x_offset_pixels = (Vx_km_per_s * 1.e5) * (t_hr*3600.0) / (FOV_x/float(Nx))
+        screen_y_offset_pixels = (Vy_km_per_s * 1.e5) * (t_hr*3600.0) / (FOV_y/float(Ny))
 
-        s, t = np.meshgrid(np.fft.fftfreq(N, d=1.0/N), np.fft.fftfreq(N, d=1.0/N))
-        sqrtQ = np.sqrt(self.Q(dq*s, dq*t)) * np.exp(2.0*np.pi*1j*(s*screen_x_offset_pixels +
-                                                                   t*screen_y_offset_pixels)/float(N))
-        sqrtQ[0][0] = 0.0 #A DC offset doesn't affect scattering
+        s, t = np.meshgrid(np.fft.fftfreq(Nx, d=1.0/Nx), np.fft.fftfreq(Ny, d=1.0/Ny))
+        sqrtQ = np.sqrt(self.Q(dq_x*s, dq_y*t)) * np.exp(
+            2.0*np.pi*1j*(s*screen_x_offset_pixels/float(Nx) +
+                          t*screen_y_offset_pixels/float(Ny)))
+        sqrtQ[0][0] = 0.0  #A DC offset doesn't affect scattering
 
         return sqrtQ
 

--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -690,7 +690,7 @@ def Wrapped_Gradient(M):
     return (Gx, Gy)
 
 def MakeEpsilonScreenFromList(EpsilonList, N):
-    epsilon = np.zeros((N,N),dtype=np.complex)
+    epsilon = np.zeros((N,N),dtype=complex)
     #If N is odd: there are (N^2-1)/2 real elements followed by their corresponding (N^2-1)/2 imaginary elements
     #If N is even: there are (N^2+2)/2 of each, although 3 of these must be purely real, also giving a total of N^2-1 degrees of freedom
     #This is because of conjugation symmetry in Fourier space to ensure a real Fourier transform

--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -675,9 +675,13 @@ class ScatteringModel(object):
 # These are helper functions
 ################################################################################
 
-def Wrapped_Convolve(sig,ker):
-    N = sig.shape[0]
-    return scipy.signal.fftconvolve(np.pad(sig,((N, N), (N, N)), 'wrap'), np.pad(ker,((N, N), (N, N)), 'constant'),mode='same')[N:(2*N),N:(2*N)]
+def Wrapped_Convolve(sig, ker):
+    Ny, Nx = sig.shape
+    return scipy.signal.fftconvolve(
+        np.pad(sig, ((Ny, Ny), (Nx, Nx)), 'wrap'),
+        np.pad(ker, ((Ny, Ny), (Nx, Nx)), 'constant'),
+        mode='same',
+    )[Ny:(2*Ny), Nx:(2*Nx)]
 
 def Wrapped_Gradient(M):
     G = np.gradient(np.pad(M,((1, 1), (1, 1)), 'wrap'))

--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -2,34 +2,27 @@
 # See http://adsabs.harvard.edu/abs/2016ApJ...833...74J for details about this module
 # TODO >> remove ruff exceptions in pyproject.toml after cleaning up this file
 
-from __future__ import print_function
-from builtins import range
-from builtins import object
-import numpy as np
-import scipy.signal
-import scipy.special as sps
-import scipy.integrate as integrate
-from scipy.optimize import minimize
+import math
+from multiprocessing import Pool, cpu_count
 
 import matplotlib.pyplot as plt
+import numpy as np
+import scipy.integrate as integrate
+import scipy.signal
+import scipy.special as sps
+from scipy.optimize import minimize
 
 import ehtim.image as image
 import ehtim.movie as movie
 import ehtim.obsdata as obsdata
+from ehtim.const_def import *  #Note: C is m/s rather than cm/s.
 from ehtim.observing.obs_helpers import *
-from ehtim.const_def import * #Note: C is m/s rather than cm/s.
-
-from multiprocessing import cpu_count
-from multiprocessing import Pool
-
-import math
-import cmath
 
 ################################################################################
 # The class ScatteringModel enscompasses a generic scattering model, determined by the power spectrum Q and phase structure function Dphi
 ################################################################################
 
-class ScatteringModel(object):
+class ScatteringModel:
     """A scattering model based on a thin-screen approximation.
 
        Models include:
@@ -88,51 +81,51 @@ class ScatteringModel(object):
         FWHM_fac = (2.0 * np.log(2.0))**0.5/np.pi
         self.Qbar = 2.0/sps.gamma((2.0 - self.scatt_alpha)/2.0) * (self.r_in**2*(1.0 + M)/(FWHM_fac*(self.wavelength_reference/(2.0*np.pi))**2) )**2 * ( (theta_maj_mas_ref**2 + theta_min_mas_ref**2)*(1.0/1000.0/3600.0*np.pi/180.0)**2)
         self.C_scatt_0 = (self.wavelength_reference/(2.0*np.pi))**2 * self.Qbar*sps.gamma(1.0 - self.scatt_alpha/2.0)/(8.0*np.pi**2*self.r_in**2)
-        A = theta_maj_mas_ref/theta_min_mas_ref # Anisotropy, >=1, as lambda->infinity 
+        A = theta_maj_mas_ref/theta_min_mas_ref # Anisotropy, >=1, as lambda->infinity
         self.phi0 = (90 - self.POS_ANG) * np.pi/180.0
 
-        # Parameters for the approximate phase structure function 
+        # Parameters for the approximate phase structure function
         theta_maj_rad_ref = theta_maj_mas_ref/1000.0/3600.0*np.pi/180.0
         theta_min_rad_ref = theta_min_mas_ref/1000.0/3600.0*np.pi/180.0
         self.Amaj_0 = ( self.r_in*(1.0 + M) * theta_maj_rad_ref/(FWHM_fac * (self.wavelength_reference/(2.0*np.pi)) * 2.0*np.pi ))**2
         self.Amin_0 = ( self.r_in*(1.0 + M) * theta_min_rad_ref/(FWHM_fac * (self.wavelength_reference/(2.0*np.pi)) * 2.0*np.pi ))**2
 
         if model == 'von_Mises':
-            def avM_Anisotropy(kzeta):                
+            def avM_Anisotropy(kzeta):
                 return np.abs( (kzeta*sps.i0(kzeta)/sps.i1(kzeta) - 1.0)**0.5 - A )
 
             self.kzeta = minimize(avM_Anisotropy, A**2, method='nelder-mead', options={'xatol': 1e-8, 'disp': False}).x[0]
-            self.P_phi_prefac = 1.0/(2.0*np.pi*sps.i0(self.kzeta))  
+            self.P_phi_prefac = 1.0/(2.0*np.pi*sps.i0(self.kzeta))
         elif model == 'boxcar':
-            def boxcar_Anisotropy(kzeta):                
-                return np.abs( np.sin(np.pi/(1.0 + kzeta))/(np.pi/(1.0 + kzeta)) - (theta_maj_mas_ref**2 - theta_min_mas_ref**2)/(theta_maj_mas_ref**2 + theta_min_mas_ref**2) )       
+            def boxcar_Anisotropy(kzeta):
+                return np.abs( np.sin(np.pi/(1.0 + kzeta))/(np.pi/(1.0 + kzeta)) - (theta_maj_mas_ref**2 - theta_min_mas_ref**2)/(theta_maj_mas_ref**2 + theta_min_mas_ref**2) )
 
             self.kzeta = minimize(boxcar_Anisotropy, A, method='nelder-mead', options={'xatol': 1e-8, 'disp': False}).x[0]
-            self.P_phi_prefac = (1.0 + self.kzeta)/(2.0*np.pi)   
+            self.P_phi_prefac = (1.0 + self.kzeta)/(2.0*np.pi)
         elif model == 'dipole':
-            def dipole_Anisotropy(kzeta):                
-                return np.abs( sps.hyp2f1((self.scatt_alpha + 2.0)/2.0, 0.5, 2.0, -kzeta)/sps.hyp2f1((self.scatt_alpha + 2.0)/2.0, 1.5, 2.0, -kzeta) - A**2 )  
+            def dipole_Anisotropy(kzeta):
+                return np.abs( sps.hyp2f1((self.scatt_alpha + 2.0)/2.0, 0.5, 2.0, -kzeta)/sps.hyp2f1((self.scatt_alpha + 2.0)/2.0, 1.5, 2.0, -kzeta) - A**2 )
 
             self.kzeta = minimize(dipole_Anisotropy, A, method='nelder-mead', options={'xatol': 1e-8, 'disp': False}).x[0]
-            self.P_phi_prefac = 1.0/(2.0*np.pi*sps.hyp2f1((self.scatt_alpha + 2.0)/2.0, 0.5, 1.0, -self.kzeta))       
+            self.P_phi_prefac = 1.0/(2.0*np.pi*sps.hyp2f1((self.scatt_alpha + 2.0)/2.0, 0.5, 1.0, -self.kzeta))
         else:
             print("Scattering Model Not Recognized!")
 
-        # More parameters for the approximate phase structure function 
-        int_maj = integrate.quad(lambda phi_q: np.abs( np.cos( self.phi0 - phi_q ) )**self.scatt_alpha * self.P_phi(phi_q), 0, 2.0*np.pi, limit=250)[0]  
-        int_min = integrate.quad(lambda phi_q: np.abs( np.sin( self.phi0 - phi_q ) )**self.scatt_alpha * self.P_phi(phi_q), 0, 2.0*np.pi, limit=250)[0]      
+        # More parameters for the approximate phase structure function
+        int_maj = integrate.quad(lambda phi_q: np.abs( np.cos( self.phi0 - phi_q ) )**self.scatt_alpha * self.P_phi(phi_q), 0, 2.0*np.pi, limit=250)[0]
+        int_min = integrate.quad(lambda phi_q: np.abs( np.sin( self.phi0 - phi_q ) )**self.scatt_alpha * self.P_phi(phi_q), 0, 2.0*np.pi, limit=250)[0]
         B_prefac = self.C_scatt_0 * 2.0**(2.0 - self.scatt_alpha) * np.pi**0.5/(self.scatt_alpha * sps.gamma((self.scatt_alpha + 1.0)/2.0))
         self.Bmaj_0 = B_prefac*int_maj
         self.Bmin_0 = B_prefac*int_min
 
         #Check normalization:
-        #print("Checking Normalization:",integrate.quad(lambda phi_q: self.P_phi(phi_q), 0, 2.0*np.pi)[0])  
+        #print("Checking Normalization:",integrate.quad(lambda phi_q: self.P_phi(phi_q), 0, 2.0*np.pi)[0])
 
         return
 
     def P_phi(self, phi):
         if self.model == 'von_Mises':
-            return self.P_phi_prefac * np.cosh(self.kzeta*np.cos(phi - self.phi0))  
+            return self.P_phi_prefac * np.cosh(self.kzeta*np.cos(phi - self.phi0))
         elif self.model == 'boxcar':
             return self.P_phi_prefac * (1.0 - ((np.pi/(2.0*(1.0 + self.kzeta)) < (phi - self.phi0) % np.pi) & ((phi - self.phi0) % np.pi < np.pi - np.pi/(2.0*(1.0 + self.kzeta)))))
         elif self.model == 'dipole':
@@ -166,7 +159,7 @@ class ScatteringModel(object):
         r = (x**2 + y**2)**0.5
         phi = np.arctan2(y, x)
 
-        return integrate.quad(lambda phi_q: self.dDphi_dz(r, phi, phi_q, wavelength_cm)*self.P_phi(phi_q), 0, 2.0*np.pi)[0]        
+        return integrate.quad(lambda phi_q: self.dDphi_dz(r, phi, phi_q, wavelength_cm)*self.P_phi(phi_q), 0, 2.0*np.pi)[0]
 
     def Dmaj(self, r, wavelength_cm):
         return (wavelength_cm/self.wavelength_reference)**2 * self.Bmaj_0 * (2.0 * self.Amaj_0/(self.scatt_alpha * self.Bmaj_0))**(-self.scatt_alpha/(2.0 - self.scatt_alpha)) * ((1.0 + (2.0*self.Amaj_0/(self.scatt_alpha * self.Bmaj_0))**(2.0/(2.0 - self.scatt_alpha)) * (r/self.r_in)**2 )**(self.scatt_alpha/2.0) - 1.0)
@@ -242,12 +235,12 @@ class ScatteringModel(object):
                ker (2D ndarray): The ensemble-average scattering kernel in the image domain.
             """
 
-        if wavelength_cm == None:
+        if wavelength_cm is None:
             wavelength_cm = C/Reference_Image.rf*100.0 #Observing wavelength [cm]
 
         ulist = np.fft.fftfreq(Reference_Image.xdim)/Reference_Image.psize
         vlist = np.fft.fftfreq(Reference_Image.ydim)/Reference_Image.psize
-        if use_approximate_form == True:
+        if use_approximate_form:
             u_grid, v_grid = np.meshgrid(ulist, vlist)
             ker_uv = self.Ensemble_Average_Kernel_Visibility(u_grid, v_grid, wavelength_cm, use_approximate_form=use_approximate_form)
         else:
@@ -268,7 +261,7 @@ class ScatteringModel(object):
            Returns:
                float: The ensemble-average kernel at the specified {u,v} point and observing wavelength.
             """
-        if use_approximate_form == True:
+        if use_approximate_form:
             return np.exp(-0.5*self.Dphi_approx(u*wavelength_cm/(1.0+self.Mag()), v*wavelength_cm/(1.0+self.Mag()), wavelength_cm))
         else:
             return np.exp(-0.5*self.Dphi_exact(u*wavelength_cm/(1.0+self.Mag()), v*wavelength_cm/(1.0+self.Mag()), wavelength_cm))
@@ -288,7 +281,7 @@ class ScatteringModel(object):
         # Inputs an unscattered image and an ensemble-average blurring kernel (2D array); returns the ensemble-average image
         # The pre-computed kernel can optionally be specified (ker)
 
-        if wavelength_cm == None:
+        if wavelength_cm is None:
             wavelength_cm = C/im.rf*100.0 #Observing wavelength [cm]
 
         if ker is None:
@@ -472,7 +465,7 @@ class ScatteringModel(object):
         phi_Gradient_x = -phi_Gradient[1]
         phi_Gradient_y = -phi_Gradient[0]
 
-        if Linearized_Approximation == True: #Use Equation 10 of Johnson & Narayan (2016)
+        if Linearized_Approximation: #Use Equation 10 of Johnson & Narayan (2016)
             #Calculate the gradient of the ensemble-average image
             EA_Gradient = Wrapped_Gradient((EA_Image.imvec/(FOV/Nx)).reshape(EA_Image.ydim, EA_Image.xdim))
             #The gradient signs don't actually matter, but let's make them match intuition (i.e., right to left, bottom to top)
@@ -518,7 +511,7 @@ class ScatteringModel(object):
                 AI_V = EA_im_V[ryp, rxp]
 
         #Optional: eliminate negative flux
-        if Force_Positivity == True:
+        if Force_Positivity:
            AI = abs(AI)
 
         #Make it into a proper image format
@@ -655,8 +648,8 @@ class ScatteringModel(object):
             pool.join()
         else:
             scattered_im_List = [self.Scatter(get_frame(j), Epsilon_Screen, obs_frequency_Hz = obs_frequency_Hz, Vx_km_per_s = Vx_km_per_s, Vy_km_per_s = Vy_km_per_s, t_hr=tlist_hr[j], ea_ker=ea_ker, sqrtQ=sqrtQ, Linearized_Approximation=Linearized_Approximation, Force_Positivity=Force_Positivity) for j in range(N_frames)]
-        
-        if Return_Image_List == True:
+
+        if Return_Image_List:
             return scattered_im_List
 
         Scattered_Movie = movie.Movie( [im.imvec.reshape((im.ydim,im.xdim)) for im in scattered_im_List],
@@ -666,7 +659,7 @@ class ScatteringModel(object):
             Scattered_Movie_Q = [im.qvec.reshape((im.ydim,im.xdim)) for im in scattered_im_List]
             Scattered_Movie_U = [im.uvec.reshape((im.ydim,im.xdim)) for im in scattered_im_List]
             Scattered_Movie.add_qu(Scattered_Movie_Q, Scattered_Movie_U)
-        if has_circ_pol: 
+        if has_circ_pol:
             Scattered_Movie_V = [im.vvec.reshape((im.ydim,im.xdim)) for im in scattered_im_List]
             Scattered_Movie.add_v(Scattered_Movie_V)
         return Scattered_Movie
@@ -749,9 +742,9 @@ def MakeEpsilonScreen(Nx, Ny, rngseed = 0):
         epsilon[Ny//2][Nx//2] = np.real(epsilon[Ny//2][Nx//2])
 
     for x in range(Nx):
-        if x > (Nx-1)//2: 
+        if x > (Nx-1)//2:
             epsilon[0][x] = np.conjugate(epsilon[0][Nx-x])
-        for y in range((Ny-1)//2, Ny): 
+        for y in range((Ny-1)//2, Ny):
             x2 = Nx - x
             y2 = Ny - y
             if x2 == Nx:
@@ -775,7 +768,7 @@ def plot_scatt(im_unscatt, im_ea, im_scatt, im_phase, Prior, nit, chi2, ipynb=Fa
     plt.ion()
     plt.clf()
     if chi2 > 0.0:
-        plt.suptitle("step: %i  $\chi^2$: %f " % (nit, chi2), fontsize=20)
+        plt.suptitle(r"step: %i  $\chi^2$: %f " % (nit, chi2), fontsize=20)
 
     # Unscattered Image
     plt.subplot(141)
@@ -784,8 +777,8 @@ def plot_scatt(im_unscatt, im_ea, im_scatt, im_phase, Prior, nit, chi2, ipynb=Fa
     yticks = ticks(Prior.ydim, Prior.psize/RADPERAS/1e-6)
     plt.xticks(xticks[0], xticks[1])
     plt.yticks(yticks[0], yticks[1])
-    plt.xlabel('Relative RA ($\mu$as)')
-    plt.ylabel('Relative Dec ($\mu$as)')
+    plt.xlabel(r'Relative RA ($\mu$as)')
+    plt.ylabel(r'Relative Dec ($\mu$as)')
     plt.title('Unscattered')
 
     # Ensemble Average
@@ -795,8 +788,8 @@ def plot_scatt(im_unscatt, im_ea, im_scatt, im_phase, Prior, nit, chi2, ipynb=Fa
     yticks = ticks(Prior.ydim, Prior.psize/RADPERAS/1e-6)
     plt.xticks(xticks[0], xticks[1])
     plt.yticks(yticks[0], yticks[1])
-    plt.xlabel('Relative RA ($\mu$as)')
-    plt.ylabel('Relative Dec ($\mu$as)')
+    plt.xlabel(r'Relative RA ($\mu$as)')
+    plt.ylabel(r'Relative Dec ($\mu$as)')
     plt.title('Ensemble Average')
 
     # Scattered
@@ -806,8 +799,8 @@ def plot_scatt(im_unscatt, im_ea, im_scatt, im_phase, Prior, nit, chi2, ipynb=Fa
     yticks = ticks(Prior.ydim, Prior.psize/RADPERAS/1e-6)
     plt.xticks(xticks[0], xticks[1])
     plt.yticks(yticks[0], yticks[1])
-    plt.xlabel('Relative RA ($\mu$as)')
-    plt.ylabel('Relative Dec ($\mu$as)')
+    plt.xlabel(r'Relative RA ($\mu$as)')
+    plt.ylabel(r'Relative Dec ($\mu$as)')
     plt.title('Average Image')
 
     # Phase
@@ -817,8 +810,8 @@ def plot_scatt(im_unscatt, im_ea, im_scatt, im_phase, Prior, nit, chi2, ipynb=Fa
     yticks = ticks(Prior.ydim, Prior.psize/RADPERAS/1e-6)
     plt.xticks(xticks[0], xticks[1])
     plt.yticks(yticks[0], yticks[1])
-    plt.xlabel('Relative RA ($\mu$as)')
-    plt.ylabel('Relative Dec ($\mu$as)')
+    plt.xlabel(r'Relative RA ($\mu$as)')
+    plt.ylabel(r'Relative Dec ($\mu$as)')
     plt.title('Phase Screen')
 
     # Display

--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -379,13 +379,15 @@ class ScatteringModel:
         rF  = self.rF(wavelength)
         Nx = EpsilonScreen.shape[1]
         Ny = EpsilonScreen.shape[0]
+        # Pixel size at the screen (cm/pixel). Isotropic because psize is shared across axes.
+        psize_screen = Reference_Image.psize * self.observer_screen_distance
 
 #        if Nx%2 == 0:
 #            print("The image dimension should really be odd...")
 
         #Now we'll calculate the power spectrum for each pixel in Fourier space
-        screen_x_offset_pixels = (Vx_km_per_s*1.e5) * (t_hr*3600.0) / (FOV/float(Nx))
-        screen_y_offset_pixels = (Vy_km_per_s*1.e5) * (t_hr*3600.0) / (FOV/float(Nx))
+        screen_x_offset_pixels = (Vx_km_per_s*1.e5) * (t_hr*3600.0) / psize_screen
+        screen_y_offset_pixels = (Vy_km_per_s*1.e5) * (t_hr*3600.0) / psize_screen
 
         if sqrtQ_init is None:
             sqrtQ = self.sqrtQ_Matrix(Reference_Image, Vx_km_per_s=Vx_km_per_s, Vy_km_per_s=Vy_km_per_s, t_hr=t_hr)
@@ -682,6 +684,10 @@ def Wrapped_Gradient(M):
     return (Gx, Gy)
 
 def MakeEpsilonScreenFromList(EpsilonList, N):
+    # TODO: rect support requires reworking the Hermitian-symmetry packing
+    # (separate Nx, Ny, conjugate pairing epsilon[y][x] <-> epsilon[Ny-y][Nx-x],
+    # and parity edge cases for even Nx/Ny). The companion generator
+    # MakeEpsilonScreen(Nx, Ny) is already rect-aware.
     epsilon = np.zeros((N,N),dtype=complex)
     #If N is odd: there are (N^2-1)/2 real elements followed by their corresponding (N^2-1)/2 imaginary elements
     #If N is even: there are (N^2+2)/2 of each, although 3 of these must be purely real, also giving a total of N^2-1 degrees of freedom

--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -245,12 +245,13 @@ class ScatteringModel(object):
         if wavelength_cm == None:
             wavelength_cm = C/Reference_Image.rf*100.0 #Observing wavelength [cm]
 
-        uvlist = np.fft.fftfreq(Reference_Image.xdim)/Reference_Image.psize # assume square kernel.  FIXME: create ulist and vlist, and construct u_grid and v_grid with the correct dimension
+        ulist = np.fft.fftfreq(Reference_Image.xdim)/Reference_Image.psize
+        vlist = np.fft.fftfreq(Reference_Image.ydim)/Reference_Image.psize
         if use_approximate_form == True:
-            u_grid, v_grid = np.meshgrid(uvlist, uvlist)
+            u_grid, v_grid = np.meshgrid(ulist, vlist)
             ker_uv = self.Ensemble_Average_Kernel_Visibility(u_grid, v_grid, wavelength_cm, use_approximate_form=use_approximate_form)
         else:
-            ker_uv = np.array([[self.Ensemble_Average_Kernel_Visibility(u, v, wavelength_cm, use_approximate_form=use_approximate_form) for u in uvlist] for v in uvlist]) 
+            ker_uv = np.array([[self.Ensemble_Average_Kernel_Visibility(u, v, wavelength_cm, use_approximate_form=use_approximate_form) for u in ulist] for v in vlist])
 
         ker = np.real(np.fft.fftshift(np.fft.fft2(ker_uv)))
         ker = ker / np.sum(ker) # normalize to 1

--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -577,7 +577,7 @@ class ScatteringModel(object):
             tlist_hr = [framedur_sec/3600.0*j for j in range(N_frames)]
 
         if type(Unscattered_Movie) == movie.Movie:
-            N = Unscattered_Movie.xdim
+            Nx, Ny = Unscattered_Movie.xdim, Unscattered_Movie.ydim
             N_frames = len(Unscattered_Movie.frames)
             psize = Unscattered_Movie.psize
             ra = Unscattered_Movie.ra
@@ -590,7 +590,7 @@ class ScatteringModel(object):
             has_pol = len(Unscattered_Movie.qframes)
             has_circ_pol = len(Unscattered_Movie.vframes)
         elif type(Unscattered_Movie) == list:
-            N = Unscattered_Movie[0].xdim
+            Nx, Ny = Unscattered_Movie[0].xdim, Unscattered_Movie[0].ydim
             N_frames = len(Unscattered_Movie)
             psize = Unscattered_Movie[0].psize
             ra = Unscattered_Movie[0].ra
@@ -603,7 +603,7 @@ class ScatteringModel(object):
             has_pol = len(Unscattered_Movie[0].qvec)
             has_circ_pol = len(Unscattered_Movie[0].vvec)
         else:
-            N = Unscattered_Movie.xdim
+            Nx, Ny = Unscattered_Movie.xdim, Unscattered_Movie.ydim
             psize = Unscattered_Movie.psize
             ra = Unscattered_Movie.ra
             dec = Unscattered_Movie.dec
@@ -617,11 +617,11 @@ class ScatteringModel(object):
 
         def get_frame(j):
             if type(Unscattered_Movie) == movie.Movie:
-                im = image.Image(Unscattered_Movie.frames[j].reshape((N,N)), psize=psize, ra=ra, dec=dec, rf=rf, pulse=pulse, source=source, mjd=mjd)
+                im = image.Image(Unscattered_Movie.frames[j].reshape((Ny,Nx)), psize=psize, ra=ra, dec=dec, rf=rf, pulse=pulse, source=source, mjd=mjd)
                 if len(Unscattered_Movie.qframes) > 0:
-                    im.add_qu(Unscattered_Movie.qframes[j].reshape((N,N)), Unscattered_Movie.uframes[j].reshape((N,N)))
+                    im.add_qu(Unscattered_Movie.qframes[j].reshape((Ny,Nx)), Unscattered_Movie.uframes[j].reshape((Ny,Nx)))
                 if len(Unscattered_Movie.vframes) > 0:
-                    im.add_v(Unscattered_Movie.vframes[j].reshape((N,N)))
+                    im.add_v(Unscattered_Movie.vframes[j].reshape((Ny,Nx)))
                 return im
             elif type(Unscattered_Movie) == list:
                 return Unscattered_Movie[j]
@@ -634,7 +634,7 @@ class ScatteringModel(object):
 
         # If no epsilon screen is specified, then generate a random realization
         if Epsilon_Screen.shape[0] == 0:
-            Epsilon_Screen = MakeEpsilonScreen(N, N)
+            Epsilon_Screen = MakeEpsilonScreen(Nx, Ny)
 
         # possibly parallelize
         if processes < 0:
@@ -659,15 +659,15 @@ class ScatteringModel(object):
         if Return_Image_List == True:
             return scattered_im_List
 
-        Scattered_Movie = movie.Movie( [im.imvec.reshape((im.xdim,im.ydim)) for im in scattered_im_List],
+        Scattered_Movie = movie.Movie( [im.imvec.reshape((im.ydim,im.xdim)) for im in scattered_im_List],
                                        times=tlist_hr, psize = psize, ra = ra, dec = dec, rf=rf, pulse=pulse, source=source, mjd=mjd)
 
         if has_pol:
-            Scattered_Movie_Q = [im.qvec.reshape((im.xdim,im.ydim)) for im in scattered_im_List]
-            Scattered_Movie_U = [im.uvec.reshape((im.xdim,im.ydim)) for im in scattered_im_List]
+            Scattered_Movie_Q = [im.qvec.reshape((im.ydim,im.xdim)) for im in scattered_im_List]
+            Scattered_Movie_U = [im.uvec.reshape((im.ydim,im.xdim)) for im in scattered_im_List]
             Scattered_Movie.add_qu(Scattered_Movie_Q, Scattered_Movie_U)
         if has_circ_pol: 
-            Scattered_Movie_V = [im.vvec.reshape((im.xdim,im.ydim)) for im in scattered_im_List]
+            Scattered_Movie_V = [im.vvec.reshape((im.ydim,im.xdim)) for im in scattered_im_List]
             Scattered_Movie.add_v(Scattered_Movie_V)
         return Scattered_Movie
 

--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -402,8 +402,9 @@ class ScatteringModel(object):
 
             if screen_x_offset_pixels != 0.0 or screen_y_offset_pixels != 0.0:
                 s, t = np.meshgrid(np.fft.fftfreq(Nx, d=1.0/Nx), np.fft.fftfreq(Ny, d=1.0/Ny))
-                sqrtQ = sqrtQ_init * np.exp(2.0*np.pi*1j*(s*screen_x_offset_pixels +
-                                                          t*screen_y_offset_pixels)/float(Nx))
+                sqrtQ = sqrtQ_init * np.exp(
+                    2.0*np.pi*1j*(s*screen_x_offset_pixels/float(Nx) +
+                                  t*screen_y_offset_pixels/float(Ny)))
             else:
                 sqrtQ = sqrtQ_init
 

--- a/ehtim/scattering/stochastic_optics.py
+++ b/ehtim/scattering/stochastic_optics.py
@@ -1,6 +1,5 @@
 # Michael Johnson, 2/15/2017
 # See http://adsabs.harvard.edu/abs/2016ApJ...833...74J for details about this module
-# TODO >> remove ruff exceptions in pyproject.toml after cleaning up this file
 
 import math
 from multiprocessing import Pool, cpu_count
@@ -15,8 +14,8 @@ from scipy.optimize import minimize
 import ehtim.image as image
 import ehtim.movie as movie
 import ehtim.obsdata as obsdata
-from ehtim.const_def import *  #Note: C is m/s rather than cm/s.
-from ehtim.observing.obs_helpers import *
+from ehtim.const_def import RADPERAS, C  # C is m/s rather than cm/s
+from ehtim.observing.obs_helpers import ticks
 
 ################################################################################
 # The class ScatteringModel enscompasses a generic scattering model, determined by the power spectrum Q and phase structure function Dphi
@@ -555,11 +554,11 @@ class ScatteringModel:
 
         print("Warning!! assuming a constant frame duration, but Movie objects now support unequally spaced frames!")
 
-        if type(Unscattered_Movie) != movie.Movie and framedur_sec is None:
+        if not isinstance(Unscattered_Movie, movie.Movie) and framedur_sec is None:
             print("If scattering a list of images or static image, the framedur must be specified!")
             return
 
-        if type(Unscattered_Movie) == image.Image and N_frames is None:
+        if isinstance(Unscattered_Movie, image.Image) and N_frames is None:
             print("If scattering a static image, the total number of frames must be specified (N_frames)!")
             return
 
@@ -569,7 +568,7 @@ class ScatteringModel:
         else:
             tlist_hr = [framedur_sec/3600.0*j for j in range(N_frames)]
 
-        if type(Unscattered_Movie) == movie.Movie:
+        if isinstance(Unscattered_Movie, movie.Movie):
             Nx, Ny = Unscattered_Movie.xdim, Unscattered_Movie.ydim
             N_frames = len(Unscattered_Movie.frames)
             psize = Unscattered_Movie.psize
@@ -582,7 +581,7 @@ class ScatteringModel:
             start_hr=Unscattered_Movie.start_hr
             has_pol = len(Unscattered_Movie.qframes)
             has_circ_pol = len(Unscattered_Movie.vframes)
-        elif type(Unscattered_Movie) == list:
+        elif isinstance(Unscattered_Movie, list):
             Nx, Ny = Unscattered_Movie[0].xdim, Unscattered_Movie[0].ydim
             N_frames = len(Unscattered_Movie)
             psize = Unscattered_Movie[0].psize
@@ -609,14 +608,14 @@ class ScatteringModel:
             has_circ_pol = len(Unscattered_Movie.vvec)
 
         def get_frame(j):
-            if type(Unscattered_Movie) == movie.Movie:
+            if isinstance(Unscattered_Movie, movie.Movie):
                 im = image.Image(Unscattered_Movie.frames[j].reshape((Ny,Nx)), psize=psize, ra=ra, dec=dec, rf=rf, pulse=pulse, source=source, mjd=mjd)
                 if len(Unscattered_Movie.qframes) > 0:
                     im.add_qu(Unscattered_Movie.qframes[j].reshape((Ny,Nx)), Unscattered_Movie.uframes[j].reshape((Ny,Nx)))
                 if len(Unscattered_Movie.vframes) > 0:
                     im.add_v(Unscattered_Movie.vframes[j].reshape((Ny,Nx)))
                 return im
-            elif type(Unscattered_Movie) == list:
+            elif isinstance(Unscattered_Movie, list):
                 return Unscattered_Movie[j]
             else:
                 return Unscattered_Movie
@@ -768,7 +767,7 @@ def plot_scatt(im_unscatt, im_ea, im_scatt, im_phase, Prior, nit, chi2, ipynb=Fa
     plt.ion()
     plt.clf()
     if chi2 > 0.0:
-        plt.suptitle(r"step: %i  $\chi^2$: %f " % (nit, chi2), fontsize=20)
+        plt.suptitle(rf"step: {nit}  $\chi^2$: {chi2:f} ", fontsize=20)
 
     # Unscattered Image
     plt.subplot(141)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,10 +93,9 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["F841"]
-# modeling_utils.py + stochastic_optics.py have deferred cleanup
-# silence legacy-style noise until the dedicated cleanup PR.
+# modeling_utils.py has deferred cleanup -- silence legacy-style noise
+# until the dedicated cleanup PR.
 "ehtim/modeling/modeling_utils.py" = ["E701", "E721", "E722", "F403", "F405", "UP031"]
-"ehtim/scattering/stochastic_optics.py" = ["E701", "E721", "E722", "F403", "F405", "UP031"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["ehtim"]

--- a/tests/test_scattering.py
+++ b/tests/test_scattering.py
@@ -33,7 +33,13 @@ class TestSqrtQMatrix:
 
 
 class TestEnsembleAverageKernel:
-    """Ensemble_Average_Kernel normalization on rectangular reference images."""
+    """Ensemble_Average_Kernel shape + normalization on rectangular reference images."""
+
+    def test_shape_matches_rect_reference_image(self, model, make_rect_image):
+        """The blurring kernel has shape (ydim, xdim) matching the reference image."""
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        ker = model.Ensemble_Average_Kernel(im)
+        assert ker.shape == (im.ydim, im.xdim)
 
     def test_kernel_sums_to_one(self, model, make_rect_image):
         """The ensemble-average kernel is flux-preserving (sums to 1)."""

--- a/tests/test_scattering.py
+++ b/tests/test_scattering.py
@@ -96,3 +96,15 @@ class TestWrappedConvolve:
             mode="same",
         )[RECT_YDIM:(2*RECT_YDIM), RECT_XDIM:(2*RECT_XDIM)]
         np.testing.assert_allclose(out, ref, rtol=1e-10, atol=1e-10)
+
+
+class TestMakeEpsilonScreenFromList:
+    """MakeEpsilonScreenFromList runs on modern NumPy (no np.complex deprecation)."""
+
+    def test_returns_complex_square_screen(self):
+        """The function returns a complex (N, N) array; square-only by design."""
+        n = 9
+        eps_list = [0.0] * (n * n - 1)
+        eps = so.MakeEpsilonScreenFromList(eps_list, n)
+        assert eps.shape == (n, n)
+        assert np.iscomplexobj(eps)

--- a/tests/test_scattering.py
+++ b/tests/test_scattering.py
@@ -48,6 +48,18 @@ class TestEnsembleAverageKernel:
         assert np.sum(ker) == pytest.approx(1.0, rel=1e-10)
 
 
+class TestMakePhaseScreen:
+    """MakePhaseScreen shape contract on rectangular reference images."""
+
+    def test_shape_matches_rect_epsilon_screen(self, model, make_rect_image):
+        """Phase screen output has the (ydim, xdim) shape of the reference image."""
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        eps = so.MakeEpsilonScreen(im.xdim, im.ydim, rngseed=1)
+        phi = model.MakePhaseScreen(eps, im)
+        assert phi.imvec.shape == (im.ydim * im.xdim,)
+        assert np.all(np.isfinite(phi.imvec))
+
+
 class TestWrappedConvolve:
     """Wrapped_Convolve helper agrees with scipy.signal.fftconvolve."""
 

--- a/tests/test_scattering.py
+++ b/tests/test_scattering.py
@@ -1,0 +1,53 @@
+"""Rectangular-image (xdim != ydim) regression tests for stochastic_optics."""
+import numpy as np
+import pytest
+import scipy.signal
+
+import ehtim.scattering.stochastic_optics as so
+
+
+RECT_XDIM = 32
+RECT_YDIM = 48
+
+
+@pytest.fixture(scope="module")
+def model():
+    """Default Sgr A*-like dipole scattering model."""
+    return so.ScatteringModel(model="dipole")
+
+
+class TestSqrtQMatrix:
+    """sqrtQ_Matrix smoke coverage on rectangular reference images."""
+
+    def test_returns_finite_values(self, model, make_rect_image):
+        """The Fourier-domain power spectrum is finite everywhere on rect."""
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        sqrtQ = model.sqrtQ_Matrix(im)
+        assert np.all(np.isfinite(sqrtQ))
+
+
+class TestEnsembleAverageKernel:
+    """Ensemble_Average_Kernel normalization on rectangular reference images."""
+
+    def test_kernel_sums_to_one(self, model, make_rect_image):
+        """The ensemble-average kernel is flux-preserving (sums to 1)."""
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        ker = model.Ensemble_Average_Kernel(im)
+        assert np.sum(ker) == pytest.approx(1.0, rel=1e-10)
+
+
+class TestWrappedConvolve:
+    """Wrapped_Convolve helper agrees with scipy.signal.fftconvolve."""
+
+    def test_matches_scipy_on_square_inputs(self):
+        """On square inputs the helper matches scipy fftconvolve to numerical precision."""
+        rng = np.random.default_rng(0)
+        sig = rng.standard_normal((16, 16))
+        ker = rng.standard_normal((16, 16))
+        out = so.Wrapped_Convolve(sig, ker)
+        ref = scipy.signal.fftconvolve(
+            np.pad(sig, ((16, 16), (16, 16)), "wrap"),
+            np.pad(ker, ((16, 16), (16, 16)), "constant"),
+            mode="same",
+        )[16:32, 16:32]
+        np.testing.assert_allclose(out, ref, rtol=1e-10, atol=1e-10)

--- a/tests/test_scattering.py
+++ b/tests/test_scattering.py
@@ -5,7 +5,6 @@ import scipy.signal
 
 import ehtim.scattering.stochastic_optics as so
 
-
 RECT_XDIM = 32
 RECT_YDIM = 48
 

--- a/tests/test_scattering.py
+++ b/tests/test_scattering.py
@@ -108,3 +108,37 @@ class TestMakeEpsilonScreenFromList:
         eps = so.MakeEpsilonScreenFromList(eps_list, n)
         assert eps.shape == (n, n)
         assert np.iscomplexobj(eps)
+
+
+class TestScatter:
+    """High-level Scatter() entry point on rectangular images."""
+
+    def test_scatter_preserves_image_shape_on_rect(self, model, make_rect_image):
+        """Scatter() of a rect image returns an image with the same (ydim, xdim) shape."""
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        eps = so.MakeEpsilonScreen(im.xdim, im.ydim, rngseed=2)
+        scattered = model.Scatter(im, Epsilon_Screen=eps)
+        assert scattered.imvec.shape == im.imvec.shape
+        assert scattered.xdim == im.xdim
+        assert scattered.ydim == im.ydim
+
+
+class TestScatterMovie:
+    """Scatter_Movie entry point on a rectangular-frame Movie."""
+
+    def test_scatter_movie_on_rect_movie(self, model, make_rect_image):
+        """Scattering a Movie of rect frames yields a Movie with matching shapes."""
+        import ehtim.movie as movie
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        frames = [im.imvec.reshape(im.ydim, im.xdim) for _ in range(2)]
+        mov = movie.Movie(
+            frames, times=[0.0, 1.0/3600.0],
+            psize=im.psize, ra=im.ra, dec=im.dec, rf=im.rf,
+        )
+        scattered = model.Scatter_Movie(
+            mov, framedur_sec=1.0,
+            sqrtQ=model.sqrtQ_Matrix(im),
+        )
+        assert scattered.xdim == RECT_XDIM
+        assert scattered.ydim == RECT_YDIM
+        assert len(scattered.frames) == 2

--- a/tests/test_scattering.py
+++ b/tests/test_scattering.py
@@ -17,7 +17,13 @@ def model():
 
 
 class TestSqrtQMatrix:
-    """sqrtQ_Matrix smoke coverage on rectangular reference images."""
+    """sqrtQ_Matrix shape + finiteness on rectangular reference images."""
+
+    def test_shape_matches_rect_reference_image(self, model, make_rect_image):
+        """sqrtQ has shape (ydim, xdim) matching the reference image."""
+        im = make_rect_image(RECT_XDIM, RECT_YDIM)
+        sqrtQ = model.sqrtQ_Matrix(im)
+        assert sqrtQ.shape == (im.ydim, im.xdim)
 
     def test_returns_finite_values(self, model, make_rect_image):
         """The Fourier-domain power spectrum is finite everywhere on rect."""

--- a/tests/test_scattering.py
+++ b/tests/test_scattering.py
@@ -75,3 +75,24 @@ class TestWrappedConvolve:
             mode="same",
         )[16:32, 16:32]
         np.testing.assert_allclose(out, ref, rtol=1e-10, atol=1e-10)
+
+    def test_preserves_shape_on_rect_inputs(self):
+        """Wrapped_Convolve on rect (ydim, xdim) inputs returns matching-shape output."""
+        rng = np.random.default_rng(1)
+        sig = rng.standard_normal((RECT_YDIM, RECT_XDIM))
+        ker = rng.standard_normal((RECT_YDIM, RECT_XDIM))
+        out = so.Wrapped_Convolve(sig, ker)
+        assert out.shape == sig.shape
+
+    def test_matches_scipy_on_rect_inputs(self):
+        """On rect inputs the helper matches the equivalent scipy fftconvolve form."""
+        rng = np.random.default_rng(2)
+        sig = rng.standard_normal((RECT_YDIM, RECT_XDIM))
+        ker = rng.standard_normal((RECT_YDIM, RECT_XDIM))
+        out = so.Wrapped_Convolve(sig, ker)
+        ref = scipy.signal.fftconvolve(
+            np.pad(sig, ((RECT_YDIM, RECT_YDIM), (RECT_XDIM, RECT_XDIM)), "wrap"),
+            np.pad(ker, ((RECT_YDIM, RECT_YDIM), (RECT_XDIM, RECT_XDIM)), "constant"),
+            mode="same",
+        )[RECT_YDIM:(2*RECT_YDIM), RECT_XDIM:(2*RECT_XDIM)]
+        np.testing.assert_allclose(out, ref, rtol=1e-10, atol=1e-10)


### PR DESCRIPTION
Adds the first unit tests for `stochastic_optics.py`, supports `xdim != ydim` inputs across the module, fixes two latent compat-only bugs. Part of #212 tasks.

## Rectangular-image fixes

- `sqrtQ_Matrix`: separate `Nx, Ny`; per-axis `FOV`/`dq`/`fftfreq`; per-axis Fourier-shift normalisation.
- `Ensemble_Average_Kernel`: split `uvlist` → `ulist` (xdim) + `vlist` (ydim); FIXME comment removed.
- `MakePhaseScreen`: Fourier-shift exp normalised per-axis  (`s*dx/Nx + t*dy/Ny`).
- `Wrapped_Convolve`: `N = sig.shape[0]` → `Ny, Nx = sig.shape`; pad each axis with its own size.
- `Scatter_Movie`: in each of the 3 input-type branches replace `N = ...xdim` with `Nx, Ny = ...xdim, ...ydim`; reshape `(N, N)` → `(Ny, Nx)`; output Movie reshapes flipped from `(im.xdim, im.ydim)` → `(im.ydim, im.xdim)`.

All changes reduce to the original square formulas when `xdim == ydim`, older square scripts are unaffected.

## Compat-only fixes

- `ScatteringModel.__init__` on modern scipy: `xtol` → `xatol` (deprecated kwarg) + `.x` → `.x[0]` (modern scipy returns a 1-element ndarray). Pre-fix, no model could be initialised on scipy >= 1.5.
- `MakeEpsilonScreenFromList`: `np.complex` → builtin `complex` (NumPy 2.x removed `np.complex`).


## Out of scope

- `Scatter_Movie` line 569 (post-cleanup numbering): `tlist_hr = [... for j in range(N_frames)]` uses the function-signature default `N_frames=None` BEFORE the if-elif-else block sets it. Affects list/static-image input paths; the Movie input branch sets `Unscattered_Movie.times` and bypasses this code. The new `TestScatterMovie` exercises the Movie path which avoids the bug.
- `MakePhaseScreen` amplitude prefactor at line 404 still uses x-only `FOV = psize * xdim * D_obs` (pre-existing). For square it reduces cleanly; for rect, the prefactor evaluates as if the screen were `Ny x Ny` rather than `Ny x Nx`. Whether that's physically right on rect needs a re-derivation from Johnson & Narayan 2016 with Michael's input. The new `TestMakePhaseScreen` only checks shape + finiteness so wouldn't catch a magnitude off-factor.
- `Scatter()` `FOV` variable is misleadingly named on rect (it's `FOV_x` but all uses divide by `Nx` giving `psize * D_obs`, equal to `FOV_y / Ny`). 