### PR TITLE
Fix tlist/bllist collapsing to 2-D when scans share a shape

### DIFF
--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -613,7 +613,12 @@ class Obsdata:
                     data, lambda x: np.searchsorted(self.scans[:, 0], x['time'])):
                 datalist.append(np.array([obs for obs in group]))
 
-        return np.array(datalist, dtype=object)
+        # np.array(datalist, dtype=object) silently stacks into 2-D when all scans
+        # share a shape, dropping the recarray dtype; pre-allocate to force 1-D.
+        out = np.empty(len(datalist), dtype=object)
+        for i, d in enumerate(datalist):
+            out[i] = d
+        return out
 
 
     def split_obs(self, t_gather=0., scan_gather=False):
@@ -692,7 +697,10 @@ class Obsdata:
         for key, group in it.groupby(data[idx], lambda x: set((x['t1'], x['t2']))):
             datalist.append(np.array([obs for obs in group]))
 
-        return np.array(datalist, dtype=object)
+        out = np.empty(len(datalist), dtype=object)
+        for i, d in enumerate(datalist):
+            out[i] = d
+        return out
 
     def unpack_bl(self, site1, site2, fields, ang_unit='deg', debias=False, timetype=False):
         """Unpack the data over time on the selected baseline site1-site2.

--- a/tests/test_obsdata.py
+++ b/tests/test_obsdata.py
@@ -374,6 +374,56 @@ def test_bllist_unique_baseline_per_chunk(obs_direct):
         assert len(pairs) == 1
 
 
+# Regression: np.array(list_of_recarrays, dtype=object) silently stacks into 2-D
+# when every scan has the same shape, dropping the recarray dtype and breaking
+# field-name indexing downstream (e.g. bispectra() -> tdata[0]['time']). See PR #186.
+
+def test_tlist_returns_1d_object_array_single_scan(obs_direct):
+    chunks = obs_direct.tlist(t_gather=1e9)  # lump all data into one scan
+    assert chunks.ndim == 1
+    assert len(chunks) == 1
+    assert chunks[0].dtype.names is not None
+    # Field-name indexing must not raise.
+    assert chunks[0]["time"].shape == (len(chunks[0]),)
+
+
+def test_tlist_returns_1d_object_array_uniform_scans(obs_direct):
+    # Synthesize an obs whose scans all have the same baseline count by
+    # restricting to one baseline that's present at every time.
+    obs = obs_direct.copy()
+    pair = (obs.data[0]["t1"], obs.data[0]["t2"])
+    mask = (obs.data["t1"] == pair[0]) & (obs.data["t2"] == pair[1])
+    obs.data = obs.data[mask]
+    chunks = obs.tlist()
+    assert len(chunks) > 1  # multiple scans
+    assert chunks.ndim == 1
+    assert chunks[0].dtype.names is not None
+    assert chunks[0]["time"].shape == (1,)
+
+
+def test_bllist_returns_1d_object_array(obs_direct):
+    # Restrict to the (ALMA, APEX)/(ALMA, SPT)/(APEX, SPT) triangle, whose
+    # baselines all share the same row count -- triggers the auto-stacking bug.
+    obs = obs_direct.copy()
+    triangle = {"ALMA", "APEX", "SPT"}
+    mask = np.array([row["t1"] in triangle and row["t2"] in triangle for row in obs.data])
+    obs.data = obs.data[mask]
+    chunks = obs.bllist()
+    assert chunks.ndim == 1
+    assert len(chunks) == 3
+    assert chunks[0].dtype.names is not None
+    assert chunks[0]["t1"].shape == (len(chunks[0]),)
+
+
+def test_bispectra_runs_when_scans_have_uniform_shape(obs_direct):
+    # Direct repro from PR #186: bispectra() does `tdata[0]['time']`, which
+    # raised when tlist() collapsed to 2-D.
+    obs = obs_direct.copy()
+    obs.data = obs.data[obs.data["time"] == obs.data[0]["time"]]
+    bs = obs.bispectra(mode="all", count="min")
+    assert len(bs) > 0
+
+
 # ---------------------------------------------------------------------------
 # Section 5: Unpacking (unpack, unpack_dat, unpack_bl)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `Obsdata.tlist()` and `Obsdata.bllist()` returned `np.array(datalist, dtype=object)`, which silently stacks equal-shape recarrays into a 2-D ndarray and drops the structured dtype. Downstream `tdata[0]['time']` then raises `IndexError`.
- Pre-allocate the 1-D object array and assign element-by-element. Preserves numpy semantics (boolean indexing in `dynamical_imaging.py`, `np.concatenate` callers) while guaranteeing shape `(n,)`.
- Adds 4 regression tests in `tests/test_obsdata.py`: single-scan tlist, multi-scan tlist with uniform shape, bllist on a closed triangle (ALMA/APEX/SPT, all share length 72), and an end-to-end `bispectra()` smoke mirroring the repro from #186.

## Why not return a Python list (as #186 proposed)?

`dynamical_imaging.py:1197` boolean-indexes the result (`tlist[[x == j for x in idx_list]]`), which requires an ndarray. The pre-allocate idiom keeps the array interface intact.

## Test plan

- [x] `pytest tests/test_obsdata.py` — 174 passed
- [x] All 4 new tests fail on the pre-fix code, pass on the fixed code
- [x] Manual repro from #186 (`obs.bispectra(...)` on a single-scan obs) no longer raises

Closes #186.