### PR TITLE
CI: keep dev-backend-mixpol in triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [dev-backend]
+    branches: [dev-backend, dev-backend-mixpol]
   pull_request:
-    branches: [dev-backend]
+    branches: [dev-backend, dev-backend-mixpol]
 
 jobs:
   lint:


### PR DESCRIPTION
Mirrors #261 (which added `dev-backend-mixpol` to the CI triggers on `dev-backend-mixpol`) onto the `dev-backend` workflow, so the trigger isn't dropped the next time `dev-backend` is synced into `dev-backend-mixpol`, and so branches cut from `dev-backend` inherit it.

Adds `dev-backend-mixpol` to the `push` and `pull_request` branch filters in `.github/workflows/ci.yml`. No behavioral change for `dev-backend` itself.