### PR TITLE
Array class migration for mixed-pol (feed_type wiring, TarrView, IO feed_type column)

### DIFF
--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -35,6 +35,81 @@ from ehtim.caltable import plot_tarr_dterms
 # Array object
 ###################################################################################################
 
+# Valid two-character feed_type strings for a single station (lowercase).
+# Mixed-basis stations (e.g. Effelsberg R+X) are explicitly enumerated.
+VALID_FEED_TYPES = frozenset({
+    'rl', 'lr', 'xy', 'yx',
+    'rx', 'ry', 'lx', 'ly',
+    'xr', 'xl', 'yr', 'yl',
+})
+
+# Default symmetric SEFD when none is supplied (legacy convention).
+_DEFAULT_SEFD = 10000.0
+
+
+def _validate_feed_type(feed_type):
+    """Raise ValueError if feed_type is not a recognised 2-char feed string."""
+    if not isinstance(feed_type, str) or feed_type.lower() not in VALID_FEED_TYPES:
+        raise ValueError(
+            f"feed_type must be one of {sorted(VALID_FEED_TYPES)}; "
+            f"got {feed_type!r}")
+
+
+def _resolve_sefd_pair(sefd, sefd_p1, sefd_p2):
+    """Resolve (sefd_p1, sefd_p2) from legacy + generic kwargs.
+
+    Rules: pass exactly one of `sefd` (symmetric, both feeds) or the
+    `sefd_p1`/`sefd_p2` pair (asymmetric, per-feed). Mixing the legacy
+    `sefd` kwarg with either generic kwarg raises. The generic kwargs
+    must be supplied as a pair. If none are given, both feeds default
+    to _DEFAULT_SEFD.
+    """
+    any_generic = (sefd_p1 is not None) or (sefd_p2 is not None)
+    if sefd is not None and any_generic:
+        raise ValueError(
+            "pass only one of sefd (legacy, symmetric) or "
+            "sefd_p1/sefd_p2 (generic, per-feed), not both")
+    if any_generic:
+        if sefd_p1 is None or sefd_p2 is None:
+            raise ValueError(
+                "sefd_p1 and sefd_p2 must be supplied together")
+        return float(sefd_p1), float(sefd_p2)
+    val = float(sefd) if sefd is not None else _DEFAULT_SEFD
+    return val, val
+
+
+def _resolve_dterm_pair(dr, dl, d_p1, d_p2, feed_type):
+    """Resolve (d_p1, d_p2) from legacy dr/dl + generic d_p1/d_p2 kwargs.
+
+    `dr`/`dl` are only valid for feed_type='rl' and cannot be combined
+    with their generic counterpart on the same feed. Missing values
+    default to 0+0j (no leakage).
+    """
+    if feed_type.lower() != 'rl' and (dr is not None or dl is not None):
+        raise ValueError(
+            f"dr/dl kwargs are only valid for feed_type='rl' "
+            f"(got feed_type={feed_type!r}); use d_p1/d_p2 instead")
+    if dr is not None and d_p1 is not None:
+        raise ValueError(
+            "pass only one of dr (legacy) or d_p1 (generic), not both")
+    if dl is not None and d_p2 is not None:
+        raise ValueError(
+            "pass only one of dl (legacy) or d_p2 (generic), not both")
+
+    if d_p1 is not None:
+        d_p1_val = complex(d_p1)
+    elif dr is not None:
+        d_p1_val = complex(dr)
+    else:
+        d_p1_val = 0 + 0j
+    if d_p2 is not None:
+        d_p2_val = complex(d_p2)
+    elif dl is not None:
+        d_p2_val = complex(dl)
+    else:
+        d_p2_val = 0 + 0j
+    return d_p1_val, d_p2_val
+
 
 class Array:
 
@@ -291,24 +366,53 @@ class Array:
 
         return axes
 
-    def add_site(self, site, coords, sefd=10000,
+    def add_site(self, site, coords, sefd=None,
                  fr_par=0, fr_elev=0, fr_off=0,
-                 dr=0.+0.j, dl=0.+0.j):
+                 dr=None, dl=None,
+                 feed_type='rl',
+                 sefd_p1=None, sefd_p2=None,
+                 d_p1=None, d_p2=None):
 
         """Add a ground station to the array
 
-           TODO (Phase 2 mixed-pol): extend signature with `feed_type='rl'` and
-           per-feed sefd/d-term kwargs (sefd_p1/sefd_p2/d_p1/d_p2). Phase 1
-           hardcodes feed_type='rl' so legacy circular workflows are unchanged.
+           Pass either the legacy symmetric kwargs (`sefd`, `dr`, `dl` — only
+           valid for feed_type='rl') OR the generic per-feed kwargs
+           (`sefd_p1`/`sefd_p2`, `d_p1`/`d_p2`). Mixing legacy and generic
+           kwargs for the same field raises ValueError.
+
+           Args:
+               site (str): site name
+               coords (tuple): (x, y, z) station coordinates in meters
+               sefd (float): legacy symmetric SEFD applied to both feeds.
+                             Defaults to 10000 Jy when none of sefd / sefd_p1
+                             / sefd_p2 is supplied.
+               fr_par, fr_elev, fr_off (float): field-rotation coefficients
+               dr (complex): legacy D-term for the R feed; only valid when
+                             feed_type='rl'.
+               dl (complex): legacy D-term for the L feed; only valid when
+                             feed_type='rl'.
+               feed_type (str): two-character feed-type string, lowercase,
+                                drawn from VALID_FEED_TYPES. Default 'rl'
+                                preserves the legacy calling convention.
+               sefd_p1, sefd_p2 (float): per-feed SEFDs. Must be supplied
+                                         together.
+               d_p1, d_p2 (complex): per-feed D-terms. Default 0+0j.
+
+           Returns:
+               Array: a new Array with the station appended.
         """
+        _validate_feed_type(feed_type)
+        sefd_p1_val, sefd_p2_val = _resolve_sefd_pair(sefd, sefd_p1, sefd_p2)
+        d_p1_val, d_p2_val = _resolve_dterm_pair(dr, dl, d_p1, d_p2, feed_type)
+
         tarr_old = self.tarr.copy()
         ephem_old = self.ephem.copy()
 
-
         tarr_newline = np.array((str(site), float(coords[0]), float(coords[1]), float(coords[2]),
-                                 float(sefd), float(sefd),
-                                 dr, dl,
-                                 float(fr_par), float(fr_elev), float(fr_off), 'rl'), dtype=ehc.DTARR)
+                                 sefd_p1_val, sefd_p2_val,
+                                 d_p1_val, d_p2_val,
+                                 float(fr_par), float(fr_elev), float(fr_off),
+                                 feed_type.lower()), dtype=ehc.DTARR)
         tarr_new = np.append(tarr_old, tarr_newline)
 
         arr_out = Array(tarr_new, ephem_old)
@@ -336,23 +440,33 @@ class Array:
         arr_out = Array(tarr_new, ephem_new)
         return arr_out
 
-    def add_satellite_tle(self, tlearr, sefd=10000):
+    def add_satellite_tle(self, tlearr, sefd=None,
+                          feed_type='rl',
+                          sefd_p1=None, sefd_p2=None,
+                          d_p1=None, d_p2=None):
 
         """Add an earth-orbiting satellite to the array from a TLE
 
            Args:
              tlearr (str) : 3 element list with [name, tle line 1, tle line 2] as strings
-             sefd (float) : assumed sefd for the array file (assumes sefdl = sefdr)
-
-           TODO (Phase 2 mixed-pol): extend signature with feed_type kwarg.
+             sefd (float) : legacy symmetric SEFD (sefdl = sefdr); defaults to 10000.
+             feed_type (str): two-character feed_type string (default 'rl').
+             sefd_p1, sefd_p2 (float): per-feed SEFDs; pass together as an
+                                       alternative to `sefd`.
+             d_p1, d_p2 (complex): per-feed D-terms.
         """
+        _validate_feed_type(feed_type)
+        sefd_p1_val, sefd_p2_val = _resolve_sefd_pair(sefd, sefd_p1, sefd_p2)
+        d_p1_val, d_p2_val = _resolve_dterm_pair(None, None, d_p1, d_p2, feed_type)
+
         satname = tlearr[0]
         tarr_new = self.tarr.copy()
         ephem_new = self.ephem.copy()
 
         tarr_newline = np.array((str(satname), 0., 0., 0.,
-                                 float(sefd), float(sefd),
-                                 0., 0., 0., 0., 0., 'rl'), dtype=ehc.DTARR)
+                                 sefd_p1_val, sefd_p2_val,
+                                 d_p1_val, d_p2_val,
+                                 0., 0., 0., feed_type.lower()), dtype=ehc.DTARR)
         tarr_new = np.append(tarr_new, tarr_newline)
         ephem_new[satname] = tlearr
         arr_out = Array(tarr_new, ephem_new)
@@ -363,7 +477,10 @@ class Array:
                                perigee_mjd=Time.now().mjd,
                                period_days=1., eccentricity=0.,
                                inclination=0., arg_perigee=0., long_ascending=0.,
-                               sefd=10000):
+                               sefd=None,
+                               feed_type='rl',
+                               sefd_p1=None, sefd_p2=None,
+                               d_p1=None, d_p2=None):
         """Add an earth-orbiting satellite to the array from simple keplerian elements
            perfect keplerian orbit is assumed, no derivatives
 
@@ -371,16 +488,23 @@ class Array:
                perigee time given in mjd
                period given in days
                inclination, arg_perigee, long_ascending given in degrees
-
-           TODO (Phase 2 mixed-pol): extend signature with feed_type kwarg.
+               sefd (float): legacy symmetric SEFD (defaults to 10000).
+               feed_type (str): two-character feed_type string (default 'rl').
+               sefd_p1, sefd_p2 (float): per-feed SEFDs; pass together as an
+                                         alternative to `sefd`.
+               d_p1, d_p2 (complex): per-feed D-terms.
         """
+        _validate_feed_type(feed_type)
+        sefd_p1_val, sefd_p2_val = _resolve_sefd_pair(sefd, sefd_p1, sefd_p2)
+        d_p1_val, d_p2_val = _resolve_dterm_pair(None, None, d_p1, d_p2, feed_type)
 
         tarr_new = self.tarr.copy()
         ephem_new = self.ephem.copy()
 
         tarr_newline = np.array((str(satname), 0., 0., 0.,
-                                 float(sefd), float(sefd),
-                                 0., 0., 0., 0., 0., 'rl'), dtype=ehc.DTARR)
+                                 sefd_p1_val, sefd_p2_val,
+                                 d_p1_val, d_p2_val,
+                                 0., 0., 0., feed_type.lower()), dtype=ehc.DTARR)
         tarr_new = np.append(tarr_new, tarr_newline)
 
         ephem_new[satname] = [perigee_mjd, period_days, eccentricity, inclination, arg_perigee, long_ascending]

--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -82,6 +82,79 @@ class Array:
         self._tarr = tarr
         self.tkey = {tarr[i]['site']: i for i in range(len(tarr))}
 
+    def is_homogeneous_feeds(self):
+        """Return True if every station shares the same feed_type.
+
+           Returns:
+                bool : True for single-feed arrays (legacy 'rl', all-'xy', ...);
+                       False for mixed-feed arrays.
+        """
+        return len(set(self._tarr['feed_type'])) <= 1
+
+    def feed_types(self):
+        """Return the set of distinct feed types present in the array.
+
+           Returns:
+                set[str] : e.g. {'rl'} for a legacy array, {'rl', 'xy'} for
+                           a mixed circular+linear array.
+        """
+        return set(str(ft) for ft in self._tarr['feed_type'])
+
+    def _row_and_feed_index(self, site, feed):
+        """Resolve (row, slot_index) for site/feed lookup; raise on miss.
+
+           slot_index is 0 if feed matches the station's first feed channel,
+           1 if it matches the second. feed and feed_type are compared
+           case-insensitively.
+        """
+        if site not in self.tkey:
+            raise KeyError(
+                f"site {site!r} not in array (have: {sorted(self.tkey)})")
+        row = self._tarr[self.tkey[site]]
+        ft = str(row['feed_type']).lower()
+        feed_lc = str(feed).lower()
+        if len(feed_lc) != 1 or len(ft) != 2:
+            raise ValueError(
+                f"feed must be a single character and feed_type a 2-char "
+                f"string; got feed={feed!r}, feed_type={ft!r}")
+        if feed_lc == ft[0]:
+            return row, 0
+        if feed_lc == ft[1]:
+            return row, 1
+        raise ValueError(
+            f"feed {feed!r} not in feed_type {ft!r} of site {site!r}")
+
+    def sefd_for_feed(self, site, feed):
+        """Return the SEFD for a single feed channel of a station.
+
+           Args:
+                site (str) : station name (key in self.tkey)
+                feed (str) : single feed character; must match one of the two
+                             feed channels of the station's feed_type
+                             (e.g. 'R'/'L' for 'rl', 'X'/'Y' for 'xy').
+                             Case-insensitive.
+
+           Returns:
+                float : SEFD in Jy
+        """
+        row, slot = self._row_and_feed_index(site, feed)
+        return float(row['sefd_p1' if slot == 0 else 'sefd_p2'])
+
+    def dterm_for_feed(self, site, feed):
+        """Return the leakage D-term for a single feed channel of a station.
+
+           Args:
+                site (str) : station name (key in self.tkey)
+                feed (str) : single feed character; must match one of the two
+                             feed channels of the station's feed_type.
+                             Case-insensitive.
+
+           Returns:
+                complex : leakage D-term
+        """
+        row, slot = self._row_and_feed_index(site, feed)
+        return complex(row['d_p1' if slot == 0 else 'd_p2'])
+
     def copy(self):
         """Copy the array object.
 

--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -78,6 +78,123 @@ def _resolve_sefd_pair(sefd, sefd_p1, sefd_p2):
     return val, val
 
 
+class TarrView:
+    """Thin wrapper around an Array's underlying telescope-array recarray.
+
+    Forwards array-like operations (indexing, iteration, length, dtype
+    lookup, numpy interop, equality, pickling) to the wrapped recarray.
+    The wrapper exists to guard column-form access of legacy feed-specific
+    field names ('sefdr', 'sefdl', 'dr', 'dl') on arrays whose stations
+    are not all 'rl'-feed: in that case the title-alias accessor would
+    return values from the underlying generic slot (sefd_p1, d_p1, etc.),
+    which on a non-RL station is the wrong-feed value. TarrView raises
+    KeyError instead and points to the per-feed accessor.
+
+    The recarray remains the storage truth; TarrView is created on the
+    fly by Array.tarr's property getter and adds no persisted state.
+
+    Note: this guard catches whole-column access (tarr['sefdr']). It does
+    not catch row-form access (tarr[i]['sefdr']) — the row is a numpy
+    void object owned by numpy. Phase 2+ code should prefer
+    Array.sefd_for_feed / Array.dterm_for_feed for per-station lookups.
+    """
+
+    _LEGACY_FIELD_HINT = {
+        'sefdr': 'Array.sefd_for_feed(site, feed)',
+        'sefdl': 'Array.sefd_for_feed(site, feed)',
+        'dr': 'Array.dterm_for_feed(site, feed)',
+        'dl': 'Array.dterm_for_feed(site, feed)',
+    }
+
+    __slots__ = ('_tarr',)
+
+    # Mark unhashable like the underlying ndarray.
+    __hash__ = None
+
+    def __init__(self, tarr):
+        object.__setattr__(self, '_tarr', tarr)
+
+    # ---- guard --------------------------------------------------------------
+    def _is_homogeneous_rl(self):
+        fts = self._tarr['feed_type']
+        if len(fts) == 0:
+            return True  # empty arrays default to legacy RL semantics
+        s = set(str(ft).lower() for ft in fts)
+        return s == {'rl'}
+
+    def _guard(self, key):
+        if isinstance(key, str) and key in self._LEGACY_FIELD_HINT \
+                and not self._is_homogeneous_rl():
+            fts = sorted({str(ft) for ft in self._tarr['feed_type']})
+            hint = self._LEGACY_FIELD_HINT[key]
+            raise KeyError(
+                f"tarr[{key!r}] is undefined on a non-RL or mixed-feed array "
+                f"(feed_types={fts}); use {hint} instead")
+
+    # ---- core forwarding ----------------------------------------------------
+    def __getitem__(self, key):
+        self._guard(key)
+        result = self._tarr[key]
+        # If the result is itself a structured-dtype slice (boolean mask,
+        # slice object, fancy index, ...), re-wrap so the guard stays in
+        # effect. Single-row integer indexing produces a numpy void and
+        # falls through unwrapped (documented limitation).
+        if isinstance(result, np.ndarray) and result.dtype.names is not None \
+                and 'feed_type' in result.dtype.names:
+            return TarrView(result)
+        return result
+
+    def __setitem__(self, key, value):
+        # Setting is delegated unguarded: callers writing whole columns
+        # are responsible for their data. Read-side guards still apply.
+        self._tarr[key] = value
+
+    def __iter__(self):
+        return iter(self._tarr)
+
+    def __len__(self):
+        return len(self._tarr)
+
+    def __array__(self, dtype=None, copy=None):
+        # Return the underlying ndarray directly; calling np.asarray() here
+        # would strip the structured dtype (numpy quirk with title aliases).
+        if dtype is None:
+            return self._tarr.copy() if copy else self._tarr
+        out = self._tarr.astype(dtype)
+        return out.copy() if copy else out
+
+    def __eq__(self, other):
+        if isinstance(other, TarrView):
+            other = other._tarr
+        return self._tarr == other
+
+    def __ne__(self, other):
+        if isinstance(other, TarrView):
+            other = other._tarr
+        return self._tarr != other
+
+    def __repr__(self):
+        return f"TarrView({self._tarr!r})"
+
+    # ---- attribute forwarding -----------------------------------------------
+    def __getattr__(self, name):
+        # __getattr__ only fires for misses; forward .dtype, .shape, .names,
+        # .copy, .view, etc. to the underlying ndarray.
+        #
+        # Numpy's __array_interface__ / __array_struct__ on a structured
+        # ndarray report 'typestr=V<nbytes>', which strips field names when
+        # numpy uses them to construct a copy. Hide them so np.asarray()
+        # falls back to our __array__ instead.
+        if name in ('__array_interface__', '__array_struct__'):
+            raise AttributeError(name)
+        return getattr(self._tarr, name)
+
+    # ---- pickle support -----------------------------------------------------
+    def __reduce__(self):
+        # Reconstruct via TarrView(recarray) on the other end.
+        return (TarrView, (self._tarr,))
+
+
 def _resolve_dterm_pair(dr, dl, d_p1, d_p2, feed_type):
     """Resolve (d_p1, d_p2) from legacy dr/dl + generic d_p1/d_p2 kwargs.
 
@@ -150,10 +267,12 @@ class Array:
 
     @property
     def tarr(self):
-        return self._tarr
+        return TarrView(self._tarr)
 
     @tarr.setter
     def tarr(self, tarr):
+        if isinstance(tarr, TarrView):
+            tarr = tarr._tarr
         self._tarr = tarr
         self.tkey = {tarr[i]['site']: i for i in range(len(tarr))}
 

--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -396,7 +396,12 @@ class Array:
 
                mjd (int): the mjd of the observation
                timetype (str): how to interpret tstart and tstop; either 'GMST' or 'UTC'
-               polrep (str): polarization representation, either 'stokes' or 'circ'
+               polrep (str): polarization representation, one of
+                             {'stokes', 'circ', 'lin', 'mixed'}. 'circ' requires
+                             all-RL feeds; 'lin' requires all-XY feeds; 'mixed'
+                             requires at least two distinct feed types. 'lin'
+                             and 'mixed' are not yet wired through the
+                             simulation backend (Phase 5).
                elevmin (float): station minimum elevation in degrees
                elevmax (float): station maximum elevation in degrees
                no_elevcut_space (bool): if True, do not apply elevation cut to orbiters
@@ -407,6 +412,29 @@ class Array:
                Obsdata: an observation object with no data
 
         """
+        valid_polreps = ('stokes', 'circ', 'lin', 'mixed')
+        if polrep not in valid_polreps:
+            raise ValueError(
+                f"polrep must be one of {valid_polreps}; got {polrep!r}")
+
+        feeds = self.feed_types()
+        if polrep == 'circ' and feeds != {'rl'}:
+            raise ValueError(
+                f"polrep='circ' requires all stations to have feed_type='rl'; "
+                f"array has feed_types={sorted(feeds)}")
+        if polrep == 'lin' and feeds != {'xy'}:
+            raise ValueError(
+                f"polrep='lin' requires all stations to have feed_type='xy'; "
+                f"array has feed_types={sorted(feeds)}")
+        if polrep == 'mixed' and len(feeds) < 2:
+            raise ValueError(
+                f"polrep='mixed' requires at least two distinct feed types; "
+                f"array has feed_types={sorted(feeds)}")
+        if polrep in ('lin', 'mixed'):
+            raise NotImplementedError(
+                f"Array.obsdata(polrep={polrep!r}) is not yet supported by "
+                f"the simulation backend (see Phase 5 of "
+                f"obsdata_mixedpol_plan_v2.md)")
 
         obsarr = simobs.make_uvpoints(self, ra, dec, rf, bw,
                                       tint, tadv, tstart, tstop,

--- a/ehtim/io/load.py
+++ b/ehtim/io/load.py
@@ -821,17 +821,25 @@ def load_array_txt(filename, ephemdir='ephemeris'):
 
 
     tdata = np.loadtxt(filename, dtype=bytes, comments='#').astype(str)
+    if tdata.ndim == 1:
+        tdata = tdata.reshape(1, -1)
     if tdata[0][0].lower() == 'site':
         tdata = tdata[1:]
 
     path = os.path.dirname(filename)
 
+    # Column count is the schema discriminator:
+    #   5  = legacy minimal (site, x, y, z, sefd)
+    #   13 = legacy circular-only (no feed_type)
+    #   14 = current format (legacy circular + explicit feed_type),
+    #        emitted by save_array_txt with a leading
+    #        '# ehtim array format v2' marker
     tdataout = []
     if (tdata.shape[1] not in (5, 13, 14)):
         raise Exception("Array file should have format: " +
-                        "(name, x, y, z, SEFDR, SEFDL " +
-                        "FR_PAR_ANGLE FR_ELEV_ANGLE FR_OFFSET" +
-                        "DR_RE   DR_IM   DL_RE    DL_IM   [FEED_TYPE])")
+                        "(name, x, y, z, SEFD_P1, SEFD_P2 " +
+                        "FR_PAR_ANGLE FR_ELEV_ANGLE FR_OFFSET " +
+                        "D_P1_RE D_P1_IM D_P2_RE D_P2_IM [FEED_TYPE])")
 
     elif tdata.shape[1] == 5:
         tdataout = [np.array((x[0], float(x[1]), float(x[2]), float(x[3]), float(x[4]), float(x[4]),

--- a/ehtim/io/save.py
+++ b/ehtim/io/save.py
@@ -276,11 +276,16 @@ def save_mov_txt(mov, fname, mjd=False):
 def save_array_txt(arr, fname):
     """Save the array data in a text file.
 
+       Emits the v2 versioned format: a leading '# ehtim array format v2'
+       comment, then one row per station with 14 whitespace-separated
+       tokens (site, x, y, z, sefd_p1, sefd_p2, fr_par, fr_elev, fr_off,
+       d_p1_re, d_p1_im, d_p2_re, d_p2_im, feed_type). The numeric layout
+       is unchanged from the legacy 13-column format; feed_type is
+       appended as the 14th column and a version header is added.
+
        Args:
             arr (Array): array object
             fname (str): name of output text file
-
-       Returns:
     """
 
     if isinstance(arr, np.ndarray):
@@ -290,23 +295,27 @@ def save_array_txt(arr, fname):
             tarr = arr.tarr
         except AttributeError:
             print("Array format not recognized!")
+            return
 
-    out = ("#Site      X(m)             Y(m)             Z(m)           " +
-           "SEFDR      SEFDL     FR_PAR   FR_EL   FR_OFF  " +
-           "DR_RE    DR_IM    DL_RE    DL_IM   \n")
+    out = ("# ehtim array format v2\n"
+           "#Site      X(m)             Y(m)             Z(m)           "
+           "SEFD_P1    SEFD_P2   FR_PAR   FR_EL   FR_OFF  "
+           "D_P1_RE  D_P1_IM  D_P2_RE  D_P2_IM   FEED\n")
     for scope in range(len(tarr)):
-        dat = (tarr[scope]['site'],
-               tarr[scope]['x'], tarr[scope]['y'], tarr[scope]['z'],
-               tarr[scope]['sefdr'], tarr[scope]['sefdl'],
-               tarr[scope]['fr_par'], tarr[scope]['fr_elev'], tarr[scope]['fr_off'],
-               tarr[scope]['dr'].real, tarr[scope]['dr'].imag,
-               tarr[scope]['dl'].real, tarr[scope]['dl'].imag
-               )
+        row = tarr[scope]
+        d_p1 = complex(row['d_p1'])
+        d_p2 = complex(row['d_p2'])
+        dat = (str(row['site']),
+               float(row['x']), float(row['y']), float(row['z']),
+               float(row['sefd_p1']), float(row['sefd_p2']),
+               float(row['fr_par']), float(row['fr_elev']), float(row['fr_off']),
+               d_p1.real, d_p1.imag, d_p2.real, d_p2.imag,
+               str(row['feed_type']))
         out += ("{:<8s} {:15.5f}  {:15.5f}  {:15.5f}  {:8.2f}   {:8.2f}  "
-                "{:5.2f}   {:5.2f}   {:5.2f}  {:8.4f} {:8.4f} {:8.4f} {:8.4f} \n").format(*dat)
-    f = open(fname, 'w')
-    f.write(out)
-    f.close()
+                "{:5.2f}   {:5.2f}   {:5.2f}  "
+                "{:8.4f} {:8.4f} {:8.4f} {:8.4f}  {:<2s}\n").format(*dat)
+    with open(fname, 'w') as f:
+        f.write(out)
     return
 
 

--- a/ehtim/io/save.py
+++ b/ehtim/io/save.py
@@ -363,20 +363,21 @@ def save_obs_txt(obs, fname):
             "----------------------------------------------------------------------" +
             "------------------------------------------------------------------\n" +
             "Site       X(m)             Y(m)             Z(m)           " +
-            "SEFDR      SEFDL     FR_PAR   FR_EL   FR_OFF  " +
-            "DR_RE    DR_IM    DL_RE    DL_IM   \n"
+            "SEFD_P1    SEFD_P2   FR_PAR   FR_EL   FR_OFF  " +
+            "D_P1_RE  D_P1_IM  D_P2_RE  D_P2_IM   FEED\n"
             )
 
     for i in range(len(obs.tarr)):
+        d_p1 = complex(obs.tarr[i]['d_p1'])
+        d_p2 = complex(obs.tarr[i]['d_p2'])
         head += ("{:<8s} {:15.5f}  {:15.5f}  {:15.5f}  {:8.2f}   {:8.2f}  "
-                 "{:5.2f}   {:5.2f}   {:5.2f}  {:8.4f} {:8.4f} {:8.4f} {:8.4f} \n").format(
-                  obs.tarr[i]['site'],
-                  obs.tarr[i]['x'], obs.tarr[i]['y'], obs.tarr[i]['z'],
-                  obs.tarr[i]['sefdr'], obs.tarr[i]['sefdl'],
-                  obs.tarr[i]['fr_par'], obs.tarr[i]['fr_elev'], obs.tarr[i]['fr_off'],
-                  (obs.tarr[i]['dr']).real, (obs.tarr[i]['dr']).imag,
-                  (obs.tarr[i]['dl']).real, (obs.tarr[i]['dl']).imag
-                  )
+                 "{:5.2f}   {:5.2f}   {:5.2f}  {:8.4f} {:8.4f} {:8.4f} {:8.4f}  {:<2s}\n").format(
+                  str(obs.tarr[i]['site']),
+                  float(obs.tarr[i]['x']), float(obs.tarr[i]['y']), float(obs.tarr[i]['z']),
+                  float(obs.tarr[i]['sefd_p1']), float(obs.tarr[i]['sefd_p2']),
+                  float(obs.tarr[i]['fr_par']), float(obs.tarr[i]['fr_elev']), float(obs.tarr[i]['fr_off']),
+                  d_p1.real, d_p1.imag, d_p2.real, d_p2.imag,
+                  str(obs.tarr[i]['feed_type']))
 
     if obs.polrep == 'stokes':
         head += (
@@ -891,20 +892,21 @@ def save_dtype_txt(obs, fname, data, dtype='cphase'):
             "----------------------------------------------------------------------" +
             "------------------------------------------------------------------\n" +
             "Site       X(m)             Y(m)             Z(m)           " +
-            "SEFDR      SEFDL     FR_PAR   FR_EL   FR_OFF  " +
-            "DR_RE    DR_IM    DL_RE    DL_IM   \n"
+            "SEFD_P1    SEFD_P2   FR_PAR   FR_EL   FR_OFF  " +
+            "D_P1_RE  D_P1_IM  D_P2_RE  D_P2_IM   FEED\n"
             )
 
     for i in range(len(obs.tarr)):
+        d_p1 = complex(obs.tarr[i]['d_p1'])
+        d_p2 = complex(obs.tarr[i]['d_p2'])
         head += ("{:<8s} {:15.5f}  {:15.5f}  {:15.5f}  {:8.2f}   {:8.2f}  "
-                 "{:5.2f}   {:5.2f}   {:5.2f}  {:8.4f} {:8.4f} {:8.4f} {:8.4f} \n").format(
-                  obs.tarr[i]['site'],
-                  obs.tarr[i]['x'], obs.tarr[i]['y'], obs.tarr[i]['z'],
-                  obs.tarr[i]['sefdr'], obs.tarr[i]['sefdl'],
-                  obs.tarr[i]['fr_par'], obs.tarr[i]['fr_elev'], obs.tarr[i]['fr_off'],
-                  (obs.tarr[i]['dr']).real, (obs.tarr[i]['dr']).imag,
-                  (obs.tarr[i]['dl']).real, (obs.tarr[i]['dl']).imag
-                  )
+                 "{:5.2f}   {:5.2f}   {:5.2f}  {:8.4f} {:8.4f} {:8.4f} {:8.4f}  {:<2s}\n").format(
+                  str(obs.tarr[i]['site']),
+                  float(obs.tarr[i]['x']), float(obs.tarr[i]['y']), float(obs.tarr[i]['z']),
+                  float(obs.tarr[i]['sefd_p1']), float(obs.tarr[i]['sefd_p2']),
+                  float(obs.tarr[i]['fr_par']), float(obs.tarr[i]['fr_elev']), float(obs.tarr[i]['fr_off']),
+                  d_p1.real, d_p1.imag, d_p2.real, d_p2.imag,
+                  str(obs.tarr[i]['feed_type']))
 
     head += ("----------------------------------------------------------------------"
              "------------------------------------------------------------------\n" +

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -572,3 +572,151 @@ def test_phase2_add_satellite_tle_invalid_feed_type_raises():
     tle = ['SAT1', 'line1', 'line2']
     with pytest.raises(ValueError, match="feed_type must be one of"):
         _empty_array().add_satellite_tle(tle, feed_type='qq')
+
+
+# ----- TarrView wrapper -----------------------------------------------------
+
+def test_phase2_tarrview_is_returned_by_tarr_property():
+    arr = ea.Array(_legacy_tarr())
+    assert isinstance(arr.tarr, ea.TarrView)
+
+
+def test_phase2_tarrview_sefdr_on_homogeneous_rl_works():
+    arr = ea.Array(_legacy_tarr())
+    # Legacy title-alias access still works on an all-RL array.
+    np.testing.assert_array_equal(arr.tarr['sefdr'], [1000., 2000.])
+    np.testing.assert_array_equal(arr.tarr['sefdl'], [1100., 2100.])
+
+
+def test_phase2_tarrview_sefdr_on_xy_array_raises():
+    arr = ea.Array(_xy_tarr())
+    with pytest.raises(KeyError, match=r"tarr\['sefdr'\].*xy"):
+        _ = arr.tarr['sefdr']
+
+
+def test_phase2_tarrview_sefdl_on_xy_array_raises():
+    arr = ea.Array(_xy_tarr())
+    with pytest.raises(KeyError, match=r"tarr\['sefdl'\].*xy"):
+        _ = arr.tarr['sefdl']
+
+
+def test_phase2_tarrview_sefdr_on_mixed_array_raises():
+    arr = ea.Array(_mixed_tarr())
+    with pytest.raises(KeyError, match=r"tarr\['sefdr'\].*"):
+        _ = arr.tarr['sefdr']
+
+
+def test_phase2_tarrview_dr_on_mixed_array_raises():
+    arr = ea.Array(_mixed_tarr())
+    with pytest.raises(KeyError, match="dterm_for_feed"):
+        _ = arr.tarr['dr']
+
+
+def test_phase2_tarrview_generic_names_always_work():
+    # Generic per-feed names are never guarded.
+    arr = ea.Array(_mixed_tarr())
+    np.testing.assert_array_equal(arr.tarr['sefd_p1'], [100., 4000.])
+    np.testing.assert_array_equal(arr.tarr['sefd_p2'], [110., 4100.])
+
+
+def test_phase2_tarrview_dtype_attribute_forwarded():
+    arr = ea.Array(_legacy_tarr())
+    assert 'feed_type' in arr.tarr.dtype.names
+    assert arr.tarr.dtype == ehc.DTARR
+
+
+def test_phase2_tarrview_len_iter_forwarded():
+    arr = ea.Array(_legacy_tarr())
+    assert len(arr.tarr) == 2
+    sites = [str(row['site']) for row in arr.tarr]
+    assert sites == ['A', 'B']
+
+
+def test_phase2_tarrview_row_index_returns_void():
+    arr = ea.Array(_legacy_tarr())
+    row = arr.tarr[0]
+    # Single-row index returns a numpy void; field access on it bypasses
+    # the guard (documented limitation).
+    assert str(row['site']) == 'A'
+
+
+def test_phase2_tarrview_boolean_mask_returns_wrapped_view():
+    arr = ea.Array(_mixed_tarr())
+    mask = np.array([True, False])
+    sub = arr.tarr[mask]
+    assert isinstance(sub, ea.TarrView)
+    assert len(sub) == 1
+    assert str(sub[0]['site']) == 'ALMA'
+
+
+def test_phase2_tarrview_boolean_mask_preserves_guard():
+    # Slicing a mixed array down to one xy station: legacy 'sefdr'
+    # still raises on the subview (feed_types still non-RL).
+    arr = ea.Array(_mixed_tarr())
+    sub = arr.tarr[np.array([True, False])]
+    with pytest.raises(KeyError):
+        _ = sub['sefdr']
+
+
+def test_phase2_tarrview_equality_recarray_lhs():
+    arr = ea.Array(_legacy_tarr())
+    raw = arr.tarr._tarr.copy()
+    cmp = raw == arr.tarr
+    assert np.all(cmp)
+
+
+def test_phase2_tarrview_equality_recarray_rhs():
+    arr = ea.Array(_legacy_tarr())
+    raw = arr.tarr._tarr.copy()
+    cmp = arr.tarr == raw
+    assert np.all(cmp)
+
+
+def test_phase2_tarrview_equality_both_views():
+    arr1 = ea.Array(_legacy_tarr())
+    arr2 = ea.Array(_legacy_tarr())
+    assert np.all(arr1.tarr == arr2.tarr)
+
+
+def test_phase2_tarrview_pickle_roundtrip():
+    arr = ea.Array(_legacy_tarr())
+    view = arr.tarr
+    view2 = pickle.loads(pickle.dumps(view))
+    assert isinstance(view2, ea.TarrView)
+    assert np.all(view == view2)
+
+
+def test_phase2_tarrview_unhashable():
+    arr = ea.Array(_legacy_tarr())
+    with pytest.raises(TypeError):
+        hash(arr.tarr)
+
+
+def test_phase2_tarrview_numpy_interop_via_array_protocol():
+    arr = ea.Array(_legacy_tarr())
+    # np.asarray should produce a recarray view (no copy required by spec).
+    asarr = np.asarray(arr.tarr)
+    assert isinstance(asarr, np.ndarray)
+    assert asarr.dtype.names == arr.tarr.dtype.names
+
+
+def test_phase2_tarrview_setter_unwraps_view():
+    # Assigning a TarrView via the property setter unwraps it so _tarr
+    # remains a plain ndarray (the storage truth).
+    arr = ea.Array(_legacy_tarr())
+    view = arr.tarr  # TarrView
+    arr.tarr = view  # round-trip via setter
+    assert not isinstance(arr._tarr, ea.TarrView)
+    assert isinstance(arr._tarr, np.ndarray)
+    assert arr._tarr.dtype.names is not None  # structured dtype preserved
+
+
+def test_phase2_tarrview_array_pickle_roundtrip_preserves_ndarray_storage():
+    # The Array itself round-trips through pickle: storage stays as an
+    # ndarray (not a TarrView), so the on-disk format is unchanged.
+    arr = ea.Array(_legacy_tarr())
+    arr2 = pickle.loads(pickle.dumps(arr))
+    assert isinstance(arr2._tarr, np.ndarray)
+    assert not isinstance(arr2._tarr, ea.TarrView)
+    assert isinstance(arr2.tarr, ea.TarrView)
+    assert np.all(arr2.tarr == arr.tarr)

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -720,3 +720,95 @@ def test_phase2_tarrview_array_pickle_roundtrip_preserves_ndarray_storage():
     assert not isinstance(arr2._tarr, ea.TarrView)
     assert isinstance(arr2.tarr, ea.TarrView)
     assert np.all(arr2.tarr == arr.tarr)
+
+
+# ----- Array.obsdata(polrep=...) validation ---------------------------------
+
+def _eht_like_rl_array():
+    """Two-site array with realistic ground-station coordinates."""
+    t = np.zeros(2, dtype=ehc.DTARR)
+    t['site'] = ['ALMA', 'APEX']
+    t['x'] = [2225061.16, 2225039.53]
+    t['y'] = [-5440057.37, -5441197.63]
+    t['z'] = [-2481681.15, -2479303.36]
+    t['sefd_p1'] = [100., 4000.]
+    t['sefd_p2'] = [100., 4000.]
+    t['feed_type'] = ['rl', 'rl']
+    return t
+
+
+def _eht_like_xy_array():
+    t = _eht_like_rl_array()
+    t['feed_type'] = ['xy', 'xy']
+    return t
+
+
+def _eht_like_mixed_array():
+    t = _eht_like_rl_array()
+    t['feed_type'] = ['xy', 'rl']
+    return t
+
+
+def _obs_kwargs():
+    # Sgr A* coords with full 24h window so ALMA/APEX intersect.
+    return dict(ra=17.76, dec=-29.0, rf=230e9, bw=1e9,
+                tint=60.0, tadv=600.0, tstart=0.0, tstop=24.0)
+
+
+def test_phase2_obsdata_polrep_invalid_raises():
+    arr = ea.Array(_eht_like_rl_array())
+    with pytest.raises(ValueError, match="polrep must be one of"):
+        arr.obsdata(polrep='bogus', **_obs_kwargs())
+
+
+def test_phase2_obsdata_polrep_stokes_on_rl_array_succeeds():
+    arr = ea.Array(_eht_like_rl_array())
+    obs = arr.obsdata(polrep='stokes', **_obs_kwargs())
+    assert obs.polrep == 'stokes'
+
+
+def test_phase2_obsdata_polrep_circ_on_rl_array_succeeds():
+    arr = ea.Array(_eht_like_rl_array())
+    obs = arr.obsdata(polrep='circ', **_obs_kwargs())
+    assert obs.polrep == 'circ'
+
+
+def test_phase2_obsdata_polrep_circ_on_xy_array_raises():
+    arr = ea.Array(_eht_like_xy_array())
+    with pytest.raises(ValueError,
+                       match="polrep='circ' requires all stations.*'rl'"):
+        arr.obsdata(polrep='circ', **_obs_kwargs())
+
+
+def test_phase2_obsdata_polrep_circ_on_mixed_array_raises():
+    arr = ea.Array(_eht_like_mixed_array())
+    with pytest.raises(ValueError, match="polrep='circ'"):
+        arr.obsdata(polrep='circ', **_obs_kwargs())
+
+
+def test_phase2_obsdata_polrep_lin_on_rl_array_raises():
+    arr = ea.Array(_eht_like_rl_array())
+    with pytest.raises(ValueError,
+                       match="polrep='lin' requires all stations.*'xy'"):
+        arr.obsdata(polrep='lin', **_obs_kwargs())
+
+
+def test_phase2_obsdata_polrep_lin_on_xy_array_raises_not_implemented():
+    # Validation passes (all xy) but simulation backend doesn't support
+    # 'lin' yet — should raise NotImplementedError pointing to Phase 5.
+    arr = ea.Array(_eht_like_xy_array())
+    with pytest.raises(NotImplementedError, match="Phase 5"):
+        arr.obsdata(polrep='lin', **_obs_kwargs())
+
+
+def test_phase2_obsdata_polrep_mixed_on_homogeneous_array_raises():
+    arr = ea.Array(_eht_like_rl_array())
+    with pytest.raises(ValueError,
+                       match="polrep='mixed' requires at least two"):
+        arr.obsdata(polrep='mixed', **_obs_kwargs())
+
+
+def test_phase2_obsdata_polrep_mixed_on_mixed_array_raises_not_implemented():
+    arr = ea.Array(_eht_like_mixed_array())
+    with pytest.raises(NotImplementedError, match="Phase 5"):
+        arr.obsdata(polrep='mixed', **_obs_kwargs())

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -962,3 +962,27 @@ def test_phase2_load_array_txt_legacy_bit_identical(fname):
         np.testing.assert_array_equal(arr.tarr['feed_type'], raw[:, 13])
     else:
         assert np.all(arr.tarr['feed_type'] == 'rl')
+
+
+# ----- save_obs_txt / load_obs_txt embedded-tarr round-trip -----------------
+
+def test_phase2_save_load_obs_txt_embedded_tarr_with_feed_type(tmp_path):
+    """The obs.txt embedded tarr block now emits feed_type; round-trip
+    must preserve it for non-trivial values."""
+    tarr = _full_tarr(['rl', 'xy', 'lx'])
+    data = np.zeros(2, dtype=ehc.DTPOL_STOKES)
+    data['t1'] = ['S0', 'S0']
+    data['t2'] = ['S1', 'S2']
+    data['u'] = [1e9, 2e9]
+    data['v'] = [1e8, 2e8]
+    data['vis'] = [1 + 0j, 0.5 + 0j]
+    data['sigma'] = [0.1, 0.1]
+    obs = eo.Obsdata(ra=17.76, dec=-29., rf=230e9, bw=1e9,
+                     datatable=data, tarr=tarr, polrep='stokes')
+    fname = str(tmp_path / 'obs.txt')
+    obs.save_txt(fname)
+    obs2 = eo.load_txt(fname, polrep='stokes')
+    np.testing.assert_array_equal(obs2.tarr['feed_type'], obs.tarr['feed_type'])
+    np.testing.assert_array_equal(obs2.tarr['site'], obs.tarr['site'])
+    np.testing.assert_allclose(obs2.tarr['sefd_p1'], obs.tarr['sefd_p1'], atol=1e-2)
+    np.testing.assert_allclose(obs2.tarr['sefd_p2'], obs.tarr['sefd_p2'], atol=1e-2)

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -331,3 +331,116 @@ def test_phase1_caltable_pickle_roundtrip_legacy_dtcal():
     assert 'dr' in caltab2.data['A'].dtype.names
     assert np.array_equal(caltab2.data['A']['rscale'],
                           caltab.data['A']['rscale'])
+
+
+# ============================================================================
+# Phase 2 — Array class migration
+# ============================================================================
+#
+# Plan reference: obsdata_mixedpol_plan_v2.md, "Phase 2".
+# Scope:
+#   - Array query methods: is_homogeneous_feeds, feed_types,
+#     sefd_for_feed, dterm_for_feed
+#   - add_site / add_satellite_tle / add_satellite_elements feed_type kwarg
+#   - TarrView wrapper raising on legacy R/L access for non-RL stations
+#   - Array.obsdata(polrep=...) extended to 'lin' and 'mixed'
+#   - save_array_txt / load_array_txt v2 versioned text format
+#   - load_obs_txt embedded-tarr versioned header
+
+def _mixed_tarr():
+    """Two-site tarr: one 'rl', one 'xy'."""
+    t = np.zeros(2, dtype=ehc.DTARR)
+    t['site'] = ['ALMA', 'APEX']
+    t['sefd_p1'] = [100., 4000.]
+    t['sefd_p2'] = [110., 4100.]
+    t['d_p1'] = [0.01 + 0.02j, 0.03 + 0.04j]
+    t['d_p2'] = [0.05 + 0.06j, 0.07 + 0.08j]
+    t['feed_type'] = ['xy', 'rl']
+    return t
+
+
+def _xy_tarr():
+    """Two-site all-linear-feed tarr."""
+    t = np.zeros(2, dtype=ehc.DTARR)
+    t['site'] = ['A', 'B']
+    t['sefd_p1'] = [1000., 2000.]
+    t['sefd_p2'] = [1100., 2100.]
+    t['d_p1'] = [0.1 + 0.0j, 0.2 + 0.0j]
+    t['d_p2'] = [0.3 + 0.0j, 0.4 + 0.0j]
+    t['feed_type'] = ['xy', 'xy']
+    return t
+
+
+# ----- Array query methods --------------------------------------------------
+
+def test_phase2_is_homogeneous_feeds_legacy_array_true():
+    arr = ea.Array(_legacy_tarr())
+    assert arr.is_homogeneous_feeds() is True
+
+
+def test_phase2_is_homogeneous_feeds_xy_array_true():
+    arr = ea.Array(_xy_tarr())
+    assert arr.is_homogeneous_feeds() is True
+
+
+def test_phase2_is_homogeneous_feeds_mixed_array_false():
+    arr = ea.Array(_mixed_tarr())
+    assert arr.is_homogeneous_feeds() is False
+
+
+def test_phase2_feed_types_legacy_array():
+    arr = ea.Array(_legacy_tarr())
+    assert arr.feed_types() == {'rl'}
+
+
+def test_phase2_feed_types_mixed_array():
+    arr = ea.Array(_mixed_tarr())
+    assert arr.feed_types() == {'rl', 'xy'}
+
+
+def test_phase2_sefd_for_feed_rl_station_returns_p1_p2():
+    arr = ea.Array(_mixed_tarr())
+    assert arr.sefd_for_feed('APEX', 'R') == 4000.
+    assert arr.sefd_for_feed('APEX', 'L') == 4100.
+
+
+def test_phase2_sefd_for_feed_xy_station_returns_p1_p2():
+    arr = ea.Array(_mixed_tarr())
+    assert arr.sefd_for_feed('ALMA', 'X') == 100.
+    assert arr.sefd_for_feed('ALMA', 'Y') == 110.
+
+
+def test_phase2_sefd_for_feed_case_insensitive():
+    arr = ea.Array(_mixed_tarr())
+    assert arr.sefd_for_feed('ALMA', 'x') == arr.sefd_for_feed('ALMA', 'X')
+
+
+def test_phase2_sefd_for_feed_wrong_feed_raises():
+    arr = ea.Array(_mixed_tarr())
+    # ALMA is 'xy'; asking for R should raise.
+    with pytest.raises(ValueError, match="feed 'R' not in feed_type 'xy'"):
+        arr.sefd_for_feed('ALMA', 'R')
+
+
+def test_phase2_sefd_for_feed_unknown_site_raises():
+    arr = ea.Array(_mixed_tarr())
+    with pytest.raises(KeyError, match="site 'NOSITE' not in array"):
+        arr.sefd_for_feed('NOSITE', 'R')
+
+
+def test_phase2_dterm_for_feed_rl_station_dispatch():
+    arr = ea.Array(_mixed_tarr())
+    assert arr.dterm_for_feed('APEX', 'R') == 0.03 + 0.04j
+    assert arr.dterm_for_feed('APEX', 'L') == 0.07 + 0.08j
+
+
+def test_phase2_dterm_for_feed_xy_station_dispatch():
+    arr = ea.Array(_mixed_tarr())
+    assert arr.dterm_for_feed('ALMA', 'X') == 0.01 + 0.02j
+    assert arr.dterm_for_feed('ALMA', 'Y') == 0.05 + 0.06j
+
+
+def test_phase2_dterm_for_feed_wrong_feed_raises():
+    arr = ea.Array(_mixed_tarr())
+    with pytest.raises(ValueError, match="not in feed_type"):
+        arr.dterm_for_feed('APEX', 'X')

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -4,6 +4,7 @@ Tests are grouped by the phase of obsdata_mixedpol_plan_v2.md they cover.
 Subsequent phases (2, 2.5, 3, ...) should append their tests to this file
 under matching headers.
 """
+import os
 import pickle
 
 import numpy as np
@@ -812,3 +813,152 @@ def test_phase2_obsdata_polrep_mixed_on_mixed_array_raises_not_implemented():
     arr = ea.Array(_eht_like_mixed_array())
     with pytest.raises(NotImplementedError, match="Phase 5"):
         arr.obsdata(polrep='mixed', **_obs_kwargs())
+
+
+# ----- save_array_txt v2 + load_array_txt round-trip ------------------------
+
+def _full_tarr(feed_types):
+    """Synthetic tarr with non-trivial values across all DTARR fields."""
+    n = len(feed_types)
+    t = np.zeros(n, dtype=ehc.DTARR)
+    t['site'] = [f'S{i}' for i in range(n)]
+    t['x'] = [1.0 * (i + 1) for i in range(n)]
+    t['y'] = [2.0 * (i + 1) for i in range(n)]
+    t['z'] = [3.0 * (i + 1) for i in range(n)]
+    t['sefd_p1'] = [100.0 * (i + 1) for i in range(n)]
+    t['sefd_p2'] = [110.0 * (i + 1) for i in range(n)]
+    t['d_p1'] = [complex(0.01 * (i + 1), 0.02 * (i + 1)) for i in range(n)]
+    t['d_p2'] = [complex(0.03 * (i + 1), 0.04 * (i + 1)) for i in range(n)]
+    t['fr_par'] = [1.0 * (i + 1) for i in range(n)]
+    t['fr_elev'] = [0.5 * (i + 1) for i in range(n)]
+    t['fr_off'] = [0.1 * (i + 1) for i in range(n)]
+    t['feed_type'] = feed_types
+    return t
+
+
+def _assert_tarr_round_trip(arr_before, arr_after, atol_sefd=1e-2,
+                             atol_d=1e-4, atol_fr=1e-2, atol_coord=1e-5):
+    """Compare numeric fields with tolerances matching save_array_txt's
+    printf precision; feed_type and site are exact."""
+    a, b = arr_before.tarr._tarr, arr_after.tarr._tarr
+    assert np.array_equal(a['site'], b['site'])
+    assert np.array_equal(a['feed_type'], b['feed_type'])
+    np.testing.assert_allclose(a['x'], b['x'], atol=atol_coord)
+    np.testing.assert_allclose(a['y'], b['y'], atol=atol_coord)
+    np.testing.assert_allclose(a['z'], b['z'], atol=atol_coord)
+    np.testing.assert_allclose(a['sefd_p1'], b['sefd_p1'], atol=atol_sefd)
+    np.testing.assert_allclose(a['sefd_p2'], b['sefd_p2'], atol=atol_sefd)
+    np.testing.assert_allclose(a['d_p1'].real, b['d_p1'].real, atol=atol_d)
+    np.testing.assert_allclose(a['d_p1'].imag, b['d_p1'].imag, atol=atol_d)
+    np.testing.assert_allclose(a['d_p2'].real, b['d_p2'].real, atol=atol_d)
+    np.testing.assert_allclose(a['d_p2'].imag, b['d_p2'].imag, atol=atol_d)
+    np.testing.assert_allclose(a['fr_par'], b['fr_par'], atol=atol_fr)
+    np.testing.assert_allclose(a['fr_elev'], b['fr_elev'], atol=atol_fr)
+    np.testing.assert_allclose(a['fr_off'], b['fr_off'], atol=atol_fr)
+
+
+def test_phase2_save_array_txt_emits_v2_header(tmp_path):
+    arr = ea.Array(_full_tarr(['rl', 'rl']))
+    fname = str(tmp_path / 'a.txt')
+    arr.save_txt(fname)
+    with open(fname) as f:
+        first = f.readline().strip()
+    assert first == '# ehtim array format v2'
+
+
+def test_phase2_save_load_array_txt_roundtrip_rl(tmp_path):
+    arr = ea.Array(_full_tarr(['rl', 'rl']))
+    fname = str(tmp_path / 'a.txt')
+    arr.save_txt(fname)
+    arr2 = ea.load_txt(fname)
+    _assert_tarr_round_trip(arr, arr2)
+    assert set(arr2.feed_types()) == {'rl'}
+
+
+def test_phase2_save_load_array_txt_roundtrip_xy(tmp_path):
+    arr = ea.Array(_full_tarr(['xy', 'xy', 'xy']))
+    fname = str(tmp_path / 'a.txt')
+    arr.save_txt(fname)
+    arr2 = ea.load_txt(fname)
+    _assert_tarr_round_trip(arr, arr2)
+    assert set(arr2.feed_types()) == {'xy'}
+
+
+def test_phase2_save_load_array_txt_roundtrip_mixed(tmp_path):
+    arr = ea.Array(_full_tarr(['rl', 'xy', 'lx']))
+    fname = str(tmp_path / 'a.txt')
+    arr.save_txt(fname)
+    arr2 = ea.load_txt(fname)
+    _assert_tarr_round_trip(arr, arr2)
+    assert arr2.feed_types() == {'rl', 'xy', 'lx'}
+
+
+# Legacy unversioned files in arrays/ must continue to load bit-identically.
+ARRAYS_DIR = os.path.join(os.path.dirname(__file__), '..', 'arrays')
+_LEGACY_ARRAY_FILES = sorted([
+    f for f in os.listdir(ARRAYS_DIR) if f.endswith('.txt')
+]) if os.path.isdir(ARRAYS_DIR) else []
+
+
+@pytest.mark.parametrize('fname', _LEGACY_ARRAY_FILES)
+def test_phase2_load_array_txt_legacy_bit_identical(fname):
+    """For every existing arrays/*.txt file, the loaded tarr's numeric
+    columns match a fresh np.loadtxt read of the same file byte-for-byte
+    (Phase 1 added a feed_type column; nothing else may differ).
+    """
+    path = os.path.join(ARRAYS_DIR, fname)
+    # SITES.txt is a non-array reference file (site name → code table).
+    if fname == 'SITES.txt':
+        pytest.skip("SITES.txt is not an Array file")
+    arr = ea.load_txt(path)
+
+    raw = np.loadtxt(path, dtype=bytes, comments='#').astype(str)
+    if raw[0][0].lower() == 'site':
+        raw = raw[1:]
+    if raw.ndim == 1:
+        raw = raw.reshape(1, -1)
+    ncols = raw.shape[1]
+    n = len(arr.tarr)
+    assert ncols in (5, 13, 14)
+    assert len(raw) == n
+
+    # site, x, y, z always in cols 0..3
+    np.testing.assert_array_equal(arr.tarr['site'], raw[:, 0])
+    np.testing.assert_array_equal(arr.tarr._tarr['x'], raw[:, 1].astype(float))
+    np.testing.assert_array_equal(arr.tarr._tarr['y'], raw[:, 2].astype(float))
+    np.testing.assert_array_equal(arr.tarr._tarr['z'], raw[:, 3].astype(float))
+
+    if ncols == 5:
+        # SEFD symmetric, all other numeric fields zero, feed_type='rl'
+        np.testing.assert_array_equal(arr.tarr._tarr['sefd_p1'],
+                                      raw[:, 4].astype(float))
+        np.testing.assert_array_equal(arr.tarr._tarr['sefd_p2'],
+                                      raw[:, 4].astype(float))
+        assert np.all(arr.tarr._tarr['fr_par'] == 0)
+        assert np.all(arr.tarr._tarr['d_p1'] == 0)
+        assert np.all(arr.tarr._tarr['d_p2'] == 0)
+    else:
+        np.testing.assert_array_equal(arr.tarr._tarr['sefd_p1'],
+                                      raw[:, 4].astype(float))
+        np.testing.assert_array_equal(arr.tarr._tarr['sefd_p2'],
+                                      raw[:, 5].astype(float))
+        np.testing.assert_array_equal(arr.tarr._tarr['fr_par'],
+                                      raw[:, 6].astype(float))
+        np.testing.assert_array_equal(arr.tarr._tarr['fr_elev'],
+                                      raw[:, 7].astype(float))
+        np.testing.assert_array_equal(arr.tarr._tarr['fr_off'],
+                                      raw[:, 8].astype(float))
+        d_p1_re = raw[:, 9].astype(float)
+        d_p1_im = raw[:, 10].astype(float)
+        d_p2_re = raw[:, 11].astype(float)
+        d_p2_im = raw[:, 12].astype(float)
+        np.testing.assert_array_equal(arr.tarr._tarr['d_p1'].real, d_p1_re)
+        np.testing.assert_array_equal(arr.tarr._tarr['d_p1'].imag, d_p1_im)
+        np.testing.assert_array_equal(arr.tarr._tarr['d_p2'].real, d_p2_re)
+        np.testing.assert_array_equal(arr.tarr._tarr['d_p2'].imag, d_p2_im)
+
+    # feed_type: 14-col files read it from disk; 5/13-col fall back to 'rl'
+    if ncols == 14:
+        np.testing.assert_array_equal(arr.tarr['feed_type'], raw[:, 13])
+    else:
+        assert np.all(arr.tarr['feed_type'] == 'rl')

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -444,3 +444,131 @@ def test_phase2_dterm_for_feed_wrong_feed_raises():
     arr = ea.Array(_mixed_tarr())
     with pytest.raises(ValueError, match="not in feed_type"):
         arr.dterm_for_feed('APEX', 'X')
+
+
+# ----- add_site signature extension -----------------------------------------
+
+def _empty_array():
+    return ea.Array(np.zeros(0, dtype=ehc.DTARR))
+
+
+def test_phase2_add_site_default_kwargs_bit_identical_to_legacy():
+    arr = _empty_array().add_site('A', (1.0, 2.0, 3.0))
+    row = arr.tarr[arr.tkey['A']]
+    assert row['sefd_p1'] == 10000.0
+    assert row['sefd_p2'] == 10000.0
+    assert row['d_p1'] == 0 + 0j
+    assert row['d_p2'] == 0 + 0j
+    assert str(row['feed_type']) == 'rl'
+
+
+def test_phase2_add_site_legacy_sefd_and_dr_dl_still_work():
+    arr = _empty_array().add_site('A', (1., 2., 3.),
+                                  sefd=5000, dr=0.1 + 0.2j, dl=0.3 + 0.4j)
+    row = arr.tarr[arr.tkey['A']]
+    assert row['sefd_p1'] == 5000.0
+    assert row['sefd_p2'] == 5000.0
+    assert row['d_p1'] == 0.1 + 0.2j
+    assert row['d_p2'] == 0.3 + 0.4j
+    assert str(row['feed_type']) == 'rl'
+
+
+def test_phase2_add_site_with_feed_type_xy_and_generic_sefds():
+    arr = _empty_array().add_site('A', (1., 2., 3.),
+                                  feed_type='xy',
+                                  sefd_p1=100., sefd_p2=110.,
+                                  d_p1=0.01 + 0j, d_p2=0.02 + 0j)
+    row = arr.tarr[arr.tkey['A']]
+    assert str(row['feed_type']) == 'xy'
+    assert row['sefd_p1'] == 100.0
+    assert row['sefd_p2'] == 110.0
+    assert row['d_p1'] == 0.01 + 0j
+    assert row['d_p2'] == 0.02 + 0j
+
+
+def test_phase2_add_site_dr_with_non_rl_feed_raises():
+    with pytest.raises(ValueError, match="dr/dl kwargs are only valid"):
+        _empty_array().add_site('A', (0., 0., 0.),
+                                feed_type='xy', dr=0.1 + 0j)
+
+
+def test_phase2_add_site_dl_with_non_rl_feed_raises():
+    with pytest.raises(ValueError, match="dr/dl kwargs are only valid"):
+        _empty_array().add_site('A', (0., 0., 0.),
+                                feed_type='xy', dl=0.1 + 0j)
+
+
+def test_phase2_add_site_dr_and_d_p1_both_raises():
+    with pytest.raises(ValueError, match="dr.*d_p1"):
+        _empty_array().add_site('A', (0., 0., 0.),
+                                dr=0.1 + 0j, d_p1=0.2 + 0j)
+
+
+def test_phase2_add_site_dl_and_d_p2_both_raises():
+    with pytest.raises(ValueError, match="dl.*d_p2"):
+        _empty_array().add_site('A', (0., 0., 0.),
+                                dl=0.1 + 0j, d_p2=0.2 + 0j)
+
+
+def test_phase2_add_site_sefd_and_sefd_p1_both_raises():
+    with pytest.raises(ValueError, match="sefd.*sefd_p1"):
+        _empty_array().add_site('A', (0., 0., 0.),
+                                sefd=5000, sefd_p1=100., sefd_p2=110.)
+
+
+def test_phase2_add_site_sefd_p1_without_p2_raises():
+    with pytest.raises(ValueError, match="sefd_p1 and sefd_p2"):
+        _empty_array().add_site('A', (0., 0., 0.),
+                                feed_type='xy', sefd_p1=100.)
+
+
+def test_phase2_add_site_invalid_feed_type_raises():
+    with pytest.raises(ValueError, match="feed_type must be one of"):
+        _empty_array().add_site('A', (0., 0., 0.), feed_type='zz')
+
+
+# ----- add_satellite_* signature extension ----------------------------------
+
+def test_phase2_add_satellite_tle_default_feed_type_rl():
+    tle = ['SAT1', 'line1', 'line2']
+    arr = _empty_array().add_satellite_tle(tle, sefd=10000)
+    row = arr.tarr[arr.tkey['SAT1']]
+    assert str(row['feed_type']) == 'rl'
+    assert row['sefd_p1'] == 10000.0
+    assert row['sefd_p2'] == 10000.0
+
+
+def test_phase2_add_satellite_tle_with_feed_type_xy():
+    tle = ['SAT1', 'line1', 'line2']
+    arr = _empty_array().add_satellite_tle(tle, feed_type='xy',
+                                            sefd_p1=500., sefd_p2=600.)
+    row = arr.tarr[arr.tkey['SAT1']]
+    assert str(row['feed_type']) == 'xy'
+    assert row['sefd_p1'] == 500.0
+    assert row['sefd_p2'] == 600.0
+
+
+def test_phase2_add_satellite_elements_default_feed_type_rl():
+    arr = _empty_array().add_satellite_elements('SAT2', sefd=2000)
+    row = arr.tarr[arr.tkey['SAT2']]
+    assert str(row['feed_type']) == 'rl'
+    assert row['sefd_p1'] == 2000.0
+
+
+def test_phase2_add_satellite_elements_with_feed_type_xy_and_dterms():
+    arr = _empty_array().add_satellite_elements('SAT2', feed_type='xy',
+                                                 sefd_p1=300., sefd_p2=400.,
+                                                 d_p1=0.05 + 0.01j,
+                                                 d_p2=0.06 + 0.02j)
+    row = arr.tarr[arr.tkey['SAT2']]
+    assert str(row['feed_type']) == 'xy'
+    assert row['sefd_p1'] == 300.0
+    assert row['sefd_p2'] == 400.0
+    assert row['d_p1'] == 0.05 + 0.01j
+    assert row['d_p2'] == 0.06 + 0.02j
+
+
+def test_phase2_add_satellite_tle_invalid_feed_type_raises():
+    tle = ['SAT1', 'line1', 'line2']
+    with pytest.raises(ValueError, match="feed_type must be one of"):
+        _empty_array().add_satellite_tle(tle, feed_type='qq')


### PR DESCRIPTION
Closes Phase 2 of `obsdata_mixedpol_plan_v2.md` (Checkpoint 2). Builds on Phase 1 (#254). Phase 2.5 is gated on this PR.

## What changed

- **Array query methods**: `is_homogeneous_feeds`, `feed_types`, `sefd_for_feed`, `dterm_for_feed`.
- **`add_site` / `add_satellite_tle` / `add_satellite_elements`** extended with `feed_type`, `sefd_p1`/`sefd_p2`, `d_p1`/`d_p2` kwargs. Mixing legacy and generic kwargs for the same field raises `ValueError` (`sefd` vs `sefd_p*`, `dr` vs `d_p1`, `dl` vs `d_p2`, `sefd_p1` without `sefd_p2`, `dr`/`dl` with `feed_type != 'rl'`). Bare `add_site('A', coords)` is bit-identical to today.
- **`TarrView`** wraps `Array.tarr`: column-form access of legacy R/L names raises `KeyError` on non-RL arrays, pointing at `sefd_for_feed` / `dterm_for_feed`. Homogeneous-RL arrays unchanged. Pickle, numpy interop, and recarray-equality patterns all preserved.
- **`Array.obsdata(polrep=...)`** accepts `{'stokes', 'circ', 'lin', 'mixed'}` with explicit feed-type validation. `'lin'` and `'mixed'` raise `NotImplementedError` pointing at Phase 5.
- **`save_array_txt`** emits `# ehtim array format v2` + a 14th `feed_type` column. Numeric layout unchanged. **`load_array_txt`** dispatches on column count (5/13/14) — every existing `arrays/*.txt` file loads bit-identically.
- **`save_obs_txt`** appends `feed_type` as the 14th column on the embedded tarr block; `load_obs_txt`'s Phase 1 `len==15` branch handles it.

## Tests

~78 new `test_phase2_*` tests, including a parametrized bit-identical regression over every `arrays/*.txt` file. Full suite: **1102 passed, 1 skipped** (`SITES.txt` — not an Array file). Baseline pre-PR was 1024 passed.

## Out of scope (deferred)

- `MixedPolConventionWarning` firings — Phase 3c/4
- `obs_simulate.py` mixed-feed noise model — Phase 5
- `model.py` hardcoded RR/RL/LR/LL dispatch — Phase 4
- `load_obs_uvfits` POLTYA/POLTYB read — Phase 3c (separate PR)
- Image/Movie/Model polrep widening — Phase 2.5, gated on this PR