### PR TITLE
CI: trigger on dev-backend-mixpol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [dev-backend]
+    branches: [dev-backend, dev-backend-mixpol]
   pull_request:
-    branches: [dev-backend]
+    branches: [dev-backend, dev-backend-mixpol]
 
 jobs:
   lint:


### PR DESCRIPTION
PRs targeting `dev-backend-mixpol` (e.g. #260) currently get no CI, the workflow only triggers on `dev-backend`. Adds `dev-backend-mixpol` to the `push` and `pull_request` branch filters.

Note: for `pull_request` events GitHub reads the trigger config from the **base branch**, so this has to land on `dev-backend-mixpol` to take effect. After merge, re-sync open PRs (e.g. push to #260) to start their checks.

Recommend mirroring the same one-line change onto `dev-backend` so the canonical config carries it forward.