### PR TITLE
Merge dev-backend into dev-backend-mixpol (sync through #266)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [dev-backend]
+    branches: [dev-backend, dev-backend-mixpol]
   pull_request:
-    branches: [dev-backend]
+    branches: [dev-backend, dev-backend-mixpol]
 
 jobs:
   lint:

--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -575,7 +575,7 @@ class Array:
 
         try:
             tarr_new = np.delete(tarr_old.copy(), self.tkey[site])
-        except IndexError:
+        except (KeyError, IndexError):
             raise Exception(f"could not find site {site} to delete from Array.tarr!")
 
         if site in ephem_old.keys():

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -976,7 +976,7 @@ class Image:
         if self.polrep == 'stokes':
             frac = 0.5 * np.angle(np.sum(self.qvec + 1j * self.uvec))
         elif self.polrep == 'circ':
-            frac = np.angle(np.sum(self.rlvec))
+            frac = 0.5 * np.angle(np.sum(self.rlvec))
 
         return frac
 
@@ -1785,7 +1785,7 @@ class Image:
             # TODO: are these in the right order??
             if gradtype == 'x':
                 gradarr = sx
-            if gradtype == 'y':
+            elif gradtype == 'y':
                 gradarr = sy
             else:
                 gradarr = np.hypot(sx, sy)

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -1723,149 +1723,6 @@ def chisqgrad_logamp_nfft(imvec, A, amp, sigma):
 # Regularizer and Gradient Functions
 ##################################################################################################
 
-def sflux(imvec, priorvec, flux, norm_reg=NORM_REGULARIZER):
-    """Total flux constraint
-    """
-    if norm_reg:
-        norm = flux**2
-    else:
-        norm = 1
-
-    out = -(np.sum(imvec) - flux)**2
-    return out/norm
-
-
-def sfluxgrad(imvec, priorvec, flux, norm_reg=NORM_REGULARIZER):
-    """Total flux constraint gradient
-    """
-    if norm_reg:
-        norm = flux**2
-    else:
-        norm = 1
-
-    out = -2*(np.sum(imvec) - flux)*np.ones(len(imvec))
-    return out / norm
-
-
-def scm(imvec, nx, ny, psize, flux, embed_mask, norm_reg=NORM_REGULARIZER, beam_size=None):
-    """Center-of-mass constraint
-    """
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = beam_size**2 * flux**2
-    else:
-        norm = 1
-
-    xx, yy = np.meshgrid(range(nx//2, -nx//2, -1), range(ny//2, -ny//2, -1))
-    xx = psize*xx.flatten()[embed_mask]
-    yy = psize*yy.flatten()[embed_mask]
-
-    out = -(np.sum(imvec*xx)**2 + np.sum(imvec*yy)**2)
-    return out/norm
-
-
-def scmgrad(imvec, nx, ny, psize, flux, embed_mask, norm_reg=NORM_REGULARIZER, beam_size=None):
-    """Center-of-mass constraint gradient
-    """
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = beam_size**2 * flux**2
-    else:
-        norm = 1
-
-    xx, yy = np.meshgrid(range(nx//2, -nx//2, -1), range(ny//2, -ny//2, -1))
-    xx = psize*xx.flatten()[embed_mask]
-    yy = psize*yy.flatten()[embed_mask]
-
-    out = -2*(np.sum(imvec*xx)*xx + np.sum(imvec*yy)*yy)
-    return out/norm
-
-
-def ssimple(imvec, priorvec, flux, norm_reg=NORM_REGULARIZER):
-    """Simple entropy
-    """
-    if norm_reg:
-        norm = flux
-    else:
-        norm = 1
-
-    entropy = -np.sum(imvec*np.log(imvec/priorvec))
-    return entropy/norm
-
-
-def ssimplegrad(imvec, priorvec, flux, norm_reg=NORM_REGULARIZER):
-    """Simple entropy gradient
-    """
-    if norm_reg:
-        norm = flux
-    else:
-        norm = 1
-
-    entropygrad = -np.log(imvec/priorvec) - 1
-    return entropygrad/norm
-
-
-def sl1(imvec, priorvec, flux, norm_reg=NORM_REGULARIZER):
-    """L1 norm regularizer
-    """
-    if norm_reg:
-        norm = flux
-    else:
-        norm = 1
-
-    # l1 = -np.sum(np.abs(imvec - priorvec))
-    l1 = -np.sum(np.abs(imvec))
-    return l1/norm
-
-
-def sl1grad(imvec, priorvec, flux, norm_reg=NORM_REGULARIZER):
-    """L1 norm gradient
-    """
-    if norm_reg:
-        norm = flux
-    else:
-        norm = 1
-
-    # l1grad = -np.sign(imvec - priorvec)
-    l1grad = -np.sign(imvec)
-    return l1grad/norm
-
-
-def sl1w(imvec, priorvec, flux, norm_reg=NORM_REGULARIZER, epsilon=ehc.EP):
-    """Weighted L1 norm regularizer a la SMILI
-    """
-
-    if norm_reg:
-        norm = 1  # should be ok?
-        # This is SMILI normalization
-        # norm = np.sum((np.sqrt(priorvec**2 + epsilon) + epsilon)/np.sqrt(priorvec**2 + epsilon))
-    else:
-        norm = 1
-
-    num = np.sqrt(imvec**2 + epsilon)
-    denom = np.sqrt(priorvec**2 + epsilon) + epsilon
-
-    l1w = -np.sum(num/denom)
-    return l1w/norm
-
-
-def sl1wgrad(imvec, priorvec, flux, norm_reg=NORM_REGULARIZER, epsilon=ehc.EP):
-    """Weighted L1 norm gradient
-    """
-    if norm_reg:
-        norm = 1  # should be ok?
-        # This is SMILI normalization
-        # norm = np.sum((np.sqrt(priorvec**2 + epsilon) + epsilon)/np.sqrt(priorvec**2 + epsilon))
-    else:
-        norm = 1
-
-    num = imvec / np.sqrt(imvec**2 + epsilon)
-    denom = np.sqrt(priorvec**2 + epsilon) + epsilon
-
-    l1wgrad = - num / denom
-    return l1wgrad/norm
 
 
 def fA(imvec, I_ref=1.0, alpha_A=1.0):
@@ -1882,671 +1739,428 @@ def fAgrad(imvec, I_ref=1.0, alpha_A=1.0):
     return (1.0 + alpha_A) / (I_ref * (1.0 + (np.pi*alpha_A/2.0*imvec/I_ref)**2))
 
 
-def slA(imvec, priorvec, psize, flux, beam_size=None, alpha_A=1.0, norm_reg=NORM_REGULARIZER):
-    """l_A regularizer
-    """
-
-    # The appropriate I_ref is something like the total flux divided by the # of pixels per beam
-    if beam_size is None:
-        beam_size = psize
-    I_ref = flux
-
-    if norm_reg:
-        norm_l1 = 1.0                  # as alpha_A ->0
-        norm_l0 = (beam_size/psize)**2  # as alpha_A ->\infty
-        weight_l1 = 1.0/(1.0 + alpha_A)
-        weight_l0 = alpha_A
-        norm = (norm_l1 * weight_l1 + norm_l0 * weight_l0)/(weight_l0 + weight_l1)
-    else:
-        norm = 1
-
-    return -np.sum(fA(imvec, I_ref, alpha_A))/norm
-
-
-def slAgrad(imvec, priorvec, psize, flux, beam_size=None, alpha_A=1.0, norm_reg=NORM_REGULARIZER):
-    """l_A gradient
-    """
-
-    # The appropriate I_ref is something like the total flux divided by the # of pixels per beam
-    if beam_size is None:
-        beam_size = psize
-    I_ref = flux
-
-    if norm_reg:
-        norm_l1 = 1.0                  # as alpha_A ->0
-        norm_l0 = (beam_size/psize)**2  # as alpha_A ->\infty
-        weight_l1 = 1.0/(1.0 + alpha_A)
-        weight_l0 = alpha_A
-        norm = (norm_l1 * weight_l1 + norm_l0 * weight_l0)/(weight_l0 + weight_l1)
-    else:
-        norm = 1
-
-    return -fAgrad(imvec, I_ref, alpha_A)/norm
-
-
-def sgs(imvec, priorvec, flux, norm_reg=NORM_REGULARIZER):
-    """Gull-skilling entropy
-    """
-    if norm_reg:
-        norm = flux
-    else:
-        norm = 1
-
-    entropy = np.sum(imvec - priorvec - imvec*np.log(imvec/priorvec))
-    return entropy/norm
-
-
-def sgsgrad(imvec, priorvec, flux, norm_reg=NORM_REGULARIZER):
-    """Gull-Skilling gradient
-    """
-    if norm_reg:
-        norm = flux
-    else:
-        norm = 1
-
-    entropygrad = -np.log(imvec/priorvec)
-    return entropygrad/norm
-
-# TODO: epsilon is 0 by default for backwards compatibilitys
-def stv(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None, epsilon=0.):
-    """Total variation regularizer
-    """
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = flux*psize / beam_size
-    else:
-        norm = 1
-
-    im = imvec.reshape(ny, nx)
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    out = -np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2 + epsilon))
-    return out/norm
-
-# TODO: epsilon is 0 by default for backwards compatibility
-def stvgrad(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None, epsilon=0.):
-    """Total variation gradient
-    """
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = flux*psize / beam_size
-    else:
-        norm = 1
-
-    im = imvec.reshape(ny, nx)
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
-    im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
-
-    # rotate images
-    im_r1l2 = np.roll(np.roll(impad,  1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
-    im_l1r2 = np.roll(np.roll(impad, -1, axis=0), 1, axis=1)[1:ny+1, 1:nx+1]
-
-    # add together terms and return
-    g1 = (2*im - im_l1 - im_l2) / np.sqrt((im - im_l1)**2 + (im - im_l2)**2 + epsilon)
-    g2 = (im - im_r1) / np.sqrt((im - im_r1)**2 + (im_r1l2 - im_r1)**2 + epsilon)
-    g3 = (im - im_r2) / np.sqrt((im - im_r2)**2 + (im_l1r2 - im_r2)**2 + epsilon)
-
-    # mask the first row column gradient terms that don't exist
-    mask1 = np.zeros(im.shape)
-    mask2 = np.zeros(im.shape)
-    mask1[0, :] = 1
-    mask2[:, 0] = 1
-    g2[mask1.astype(bool)] = 0
-    g3[mask2.astype(bool)] = 0
-
-    # add terms together and return
-    out = -(g1 + g2 + g3).flatten()
-    return out/norm
-
-
-def stv2(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None):
-    """Squared Total variation regularizer
-    """
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = psize**4 * flux**2 / beam_size**4
-    else:
-        norm = 1
-
-    im = imvec.reshape(ny, nx)
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    out = -np.sum((im_l1 - im)**2 + (im_l2 - im)**2)
-    return out/norm
-
-
-def stv2grad(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None):
-    """Squared Total variation gradient
-    """
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = psize**4 * flux**2 / beam_size**4
-    else:
-        norm = 1
-
-    im = imvec.reshape(ny, nx)
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
-    im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
-
-    g1 = (2*im - im_l1 - im_l2)
-    g2 = (im - im_r1)
-    g3 = (im - im_r2)
-
-    # mask the first row column gradient terms that don't exist
-    mask1 = np.zeros(im.shape)
-    mask2 = np.zeros(im.shape)
-    mask1[0, :] = 1
-    mask2[:, 0] = 1
-    g2[mask1.astype(bool)] = 0
-    g3[mask2.astype(bool)] = 0
-
-    # add together terms and return
-    out = -2*(g1 + g2 + g3).flatten()
-    return out/norm
-
-
-def stvlog(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None, epsilon=0.):
-    """Total variation regularizer applied to log(imvec).
-
-    Forwards to stv with the log-transformed image and a transformed flux
-    `logflux = npix * |log(flux/npix)|` so the regularizer has a sensible
-    norm when norm_reg=True.
-    """
-    npix = nx * ny
-    logflux = npix * np.abs(np.log(flux / npix))
-    return stv(np.log(imvec), nx, ny, psize, logflux,
-               norm_reg=norm_reg, beam_size=beam_size, epsilon=epsilon)
-
-
-def stvloggrad(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None, epsilon=0.):
-    """Gradient of stvlog: applies stvgrad to log(imvec), then chain rule 1/imvec.
-    """
-    npix = nx * ny
-    logflux = npix * np.abs(np.log(flux / npix))
-    g = stvgrad(np.log(imvec), nx, ny, psize, logflux,
-                norm_reg=norm_reg, beam_size=beam_size, epsilon=epsilon)
-    return g / imvec
-
-
-def stv2log(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None):
-    """Squared total variation regularizer applied to log(imvec).
-
-    Forwards to stv2 with the log-transformed image and the transformed flux
-    used by stvlog.
-    """
-    npix = nx * ny
-    logflux = npix * np.abs(np.log(flux / npix))
-    return stv2(np.log(imvec), nx, ny, psize, logflux,
-                norm_reg=norm_reg, beam_size=beam_size)
-
-
-def stv2loggrad(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None):
-    """Gradient of stv2log: applies stv2grad to log(imvec), then chain rule 1/imvec.
-    """
-    npix = nx * ny
-    logflux = npix * np.abs(np.log(flux / npix))
-    g = stv2grad(np.log(imvec), nx, ny, psize, logflux,
-                 norm_reg=norm_reg, beam_size=beam_size)
-    return g / imvec
-
-
-def spatch(imvec, priorvec, flux, norm_reg=NORM_REGULARIZER):
-    """Patch prior regularizer
-    """
-    if norm_reg:
-        norm = flux**2
-    else:
-        norm = 1
-
-    out = -0.5*np.sum((imvec - priorvec) ** 2)
-    return out/norm
-
-
-def spatchgrad(imvec, priorvec, flux, norm_reg=NORM_REGULARIZER):
-    """Patch prior gradient
-    """
-    if norm_reg:
-        norm = flux**2
-    else:
-        norm = 1
-
-    out = -(imvec - priorvec)
-    return out/norm
-
-# TODO FIGURE OUT NORMALIZATIONS FOR COMPACT 1 & 2 REGULARIZERS
-
-
-def scompact(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None):
-    """I r^2 source size regularizer
-    """
-
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = flux * (beam_size**2)
-    else:
-        norm = 1
-
-    im = imvec.reshape(ny, nx)
-
-    xx, yy = np.meshgrid(range(nx), range(ny))
-    xx = xx - (nx-1)/2.0
-    yy = yy - (ny-1)/2.0
-    xxpsize = xx * psize
-    yypsize = yy * psize
-
-    x0 = np.sum(np.sum(im * xxpsize))/flux
-    y0 = np.sum(np.sum(im * yypsize))/flux
-
-    out = -np.sum(np.sum(im * ((xxpsize - x0)**2 + (yypsize - y0)**2)))
-    return out/norm
-
-
-def scompactgrad(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None):
-    """Gradient for I r^2 source size regularizer
-    """
-
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = flux * beam_size**2
-    else:
-        norm = 1
-
-    im = imvec.reshape(ny, nx)
-
-    xx, yy = np.meshgrid(range(nx), range(ny))
-    xx = xx - (nx-1)/2.0
-    yy = yy - (ny-1)/2.0
-    xxpsize = xx * psize
-    yypsize = yy * psize
-
-    x0 = np.sum(np.sum(im * xxpsize))/flux
-    y0 = np.sum(np.sum(im * yypsize))/flux
-
-    term1 = np.sum(np.sum(im * (xxpsize - x0)))
-    term2 = np.sum(np.sum(im * (yypsize - y0)))
-
-    grad = -2*xxpsize*term1 - 2*yypsize*term2 + (xxpsize - x0)**2 + (yypsize - y0)**2
-
-    return -grad.reshape(-1)/norm
-
-
-def scompact2(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None):
-    """I^2r^2 source size regularizer
-    """
-
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = flux**2 * beam_size**2
-    else:
-        norm = 1
-
-    im = imvec.reshape(ny, nx)
-
-    xx, yy = np.meshgrid(range(nx), range(ny))
-    xx = xx - (nx-1)/2.0
-    yy = yy - (ny-1)/2.0
-    xxpsize = xx * psize
-    yypsize = yy * psize
-
-    out = -np.sum(np.sum(im**2 * (xxpsize**2 + yypsize**2)))
-    return out/norm
-
-
-def scompact2grad(imvec, nx, ny, psize, flux, norm_reg=NORM_REGULARIZER, beam_size=None):
-    """Gradient for I^2r^2 source size regularizer
-    """
-
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = flux**2 * beam_size**2
-    else:
-        norm = 1
-
-    im = imvec.reshape(ny, nx)
-
-    xx, yy = np.meshgrid(range(nx), range(ny))
-    xx = xx - (nx-1)/2.0
-    yy = yy - (ny-1)/2.0
-    xxpsize = xx * psize
-    yypsize = yy * psize
-
-    grad = -2*im*(xxpsize**2 + yypsize**2)
-
-    return grad.reshape(-1)/norm
-
-
-def sgauss(imvec, xdim, ydim, psize, major, minor, PA):
-    """Gaussian source size regularizer
-    """
-
-    # major, minor and PA are all in radians
-    phi = PA
-
-    # eigenvalues of covariance matrix
-    lambda1 = minor**2./(8.*np.log(2.))
-    lambda2 = major**2./(8.*np.log(2.))
-
-    # now compute covariance matrix elements from user inputs
-    sigxx_prime = lambda1*(np.cos(phi)**2.) + lambda2*(np.sin(phi)**2.)
-    sigyy_prime = lambda1*(np.sin(phi)**2.) + lambda2*(np.cos(phi)**2.)
-    sigxy_prime = (lambda2 - lambda1)*np.cos(phi)*np.sin(phi)
-
-    # we get the dimensions and image vector
-    im = imvec.reshape(ydim, xdim)
-    xlist, ylist = np.meshgrid(range(xdim), range(ydim))
-    xlist = xlist - (xdim-1)/2.0
-    ylist = ylist - (ydim-1)/2.0
-
-    xx = xlist * psize
-    yy = ylist * psize
-
-    # the centroid parameters
-    x0 = np.sum(xx*im) / np.sum(im)
-    y0 = np.sum(yy*im) / np.sum(im)
-
-    # we calculate the elements of the covariance matrix
-    sigxx = (np.sum((xx - x0)**2.*im)/np.sum(im))
-    sigyy = (np.sum((yy - y0)**2.*im)/np.sum(im))
-    sigxy = (np.sum((xx - x0)*(yy - y0)*im)/np.sum(im))
-
-    # We calculate the regularizer #this line was CHANGED
-    rgauss = -((sigxx - sigxx_prime)**2. + (sigyy - sigyy_prime)**2. + 2*(sigxy - sigxy_prime)**2.)
-    # normalization will need to be redone, right now requires alpha~1000
-    rgauss = rgauss/(major**2. * minor**2.)
-    return rgauss
-
-
-def sgauss_grad(imvec, xdim, ydim, psize, major, minor, PA):
-    """Gradient for Gaussian source size regularizer
-    """
-
-    # major, minor and PA are all in radians
-    phi = PA
-
-    # computing eigenvalues of the covariance matrix
-    lambda1 = (minor**2.)/(8.*np.log(2.))
-    lambda2 = (major**2.)/(8.*np.log(2.))
-
-    # now compute covariance matrix elements from user inputs
-
-    sigxx_prime = lambda1*(np.cos(phi)**2.) + lambda2*(np.sin(phi)**2.)
-    sigyy_prime = lambda1*(np.sin(phi)**2.) + lambda2*(np.cos(phi)**2.)
-    sigxy_prime = (lambda2 - lambda1)*np.cos(phi)*np.sin(phi)
-
-    # we get the dimensions and image vector
-    im = imvec.reshape(ydim, xdim)
-    xlist, ylist = np.meshgrid(range(xdim), range(ydim))
-    xlist = xlist - (xdim-1)/2.0
-    ylist = ylist - (ydim-1)/2.0
-
-    xx = xlist * psize
-    yy = ylist * psize
-
-    # the centroid parameters
-    x0 = np.sum(xx*im) / np.sum(im)
-    y0 = np.sum(yy*im) / np.sum(im)
-
-    # we calculate the elements of the covariance matrix of the image
-    sigxx = (np.sum((xx - x0)**2.*im)/np.sum(im))
-    sigyy = (np.sum((yy - y0)**2.*im)/np.sum(im))
-    sigxy = (np.sum((xx - x0)*(yy - y0)*im)/np.sum(im))
-
-    # gradients of covariance matrix elements
-    # d(sig_ab)/d(im_k) = [(a_k - a0)(b_k - b0) - sig_ab] / sum(im)
-    # cross-term through centroid dependence sums to zero by definition of centroid
-    S = np.sum(im)
-    dxx = ((xx - x0)**2. - sigxx) / S
-    dyy = ((yy - y0)**2. - sigyy) / S
-    dxy = ((xx - x0)*(yy - y0) - sigxy) / S
-
-    # gradient of the regularizer #this line was CHANGED
-    drgauss = (2.*(sigxx - sigxx_prime)*dxx +
-               2.*(sigyy - sigyy_prime)*dyy +
-               4.*(sigxy - sigxy_prime)*dxy)
-
-    # normalization will need to be redone, right now requires alpha~1000
-    drgauss = drgauss/(major**2. * minor**2.)
-
-    return -drgauss.reshape(-1)
 
 
 ##################################################################################################
-# Imager-backend wrappers
+# Stokes-I regularizers
 #
-# Each `reg_X` / `reggrad_X` adapts an `sX` / `sXgrad` regularizer above to the
-# uniform `(imvec, mask, **kwargs)` signature used by the `_REGULARIZER_DISPATCH`
-# table in `imager_backend.py`. The wrappers add the sign convention (the
-# imager minimizes `-regularizer`), unpack kwargs into the leaf's positional
-# args, and handle the embed-pre / mask-post-slice pattern for spatial regs.
+# Each `reg_X` / `reggrad_X` implements a Stokes-I regularizer with the uniform
+# `(imvec, mask, **kwargs)` signature used by the `_REGULARIZER_DISPATCH` table
+# in `imager_backend.py`. Each returns the penalty value (positive; the imager
+# solver minimises it). Spatial regularizers (cm, tv, tvlog, tv2, tv2log,
+# compact, compact2, rgauss) use the embed-pre / mask-post-slice pattern; flat
+# regularizers (flux, simple, l1, l1w, lA, gs, patch) operate directly.
 ##################################################################################################
 
 
 def reg_flux(imvec, mask, **kwargs):
-    return -sflux(imvec, kwargs['nprior'], kwargs['flux'],
-                  norm_reg=kwargs.get('norm_reg', True))
+    flux = kwargs['flux']
+    norm = flux**2 if kwargs.get('norm_reg', True) else 1
+    return (np.sum(imvec) - flux)**2 / norm
 
 
 def reggrad_flux(imvec, mask, **kwargs):
-    return -sfluxgrad(imvec, kwargs['nprior'], kwargs['flux'],
-                      norm_reg=kwargs.get('norm_reg', True))
+    flux = kwargs['flux']
+    norm = flux**2 if kwargs.get('norm_reg', True) else 1
+    return 2 * (np.sum(imvec) - flux) * np.ones(len(imvec)) / norm
 
 
 def reg_simple(imvec, mask, **kwargs):
-    return -ssimple(imvec, kwargs['nprior'], kwargs['flux'],
-                    norm_reg=kwargs.get('norm_reg', True))
+    priorvec = kwargs['nprior']
+    flux = kwargs['flux']
+    norm = flux if kwargs.get('norm_reg', True) else 1
+    return np.sum(imvec * np.log(imvec / priorvec)) / norm
 
 
 def reggrad_simple(imvec, mask, **kwargs):
-    return -ssimplegrad(imvec, kwargs['nprior'], kwargs['flux'],
-                        norm_reg=kwargs.get('norm_reg', True))
+    priorvec = kwargs['nprior']
+    flux = kwargs['flux']
+    norm = flux if kwargs.get('norm_reg', True) else 1
+    return (np.log(imvec / priorvec) + 1) / norm
 
 
 def reg_l1(imvec, mask, **kwargs):
-    return -sl1(imvec, kwargs['nprior'], kwargs['flux'],
-                norm_reg=kwargs.get('norm_reg', True))
+    flux = kwargs['flux']
+    norm = flux if kwargs.get('norm_reg', True) else 1
+    return np.sum(np.abs(imvec)) / norm
 
 
 def reggrad_l1(imvec, mask, **kwargs):
-    return -sl1grad(imvec, kwargs['nprior'], kwargs['flux'],
-                    norm_reg=kwargs.get('norm_reg', True))
+    flux = kwargs['flux']
+    norm = flux if kwargs.get('norm_reg', True) else 1
+    return np.sign(imvec) / norm
 
 
 def reg_l1w(imvec, mask, **kwargs):
-    return -sl1w(imvec, kwargs['nprior'], kwargs['flux'],
-                 norm_reg=kwargs.get('norm_reg', True))
+    priorvec = kwargs['nprior']
+    epsilon = ehc.EP
+    norm = 1  # placeholder: legacy sl1w normalized by unity in both norm_reg branches
+    num = np.sqrt(imvec**2 + epsilon)
+    denom = np.sqrt(priorvec**2 + epsilon) + epsilon
+    return np.sum(num / denom) / norm
 
 
 def reggrad_l1w(imvec, mask, **kwargs):
-    return -sl1wgrad(imvec, kwargs['nprior'], kwargs['flux'],
-                     norm_reg=kwargs.get('norm_reg', True))
+    priorvec = kwargs['nprior']
+    epsilon = ehc.EP
+    norm = 1  # placeholder: matches reg_l1w
+    num = imvec / np.sqrt(imvec**2 + epsilon)
+    denom = np.sqrt(priorvec**2 + epsilon) + epsilon
+    return num / denom / norm
 
 
 def reg_lA(imvec, mask, **kwargs):
-    return -slA(imvec, kwargs['nprior'], kwargs['psize'], kwargs['flux'],
-                kwargs.get('beam_size'), kwargs.get('alpha_A', 1.0),
-                kwargs.get('norm_reg', True))
+    psize = kwargs['psize']
+    flux = kwargs['flux']
+    beam_size = kwargs.get('beam_size') or psize
+    alpha_A = kwargs.get('alpha_A', 1.0)
+    if kwargs.get('norm_reg', True):
+        norm_l1 = 1.0
+        norm_l0 = (beam_size / psize)**2
+        weight_l1 = 1.0 / (1.0 + alpha_A)
+        weight_l0 = alpha_A
+        norm = (norm_l1 * weight_l1 + norm_l0 * weight_l0) / (weight_l0 + weight_l1)
+    else:
+        norm = 1
+    return np.sum(fA(imvec, flux, alpha_A)) / norm
 
 
 def reggrad_lA(imvec, mask, **kwargs):
-    return -slAgrad(imvec, kwargs['nprior'], kwargs['psize'], kwargs['flux'],
-                    kwargs.get('beam_size'), kwargs.get('alpha_A', 1.0),
-                    kwargs.get('norm_reg', True))
+    psize = kwargs['psize']
+    flux = kwargs['flux']
+    beam_size = kwargs.get('beam_size') or psize
+    alpha_A = kwargs.get('alpha_A', 1.0)
+    if kwargs.get('norm_reg', True):
+        norm_l1 = 1.0
+        norm_l0 = (beam_size / psize)**2
+        weight_l1 = 1.0 / (1.0 + alpha_A)
+        weight_l0 = alpha_A
+        norm = (norm_l1 * weight_l1 + norm_l0 * weight_l0) / (weight_l0 + weight_l1)
+    else:
+        norm = 1
+    return fAgrad(imvec, flux, alpha_A) / norm
 
 
 def reg_gs(imvec, mask, **kwargs):
-    return -sgs(imvec, kwargs['nprior'], kwargs['flux'],
-                norm_reg=kwargs.get('norm_reg', True))
+    priorvec = kwargs['nprior']
+    flux = kwargs['flux']
+    norm = flux if kwargs.get('norm_reg', True) else 1
+    return -np.sum(imvec - priorvec - imvec * np.log(imvec / priorvec)) / norm
 
 
 def reggrad_gs(imvec, mask, **kwargs):
-    return -sgsgrad(imvec, kwargs['nprior'], kwargs['flux'],
-                    norm_reg=kwargs.get('norm_reg', True))
+    priorvec = kwargs['nprior']
+    flux = kwargs['flux']
+    norm = flux if kwargs.get('norm_reg', True) else 1
+    return np.log(imvec / priorvec) / norm
 
 
 def reg_patch(imvec, mask, **kwargs):
-    return -spatch(imvec, kwargs['nprior'], kwargs['flux'],
-                   norm_reg=kwargs.get('norm_reg', True))
+    priorvec = kwargs['nprior']
+    flux = kwargs['flux']
+    norm = flux**2 if kwargs.get('norm_reg', True) else 1
+    return 0.5 * np.sum((imvec - priorvec)**2) / norm
 
 
 def reggrad_patch(imvec, mask, **kwargs):
-    return -spatchgrad(imvec, kwargs['nprior'], kwargs['flux'],
-                       norm_reg=kwargs.get('norm_reg', True))
+    priorvec = kwargs['nprior']
+    flux = kwargs['flux']
+    norm = flux**2 if kwargs.get('norm_reg', True) else 1
+    return (imvec - priorvec) / norm
 
 
-# scm / scmgrad take the embed mask as a positional and handle masking internally,
-# so these wrappers skip the embed-pre / mask-post pattern used by other spatial regs.
 def reg_cm(imvec, mask, **kwargs):
-    return -scm(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
-                kwargs['flux'], mask,
-                norm_reg=kwargs.get('norm_reg', True),
-                beam_size=kwargs.get('beam_size'))
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, randomfloor=True)
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    flux = kwargs['flux']
+    beam_size = kwargs.get('beam_size') or psize
+    norm = beam_size**2 * flux**2 if kwargs.get('norm_reg', True) else 1
+    xx, yy = np.meshgrid(range(nx//2, -nx//2, -1), range(ny//2, -ny//2, -1))
+    xx = psize * xx.flatten()
+    yy = psize * yy.flatten()
+    return (np.sum(imvec*xx)**2 + np.sum(imvec*yy)**2) / norm
 
 
 def reggrad_cm(imvec, mask, **kwargs):
-    return -scmgrad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
-                    kwargs['flux'], mask,
-                    norm_reg=kwargs.get('norm_reg', True),
-                    beam_size=kwargs.get('beam_size'))
+    if np.any(np.invert(mask)):
+        imvec = embed(imvec, mask, randomfloor=True)
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    flux = kwargs['flux']
+    beam_size = kwargs.get('beam_size') or psize
+    norm = beam_size**2 * flux**2 if kwargs.get('norm_reg', True) else 1
+    xx, yy = np.meshgrid(range(nx//2, -nx//2, -1), range(ny//2, -ny//2, -1))
+    xx = psize * xx.flatten()
+    yy = psize * yy.flatten()
+    g = 2 * (np.sum(imvec*xx)*xx + np.sum(imvec*yy)*yy) / norm
+    return g[mask]
 
 
 def reg_tv(imvec, mask, **kwargs):
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
-    return -stv(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
-                norm_reg=kwargs.get('norm_reg', True),
-                beam_size=kwargs.get('beam_size'),
-                epsilon=kwargs.get('epsilon_tv', 0.))
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    flux = kwargs['flux']
+    beam_size = kwargs.get('beam_size') or psize
+    epsilon = kwargs.get('epsilon_tv', 0.)
+    norm = flux * psize / beam_size if kwargs.get('norm_reg', True) else 1
+    im = imvec.reshape(ny, nx)
+    impad = np.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    return np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2 + epsilon)) / norm
 
 
 def reggrad_tv(imvec, mask, **kwargs):
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
-    g = -stvgrad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
-                 norm_reg=kwargs.get('norm_reg', True),
-                 beam_size=kwargs.get('beam_size'),
-                 epsilon=kwargs.get('epsilon_tv', 0.))
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    flux = kwargs['flux']
+    beam_size = kwargs.get('beam_size') or psize
+    epsilon = kwargs.get('epsilon_tv', 0.)
+    norm = flux * psize / beam_size if kwargs.get('norm_reg', True) else 1
+    im = imvec.reshape(ny, nx)
+    impad = np.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
+    im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
+    im_r1l2 = np.roll(np.roll(impad,  1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
+    im_l1r2 = np.roll(np.roll(impad, -1, axis=0),  1, axis=1)[1:ny+1, 1:nx+1]
+    g1 = (2*im - im_l1 - im_l2) / np.sqrt((im - im_l1)**2 + (im - im_l2)**2 + epsilon)
+    g2 = (im - im_r1) / np.sqrt((im - im_r1)**2 + (im_r1l2 - im_r1)**2 + epsilon)
+    g3 = (im - im_r2) / np.sqrt((im - im_r2)**2 + (im_l1r2 - im_r2)**2 + epsilon)
+    mask1 = np.zeros(im.shape)
+    mask2 = np.zeros(im.shape)
+    mask1[0, :] = 1
+    mask2[:, 0] = 1
+    g2[mask1.astype(bool)] = 0
+    g3[mask2.astype(bool)] = 0
+    g = (g1 + g2 + g3).flatten() / norm
     return g[mask]
 
 
 # tvlog / tv2log use clipfloor=epsilon_tv (not the default 0) so the log
-# transform inside stvlog / stv2log stays defined where mask filled in values.
+# transform stays defined where mask filled in values.
 def reg_tvlog(imvec, mask, **kwargs):
     epsilon = kwargs.get('epsilon_tv', 0.)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
-    return -stvlog(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
-                   norm_reg=kwargs.get('norm_reg', True),
-                   beam_size=kwargs.get('beam_size'),
-                   epsilon=epsilon)
+    nx, ny = kwargs['xdim'], kwargs['ydim']
+    flux = kwargs['flux']
+    npix = nx * ny
+    logflux = npix * np.abs(np.log(flux / npix))
+    log_kwargs = dict(kwargs)
+    log_kwargs['flux'] = logflux
+    return reg_tv(np.log(imvec), np.ones_like(imvec, dtype=bool), **log_kwargs)
 
 
 def reggrad_tvlog(imvec, mask, **kwargs):
     epsilon = kwargs.get('epsilon_tv', 0.)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
-    g = -stvloggrad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
-                    norm_reg=kwargs.get('norm_reg', True),
-                    beam_size=kwargs.get('beam_size'),
-                    epsilon=epsilon)
+    nx, ny = kwargs['xdim'], kwargs['ydim']
+    flux = kwargs['flux']
+    npix = nx * ny
+    logflux = npix * np.abs(np.log(flux / npix))
+    log_kwargs = dict(kwargs)
+    log_kwargs['flux'] = logflux
+    g = reggrad_tv(np.log(imvec), np.ones_like(imvec, dtype=bool), **log_kwargs) / imvec
     return g[mask]
 
 
 def reg_tv2(imvec, mask, **kwargs):
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
-    return -stv2(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
-                 norm_reg=kwargs.get('norm_reg', True),
-                 beam_size=kwargs.get('beam_size'))
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    flux = kwargs['flux']
+    beam_size = kwargs.get('beam_size') or psize
+    norm = psize**4 * flux**2 / beam_size**4 if kwargs.get('norm_reg', True) else 1
+    im = imvec.reshape(ny, nx)
+    impad = np.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    return np.sum((im_l1 - im)**2 + (im_l2 - im)**2) / norm
 
 
 def reggrad_tv2(imvec, mask, **kwargs):
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
-    g = -stv2grad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
-                  norm_reg=kwargs.get('norm_reg', True),
-                  beam_size=kwargs.get('beam_size'))
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    flux = kwargs['flux']
+    beam_size = kwargs.get('beam_size') or psize
+    norm = psize**4 * flux**2 / beam_size**4 if kwargs.get('norm_reg', True) else 1
+    im = imvec.reshape(ny, nx)
+    impad = np.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
+    im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
+    g1 = 2*im - im_l1 - im_l2
+    g2 = im - im_r1
+    g3 = im - im_r2
+    mask1 = np.zeros(im.shape)
+    mask2 = np.zeros(im.shape)
+    mask1[0, :] = 1
+    mask2[:, 0] = 1
+    g2[mask1.astype(bool)] = 0
+    g3[mask2.astype(bool)] = 0
+    g = 2 * (g1 + g2 + g3).flatten() / norm
     return g[mask]
 
 
 def reg_tv2log(imvec, mask, **kwargs):
+    epsilon = kwargs.get('epsilon_tv', 0.)
     if np.any(np.invert(mask)):
-        imvec = embed(imvec, mask, randomfloor=True)
-    return -stv2log(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
-                    norm_reg=kwargs.get('norm_reg', True),
-                    beam_size=kwargs.get('beam_size'))
+        imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
+    nx, ny = kwargs['xdim'], kwargs['ydim']
+    flux = kwargs['flux']
+    npix = nx * ny
+    logflux = npix * np.abs(np.log(flux / npix))
+    log_kwargs = dict(kwargs)
+    log_kwargs['flux'] = logflux
+    return reg_tv2(np.log(imvec), np.ones_like(imvec, dtype=bool), **log_kwargs)
 
 
 def reggrad_tv2log(imvec, mask, **kwargs):
+    epsilon = kwargs.get('epsilon_tv', 0.)
     if np.any(np.invert(mask)):
-        imvec = embed(imvec, mask, randomfloor=True)
-    g = -stv2loggrad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
-                     norm_reg=kwargs.get('norm_reg', True),
-                     beam_size=kwargs.get('beam_size'))
+        imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
+    nx, ny = kwargs['xdim'], kwargs['ydim']
+    flux = kwargs['flux']
+    npix = nx * ny
+    logflux = npix * np.abs(np.log(flux / npix))
+    log_kwargs = dict(kwargs)
+    log_kwargs['flux'] = logflux
+    g = reggrad_tv2(np.log(imvec), np.ones_like(imvec, dtype=bool), **log_kwargs) / imvec
     return g[mask]
 
 
+# TODO: figure out normalizations for compact and compact2 regularizers
+# (carried over from legacy code; not formally verified).
 def reg_compact(imvec, mask, **kwargs):
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
-    return -scompact(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
-                     norm_reg=kwargs.get('norm_reg', True))
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    flux = kwargs['flux']
+    beam_size = kwargs.get('beam_size') or psize
+    norm = flux * beam_size**2 if kwargs.get('norm_reg', True) else 1
+    im = imvec.reshape(ny, nx)
+    xx, yy = np.meshgrid(range(nx), range(ny))
+    xxpsize = (xx - (nx-1)/2.0) * psize
+    yypsize = (yy - (ny-1)/2.0) * psize
+    x0 = np.sum(im * xxpsize) / flux
+    y0 = np.sum(im * yypsize) / flux
+    return np.sum(im * ((xxpsize - x0)**2 + (yypsize - y0)**2)) / norm
 
 
 def reggrad_compact(imvec, mask, **kwargs):
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
-    g = -scompactgrad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
-                      norm_reg=kwargs.get('norm_reg', True))
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    flux = kwargs['flux']
+    beam_size = kwargs.get('beam_size') or psize
+    norm = flux * beam_size**2 if kwargs.get('norm_reg', True) else 1
+    im = imvec.reshape(ny, nx)
+    xx, yy = np.meshgrid(range(nx), range(ny))
+    xxpsize = (xx - (nx-1)/2.0) * psize
+    yypsize = (yy - (ny-1)/2.0) * psize
+    x0 = np.sum(im * xxpsize) / flux
+    y0 = np.sum(im * yypsize) / flux
+    term1 = np.sum(im * (xxpsize - x0))
+    term2 = np.sum(im * (yypsize - y0))
+    grad = -2*xxpsize*term1 - 2*yypsize*term2 + (xxpsize - x0)**2 + (yypsize - y0)**2
+    g = grad.reshape(-1) / norm
     return g[mask]
 
 
 def reg_compact2(imvec, mask, **kwargs):
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
-    return -scompact2(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
-                      norm_reg=kwargs.get('norm_reg', True))
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    flux = kwargs['flux']
+    beam_size = kwargs.get('beam_size') or psize
+    norm = flux**2 * beam_size**2 if kwargs.get('norm_reg', True) else 1
+    im = imvec.reshape(ny, nx)
+    xx, yy = np.meshgrid(range(nx), range(ny))
+    xxpsize = (xx - (nx-1)/2.0) * psize
+    yypsize = (yy - (ny-1)/2.0) * psize
+    return np.sum(im**2 * (xxpsize**2 + yypsize**2)) / norm
 
 
 def reggrad_compact2(imvec, mask, **kwargs):
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
-    g = -scompact2grad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'], kwargs['flux'],
-                       norm_reg=kwargs.get('norm_reg', True))
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    flux = kwargs['flux']
+    beam_size = kwargs.get('beam_size') or psize
+    norm = flux**2 * beam_size**2 if kwargs.get('norm_reg', True) else 1
+    im = imvec.reshape(ny, nx)
+    xx, yy = np.meshgrid(range(nx), range(ny))
+    xxpsize = (xx - (nx-1)/2.0) * psize
+    yypsize = (yy - (ny-1)/2.0) * psize
+    g = 2 * im * (xxpsize**2 + yypsize**2)
+    g = g.reshape(-1) / norm
     return g[mask]
 
 
 def reg_rgauss(imvec, mask, **kwargs):
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
-    return -sgauss(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
-                   major=kwargs.get('major', 1.0),
-                   minor=kwargs.get('minor', 1.0),
-                   PA=kwargs.get('PA', 1.0))
+    xdim, ydim, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    major = kwargs.get('major', 1.0)
+    minor = kwargs.get('minor', 1.0)
+    phi = kwargs.get('PA', 1.0)
+    lambda1 = minor**2 / (8 * np.log(2))
+    lambda2 = major**2 / (8 * np.log(2))
+    sigxx_prime = lambda1 * np.cos(phi)**2 + lambda2 * np.sin(phi)**2
+    sigyy_prime = lambda1 * np.sin(phi)**2 + lambda2 * np.cos(phi)**2
+    sigxy_prime = (lambda2 - lambda1) * np.cos(phi) * np.sin(phi)
+    im = imvec.reshape(ydim, xdim)
+    xlist, ylist = np.meshgrid(range(xdim), range(ydim))
+    xx = (xlist - (xdim-1)/2.0) * psize
+    yy = (ylist - (ydim-1)/2.0) * psize
+    S = np.sum(im)
+    x0 = np.sum(xx * im) / S
+    y0 = np.sum(yy * im) / S
+    sigxx = np.sum((xx - x0)**2 * im) / S
+    sigyy = np.sum((yy - y0)**2 * im) / S
+    sigxy = np.sum((xx - x0) * (yy - y0) * im) / S
+    rgauss = (sigxx - sigxx_prime)**2 + (sigyy - sigyy_prime)**2 + 2*(sigxy - sigxy_prime)**2
+    # reg_rgauss has no norm_reg option; always normalized by major^2 * minor^2.
+    return rgauss / (major**2 * minor**2)
 
 
 def reggrad_rgauss(imvec, mask, **kwargs):
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
-    g = -sgauss_grad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
-                     kwargs.get('major', 1.0),
-                     kwargs.get('minor', 1.0),
-                     kwargs.get('PA', 1.0))
+    xdim, ydim, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    major = kwargs.get('major', 1.0)
+    minor = kwargs.get('minor', 1.0)
+    phi = kwargs.get('PA', 1.0)
+    lambda1 = minor**2 / (8 * np.log(2))
+    lambda2 = major**2 / (8 * np.log(2))
+    sigxx_prime = lambda1 * np.cos(phi)**2 + lambda2 * np.sin(phi)**2
+    sigyy_prime = lambda1 * np.sin(phi)**2 + lambda2 * np.cos(phi)**2
+    sigxy_prime = (lambda2 - lambda1) * np.cos(phi) * np.sin(phi)
+    im = imvec.reshape(ydim, xdim)
+    xlist, ylist = np.meshgrid(range(xdim), range(ydim))
+    xx = (xlist - (xdim-1)/2.0) * psize
+    yy = (ylist - (ydim-1)/2.0) * psize
+    S = np.sum(im)
+    x0 = np.sum(xx * im) / S
+    y0 = np.sum(yy * im) / S
+    sigxx = np.sum((xx - x0)**2 * im) / S
+    sigyy = np.sum((yy - y0)**2 * im) / S
+    sigxy = np.sum((xx - x0) * (yy - y0) * im) / S
+    dxx = ((xx - x0)**2 - sigxx) / S
+    dyy = ((yy - y0)**2 - sigyy) / S
+    dxy = ((xx - x0) * (yy - y0) - sigxy) / S
+    drgauss = (2 * (sigxx - sigxx_prime) * dxx +
+               2 * (sigyy - sigyy_prime) * dyy +
+               4 * (sigxy - sigxy_prime) * dxy)
+    # reggrad_rgauss has no norm_reg option; always normalized by major^2 * minor^2.
+    g = drgauss.flatten() / (major**2 * minor**2)
     return g[mask]
 
 

--- a/ehtim/imaging/multifreq_imager_utils.py
+++ b/ehtim/imaging/multifreq_imager_utils.py
@@ -213,123 +213,70 @@ def regularizergrad_mf(imvec, nprior, mask, xdim, ydim, psize, stype, **kwargs):
                                         xdim=xdim, ydim=ydim, psize=psize, **kwargs)
 
 
-def l2_spec(imvec, priorvec, norm_reg=NORM_REGULARIZER):
-    """L2 norm on spectral index w/r/t prior
-    """
-
-    if norm_reg:
-        norm = float(len(imvec))
-    else:
-        norm = 1
-
-    out = -(np.sum((imvec - priorvec)**2))
-    return out/norm
-
-def l2_spec_grad(imvec, priorvec, norm_reg=NORM_REGULARIZER):
-    """L2 norm on spectral index w/r/t prior
-    """
-
-    if norm_reg:
-        norm = float(len(imvec))
-    else:
-        norm = 1
-    out = -2*(imvec - priorvec)
-    # PIN TODO HOW WAS THIS WRONG???????????
-#    out = -2*(np.sum(imvec - priorvec))*np.ones(len(imvec))
-    return out/norm
-
-
-def tv_spec(imvec, nx, ny, psize, norm_reg=NORM_REGULARIZER, beam_size=None):
-    """Total variation regularizer
-    """
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = len(imvec)*psize / beam_size
-    else:
-        norm = 1
-
-    im = imvec.reshape(ny, nx)
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    out = -np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2 + EPSILON))
-
-    return out/norm
-
-def tv_spec_grad(imvec, nx, ny, psize, norm_reg=NORM_REGULARIZER, beam_size=None):
-    """Total variation gradient
-    """
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = len(imvec)*psize / beam_size
-    else:
-        norm = 1
-
-    im = imvec.reshape(ny,nx)
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
-    im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
-
-    #rotate images
-    im_r1l2 = np.roll(np.roll(impad,  1, axis=0),-1, axis=1)[1:ny+1, 1:nx+1]
-    im_l1r2 = np.roll(np.roll(impad, -1, axis=0), 1, axis=1)[1:ny+1, 1:nx+1]
-
-    #add together terms and return
-    g1 = (2*im - im_l1 - im_l2) / np.sqrt((im - im_l1)**2 + (im - im_l2)**2 + EPSILON)
-    g2 = (im - im_r1) / np.sqrt((im - im_r1)**2 + (im_r1l2 - im_r1)**2 + EPSILON)
-    g3 = (im - im_r2) / np.sqrt((im - im_r2)**2 + (im_l1r2 - im_r2)**2 + EPSILON)
-
-    #mask the first row column gradient terms that don't exist
-    mask1 = np.zeros(im.shape)
-    mask2 = np.zeros(im.shape)
-    mask1[0,:] = 1
-    mask2[:,0] = 1
-    g2[mask1.astype(bool)] = 0
-    g3[mask2.astype(bool)] = 0
-
-    # add terms together and return
-    out= -(g1 + g2 + g3).flatten()
-    return out/norm
-
-
 ##################################################################################################
-# Imager-backend wrappers
+# Multifrequency regularizers
 #
-# Same pattern as `reg_X` / `reggrad_X` in `imager_utils.py`: each wrapper adapts
-# `l2_spec` / `tv_spec` to the uniform `(imvec, mask, **kwargs)` signature used by
-# `_REGULARIZER_DISPATCH`. tv_spec uses clipfloor=0 (not the default) and
-# randomfloor=False for embed since spectral-index images can be negative.
+# Each `reg_X` / `reggrad_X` implements a spectral-index regularizer with the
+# uniform `(imvec, mask, **kwargs)` signature used by the `_REGULARIZER_DISPATCH`
+# table in `imager_backend.py`. The four entry points (`reg_l2_spec`,
+# `reggrad_l2_spec`, `reg_tv_spec`, `reggrad_tv_spec`) cover six spectral slots
+# each (alpha, beta, rm, cm, alphap, betap) via the `spectral_slot()` runtime
+# dispatch. `reg_tv_spec` uses `clipfloor=0` (not the default) and
+# `randomfloor=False` for embed since spectral-index images can be negative.
 ##################################################################################################
 
 
 def reg_l2_spec(imvec, mask, **kwargs):
-    return -l2_spec(imvec, kwargs['nprior'], norm_reg=kwargs.get('norm_reg', True))
+    priorvec = kwargs['nprior']
+    norm = float(len(imvec)) if kwargs.get('norm_reg', True) else 1
+    return np.sum((imvec - priorvec)**2) / norm
 
 
 def reggrad_l2_spec(imvec, mask, **kwargs):
-    return -l2_spec_grad(imvec, kwargs['nprior'], norm_reg=kwargs.get('norm_reg', True))
+    priorvec = kwargs['nprior']
+    norm = float(len(imvec)) if kwargs.get('norm_reg', True) else 1
+    return 2 * (imvec - priorvec) / norm
 
 
 def reg_tv_spec(imvec, mask, **kwargs):
     from ehtim.imaging.imager_utils import embed
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, clipfloor=0, randomfloor=False)
-    return -tv_spec(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
-                    norm_reg=kwargs.get('norm_reg', True),
-                    beam_size=kwargs.get('beam_size'))
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    beam_size = kwargs.get('beam_size') or psize
+    norm = len(imvec) * psize / beam_size if kwargs.get('norm_reg', True) else 1
+    im = imvec.reshape(ny, nx)
+    impad = np.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    return np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2 + EPSILON)) / norm
 
 
 def reggrad_tv_spec(imvec, mask, **kwargs):
     from ehtim.imaging.imager_utils import embed
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, clipfloor=0, randomfloor=False)
-    g = -tv_spec_grad(imvec, kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
-                      norm_reg=kwargs.get('norm_reg', True),
-                      beam_size=kwargs.get('beam_size'))
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    beam_size = kwargs.get('beam_size') or psize
+    norm = len(imvec) * psize / beam_size if kwargs.get('norm_reg', True) else 1
+    im = imvec.reshape(ny, nx)
+    impad = np.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
+    im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
+    im_r1l2 = np.roll(np.roll(impad,  1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
+    im_l1r2 = np.roll(np.roll(impad, -1, axis=0),  1, axis=1)[1:ny+1, 1:nx+1]
+    g1 = (2*im - im_l1 - im_l2) / np.sqrt((im - im_l1)**2 + (im - im_l2)**2 + EPSILON)
+    g2 = (im - im_r1) / np.sqrt((im - im_r1)**2 + (im_r1l2 - im_r1)**2 + EPSILON)
+    g3 = (im - im_r2) / np.sqrt((im - im_r2)**2 + (im_l1r2 - im_r2)**2 + EPSILON)
+    mask1 = np.zeros(im.shape)
+    mask2 = np.zeros(im.shape)
+    mask1[0, :] = 1
+    mask2[:, 0] = 1
+    g2[mask1.astype(bool)] = 0
+    g3[mask2.astype(bool)] = 0
+    g = (g1 + g2 + g3).flatten() / norm
     return g[mask]
 
 

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -782,620 +782,367 @@ def chisqgrad_vvis_nfft(imarr, A, v, sigmav,pol_solve=POL_SOLVE_DEFAULT):
 
     return gradout
 
-##################################################################################################
-# Polarimetric Entropy and Gradient Functions
-##################################################################################################
-
-def sm(imarr, flux, norm_reg=NORM_REGULARIZER):
-    """I log m entropy
-    """
-    if norm_reg:
-        norm = flux
-    else:
-        norm = 1
-
-    iimage = make_i_image(imarr)
-    mimage = make_m_image(imarr)
-    S = -np.sum(iimage * np.log(mimage))
-    return S/norm
-
-def smgrad(imarr, flux, pol_solve=POL_SOLVE_DEFAULT,
-           norm_reg=NORM_REGULARIZER):
-    """I log m entropy gradient
-    """
-    gradout = np.zeros(imarr.shape)
-
-    if norm_reg:
-        norm = flux
-    else:
-        norm = 1
-
-    iimage = make_i_image(imarr)
-    mimage = make_m_image(imarr)
-    psiimage = make_psi_image(imarr)
-
-    if pol_solve[0]!=0:
-        gradi = -np.log(mimage)
-        gradout[0] = gradi
-
-    if pol_solve[1]!=0:
-        gradm = -iimage / mimage
-        gradrho = gradm * np.cos(psiimage)
-        gradout[1] = gradrho
-
-    if pol_solve[3]!=0:
-        gradm = -iimage / mimage
-        gradpsi = gradm * (-mimage*np.tan(psiimage))
-        gradout[3] = gradpsi
-
-    return gradout/norm
-
-def shw(imarr, flux, norm_reg=NORM_REGULARIZER):
-    """Holdaway-Wardle polarimetric entropy
-    """
-
-    if norm_reg:
-        norm = flux
-    else:
-        norm = 1
-
-    iimage = make_i_image(imarr)
-    mimage = make_m_image(imarr)
-    S = -np.sum(iimage * (((1+mimage)/2) * np.log((1+mimage)/2) + ((1-mimage)/2) * np.log((1-mimage)/2)))
-    return S/norm
-
-def shwgrad(imarr, flux,pol_solve=POL_SOLVE_DEFAULT,
-            norm_reg=NORM_REGULARIZER):
-    """Gradient of the Holdaway-Wardle polarimetric entropy
-    """
-    gradout = np.zeros(imarr.shape)
-
-    if norm_reg:
-        norm = flux
-    else:
-        norm = 1
-
-    iimage = make_i_image(imarr)
-    mimage = make_m_image(imarr)
-    psiimage = make_psi_image(imarr)
-
-    if pol_solve[0]!=0:
-        gradi =  -(((1+mimage)/2) * np.log((1+mimage)/2) + ((1-mimage)/2) * np.log((1-mimage)/2))
-        gradout[0] = gradi
-
-    if pol_solve[1]!=0:
-        gradm = -iimage * np.arctanh(mimage)
-        gradrho = gradm * np.cos(psiimage)
-        gradout[1] = gradrho
-
-    if pol_solve[3]!=0:
-        gradm = -iimage * np.arctanh(mimage)
-        gradpsi = gradm * (-mimage*np.tan(psiimage))
-        gradout[3] = gradpsi
-
-    return gradout/norm
-
-def stv_pol(imarr, flux, nx, ny, psize,
-            norm_reg=NORM_REGULARIZER, beam_size=None):
-    """Total variation of I*m*exp(2Ichi)"""
-
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = flux*psize / beam_size
-    else:
-        norm = 1
-
-    pimage = make_p_image(imarr)
-    im = pimage.reshape(ny, nx)
-
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    S = -np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2))
-    return S/norm
-
-def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT,
-             norm_reg=NORM_REGULARIZER, beam_size=None):
-    """Total variation entropy gradient"""
-    gradout = np.zeros(imarr.shape)
-
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = flux*psize / beam_size
-    else:
-        norm = 1
-
-    iimage = make_i_image(imarr)
-    pimage = make_p_image(imarr)
-    mimage = make_m_image(imarr)
-    psiimage = make_psi_image(imarr)
-
-    im = pimage.reshape(ny, nx)
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
-    im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
-    im_r1l2 = np.roll(np.roll(impad, 1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
-    im_l1r2 = np.roll(np.roll(impad, -1, axis=0), 1, axis=1)[1:ny+1, 1:nx+1]
-
-    # Denominators
-    d1 = np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2)
-    d2 = np.sqrt(np.abs(im_r1 - im)**2 + np.abs(im_r1l2 - im_r1)**2)
-    d3 = np.sqrt(np.abs(im_r2 - im)**2 + np.abs(im_l1r2 - im_r2)**2)
-
-    # Numerators use cos/sin of the single-angle difference between neighbors,
-    # from d|P_l1 - P|^2 / d|P| = 2|P| - 2|P_l1|*cos(angle(P_l1) - angle(P)).
-
-    # dS/dI Numerators
-    if pol_solve[0]!=0:
-        m1 = 2*np.abs(im*im) - np.abs(im*im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im*im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
-        m2 = np.abs(im*im) - np.abs(im*im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
-        m3 = np.abs(im*im) - np.abs(im*im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
-        gradi = -(1./iimage)*(m1/d1 + m2/d2 + m3/d3).flatten()
-        gradout[0] = gradi
-
-    # dS/dm numerators
-    if pol_solve[1]!=0:
-        m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
-        m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
-        m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
-        gradm = -iimage*(m1/d1 + m2/d2 + m3/d3).flatten()
-        gradrho = gradm * np.cos(psiimage)
-        gradout[1] = gradrho
-
-    # dS/dphi numerators (\phi=2\chi)
-    if pol_solve[2]!=0:
-        c1 = -2*np.abs(im*im_l1)*np.sin(np.angle(im_l1) - np.angle(im)) - 2*np.abs(im*im_l2)*np.sin(np.angle(im_l2) - np.angle(im))
-        c2 = 2*np.abs(im*im_r1)*np.sin(np.angle(im) - np.angle(im_r1))
-        c3 = 2*np.abs(im*im_r2)*np.sin(np.angle(im) - np.angle(im_r2))
-        gradchi = -(c1/d1 + c2/d2 + c3/d3).flatten()
-        gradphi = 0.5*gradchi
-        gradout[2] = gradphi
-
-    # dS/dpsi
-    if pol_solve[3]!=0:
-        m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
-        m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
-        m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
-        gradm = -iimage*(m1/d1 + m2/d2 + m3/d3).flatten()
-        gradpsi = gradm * (-mimage*np.tan(psiimage))
-        gradout[3] = gradpsi
-
-    return gradout/norm
-
-###############################################################
-# circular polarization
-# TODO check!!
-def svflux(imarr, vflux, norm_reg=NORM_REGULARIZER):
-    """Total flux constraint
-    """
-    if norm_reg:
-        norm = np.abs(vflux)**2
-    else:
-        norm = 1
-
-    vimage = make_v_image(imarr)
-
-    out = -(np.sum(vimage) - vflux)**2
-    return out/norm
-
-
-def svfluxgrad(imarr, vflux,  pol_solve=POL_SOLVE_DEFAULT_V, norm_reg=NORM_REGULARIZER):
-    """Total flux constraint gradient
-    """
-    gradout = np.zeros(imarr.shape)
-
-    if norm_reg:
-        norm = np.abs(vflux)**2
-    else:
-        norm = 1
-
-    iimage = make_i_image(imarr)
-    vimage = make_v_image(imarr)
-    vfimage = make_vf_image(imarr)
-    psiimage = make_psi_image(imarr)
-    grad = -2*(np.sum(vimage) - vflux)*np.ones(len(vimage))
-
-
-    # dS/dI Numerators
-    if pol_solve[0]!=0:
-        gradi = (vimage/iimage)*grad
-        gradout[0] = gradi
-
-    # dS/dv numerators
-    if pol_solve[1]!=0:
-        gradv = iimage*grad
-        gradrho = gradv*np.sin(psiimage)
-        gradout[1] = gradrho
-
-    if pol_solve[3]!=0:
-        gradv = iimage*grad
-        gradpsi = gradv * (vfimage/np.tan(psiimage))
-        gradout[3] = gradpsi
-
-    return gradout/norm
-
-def sl1v(imarr, vflux, norm_reg=NORM_REGULARIZER):
-    """L1 norm regularizer on V
-    """
-    if norm_reg:
-        norm = np.abs(vflux)
-    else:
-        norm = 1
-
-    vimage = make_v_image(imarr)
-    l1 = -np.sum(np.abs(vimage))
-    return l1/norm
-
-
-def sl1vgrad(imarr, vflux, pol_solve=POL_SOLVE_DEFAULT_V,  norm_reg=NORM_REGULARIZER):
-    """L1 norm gradient
-    """
-    gradout = np.zeros(imarr.shape)
-
-    if norm_reg:
-        norm = np.abs(vflux)
-    else:
-        norm = 1
-
-    iimage = make_i_image(imarr)
-    vimage = make_v_image(imarr)
-    vfimage = make_vf_image(imarr)
-    psiimage = make_psi_image(imarr)
-
-    grad = -np.sign(vimage)
-
-    # dS/dI Numerators
-    if pol_solve[0]!=0:
-        gradi = vfimage*grad
-        gradout[0] = gradi
-
-    # dS/dv numerators
-    if pol_solve[1]!=0:
-        gradv = iimage*grad
-        gradrho = gradv*np.sin(psiimage)
-        gradout[1] = gradrho
-
-    if pol_solve[3]!=0:
-        gradv = iimage*grad
-        gradpsi = gradv * (vfimage/np.tan(psiimage))
-        gradout[3] = gradpsi
-
-    return gradout/norm
-
-def sl2v(imarr, vflux, norm_reg=NORM_REGULARIZER):
-    """L1 norm regularizer on V
-    """
-    if norm_reg:
-        norm = np.abs(vflux**2)
-    else:
-        norm = 1
-
-    vimage = make_v_image(imarr)
-    l2 = -np.sum((vimage)**2)
-    return l2/norm
-
-
-def sl2vgrad(imarr, vflux,pol_solve=POL_SOLVE_DEFAULT_V, norm_reg=NORM_REGULARIZER):
-    """L2 norm gradient
-    """
-    gradout = np.zeros(imarr.shape)
-
-    if norm_reg:
-        norm = np.abs(vflux**2)
-    else:
-        norm = 1
-
-    iimage = make_i_image(imarr)
-    vimage = make_v_image(imarr)
-    vfimage = make_vf_image(imarr)
-    psiimage = make_psi_image(imarr)
-
-    grad = -2*vimage
-
-    # dS/dI Numerators
-    if pol_solve[0]!=0:
-        gradi = (vfimage)*grad
-        gradout[0] = gradi
-
-    # dS/dv numerators
-    if pol_solve[1]!=0:
-        gradv = iimage*grad
-        gradrho = gradv*np.sin(psiimage)
-        gradout[1] = gradrho
-
-    if pol_solve[3]!=0:
-        gradv = iimage*grad
-        gradpsi = gradv * (vfimage/np.tan(psiimage))
-        gradout[3] = gradpsi
-
-    return gradout/norm
-
-def stv_v(imarr, vflux, nx, ny, psize,
-          norm_reg=NORM_REGULARIZER, beam_size=None, epsilon=0.):
-    """Total variation of I*vfrac"""
-
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = np.abs(vflux)*psize / beam_size
-    else:
-        norm = 1
-
-    vimage = make_v_image(imarr)
-    im = vimage.reshape(ny, nx)
-
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    S = -np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2+epsilon))
-    return S/norm
-
-def stv_v_grad(imarr, vflux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT_V,
-               norm_reg=NORM_REGULARIZER, beam_size=None, epsilon=0.):
-    """Total variation gradient"""
-    gradout = np.zeros(imarr.shape)
-
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = np.abs(vflux)*psize / beam_size
-    else:
-        norm = 1
-
-    iimage = make_i_image(imarr)
-    vimage = make_v_image(imarr)
-    vfimage = make_vf_image(imarr)
-    psiimage = make_psi_image(imarr)
-
-    im = vimage.reshape(ny, nx)
-
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
-    im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
-
-    # rotate images
-    im_r1l2 = np.roll(np.roll(impad,  1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
-    im_l1r2 = np.roll(np.roll(impad, -1, axis=0), 1, axis=1)[1:ny+1, 1:nx+1]
-
-    # add together terms and return
-    g1 = (2*im - im_l1 - im_l2) / np.sqrt((im - im_l1)**2 + (im - im_l2)**2 + epsilon)
-    g2 = (im - im_r1) / np.sqrt((im - im_r1)**2 + (im_r1l2 - im_r1)**2 + epsilon)
-    g3 = (im - im_r2) / np.sqrt((im - im_r2)**2 + (im_l1r2 - im_r2)**2 + epsilon)
-
-    # mask the first row column gradient terms that don't exist
-    mask1 = np.zeros(im.shape)
-    mask2 = np.zeros(im.shape)
-    mask1[0, :] = 1
-    mask2[:, 0] = 1
-    g2[mask1.astype(bool)] = 0
-    g3[mask2.astype(bool)] = 0
-
-    # add terms together and return
-    grad = -(g1 + g2 + g3).flatten()
-
-    # dS/dI Numerators
-    if pol_solve[0]!=0:
-        gradi = vfimage*grad
-        gradout[0] = gradi
-
-    # dS/dv numerators
-    if pol_solve[1]!=0:
-        gradv = iimage*grad
-        gradrho = gradv*np.sin(psiimage)
-        gradout[1] = gradrho
-
-    if pol_solve[3]!=0:
-        gradv = iimage*grad
-        gradpsi = gradv * (vfimage/np.tan(psiimage))
-        gradout[3] = gradpsi
-
-    return gradout/norm
-
-def stv2_v(imarr, vflux, nx, ny, psize,
-           norm_reg=NORM_REGULARIZER, beam_size=None):
-    """Squared Total variation of I*vfrac
-    """
-
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = psize**4 * np.abs(vflux**2) / beam_size**4
-    else:
-        norm = 1
-
-    vimage = make_v_image(imarr)
-    im = vimage.reshape(ny, nx)
-
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    out = -np.sum((im_l1 - im)**2 + (im_l2 - im)**2)
-    return out/norm
-
-def stv2_v_grad(imarr, vflux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT_V,
-               norm_reg=NORM_REGULARIZER, beam_size=None):
-    """Squared Total variation gradient
-    """
-    gradout = np.zeros(imarr.shape)
-    if beam_size is None:
-        beam_size = psize
-    if norm_reg:
-        norm = psize**4 * np.abs(vflux**2) / beam_size**4
-    else:
-        norm = 1
-
-    iimage = make_i_image(imarr)
-    vimage = make_v_image(imarr)
-    vfimage = make_vf_image(imarr)
-    psiimage = make_psi_image(imarr)
-
-    im = vimage.reshape(ny, nx)
-
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
-    im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
-
-    g1 = (2*im - im_l1 - im_l2)
-    g2 = (im - im_r1)
-    g3 = (im - im_r2)
-
-    # mask the first row column gradient terms that don't exist
-    mask1 = np.zeros(im.shape)
-    mask2 = np.zeros(im.shape)
-    mask1[0, :] = 1
-    mask2[:, 0] = 1
-    g2[mask1.astype(bool)] = 0
-    g3[mask2.astype(bool)] = 0
-
-    # add together terms and return
-    grad = -2*(g1 + g2 + g3).flatten()
-
-    # dS/dI Numerators
-    if pol_solve[0]!=0:
-        gradi = vfimage*grad
-        gradout[0] = gradi
-
-    # dS/dv numerators
-    if pol_solve[1]!=0:
-        gradv = iimage*grad
-        gradrho = gradv*np.sin(psiimage)
-        gradout[1] = gradrho
-
-    if pol_solve[3]!=0:
-        gradv = iimage*grad
-        gradpsi = gradv * (vfimage/np.tan(psiimage))
-        gradout[3] = gradpsi
-
-    return gradout/norm
-
 
 ##################################################################################################
-# Imager-backend wrappers
+# Polarimetric regularizers
 #
-# Same pattern as `reg_X` / `reggrad_X` in `imager_utils.py`: each wrapper adapts
-# a pol regularizer above to the uniform `(imarr, mask, **kwargs)` signature used
-# by `_REGULARIZER_DISPATCH`. Pol spatial regularizers use `embed_imarr` (not
-# `embed`) for the pre-step and slice the gradient as `g[:, mask]` because the
-# pol gradient is shaped (4, nimage) — one row per Stokes component.
+# Each `reg_X` / `reggrad_X` implements a polarimetric regularizer with the
+# uniform `(imarr, mask, **kwargs)` signature used by the `_REGULARIZER_DISPATCH`
+# table in `imager_backend.py`. Each returns the penalty value (positive; the
+# imager solver minimises it). Spatial regularizers (ptv, vtv, vtv2) use
+# `embed_imarr` (not `embed`) for the pre-step and slice the gradient as
+# `g[:, mask]` since the pol gradient is shaped (4, nimage) — one row per
+# Stokes component, gated on `pol_solve[0..3]`.
 ##################################################################################################
 
 
 def reg_msimple(imarr, mask, **kwargs):
-    return -sm(imarr, kwargs['flux'], norm_reg=kwargs.get('norm_reg', True))
+    flux = kwargs['flux']
+    norm = flux if kwargs.get('norm_reg', True) else 1
+    iimage = make_i_image(imarr)
+    mimage = make_m_image(imarr)
+    return np.sum(iimage * np.log(mimage)) / norm
 
 
 def reggrad_msimple(imarr, mask, **kwargs):
-    return -smgrad(imarr, kwargs['flux'],
-                   pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT),
-                   norm_reg=kwargs.get('norm_reg', True))
+    flux = kwargs['flux']
+    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT)
+    norm = flux if kwargs.get('norm_reg', True) else 1
+    iimage = make_i_image(imarr)
+    mimage = make_m_image(imarr)
+    psiimage = make_psi_image(imarr)
+    gradout = np.zeros(imarr.shape)
+    if pol_solve[0] != 0:
+        gradout[0] = np.log(mimage)
+    if pol_solve[1] != 0:
+        gradm = iimage / mimage
+        gradout[1] = gradm * np.cos(psiimage)
+    if pol_solve[3] != 0:
+        gradm = iimage / mimage
+        gradout[3] = gradm * (-mimage * np.tan(psiimage))
+    return gradout / norm
 
 
 def reg_hw(imarr, mask, **kwargs):
-    return -shw(imarr, kwargs['flux'], norm_reg=kwargs.get('norm_reg', True))
+    flux = kwargs['flux']
+    norm = flux if kwargs.get('norm_reg', True) else 1
+    iimage = make_i_image(imarr)
+    mimage = make_m_image(imarr)
+    return np.sum(iimage * (((1+mimage)/2) * np.log((1+mimage)/2)
+                            + ((1-mimage)/2) * np.log((1-mimage)/2))) / norm
 
 
 def reggrad_hw(imarr, mask, **kwargs):
-    return -shwgrad(imarr, kwargs['flux'],
-                    pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT),
-                    norm_reg=kwargs.get('norm_reg', True))
+    flux = kwargs['flux']
+    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT)
+    norm = flux if kwargs.get('norm_reg', True) else 1
+    iimage = make_i_image(imarr)
+    mimage = make_m_image(imarr)
+    psiimage = make_psi_image(imarr)
+    gradout = np.zeros(imarr.shape)
+    if pol_solve[0] != 0:
+        gradout[0] = (((1+mimage)/2) * np.log((1+mimage)/2)
+                      + ((1-mimage)/2) * np.log((1-mimage)/2))
+    if pol_solve[1] != 0:
+        gradm = iimage * np.arctanh(mimage)
+        gradout[1] = gradm * np.cos(psiimage)
+    if pol_solve[3] != 0:
+        gradm = iimage * np.arctanh(mimage)
+        gradout[3] = gradm * (-mimage * np.tan(psiimage))
+    return gradout / norm
 
 
 def reg_ptv(imarr, mask, **kwargs):
     from ehtim.imaging.imager_utils import embed_imarr
     if np.any(np.invert(mask)):
         imarr = embed_imarr(imarr, mask, randomfloor=True)
-    return -stv_pol(imarr, kwargs['flux'], kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
-                    norm_reg=kwargs.get('norm_reg', True),
-                    beam_size=kwargs.get('beam_size', 1))
+    flux = kwargs['flux']
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    beam_size = kwargs.get('beam_size', 1) or psize
+    norm = flux * psize / beam_size if kwargs.get('norm_reg', True) else 1
+    pimage = make_p_image(imarr)
+    im = pimage.reshape(ny, nx)
+    impad = np.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    return np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2)) / norm
 
 
 def reggrad_ptv(imarr, mask, **kwargs):
     from ehtim.imaging.imager_utils import embed_imarr
-    if np.any(np.invert(mask)):
+    do_slice = np.any(np.invert(mask))
+    if do_slice:
         imarr = embed_imarr(imarr, mask, randomfloor=True)
-    g = -stv_pol_grad(imarr, kwargs['flux'], kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
-                      pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT),
-                      norm_reg=kwargs.get('norm_reg', True),
-                      beam_size=kwargs.get('beam_size', 1))
-    return g[:, mask] if np.any(np.invert(mask)) else g
+    flux = kwargs['flux']
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT)
+    beam_size = kwargs.get('beam_size', 1) or psize
+    norm = flux * psize / beam_size if kwargs.get('norm_reg', True) else 1
+    iimage = make_i_image(imarr)
+    pimage = make_p_image(imarr)
+    mimage = make_m_image(imarr)
+    psiimage = make_psi_image(imarr)
+    im = pimage.reshape(ny, nx)
+    impad = np.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
+    im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
+    im_r1l2 = np.roll(np.roll(impad,  1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
+    im_l1r2 = np.roll(np.roll(impad, -1, axis=0),  1, axis=1)[1:ny+1, 1:nx+1]
+    # Denominators: |forward-l1|+|forward-l2|, |back-r1|+|cross|, |back-r2|+|cross|.
+    d1 = np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2)
+    d2 = np.sqrt(np.abs(im_r1 - im)**2 + np.abs(im_r1l2 - im_r1)**2)
+    d3 = np.sqrt(np.abs(im_r2 - im)**2 + np.abs(im_l1r2 - im_r2)**2)
+    # Numerators below use cos/sin of the single-angle difference between
+    # neighbors, from d|P_l1 - P|^2/d|P| = 2|P| - 2|P_l1|*cos(angle(P_l1) - angle(P)).
+    gradout = np.zeros(imarr.shape)
+    if pol_solve[0] != 0:
+        # dS/dI numerators (chain through |P| = I*m)
+        m1 = 2*np.abs(im*im) - np.abs(im*im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im*im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
+        m2 = np.abs(im*im) - np.abs(im*im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
+        m3 = np.abs(im*im) - np.abs(im*im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        gradout[0] = (1./iimage) * (m1/d1 + m2/d2 + m3/d3).flatten()
+    if pol_solve[1] != 0:
+        # dS/dm numerators; m enters via |P| = I*m, so dS/dm = I * dS/d|P|.
+        # Then dm/dprimitive[1] = cos(psi) on the (m, psi) -> (m, v) chart.
+        m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
+        m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
+        m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        gradm = iimage * (m1/d1 + m2/d2 + m3/d3).flatten()
+        gradout[1] = gradm * np.cos(psiimage)
+    if pol_solve[2] != 0:
+        # dS/dphi numerators (primitive is phi = 2*chi, see PR #240).
+        # `gradchi` is dS/dchi; chain through chi(phi) = phi/2 gives the *0.5.
+        c1 = -2*np.abs(im*im_l1)*np.sin(np.angle(im_l1) - np.angle(im)) - 2*np.abs(im*im_l2)*np.sin(np.angle(im_l2) - np.angle(im))
+        c2 = 2*np.abs(im*im_r1)*np.sin(np.angle(im) - np.angle(im_r1))
+        c3 = 2*np.abs(im*im_r2)*np.sin(np.angle(im) - np.angle(im_r2))
+        gradchi = (c1/d1 + c2/d2 + c3/d3).flatten()
+        gradout[2] = 0.5 * gradchi
+    if pol_solve[3] != 0:
+        # dS/dpsi numerators; reuse dS/dm and chain through dm/dpsi = -m*tan(psi).
+        m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
+        m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
+        m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        gradm = iimage * (m1/d1 + m2/d2 + m3/d3).flatten()
+        gradout[3] = gradm * (-mimage * np.tan(psiimage))
+    g = gradout / norm
+    return g[:, mask] if do_slice else g
 
 
+# --- circular-polarization (V) regularizers ---------------------------------
+# TODO check!! The V-pol regularizers below were never thoroughly audited; the
+# `gradv * (vfimage / np.tan(psiimage))` chain-rule form (dS/dpsi) is unusual
+# and the test coverage only exercises generic random pol structure.
 def reg_vflux(imarr, mask, **kwargs):
-    return -svflux(imarr, kwargs['vflux'], norm_reg=kwargs.get('norm_reg', True))
+    vflux = kwargs['vflux']
+    norm = np.abs(vflux)**2 if kwargs.get('norm_reg', True) else 1
+    vimage = make_v_image(imarr)
+    return (np.sum(vimage) - vflux)**2 / norm
 
 
 def reggrad_vflux(imarr, mask, **kwargs):
-    return -svfluxgrad(imarr, kwargs['vflux'],
-                       pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V),
-                       norm_reg=kwargs.get('norm_reg', True))
+    vflux = kwargs['vflux']
+    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
+    norm = np.abs(vflux)**2 if kwargs.get('norm_reg', True) else 1
+    iimage = make_i_image(imarr)
+    vimage = make_v_image(imarr)
+    vfimage = make_vf_image(imarr)
+    psiimage = make_psi_image(imarr)
+    # base = dS/dV via V = I * vf, vf = m*sin(psi); pol_solve branches below
+    # chain through dV/dI = V/I, dV/dm = I*sin(psi), dV/dpsi = I*m*cos(psi).
+    base = 2 * (np.sum(vimage) - vflux) * np.ones(len(vimage))
+    gradout = np.zeros(imarr.shape)
+    if pol_solve[0] != 0:
+        gradout[0] = (vimage / iimage) * base  # dS/dI
+    if pol_solve[1] != 0:
+        gradv = iimage * base
+        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+    if pol_solve[3] != 0:
+        gradv = iimage * base
+        gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi; vf/tan(psi) = m*cos(psi)
+    return gradout / norm
 
 
 def reg_l1v(imarr, mask, **kwargs):
-    return -sl1v(imarr, kwargs['vflux'], norm_reg=kwargs.get('norm_reg', True))
+    vflux = kwargs['vflux']
+    norm = np.abs(vflux) if kwargs.get('norm_reg', True) else 1
+    vimage = make_v_image(imarr)
+    return np.sum(np.abs(vimage)) / norm
 
 
 def reggrad_l1v(imarr, mask, **kwargs):
-    return -sl1vgrad(imarr, kwargs['vflux'],
-                     pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V),
-                     norm_reg=kwargs.get('norm_reg', True))
+    vflux = kwargs['vflux']
+    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
+    norm = np.abs(vflux) if kwargs.get('norm_reg', True) else 1
+    iimage = make_i_image(imarr)
+    vimage = make_v_image(imarr)
+    vfimage = make_vf_image(imarr)
+    psiimage = make_psi_image(imarr)
+    # base = dS/dV via V = I*vf; chain rules per reggrad_vflux.
+    base = np.sign(vimage)
+    gradout = np.zeros(imarr.shape)
+    if pol_solve[0] != 0:
+        gradout[0] = vfimage * base  # dS/dI (vfimage = V/I)
+    if pol_solve[1] != 0:
+        gradv = iimage * base
+        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+    if pol_solve[3] != 0:
+        gradv = iimage * base
+        gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi
+    return gradout / norm
 
 
 def reg_l2v(imarr, mask, **kwargs):
-    return -sl2v(imarr, kwargs['vflux'], norm_reg=kwargs.get('norm_reg', True))
+    vflux = kwargs['vflux']
+    norm = np.abs(vflux**2) if kwargs.get('norm_reg', True) else 1
+    vimage = make_v_image(imarr)
+    return np.sum(vimage**2) / norm
 
 
 def reggrad_l2v(imarr, mask, **kwargs):
-    return -sl2vgrad(imarr, kwargs['vflux'],
-                     pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V),
-                     norm_reg=kwargs.get('norm_reg', True))
+    vflux = kwargs['vflux']
+    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
+    norm = np.abs(vflux**2) if kwargs.get('norm_reg', True) else 1
+    iimage = make_i_image(imarr)
+    vimage = make_v_image(imarr)
+    vfimage = make_vf_image(imarr)
+    psiimage = make_psi_image(imarr)
+    # base = dS/dV via V = I*vf; chain rules per reggrad_vflux.
+    base = 2 * vimage
+    gradout = np.zeros(imarr.shape)
+    if pol_solve[0] != 0:
+        gradout[0] = vfimage * base  # dS/dI
+    if pol_solve[1] != 0:
+        gradv = iimage * base
+        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+    if pol_solve[3] != 0:
+        gradv = iimage * base
+        gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi
+    return gradout / norm
 
 
 def reg_vtv(imarr, mask, **kwargs):
     from ehtim.imaging.imager_utils import embed_imarr
     if np.any(np.invert(mask)):
         imarr = embed_imarr(imarr, mask, randomfloor=True)
-    return -stv_v(imarr, kwargs['vflux'], kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
-                  norm_reg=kwargs.get('norm_reg', True),
-                  beam_size=kwargs.get('beam_size', 1))
+    vflux = kwargs['vflux']
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    beam_size = kwargs.get('beam_size', 1) or psize
+    norm = np.abs(vflux) * psize / beam_size if kwargs.get('norm_reg', True) else 1
+    vimage = make_v_image(imarr)
+    im = vimage.reshape(ny, nx)
+    impad = np.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    return np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2)) / norm
 
 
 def reggrad_vtv(imarr, mask, **kwargs):
     from ehtim.imaging.imager_utils import embed_imarr
-    if np.any(np.invert(mask)):
+    do_slice = np.any(np.invert(mask))
+    if do_slice:
         imarr = embed_imarr(imarr, mask, randomfloor=True)
-    g = -stv_v_grad(imarr, kwargs['vflux'], kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
-                    pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V),
-                    norm_reg=kwargs.get('norm_reg', True),
-                    beam_size=kwargs.get('beam_size', 1))
-    return g[:, mask] if np.any(np.invert(mask)) else g
+    vflux = kwargs['vflux']
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
+    beam_size = kwargs.get('beam_size', 1) or psize
+    norm = np.abs(vflux) * psize / beam_size if kwargs.get('norm_reg', True) else 1
+    epsilon = 0.
+    iimage = make_i_image(imarr)
+    vimage = make_v_image(imarr)
+    vfimage = make_vf_image(imarr)
+    psiimage = make_psi_image(imarr)
+    im = vimage.reshape(ny, nx)
+    impad = np.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
+    im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
+    im_r1l2 = np.roll(np.roll(impad,  1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
+    im_l1r2 = np.roll(np.roll(impad, -1, axis=0),  1, axis=1)[1:ny+1, 1:nx+1]
+    g1 = (2*im - im_l1 - im_l2) / np.sqrt((im - im_l1)**2 + (im - im_l2)**2 + epsilon)
+    g2 = (im - im_r1) / np.sqrt((im - im_r1)**2 + (im_r1l2 - im_r1)**2 + epsilon)
+    g3 = (im - im_r2) / np.sqrt((im - im_r2)**2 + (im_l1r2 - im_r2)**2 + epsilon)
+    mask1 = np.zeros(im.shape)
+    mask2 = np.zeros(im.shape)
+    mask1[0, :] = 1
+    mask2[:, 0] = 1
+    g2[mask1.astype(bool)] = 0
+    g3[mask2.astype(bool)] = 0
+    # base = dS/dV via V = I*vf; chain rules per reggrad_vflux.
+    base = (g1 + g2 + g3).flatten()
+    gradout = np.zeros(imarr.shape)
+    if pol_solve[0] != 0:
+        gradout[0] = vfimage * base  # dS/dI
+    if pol_solve[1] != 0:
+        gradv = iimage * base
+        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+    if pol_solve[3] != 0:
+        gradv = iimage * base
+        gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi
+    g = gradout / norm
+    return g[:, mask] if do_slice else g
 
 
 def reg_vtv2(imarr, mask, **kwargs):
     from ehtim.imaging.imager_utils import embed_imarr
     if np.any(np.invert(mask)):
         imarr = embed_imarr(imarr, mask, randomfloor=True)
-    return -stv2_v(imarr, kwargs['vflux'], kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
-                   norm_reg=kwargs.get('norm_reg', True),
-                   beam_size=kwargs.get('beam_size', 1))
+    vflux = kwargs['vflux']
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    beam_size = kwargs.get('beam_size', 1) or psize
+    norm = psize**4 * np.abs(vflux**2) / beam_size**4 if kwargs.get('norm_reg', True) else 1
+    vimage = make_v_image(imarr)
+    im = vimage.reshape(ny, nx)
+    impad = np.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    return np.sum((im_l1 - im)**2 + (im_l2 - im)**2) / norm
 
 
 def reggrad_vtv2(imarr, mask, **kwargs):
     from ehtim.imaging.imager_utils import embed_imarr
-    if np.any(np.invert(mask)):
+    do_slice = np.any(np.invert(mask))
+    if do_slice:
         imarr = embed_imarr(imarr, mask, randomfloor=True)
-    g = -stv2_v_grad(imarr, kwargs['vflux'], kwargs['xdim'], kwargs['ydim'], kwargs['psize'],
-                     pol_solve=kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V),
-                     norm_reg=kwargs.get('norm_reg', True),
-                     beam_size=kwargs.get('beam_size', 1))
-    return g[:, mask] if np.any(np.invert(mask)) else g
+    vflux = kwargs['vflux']
+    nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
+    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
+    beam_size = kwargs.get('beam_size', 1) or psize
+    norm = psize**4 * np.abs(vflux**2) / beam_size**4 if kwargs.get('norm_reg', True) else 1
+    iimage = make_i_image(imarr)
+    vimage = make_v_image(imarr)
+    vfimage = make_vf_image(imarr)
+    psiimage = make_psi_image(imarr)
+    im = vimage.reshape(ny, nx)
+    impad = np.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
+    im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
+    g1 = 2*im - im_l1 - im_l2
+    g2 = im - im_r1
+    g3 = im - im_r2
+    mask1 = np.zeros(im.shape)
+    mask2 = np.zeros(im.shape)
+    mask1[0, :] = 1
+    mask2[:, 0] = 1
+    g2[mask1.astype(bool)] = 0
+    g3[mask2.astype(bool)] = 0
+    # base = dS/dV via V = I*vf; chain rules per reggrad_vflux.
+    base = 2 * (g1 + g2 + g3).flatten()
+    gradout = np.zeros(imarr.shape)
+    if pol_solve[0] != 0:
+        gradout[0] = vfimage * base  # dS/dI
+    if pol_solve[1] != 0:
+        gradv = iimage * base
+        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+    if pol_solve[3] != 0:
+        gradv = iimage * base
+        gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi
+    g = gradout / norm
+    return g[:, mask] if do_slice else g
 
 
 ##################################################################################################

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -613,7 +613,12 @@ class Obsdata:
                     data, lambda x: np.searchsorted(self.scans[:, 0], x['time'])):
                 datalist.append(np.array([obs for obs in group]))
 
-        return np.array(datalist, dtype=object)
+        # np.array(datalist, dtype=object) silently stacks into 2-D when all scans
+        # share a shape, dropping the recarray dtype; pre-allocate to force 1-D.
+        out = np.empty(len(datalist), dtype=object)
+        for i, d in enumerate(datalist):
+            out[i] = d
+        return out
 
 
     def split_obs(self, t_gather=0., scan_gather=False):
@@ -692,7 +697,10 @@ class Obsdata:
         for key, group in it.groupby(data[idx], lambda x: set((x['t1'], x['t2']))):
             datalist.append(np.array([obs for obs in group]))
 
-        return np.array(datalist, dtype=object)
+        out = np.empty(len(datalist), dtype=object)
+        for i, d in enumerate(datalist):
+            out[i] = d
+        return out
 
     def unpack_bl(self, site1, site2, fields, ang_unit='deg', debias=False, timetype=False):
         """Unpack the data over time on the selected baseline site1-site2.

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -1266,7 +1266,7 @@ def add_noise(obs, add_th_noise=True, opacitycal=True, ampcal=True, phasecal=Tru
         sig_rr = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[sites[i][0]]]['sefdr'],
                                            obs.tarr[obs.tkey[sites[i][1]]]['sefdr'], tint[i], bw)
                               for i in range(len(tint))), float)
-        sig_ll = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[sites[i][0]]]['sefdr'],
+        sig_ll = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[sites[i][0]]]['sefdl'],
                                            obs.tarr[obs.tkey[sites[i][1]]]['sefdl'], tint[i], bw)
                               for i in range(len(tint))), float)
         sig_rl = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[sites[i][0]]]['sefdr'],

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -741,7 +741,8 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
             obs_tmp.tarr[i]['dl'] = dL
             datatable = []
             for j in range(len(times)):
-                datatable.append(np.array((times[j], gainR[j], gainL[j]), dtype=ehc.DTCAL))
+                datatable.append(np.array((times[j], gainR[j], gainL[j], dR, dL),
+                                          dtype=ehc.DTCAL))
             datatables[site] = np.array(datatable)
 
     # Save a calibration table with the synthetic gains and dterms added

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -58,11 +58,13 @@ def test_init_builds_tkey_from_sites(eht_array):
 
 
 def test_init_tarr_dtype_has_legacy_columns(eht_array):
-    # PR #260 will add a feed_type column, but the legacy columns must remain.
-    names = _DTARR_DTYPE.names
+    # PR #260 added a feed_type column and promoted sefdr/sefdl/dr/dl to title
+    # aliases over sefd_p1/sefd_p2/d_p1/d_p2. Title aliases live in
+    # dtype.fields (a dict including aliases), not dtype.names (primary only).
+    fields = _DTARR_DTYPE.fields
     for col in ("site", "x", "y", "z", "sefdr", "sefdl",
                 "dr", "dl", "fr_par", "fr_elev", "fr_off"):
-        assert col in names
+        assert col in fields
 
 
 def test_init_empty_array_has_empty_tkey():

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1,0 +1,466 @@
+"""Tests for Array methods.
+
+Method-by-method coverage of ehtim/array.py. Sections mirror the class
+itself and reuse the session-scoped ``eht_array`` fixture from conftest.py
+so the I/O cost is amortised.
+
+Designed to survive the Phase-2 mixed-pol changes landing in PR #260
+(branch ``feature/mixpol-phase2-array`` on ``dev-backend-mixpol``):
+
+* Legacy field names ('sefdr', 'sefdl', 'dr', 'dl') will become title
+  aliases on RL-feed arrays after #260, so tests using them on
+  homogeneous-RL arrays continue to pass.
+* DTARR will gain a ``feed_type`` column. Tests avoid asserting the full
+  ``dtype.names`` tuple — they only check that the legacy columns are
+  present.
+* ``Array.tarr`` will return a ``TarrView`` wrapper instead of a raw
+  recarray. Tests interact with ``tarr`` only via behaviour that the
+  wrapper preserves (column access on homogeneous-RL arrays, iteration,
+  ``len``, ``copy``, row indexing, numpy interop).
+* ``add_site`` / ``add_satellite_*`` gain extra kwargs; this suite uses
+  the legacy positional/keyword signatures only.
+* ``Array.obsdata(polrep=...)`` will gain ``'lin'`` and ``'mixed'``
+  options with stricter validation; tests here use only ``'stokes'`` and
+  ``'circ'``, both of which remain valid on RL-feed arrays.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+import ehtim as eh
+import ehtim.const_def as ehc
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_DTARR_DTYPE = np.dtype(ehc.DTARR)
+
+
+def _site_row(arr, site):
+    """Fetch a row by site name. ``arr.tarr`` may be a recarray today or a
+    TarrView wrapper after PR #260 — both support row indexing."""
+    return arr.tarr[arr.tkey[site]]
+
+
+# ---------------------------------------------------------------------------
+# Section 1: Construction, tarr setter, copy
+# ---------------------------------------------------------------------------
+
+
+def test_init_builds_tkey_from_sites(eht_array):
+    for site in eht_array.tarr["site"]:
+        assert eht_array.tkey[str(site)] >= 0
+        assert str(_site_row(eht_array, site)["site"]) == str(site)
+
+
+def test_init_tarr_dtype_has_legacy_columns(eht_array):
+    # PR #260 will add a feed_type column, but the legacy columns must remain.
+    names = _DTARR_DTYPE.names
+    for col in ("site", "x", "y", "z", "sefdr", "sefdl",
+                "dr", "dl", "fr_par", "fr_elev", "fr_off"):
+        assert col in names
+
+
+def test_init_empty_array_has_empty_tkey():
+    arr = eh.array.Array(np.zeros(0, dtype=ehc.DTARR))
+    assert arr.tkey == {}
+    assert len(arr.tarr) == 0
+
+
+def test_init_nan_coords_without_ephemeris_raises():
+    tarr = np.zeros(1, dtype=ehc.DTARR)
+    tarr["site"] = ["SAT_BAD"]
+    tarr["x"] = [np.nan]
+    tarr["y"] = [np.nan]
+    tarr["z"] = [np.nan]
+    # Today the missing-ephem path leaks a KeyError; the message
+    # "no ephemeris" inside Array.__init__ would be raised if the except
+    # clause caught KeyError. We assert "something raised" to stay
+    # robust if the except-clause is later fixed.
+    with pytest.raises(Exception):
+        eh.array.Array(tarr)
+
+
+def test_init_nan_coords_with_ephemeris_succeeds():
+    tarr = np.zeros(1, dtype=ehc.DTARR)
+    tarr["site"] = ["SAT_OK"]
+    tarr["x"] = [np.nan]
+    tarr["y"] = [np.nan]
+    tarr["z"] = [np.nan]
+    arr = eh.array.Array(tarr, ephem={"SAT_OK": ["name", "line1", "line2"]})
+    assert len(arr.tarr) == 1
+
+
+def test_init_wrong_length_ephemeris_raises():
+    tarr = np.zeros(1, dtype=ehc.DTARR)
+    tarr["site"] = ["SAT_BAD"]
+    tarr["x"] = [np.nan]
+    tarr["y"] = [np.nan]
+    tarr["z"] = [np.nan]
+    with pytest.raises(Exception, match="wrong ephemeris"):
+        eh.array.Array(tarr, ephem={"SAT_BAD": ["only_one"]})
+
+
+def test_tarr_setter_rebuilds_tkey(eht_array):
+    arr = eht_array.copy()
+    # Pull the underlying recarray out so we can reverse-index safely
+    # whether tarr is a raw ndarray (today) or a TarrView (post-#260).
+    reversed_tarr = np.asarray(arr.tarr).copy()[::-1]
+    arr.tarr = reversed_tarr
+    for site in arr.tarr["site"]:
+        assert str(_site_row(arr, site)["site"]) == str(site)
+
+
+def test_copy_is_deep(eht_array):
+    other = eht_array.copy()
+    assert other is not eht_array
+    # Mutating the copy's underlying ndarray must not touch the fixture.
+    raw_other = np.asarray(other.tarr)
+    raw_other["x"][0] += 1.0
+    np.testing.assert_array_equal(
+        np.asarray(other.tarr)["x"][0],
+        raw_other["x"][0],
+    )
+    assert np.asarray(eht_array.tarr)["x"][0] != raw_other["x"][0]
+
+
+# ---------------------------------------------------------------------------
+# Section 2: listbls
+# ---------------------------------------------------------------------------
+
+
+def test_listbls_count_matches_combinations(eht_array):
+    n = len(eht_array.tarr)
+    assert eht_array.listbls().shape == (n * (n - 1) // 2, 2)
+
+
+def test_listbls_no_self_baselines(eht_array):
+    bls = eht_array.listbls()
+    for t1, t2 in bls:
+        assert t1 != t2
+
+
+def test_listbls_baselines_unique(eht_array):
+    bls = eht_array.listbls()
+    pairs = {frozenset((t1, t2)) for t1, t2 in bls}
+    assert len(pairs) == len(bls)
+
+
+def test_listbls_sorted_lexicographically(eht_array):
+    # listbls iterates over sorted(tarr['site']) so the output is
+    # lexicographic by t1, then t2.
+    bls = eht_array.listbls()
+    sites = sorted(str(s) for s in eht_array.tarr["site"])
+    expected = []
+    for i, s1 in enumerate(sites):
+        for s2 in sites[i + 1:]:
+            expected.append([s1, s2])
+    np.testing.assert_array_equal(bls, np.array(expected))
+
+
+def test_listbls_empty_array_returns_empty():
+    arr = eh.array.Array(np.zeros(0, dtype=ehc.DTARR))
+    bls = arr.listbls()
+    assert bls.shape == (0,)
+
+
+# ---------------------------------------------------------------------------
+# Section 3: make_subarray
+# ---------------------------------------------------------------------------
+
+
+def test_make_subarray_keeps_requested_sites(eht_array):
+    requested = ["ALMA", "SMA"]
+    sub = eht_array.make_subarray(requested)
+    assert set(str(s) for s in sub.tarr["site"]) == set(requested)
+
+
+def test_make_subarray_preserves_metadata(eht_array):
+    sub = eht_array.make_subarray(["ALMA", "SMA"])
+    alma_row = _site_row(eht_array, "ALMA")
+    alma_sub = _site_row(sub, "ALMA")
+    for col in ("x", "y", "z", "sefdr", "sefdl", "fr_par"):
+        assert alma_sub[col] == alma_row[col]
+
+
+def test_make_subarray_with_unknown_site_returns_empty(eht_array):
+    sub = eht_array.make_subarray(["NOTASITE"])
+    assert len(sub.tarr) == 0
+
+
+def test_make_subarray_preserves_ephem(eht_array):
+    sub = eht_array.make_subarray(["ALMA"])
+    assert sub.ephem == eht_array.ephem
+
+
+# ---------------------------------------------------------------------------
+# Section 4: add_site
+# ---------------------------------------------------------------------------
+
+
+def test_add_site_appends_row(eht_array):
+    n0 = len(eht_array.tarr)
+    out = eht_array.add_site("NEW", (1.0, 2.0, 3.0))
+    assert len(out.tarr) == n0 + 1
+    assert "NEW" in out.tkey
+
+
+def test_add_site_does_not_mutate_original(eht_array):
+    n0 = len(eht_array.tarr)
+    eht_array.add_site("TMPSITE", (1.0, 2.0, 3.0))
+    assert len(eht_array.tarr) == n0
+    assert "TMPSITE" not in eht_array.tkey
+
+
+def test_add_site_writes_coords(eht_array):
+    out = eht_array.add_site("NEW", (1.0, 2.0, 3.0))
+    row = _site_row(out, "NEW")
+    assert row["x"] == 1.0
+    assert row["y"] == 2.0
+    assert row["z"] == 3.0
+
+
+def test_add_site_default_sefd_is_10000(eht_array):
+    out = eht_array.add_site("NEW", (1.0, 2.0, 3.0))
+    row = _site_row(out, "NEW")
+    assert row["sefdr"] == 10000.0
+    assert row["sefdl"] == 10000.0
+
+
+def test_add_site_sefd_kwarg_applies_to_both_feeds(eht_array):
+    out = eht_array.add_site("NEW", (1.0, 2.0, 3.0), sefd=5000)
+    row = _site_row(out, "NEW")
+    assert row["sefdr"] == 5000.0
+    assert row["sefdl"] == 5000.0
+
+
+def test_add_site_dr_dl_propagate(eht_array):
+    out = eht_array.add_site("NEW", (1.0, 2.0, 3.0),
+                             dr=0.1 + 0.2j, dl=0.3 + 0.4j)
+    row = _site_row(out, "NEW")
+    assert row["dr"] == 0.1 + 0.2j
+    assert row["dl"] == 0.3 + 0.4j
+
+
+def test_add_site_fr_params_propagate(eht_array):
+    out = eht_array.add_site("NEW", (1.0, 2.0, 3.0),
+                             fr_par=1.5, fr_elev=-1.0, fr_off=0.25)
+    row = _site_row(out, "NEW")
+    assert row["fr_par"] == 1.5
+    assert row["fr_elev"] == -1.0
+    assert row["fr_off"] == 0.25
+
+
+# ---------------------------------------------------------------------------
+# Section 5: remove_site
+# ---------------------------------------------------------------------------
+
+
+def test_remove_site_drops_row(eht_array):
+    added = eht_array.add_site("TMP", (1.0, 2.0, 3.0))
+    rem = added.remove_site("TMP")
+    assert len(rem.tarr) == len(eht_array.tarr)
+    assert "TMP" not in rem.tkey
+
+
+def test_remove_site_unknown_raises(eht_array):
+    with pytest.raises(Exception, match="could not find site"):
+        eht_array.remove_site("NOTASITE")
+
+
+def test_remove_site_does_not_mutate_original(eht_array):
+    added = eht_array.add_site("TMP", (1.0, 2.0, 3.0))
+    n_before = len(added.tarr)
+    added.remove_site("TMP")
+    assert len(added.tarr) == n_before
+
+
+def test_remove_site_also_removes_ephem_entry():
+    tarr = np.zeros(1, dtype=ehc.DTARR)
+    tarr["site"] = ["SAT"]
+    tarr["x"] = [np.nan]
+    tarr["y"] = [np.nan]
+    tarr["z"] = [np.nan]
+    arr = eh.array.Array(tarr, ephem={"SAT": ["n", "l1", "l2"]})
+    out = arr.remove_site("SAT")
+    assert "SAT" not in out.ephem
+
+
+# ---------------------------------------------------------------------------
+# Section 6: add_satellite_tle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(reason="Bug in Array.add_satellite_tle (array.py:264): "
+                          "body references `tlearr` but the kwarg is `tlelist`. "
+                          "Fixed by PR #260 which renames the kwarg to `tlearr`.")
+def test_add_satellite_tle_appends_row(eht_array):
+    tle = ["SAT1", "tle_line_1", "tle_line_2"]
+    out = eht_array.add_satellite_tle(tle, sefd=8000)
+    assert "SAT1" in out.tkey
+    row = _site_row(out, "SAT1")
+    assert row["sefdr"] == 8000.0
+    assert row["sefdl"] == 8000.0
+    assert out.ephem["SAT1"] == tle
+
+
+# ---------------------------------------------------------------------------
+# Section 7: add_satellite_elements
+# ---------------------------------------------------------------------------
+
+
+def test_add_satellite_elements_appends_row(eht_array):
+    out = eht_array.add_satellite_elements("SAT_KEP", sefd=8000)
+    assert "SAT_KEP" in out.tkey
+    row = _site_row(out, "SAT_KEP")
+    assert row["sefdr"] == 8000.0
+    assert row["sefdl"] == 8000.0
+
+
+def test_add_satellite_elements_coords_zero(eht_array):
+    out = eht_array.add_satellite_elements("SAT_KEP")
+    row = _site_row(out, "SAT_KEP")
+    assert row["x"] == 0.0
+    assert row["y"] == 0.0
+    assert row["z"] == 0.0
+
+
+def test_add_satellite_elements_ephem_has_six_kepler_elements(eht_array):
+    out = eht_array.add_satellite_elements(
+        "SAT_KEP",
+        perigee_mjd=58000.0, period_days=1.0, eccentricity=0.1,
+        inclination=45.0, arg_perigee=30.0, long_ascending=15.0,
+    )
+    assert len(out.ephem["SAT_KEP"]) == 6
+    assert out.ephem["SAT_KEP"][0] == 58000.0
+    assert out.ephem["SAT_KEP"][1] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Section 8: obsdata
+# ---------------------------------------------------------------------------
+
+
+def test_obsdata_returns_obsdata_with_stokes(eht_array):
+    obs = eht_array.obsdata(17.761, -29.0, 230e9, 4e9,
+                             tint=5, tadv=600, tstart=0, tstop=24)
+    assert isinstance(obs, eh.obsdata.Obsdata)
+    assert obs.polrep == "stokes"
+    assert len(obs.data) > 0
+
+
+def test_obsdata_polrep_circ(eht_array):
+    obs = eht_array.obsdata(17.761, -29.0, 230e9, 4e9,
+                             tint=5, tadv=600, tstart=0, tstop=24,
+                             polrep="circ")
+    assert obs.polrep == "circ"
+
+
+def test_obsdata_propagates_ra_dec_rf_bw(eht_array):
+    obs = eht_array.obsdata(17.761, -29.0, 230e9, 4e9,
+                             tint=5, tadv=600, tstart=0, tstop=24)
+    assert obs.ra == pytest.approx(17.761)
+    assert obs.dec == pytest.approx(-29.0)
+    assert obs.rf == pytest.approx(230e9)
+    assert obs.bw == pytest.approx(4e9)
+
+
+def test_obsdata_default_timetype_utc(eht_array):
+    obs = eht_array.obsdata(17.761, -29.0, 230e9, 4e9,
+                             tint=5, tadv=600, tstart=0, tstop=24)
+    assert obs.timetype == "UTC"
+
+
+def test_obsdata_timetype_gmst(eht_array):
+    obs = eht_array.obsdata(17.761, -29.0, 230e9, 4e9,
+                             tint=5, tadv=600, tstart=0, tstop=24,
+                             timetype="GMST")
+    assert obs.timetype == "GMST"
+
+
+def test_obsdata_calibration_flags_all_true(eht_array):
+    obs = eht_array.obsdata(17.761, -29.0, 230e9, 4e9,
+                             tint=5, tadv=600, tstart=0, tstop=24)
+    # Array.obsdata always builds a perfect-calibration empty obs.
+    assert obs.ampcal is True
+    assert obs.phasecal is True
+    assert obs.opacitycal is True
+    assert obs.dcal is True
+    assert obs.frcal is True
+
+
+# ---------------------------------------------------------------------------
+# Section 9: save_txt / load_txt round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_save_load_txt_roundtrip_sites(eht_array, tmp_path):
+    fname = str(tmp_path / "arr.txt")
+    eht_array.save_txt(fname)
+    loaded = eh.array.load_txt(fname)
+    assert set(str(s) for s in loaded.tarr["site"]) == \
+           set(str(s) for s in eht_array.tarr["site"])
+
+
+def test_save_load_txt_roundtrip_coords(eht_array, tmp_path):
+    fname = str(tmp_path / "arr.txt")
+    eht_array.save_txt(fname)
+    loaded = eh.array.load_txt(fname)
+    # Sites may be reordered, so compare via tkey lookups.
+    for site in eht_array.tarr["site"]:
+        site = str(site)
+        a = _site_row(eht_array, site)
+        b = _site_row(loaded, site)
+        assert a["x"] == pytest.approx(b["x"], rel=1e-6)
+        assert a["y"] == pytest.approx(b["y"], rel=1e-6)
+        assert a["z"] == pytest.approx(b["z"], rel=1e-6)
+
+
+def test_save_load_txt_roundtrip_sefds(eht_array, tmp_path):
+    fname = str(tmp_path / "arr.txt")
+    eht_array.save_txt(fname)
+    loaded = eh.array.load_txt(fname)
+    for site in eht_array.tarr["site"]:
+        site = str(site)
+        a = _site_row(eht_array, site)
+        b = _site_row(loaded, site)
+        # Save uses %.2f for SEFD, so allow a small absolute tolerance.
+        assert a["sefdr"] == pytest.approx(b["sefdr"], abs=1e-2)
+        assert a["sefdl"] == pytest.approx(b["sefdl"], abs=1e-2)
+
+
+def test_load_txt_known_array_has_eht2017_sites():
+    arr = eh.array.load_txt(
+        os.path.join(os.path.dirname(__file__), "..", "arrays", "EHT2017.txt"))
+    sites = set(str(s) for s in arr.tarr["site"])
+    # Pinning the EHT 2017 site list — any change to the canonical file
+    # should surface in tests.
+    assert sites == {"ALMA", "APEX", "JCMT", "LMT", "PV", "SMA", "SMT", "SPT"}
+
+
+# ---------------------------------------------------------------------------
+# Section 10: Pickle / interop smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_array_deepcopy_independent(eht_array):
+    import copy
+    other = copy.deepcopy(eht_array)
+    raw_other = np.asarray(other.tarr)
+    raw_other["x"][0] += 1.0
+    assert np.asarray(eht_array.tarr)["x"][0] != raw_other["x"][0]
+
+
+def test_array_pickle_roundtrip(eht_array):
+    import pickle
+    rt = pickle.loads(pickle.dumps(eht_array))
+    assert set(rt.tkey.keys()) == set(eht_array.tkey.keys())
+    for site in eht_array.tarr["site"]:
+        a = _site_row(eht_array, site)
+        b = _site_row(rt, site)
+        assert a["x"] == b["x"]
+        assert a["sefdr"] == b["sefdr"]

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,972 @@
+"""Tests for Image methods.
+
+Method-by-method coverage of ehtim/image.py. Sections mirror the structure
+of the class itself and follow the pattern established by tests/test_obsdata.py:
+session-scoped fixtures from conftest.py (gauss_im, gauss_im_pol, eht_array,
+obs_direct, ...) are reused so the expensive constructors are amortised
+across the whole module.
+"""
+
+import numpy as np
+import pytest
+
+import ehtim as eh
+
+# ---------------------------------------------------------------------------
+# Section 1: Construction, basic state, image_args, copy
+# ---------------------------------------------------------------------------
+
+
+def test_init_requires_2d_array():
+    with pytest.raises(Exception, match="2D"):
+        eh.image.Image(np.zeros(16), 1e-10, 17.761, -29.0)
+
+
+def test_init_rejects_bad_polrep():
+    with pytest.raises(Exception, match="polrep"):
+        eh.image.Image(np.zeros((4, 4)), 1e-10, 17.761, -29.0, polrep="lin")
+
+
+def test_init_rejects_bad_pol_prim_stokes():
+    with pytest.raises(Exception, match="pol_prim"):
+        eh.image.Image(np.zeros((4, 4)), 1e-10, 17.761, -29.0,
+                       polrep="stokes", pol_prim="RR")
+
+
+def test_init_rejects_bad_pol_prim_circ():
+    with pytest.raises(Exception, match="pol_prim"):
+        eh.image.Image(np.zeros((4, 4)), 1e-10, 17.761, -29.0,
+                       polrep="circ", pol_prim="I")
+
+
+def test_init_default_polrep_is_stokes(gauss_im):
+    assert gauss_im.polrep == "stokes"
+    assert gauss_im.pol_prim == "I"
+
+
+def test_init_xdim_ydim_from_image_shape():
+    arr = np.zeros((5, 7))  # (ydim, xdim)
+    im = eh.image.Image(arr, 1e-10, 17.761, -29.0)
+    assert im.ydim == 5
+    assert im.xdim == 7
+
+
+def test_init_time_over_24_wraps_into_mjd():
+    arr = np.zeros((4, 4))
+    im = eh.image.Image(arr, 1e-10, 17.761, -29.0,
+                        mjd=58000, time=27.5)
+    assert im.mjd == 58001
+    assert im.time == pytest.approx(3.5)
+
+
+def test_image_args_roundtrip(gauss_im):
+    arglist, argdict = gauss_im.image_args()
+    rebuilt = eh.image.Image(*arglist, **argdict)
+    assert rebuilt.xdim == gauss_im.xdim
+    assert rebuilt.ydim == gauss_im.ydim
+    assert rebuilt.psize == gauss_im.psize
+    assert rebuilt.polrep == gauss_im.polrep
+    np.testing.assert_array_equal(rebuilt.imvec, gauss_im.imvec)
+
+
+def test_copy_is_deep(gauss_im):
+    other = gauss_im.copy()
+    other._imdict[other.pol_prim][0] += 1.0
+    assert other.imvec[0] != gauss_im.imvec[0]
+    assert other is not gauss_im
+
+
+def test_copy_preserves_pol_images(gauss_im_pol):
+    other = gauss_im_pol.copy()
+    np.testing.assert_array_equal(other.qvec, gauss_im_pol.qvec)
+    np.testing.assert_array_equal(other.uvec, gauss_im_pol.uvec)
+    np.testing.assert_array_equal(other.vvec, gauss_im_pol.vvec)
+
+
+def test_copy_preserves_mflist(gauss_im):
+    im = gauss_im.add_const_mf(alpha=2.5, beta=0.1)
+    other = im.copy()
+    np.testing.assert_array_equal(other.specvec, im.specvec)
+    np.testing.assert_array_equal(other.curvvec, im.curvvec)
+
+
+# ---------------------------------------------------------------------------
+# Section 2: Imvec / property getters & setters
+# ---------------------------------------------------------------------------
+
+
+def test_imvec_get_matches_imdict(gauss_im):
+    np.testing.assert_array_equal(gauss_im.imvec, gauss_im._imdict["I"])
+
+
+def test_imvec_setter_rejects_wrong_size(gauss_im):
+    im = gauss_im.copy()
+    with pytest.raises(Exception, match="xdim"):
+        im.imvec = np.zeros(5)
+
+
+def test_imvec_setter_updates_imdict(gauss_im):
+    im = gauss_im.copy()
+    new = np.arange(im.xdim * im.ydim, dtype=float)
+    im.imvec = new
+    np.testing.assert_array_equal(im._imdict["I"], new)
+
+
+@pytest.mark.parametrize("propname", ["specvec", "curvvec", "specvec_pol",
+                                       "curvvec_pol", "rmvec", "cmvec"])
+def test_mflist_setter_rejects_wrong_size(gauss_im, propname):
+    im = gauss_im.copy()
+    with pytest.raises(Exception, match="xdim"):
+        setattr(im, propname, np.zeros(5))
+
+
+@pytest.mark.parametrize("propname,idx", [
+    ("specvec", 0), ("curvvec", 1), ("specvec_pol", 2),
+    ("curvvec_pol", 3), ("rmvec", 4), ("cmvec", 5),
+])
+def test_mflist_setter_updates_mflist(gauss_im, propname, idx):
+    im = gauss_im.copy()
+    new = np.linspace(0.1, 0.2, im.xdim * im.ydim)
+    setattr(im, propname, new)
+    np.testing.assert_array_equal(im._mflist[idx], new)
+
+
+@pytest.mark.parametrize("propname", ["qvec", "uvec", "vvec"])
+def test_polvec_setter_rejects_non_stokes(gauss_im_pol, propname):
+    im_circ = gauss_im_pol.switch_polrep("circ")
+    with pytest.raises(Exception, match="polrep"):
+        setattr(im_circ, propname, np.zeros(im_circ.xdim * im_circ.ydim))
+
+
+@pytest.mark.parametrize("propname", ["rrvec", "llvec", "rlvec", "lrvec"])
+def test_circ_polvec_setter_rejects_non_circ(gauss_im, propname):
+    with pytest.raises(Exception, match="polrep"):
+        setattr(gauss_im.copy(), propname,
+                np.zeros(gauss_im.xdim * gauss_im.ydim))
+
+
+def test_rrvec_derived_from_stokes_with_v(gauss_im):
+    im = gauss_im.copy()
+    im.add_v(0.0 * im.imarr())  # V = 0 -> RR = I
+    np.testing.assert_allclose(im.rrvec, im.ivec)
+
+
+def test_rrvec_empty_when_no_v(gauss_im):
+    assert gauss_im.rrvec.size == 0
+
+
+def test_rlvec_derived_from_q_and_u(gauss_im_pol):
+    expected = gauss_im_pol.qvec + 1j * gauss_im_pol.uvec
+    np.testing.assert_allclose(gauss_im_pol.rlvec, expected)
+
+
+def test_pvec_matches_qplusiu(gauss_im_pol):
+    expected = np.abs(gauss_im_pol.qvec + 1j * gauss_im_pol.uvec)
+    np.testing.assert_allclose(gauss_im_pol.pvec, expected)
+
+
+def test_mvec_matches_p_over_i(gauss_im_pol):
+    expected = gauss_im_pol.pvec / gauss_im_pol.ivec
+    np.testing.assert_allclose(gauss_im_pol.mvec, expected)
+
+
+def test_chivec_matches_half_angle(gauss_im_pol):
+    expected = 0.5 * np.angle(
+        (gauss_im_pol.qvec + 1j * gauss_im_pol.uvec) / gauss_im_pol.ivec
+    )
+    np.testing.assert_allclose(gauss_im_pol.chivec, expected)
+
+
+def test_phivec_is_twice_chivec(gauss_im_pol):
+    np.testing.assert_allclose(gauss_im_pol.phivec, 2 * gauss_im_pol.chivec)
+
+
+def test_evpavec_aliases_chivec(gauss_im_pol):
+    np.testing.assert_array_equal(gauss_im_pol.evpavec, gauss_im_pol.chivec)
+
+
+def test_rhovec_total_polfrac(gauss_im_pol):
+    expected = np.sqrt(gauss_im_pol.qvec**2 + gauss_im_pol.uvec**2
+                       + gauss_im_pol.vvec**2) / gauss_im_pol.ivec
+    np.testing.assert_allclose(gauss_im_pol.rhovec, expected)
+
+
+def test_psivec_circular_poincare(gauss_im_pol):
+    expected = np.arctan2(gauss_im_pol.vvec, gauss_im_pol.pvec)
+    np.testing.assert_allclose(gauss_im_pol.psivec, expected)
+
+
+def test_evec_bvec_shape(gauss_im_pol):
+    assert gauss_im_pol.evec.shape == gauss_im_pol.ivec.shape
+    assert gauss_im_pol.bvec.shape == gauss_im_pol.ivec.shape
+    assert np.all(np.isreal(gauss_im_pol.evec))
+    assert np.all(np.isreal(gauss_im_pol.bvec))
+
+
+def test_evec_bvec_zero_for_no_polarization(gauss_im):
+    # With Q=U=0 the E and B modes must vanish.
+    im = gauss_im.copy()
+    im.add_qu(0.0 * im.imarr(), 0.0 * im.imarr())
+    np.testing.assert_allclose(im.evec, 0.0, atol=1e-12)
+    np.testing.assert_allclose(im.bvec, 0.0, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Section 3: get_polvec, imarr, sourcevec, fovx/fovy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("pol", ["I", "i"])
+def test_get_polvec_case_insensitive(gauss_im, pol):
+    np.testing.assert_array_equal(gauss_im.get_polvec(pol), gauss_im.ivec)
+
+
+def test_get_polvec_default_uses_pol_prim(gauss_im):
+    np.testing.assert_array_equal(gauss_im.get_polvec(None), gauss_im.imvec)
+
+
+@pytest.mark.parametrize("pol", ["I", "Q", "U", "V", "P", "M", "chi",
+                                  "evpa", "E", "B"])
+def test_get_polvec_shapes(gauss_im_pol, pol):
+    v = gauss_im_pol.get_polvec(pol)
+    assert v.shape == gauss_im_pol.imvec.shape
+
+
+def test_get_polvec_unknown_raises(gauss_im):
+    with pytest.raises(Exception, match="not recognized"):
+        gauss_im.get_polvec("banana")
+
+
+def test_imarr_default_returns_primary(gauss_im):
+    arr = gauss_im.imarr()
+    assert arr.shape == (gauss_im.ydim, gauss_im.xdim)
+    np.testing.assert_array_equal(arr.flatten(), gauss_im.imvec)
+
+
+def test_imarr_returns_empty_for_missing_pol(gauss_im):
+    arr = gauss_im.imarr("Q")  # no Q image present
+    assert arr.size == 0
+
+
+def test_sourcevec_unit_norm(gauss_im):
+    sv = gauss_im.sourcevec()
+    np.testing.assert_allclose(np.linalg.norm(sv), 1.0)
+    assert sv[1] == 0.0
+
+
+def test_fovx_fovy(gauss_im):
+    assert gauss_im.fovx() == pytest.approx(gauss_im.psize * gauss_im.xdim)
+    assert gauss_im.fovy() == pytest.approx(gauss_im.psize * gauss_im.ydim)
+
+
+# ---------------------------------------------------------------------------
+# Section 4: add_pol_image, add_qu, add_v, copy_pol_images
+# ---------------------------------------------------------------------------
+
+
+def test_add_pol_image_rejects_pol_prim(gauss_im):
+    im = gauss_im.copy()
+    with pytest.raises(Exception, match="pol_prim"):
+        im.add_pol_image(im.imarr(), "I")
+
+
+def test_add_pol_image_rejects_bad_shape(gauss_im):
+    im = gauss_im.copy()
+    with pytest.raises(Exception, match="shapes"):
+        im.add_pol_image(np.zeros((3, 3)), "Q")
+
+
+def test_add_pol_image_rejects_unknown_pol(gauss_im):
+    im = gauss_im.copy()
+    with pytest.raises(Exception, match="add_pol_image"):
+        im.add_pol_image(np.zeros((im.ydim, im.xdim)), "X")
+
+
+def test_add_qu_rejects_non_stokes(gauss_im_pol):
+    im_circ = gauss_im_pol.switch_polrep("circ")
+    with pytest.raises(Exception, match="stokes"):
+        im_circ.add_qu(np.zeros((im_circ.ydim, im_circ.xdim)),
+                       np.zeros((im_circ.ydim, im_circ.xdim)))
+
+
+def test_add_v_rejects_non_stokes(gauss_im_pol):
+    im_circ = gauss_im_pol.switch_polrep("circ")
+    with pytest.raises(Exception, match="stokes"):
+        im_circ.add_v(np.zeros((im_circ.ydim, im_circ.xdim)))
+
+
+def test_copy_pol_images_brings_q_u_v(gauss_im, gauss_im_pol):
+    empty = gauss_im.copy()
+    empty.copy_pol_images(gauss_im_pol)
+    np.testing.assert_array_equal(empty.qvec, gauss_im_pol.qvec)
+    np.testing.assert_array_equal(empty.uvec, gauss_im_pol.uvec)
+    np.testing.assert_array_equal(empty.vvec, gauss_im_pol.vvec)
+
+
+# ---------------------------------------------------------------------------
+# Section 5: switch_polrep
+# ---------------------------------------------------------------------------
+
+
+def test_switch_polrep_invalid_raises(gauss_im):
+    with pytest.raises(Exception, match="polrep_out"):
+        gauss_im.switch_polrep("lin")
+
+
+def test_switch_polrep_noop_returns_copy(gauss_im):
+    out = gauss_im.switch_polrep("stokes", "I")
+    assert out is not gauss_im
+    np.testing.assert_array_equal(out.imvec, gauss_im.imvec)
+
+
+def test_switch_polrep_stokes_to_circ_roundtrip(gauss_im_pol):
+    rt = gauss_im_pol.switch_polrep("circ").switch_polrep("stokes")
+    for vec in ("ivec", "qvec", "uvec", "vvec"):
+        np.testing.assert_allclose(
+            getattr(rt, vec), getattr(gauss_im_pol, vec), atol=1e-12,
+        )
+
+
+def test_switch_polrep_stokes_to_circ_formulae(gauss_im_pol):
+    out = gauss_im_pol.switch_polrep("circ")
+    np.testing.assert_allclose(out.rrvec,
+                               gauss_im_pol.ivec + gauss_im_pol.vvec, atol=1e-12)
+    np.testing.assert_allclose(out.llvec,
+                               gauss_im_pol.ivec - gauss_im_pol.vvec, atol=1e-12)
+    np.testing.assert_allclose(out.rlvec,
+                               gauss_im_pol.qvec + 1j * gauss_im_pol.uvec,
+                               atol=1e-12)
+    np.testing.assert_allclose(out.lrvec,
+                               gauss_im_pol.qvec - 1j * gauss_im_pol.uvec,
+                               atol=1e-12)
+
+
+def test_switch_polrep_raises_if_output_pol_missing(gauss_im):
+    # stokes-only image with pol_prim='I' cannot promote to circ pol_prim='RR'
+    # because V is not defined.
+    with pytest.raises(Exception, match="not defined"):
+        gauss_im.switch_polrep("circ", "RR")
+
+
+def test_orth_chi_flips_qu_signs(gauss_im_pol):
+    im = gauss_im_pol.orth_chi()
+    np.testing.assert_array_equal(im.qvec, -gauss_im_pol.qvec)
+    np.testing.assert_array_equal(im.uvec, -gauss_im_pol.uvec)
+
+
+def test_orth_chi_flips_rl_signs(gauss_im_pol):
+    im_circ = gauss_im_pol.switch_polrep("circ")
+    im = im_circ.orth_chi()
+    np.testing.assert_array_equal(im.rlvec, -im_circ.rlvec)
+    np.testing.assert_array_equal(im.lrvec, -im_circ.lrvec)
+
+
+# ---------------------------------------------------------------------------
+# Section 6: Summary quantities — total_flux, lin_polfrac, evpa, etc.
+# ---------------------------------------------------------------------------
+
+
+def test_total_flux_stokes(gauss_im):
+    assert gauss_im.total_flux() == pytest.approx(1.0)
+
+
+def test_total_flux_circ_average(gauss_im_pol):
+    im_circ = gauss_im_pol.switch_polrep("circ")
+    assert im_circ.total_flux() == pytest.approx(gauss_im_pol.total_flux(),
+                                                  rel=1e-12)
+
+
+def test_lin_polfrac_matches_circ(gauss_im_pol):
+    f_stokes = gauss_im_pol.lin_polfrac()
+    f_circ = gauss_im_pol.switch_polrep("circ").lin_polfrac()
+    assert f_stokes == pytest.approx(f_circ, rel=1e-12)
+
+
+def test_circ_polfrac_matches_circ(gauss_im_pol):
+    f_stokes = gauss_im_pol.circ_polfrac()
+    f_circ = gauss_im_pol.switch_polrep("circ").circ_polfrac()
+    assert f_stokes == pytest.approx(f_circ, rel=1e-12)
+
+
+def test_evpa_stokes_recovers_input_angle(gauss_im_pol):
+    # gauss_im_pol has Q = 0.10*I, U = 0.05*I -> EVPA = 0.5*atan2(0.05, 0.10).
+    expected = 0.5 * np.arctan2(0.05, 0.10)
+    assert gauss_im_pol.evpa() == pytest.approx(expected, rel=1e-10)
+
+
+def test_evpa_matches_across_polreps(gauss_im_pol):
+    e_stokes = gauss_im_pol.evpa()
+    e_circ = gauss_im_pol.switch_polrep("circ").evpa()
+    assert e_stokes == pytest.approx(e_circ, rel=1e-12)
+
+
+def test_mavg_geq_lin_polfrac(gauss_im_pol):
+    # |<p>| <= <|p|> for any image (Jensen).
+    assert gauss_im_pol.mavg() >= gauss_im_pol.lin_polfrac() - 1e-12
+
+
+def test_vavg_matches_circ(gauss_im_pol):
+    v_stokes = gauss_im_pol.vavg()
+    v_circ = gauss_im_pol.switch_polrep("circ").vavg()
+    assert v_stokes == pytest.approx(v_circ, rel=1e-12)
+
+
+def test_betamodes_returns_complex_list(gauss_im_pol):
+    out = gauss_im_pol.betamodes(ms=[2], verbose=False)
+    assert isinstance(out, list)
+    assert isinstance(out[0], complex) or np.iscomplexobj(out[0])
+
+
+def test_betamodes_output_fluxes_shape(gauss_im_pol):
+    out = gauss_im_pol.betamodes(ms=[2], output_fluxes=True, verbose=False)
+    coeffs, flux, pflux, area = out
+    assert len(coeffs) == 1
+    assert flux > 0
+    assert area > 0
+
+
+def test_betamodes_rejects_non_integer_m(gauss_im_pol):
+    with pytest.raises(Exception, match="integer"):
+        gauss_im_pol.betamodes(ms=[2.5], verbose=False)
+
+
+# ---------------------------------------------------------------------------
+# Section 7: centroid / center
+# ---------------------------------------------------------------------------
+
+
+def test_centroid_zero_for_symmetric_gaussian(gauss_im):
+    x0, y0 = gauss_im.centroid()
+    # Symmetric Gaussian at the image center -> centroid at (0,0).
+    assert abs(x0) < gauss_im.psize
+    assert abs(y0) < gauss_im.psize
+
+
+def test_centroid_raises_on_missing_pol(gauss_im):
+    with pytest.raises(Exception, match="No"):
+        gauss_im.centroid(pol="Q")
+
+
+def test_center_shifts_centroid_to_origin():
+    # An offset Gaussian should have a non-zero centroid; center() should
+    # bring it close to zero.
+    im = eh.image.make_empty(64, 200 * eh.RADPERUAS, 17.761, -29.0, rf=230e9)
+    im = im.add_gauss(1.0, (40 * eh.RADPERUAS, 40 * eh.RADPERUAS, 0,
+                            20 * eh.RADPERUAS, 0))
+    centered = im.center()
+    x0, y0 = centered.centroid()
+    assert abs(x0) < im.psize
+    assert abs(y0) < im.psize
+
+
+# ---------------------------------------------------------------------------
+# Section 8: Geometric transforms — pad, regrid, rotate, shift, shift_fft, resample
+# ---------------------------------------------------------------------------
+
+
+def test_pad_preserves_total_flux(gauss_im):
+    out = gauss_im.pad(2 * gauss_im.fovx(), 2 * gauss_im.fovy())
+    assert out.xdim > gauss_im.xdim
+    assert out.total_flux() == pytest.approx(gauss_im.total_flux(), rel=1e-12)
+    assert out.psize == pytest.approx(gauss_im.psize)
+
+
+def test_pad_preserves_polarizations(gauss_im_pol):
+    out = gauss_im_pol.pad(2 * gauss_im_pol.fovx(), 2 * gauss_im_pol.fovy())
+    assert out.qvec.size == out.xdim * out.ydim
+    assert np.sum(out.qvec) == pytest.approx(np.sum(gauss_im_pol.qvec))
+
+
+def test_regrid_image_changes_dimensions(gauss_im):
+    out = gauss_im.regrid_image(gauss_im.fovx(), 16)
+    assert out.xdim == 16
+    assert out.ydim == 16
+    assert out.psize == pytest.approx(gauss_im.fovx() / 16)
+
+
+def test_regrid_image_roughly_preserves_flux(gauss_im):
+    out = gauss_im.regrid_image(gauss_im.fovx(), 16)
+    # Coarser grid + interpolation -> within ~10%.
+    assert out.total_flux() == pytest.approx(gauss_im.total_flux(), rel=0.1)
+
+
+def test_rotate_preserves_flux(gauss_im):
+    out = gauss_im.rotate(np.pi / 4)
+    assert out.total_flux() == pytest.approx(gauss_im.total_flux(), rel=1e-3)
+
+
+def test_rotate_rejects_non_scalar_pol_prim():
+    arr = np.zeros((8, 8))
+    arr[4, 4] = 1.0
+    im = eh.image.Image(arr, 1e-10, 17.761, -29.0,
+                        polrep="circ", pol_prim="RR")
+    # Manually flip to a non-rotatable prim:
+    im.pol_prim = "RL"
+    with pytest.raises(Exception, match="scalar"):
+        im.rotate(np.pi / 4)
+
+
+def test_shift_integer_pixels(gauss_im):
+    out = gauss_im.shift([2, 0])
+    # A roll-based shift is a permutation, so total flux is exactly preserved.
+    assert out.total_flux() == pytest.approx(gauss_im.total_flux())
+
+
+def test_shift_fft_preserves_flux(gauss_im):
+    out = gauss_im.shift_fft([5 * eh.RADPERUAS, 0.0])
+    assert out.total_flux() == pytest.approx(gauss_im.total_flux(), rel=1e-10)
+
+
+def test_resample_square_changes_xdim(gauss_im):
+    out = gauss_im.resample_square(16)
+    assert out.xdim == 16
+    assert out.ydim == 16
+    assert out.total_flux() == pytest.approx(gauss_im.total_flux(), rel=1e-12)
+
+
+def test_resample_square_rejects_rect(make_rect_image):
+    rect = make_rect_image(32, 16)
+    with pytest.raises(Exception, match="square"):
+        rect.resample_square(8)
+
+
+# ---------------------------------------------------------------------------
+# Section 9: Blur, mask, threshold, gradient
+# ---------------------------------------------------------------------------
+
+
+def test_blur_gauss_preserves_flux(gauss_im):
+    out = gauss_im.blur_gauss([30 * eh.RADPERUAS, 30 * eh.RADPERUAS, 0])
+    assert out.total_flux() == pytest.approx(gauss_im.total_flux(), rel=1e-3)
+
+
+def test_blur_gauss_zero_frac_is_copy(gauss_im):
+    out = gauss_im.blur_gauss([30 * eh.RADPERUAS, 30 * eh.RADPERUAS, 0],
+                              frac=0.0)
+    np.testing.assert_array_equal(out.imvec, gauss_im.imvec)
+
+
+def test_blur_circ_preserves_flux(gauss_im):
+    out = gauss_im.blur_circ(30 * eh.RADPERUAS)
+    assert out.total_flux() == pytest.approx(gauss_im.total_flux(), rel=1e-3)
+
+
+def test_blur_circ_butter_filter(gauss_im):
+    out = gauss_im.blur_circ(30 * eh.RADPERUAS, filttype="butter")
+    assert out.imvec.shape == gauss_im.imvec.shape
+
+
+def test_blur_circ_rejects_bad_filttype(gauss_im):
+    with pytest.raises(Exception, match="filttype"):
+        gauss_im.blur_circ(30 * eh.RADPERUAS, filttype="square")
+
+
+def test_blur_mf_rejects_bad_fit_order(gauss_im):
+    with pytest.raises(Exception, match="fit_order"):
+        gauss_im.blur_mf([230e9, 350e9], 30 * eh.RADPERUAS, fit_order=3)
+
+
+def test_blur_mf_populates_specvec(gauss_im):
+    im_mf = gauss_im.add_const_mf(alpha=2.5)
+    out = im_mf.blur_mf([230e9, 350e9], 30 * eh.RADPERUAS, fit_order=1)
+    assert out.specvec.size == out.xdim * out.ydim
+
+
+def test_mask_returns_binary_image(gauss_im):
+    out = gauss_im.mask(cutoff=0.5)
+    assert set(np.unique(out.imvec)).issubset({0, 1})
+
+
+def test_mask_with_beam_blurs_first(gauss_im):
+    out = gauss_im.mask(cutoff=0.5, beamparams=30 * eh.RADPERUAS, frac=1.0)
+    assert set(np.unique(out.imvec)).issubset({0, 1})
+
+
+def test_apply_mask_dimension_mismatch(gauss_im):
+    other = eh.image.make_empty(8, gauss_im.fovx() / 4,
+                                17.761, -29.0, rf=230e9)
+    with pytest.raises(Exception, match="dimensions"):
+        gauss_im.apply_mask(other)
+
+
+def test_apply_mask_zeros_outside(gauss_im):
+    # NOTE: apply_mask mutates self.imvec in place (image.py:1895-1896), so
+    # work off a copy to keep the session-scoped fixture untouched.
+    im = gauss_im.copy()
+    m = im.mask(cutoff=0.5)
+    out = im.apply_mask(m, fill_val=0.0)
+    # Pixels outside the mask must be zero.
+    assert np.all(out.imvec[m.imvec == 0] == 0.0)
+
+
+def test_threshold_floor_value(gauss_im):
+    # threshold internally calls apply_mask, which mutates self.imvec; use a copy.
+    out = gauss_im.copy().threshold(cutoff=0.5, fill_val=0.0)
+    assert np.min(out.imvec) >= 0.0
+
+
+def test_grad_shape(gauss_im):
+    out = gauss_im.grad()
+    assert out.imvec.shape == gauss_im.imvec.shape
+
+
+def test_grad_zero_for_uniform_image():
+    arr = np.ones((16, 16))
+    im = eh.image.Image(arr, 1e-10, 17.761, -29.0)
+    out = im.grad()
+    # Sobel on a uniform field is zero everywhere.
+    np.testing.assert_allclose(out.imvec, 0.0, atol=1e-12)
+
+
+def test_grad_x_differs_from_abs():
+    arr = np.zeros((16, 16))
+    arr[8, 3] = 1.0
+    im = eh.image.Image(arr, 1e-10, 17.761, -29.0)
+    gx = im.grad(gradtype="x")
+    gabs = im.grad(gradtype="abs")
+    assert not np.allclose(gx.imvec, gabs.imvec)
+
+
+# ---------------------------------------------------------------------------
+# Section 10: Source-adding methods
+# ---------------------------------------------------------------------------
+
+
+def test_add_flat_increases_flux(gauss_im):
+    out = gauss_im.add_flat(0.5)
+    assert out.total_flux() == pytest.approx(gauss_im.total_flux() + 0.5,
+                                              rel=1e-12)
+
+
+def test_add_flat_rejects_missing_pol(gauss_im):
+    with pytest.raises(Exception, match="no image"):
+        gauss_im.add_flat(0.5, pol="Q")
+
+
+def test_add_flat_rejects_unknown_pol(gauss_im):
+    with pytest.raises(Exception, match="pol must"):
+        gauss_im.add_flat(0.5, pol="banana")
+
+
+def test_add_tophat_increases_flux(gauss_im):
+    out = gauss_im.add_tophat(0.7, 50 * eh.RADPERUAS)
+    assert out.total_flux() > gauss_im.total_flux()
+
+
+def test_add_gauss_increases_flux(gauss_im):
+    out = gauss_im.add_gauss(0.3, (20 * eh.RADPERUAS, 20 * eh.RADPERUAS, 0))
+    assert out.total_flux() == pytest.approx(gauss_im.total_flux() + 0.3,
+                                              rel=1e-3)
+
+
+def test_add_crescent_positive_flux(gauss_im):
+    out = gauss_im.add_crescent(0.5, 50 * eh.RADPERUAS, 25 * eh.RADPERUAS,
+                                10 * eh.RADPERUAS, 0)
+    assert out.total_flux() > gauss_im.total_flux()
+
+
+def test_add_ring_m1_returns_image(gauss_im):
+    out = gauss_im.add_ring_m1(1.0, 0.5, 40 * eh.RADPERUAS, 0,
+                               5 * eh.RADPERUAS)
+    assert out.imvec.shape == gauss_im.imvec.shape
+
+
+def test_add_const_pol_sets_linfrac(gauss_im):
+    out = gauss_im.add_const_pol(0.3, 0.0)
+    # Background pixels with I = 0 give NaN mvec; check only where I > 0.
+    mask = out.ivec > 1e-12
+    np.testing.assert_allclose(out.mvec[mask], 0.3, atol=1e-10)
+
+
+def test_add_const_pol_rejects_out_of_range(gauss_im):
+    with pytest.raises(Exception, match="magnitude"):
+        gauss_im.add_const_pol(1.5, 0.0)
+
+
+def test_add_random_pol_seed_reproducible(gauss_im):
+    a = gauss_im.add_random_pol(0.2, 50 * eh.RADPERUAS, seed=42)
+    b = gauss_im.add_random_pol(0.2, 50 * eh.RADPERUAS, seed=42)
+    np.testing.assert_array_equal(a.qvec, b.qvec)
+    np.testing.assert_array_equal(a.uvec, b.uvec)
+
+
+def test_add_const_mf_sets_avec_and_bvec(gauss_im):
+    out = gauss_im.add_const_mf(alpha=2.5, beta=0.1)
+    np.testing.assert_allclose(out.specvec, 2.5)
+    np.testing.assert_allclose(out.curvvec, 0.1)
+
+
+def test_add_const_mf_pol_terms(gauss_im_pol):
+    out = gauss_im_pol.add_const_mf(alpha=2.5, alpha_pol=0.5, rm=10.0)
+    np.testing.assert_allclose(out.specvec_pol, 0.5)
+    np.testing.assert_allclose(out.rmvec, 10.0)
+    assert out.curvvec_pol.size == 0  # not requested
+    assert out.cmvec.size == 0
+
+
+# ---------------------------------------------------------------------------
+# Section 11: get_image_mf — multifrequency
+# ---------------------------------------------------------------------------
+
+
+def test_get_image_mf_scales_by_power_law(gauss_im):
+    # I(nu) = I0 * (nu/nu0)^alpha with alpha=2 and nu=2*nu0 -> I scales 4x.
+    im_mf = gauss_im.add_const_mf(alpha=2.0)
+    out = im_mf.get_image_mf(2 * gauss_im.rf)
+    np.testing.assert_allclose(out.imvec, 4.0 * gauss_im.imvec, rtol=1e-10)
+    assert out.rf == pytest.approx(2 * gauss_im.rf)
+
+
+def test_get_image_mf_identity_at_reference(gauss_im):
+    im_mf = gauss_im.add_const_mf(alpha=2.5, beta=0.1)
+    out = im_mf.get_image_mf(gauss_im.rf)
+    np.testing.assert_allclose(out.imvec, gauss_im.imvec, rtol=1e-10)
+
+
+def test_get_image_mf_with_polarization(gauss_im_pol):
+    im_mf = gauss_im_pol.add_const_mf(alpha=2.0, alpha_pol=0.5, rm=10.0)
+    out = im_mf.get_image_mf(0.5 * gauss_im_pol.rf)
+    # Intensity should scale; polarization gets a Faraday rotation but stays real.
+    assert out.qvec.size == out.imvec.size
+    assert np.all(np.isfinite(out.qvec))
+
+
+# ---------------------------------------------------------------------------
+# Section 12: Sampling and observation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ttype", ["direct", "fast", "nfft"])
+def test_sample_uv_zero_baseline_is_total_flux(gauss_im, ttype):
+    uv = np.array([[0.0, 0.0]])
+    data = gauss_im.sample_uv(uv, ttype=ttype, verbose=False)
+    np.testing.assert_allclose(np.real(data[0][0]),
+                               gauss_im.total_flux(), rtol=1e-3)
+
+
+def test_sample_uv_rejects_bad_polrep(gauss_im):
+    with pytest.raises(Exception, match="polrep_obs"):
+        gauss_im.sample_uv(np.array([[0.0, 0.0]]), polrep_obs="lin",
+                           verbose=False)
+
+
+def test_observe_same_nonoise_matches_obs_baselines(gauss_im, obs_direct):
+    out = gauss_im.observe_same_nonoise(obs_direct, ttype="direct",
+                                         verbose=False)
+    assert len(out.data) == len(obs_direct.data)
+    np.testing.assert_array_equal(out.data["u"], obs_direct.data["u"])
+    np.testing.assert_array_equal(out.data["v"], obs_direct.data["v"])
+
+
+def test_observe_same_nonoise_zero_baseline_flux(gauss_im, obs_direct):
+    # Synthesise visibilities, find a near-zero baseline, check flux.
+    out = gauss_im.observe_same_nonoise(obs_direct, ttype="direct",
+                                         verbose=False)
+    uvdist = np.sqrt(out.data["u"] ** 2 + out.data["v"] ** 2)
+    closest = np.argmin(uvdist)
+    if uvdist[closest] < 1e9:  # only meaningful for short baselines
+        assert np.abs(out.data["vis"][closest]) <= gauss_im.total_flux() + 1e-3
+
+
+def test_observe_same_nonoise_coord_mismatch_raises(gauss_im, obs_direct):
+    im_bad = gauss_im.copy()
+    im_bad.ra = obs_direct.ra + 1.0
+    with pytest.raises(Exception, match="coordinates"):
+        im_bad.observe_same_nonoise(obs_direct, ttype="direct", verbose=False)
+
+
+def test_observe_same_nonoise_freq_mismatch_raises(gauss_im, obs_direct):
+    im_bad = gauss_im.copy()
+    im_bad.rf = 2 * obs_direct.rf
+    with pytest.raises(Exception, match="frequency"):
+        im_bad.observe_same_nonoise(obs_direct, ttype="direct", verbose=False)
+
+
+def test_observe_same_nonoise_bad_ttype_raises(gauss_im, obs_direct):
+    with pytest.raises(Exception, match="ttype"):
+        gauss_im.observe_same_nonoise(obs_direct, ttype="banana",
+                                       verbose=False)
+
+
+def test_observe_creates_obsdata(gauss_im, eht_array):
+    obs = gauss_im.observe(eht_array, 5, 600, 0, 24, 4e9,
+                            ttype="direct", add_th_noise=False, verbose=False)
+    assert isinstance(obs, eh.obsdata.Obsdata)
+    assert len(obs.data) > 0
+
+
+def test_observe_with_noise_seed_reproducible(gauss_im, eht_array):
+    a = gauss_im.observe(eht_array, 5, 600, 0, 24, 4e9,
+                          ttype="direct", add_th_noise=True, seed=42,
+                          verbose=False)
+    b = gauss_im.observe(eht_array, 5, 600, 0, 24, 4e9,
+                          ttype="direct", add_th_noise=True, seed=42,
+                          verbose=False)
+    np.testing.assert_array_equal(a.data["vis"], b.data["vis"])
+
+
+# ---------------------------------------------------------------------------
+# Section 13: compare_images, align_images, find_shift
+# ---------------------------------------------------------------------------
+
+
+def test_compare_images_self_is_identity(gauss_im):
+    err, im1_pad, im2_shift = gauss_im.compare_images(gauss_im)
+    nxcorr, nrmse, rssd = err
+    # Self comparison: normalized cross-corr = 1, error metrics = 0.
+    assert nxcorr == pytest.approx(1.0, abs=1e-6)
+    assert nrmse == pytest.approx(0.0, abs=1e-9)
+    assert rssd == pytest.approx(0.0, abs=1e-9)
+
+
+def test_compare_images_polrep_handled_internally(gauss_im_pol):
+    im_circ = gauss_im_pol.switch_polrep("circ")
+    err, _, _ = gauss_im_pol.compare_images(im_circ)
+    assert err[0] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_find_shift_returns_idx_and_xcorr(gauss_im):
+    idx, xcorr, im1, im2 = gauss_im.find_shift(gauss_im)
+    assert len(idx) == 2
+    assert xcorr.shape == (im1.ydim, im1.xdim)
+
+
+def test_find_shift_rejects_complex_pol(gauss_im_pol):
+    with pytest.raises(Exception, match="complex"):
+        gauss_im_pol.find_shift(gauss_im_pol, pol="RL")
+
+
+def test_align_images_returns_tuple(gauss_im):
+    im2 = gauss_im.copy()
+    out_list, shifts, base = gauss_im.align_images([im2])
+    assert len(out_list) == 1
+    assert len(shifts) == 1
+
+
+# ---------------------------------------------------------------------------
+# Section 14: Gaussian fit
+# ---------------------------------------------------------------------------
+
+
+def test_fit_gauss_recovers_fwhm(gauss_im):
+    fwhm_maj, fwhm_min, theta = gauss_im.fit_gauss()
+    # gauss_im was built with 50 uas FWHM in both axes.
+    assert fwhm_maj / eh.RADPERUAS == pytest.approx(50.0, rel=0.01)
+    assert fwhm_min / eh.RADPERUAS == pytest.approx(50.0, rel=0.01)
+
+
+def test_fit_gauss_natural_units(gauss_im):
+    fwhm_maj, fwhm_min, pa = gauss_im.fit_gauss(units="natural")
+    assert fwhm_maj == pytest.approx(50.0, rel=0.01)
+    # Natural units use degrees for the position angle.
+    assert 0 <= pa < 180
+
+
+def test_fit_gauss_empirical_runs(gauss_im):
+    out = gauss_im.fit_gauss_empirical()
+    assert len(out) == 3
+    # The major axis should be >= minor axis after sorting.
+    assert out[0] >= out[1]
+
+
+# ---------------------------------------------------------------------------
+# Section 15: Save / load round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_save_load_txt_roundtrip(gauss_im, tmp_path):
+    fname = tmp_path / "im.txt"
+    gauss_im.save_txt(str(fname))
+    loaded = eh.image.load_txt(str(fname))
+    assert loaded.xdim == gauss_im.xdim
+    assert loaded.ydim == gauss_im.ydim
+    assert loaded.total_flux() == pytest.approx(gauss_im.total_flux(),
+                                                 rel=1e-6)
+
+
+def test_save_load_fits_roundtrip(gauss_im, tmp_path):
+    fname = tmp_path / "im.fits"
+    gauss_im.save_fits(str(fname))
+    loaded = eh.image.load_fits(str(fname))
+    assert loaded.xdim == gauss_im.xdim
+    assert loaded.ydim == gauss_im.ydim
+    assert loaded.total_flux() == pytest.approx(gauss_im.total_flux(),
+                                                 rel=1e-6)
+    np.testing.assert_allclose(loaded.imvec, gauss_im.imvec, rtol=1e-6,
+                                atol=1e-10)
+
+
+def test_load_image_dispatch_unknown_extension(tmp_path):
+    f = tmp_path / "im.unknown"
+    f.write_text("hello")
+    out = eh.image.load_image(str(f))
+    assert out is False
+
+
+def test_load_image_passthrough_image_object(gauss_im):
+    out = eh.image.load_image(gauss_im)
+    assert out is gauss_im
+
+
+# ---------------------------------------------------------------------------
+# Section 16: Module-level constructors and helpers
+# ---------------------------------------------------------------------------
+
+
+def test_make_empty_zero_image():
+    im = eh.image.make_empty(16, 200 * eh.RADPERUAS, 17.761, -29.0, rf=230e9)
+    assert im.xdim == 16
+    assert im.ydim == 16
+    assert im.total_flux() == 0.0
+    assert im.polrep == "stokes"
+    assert im.pol_prim == "I"
+
+
+def test_make_square_uses_obs_metadata(obs_direct):
+    sq = eh.image.make_square(obs_direct, 16, 100 * eh.RADPERUAS)
+    assert sq.xdim == 16
+    assert sq.ra == pytest.approx(obs_direct.ra)
+    assert sq.dec == pytest.approx(obs_direct.dec)
+    assert sq.rf == pytest.approx(obs_direct.rf)
+
+
+def test_avg_imlist_two_copies_returns_same_flux(gauss_im):
+    avg = eh.image.avg_imlist([gauss_im.copy(), gauss_im.copy()])
+    assert avg.total_flux() == pytest.approx(gauss_im.total_flux(), rel=1e-12)
+
+
+def test_avg_imlist_polrep_mismatch_raises(gauss_im_pol):
+    # Needs a fully polarized image because switch_polrep("circ") requires V.
+    im_circ = gauss_im_pol.switch_polrep("circ")
+    with pytest.raises(Exception, match="polrep"):
+        eh.image.avg_imlist([gauss_im_pol.copy(), im_circ])
+
+
+def test_avg_imlist_source_mismatch_raises(gauss_im):
+    other = gauss_im.copy()
+    other.source = "other"
+    with pytest.raises(Exception, match="source"):
+        eh.image.avg_imlist([gauss_im.copy(), other])
+
+
+def test_avg_imlist_rf_mismatch_raises(gauss_im):
+    other = gauss_im.copy()
+    other.rf = 2 * gauss_im.rf
+    with pytest.raises(Exception, match="rf"):
+        eh.image.avg_imlist([gauss_im.copy(), other])
+
+
+def test_get_specim_recovers_alpha(gauss_im):
+    im_mf = gauss_im.add_const_mf(alpha=2.5)
+    im_350 = im_mf.get_image_mf(350e9)
+    out = eh.image.get_specim([im_mf.copy(), im_350], reffreq=gauss_im.rf,
+                               fit_order=1)
+    # The recovered spectral index should match the input alpha.
+    np.testing.assert_allclose(out.specvec, 2.5, rtol=1e-6)
+
+
+def test_get_specim_invalid_fit_order(gauss_im):
+    im_mf = gauss_im.add_const_mf(alpha=2.5)
+    im_350 = im_mf.get_image_mf(350e9)
+    with pytest.raises(Exception):
+        eh.image.get_specim([im_mf, im_350], reffreq=gauss_im.rf, fit_order=3)

--- a/tests/test_obs_simulate.py
+++ b/tests/test_obs_simulate.py
@@ -1,10 +1,17 @@
-"""Tests for ehtim.observing.obs_simulate.sample_vis."""
+"""Tests for ehtim.observing.obs_simulate.
+
+Covers all seven public functions: make_uvpoints, sample_vis, make_jones,
+make_jones_inverse, add_jones_and_noise, apply_jones_inverse, add_noise.
+"""
 import os
 
 import numpy as np
 import pytest
 
 import ehtim as eh
+import ehtim.const_def as ehc
+from ehtim.observing import obs_helpers as obsh
+from ehtim.observing import obs_simulate as os_sim
 
 ARRAY_PATH = os.path.join(os.path.dirname(__file__), "..", "arrays", "EHT2017.txt")
 
@@ -15,9 +22,26 @@ TSTOP = 24.0
 BW = 1e9
 
 
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
 @pytest.fixture(scope="module")
 def array():
     return eh.array.load_txt(ARRAY_PATH)
+
+
+@pytest.fixture(scope="module")
+def asymmetric_array(array):
+    """Array with sefdr != sefdl and nonzero D-terms (so circ sigmas/dterms differ)."""
+    arr = array.copy()
+    tarr = np.asarray(arr.tarr).copy()
+    tarr["sefdl"] = tarr["sefdr"] * 1.5
+    tarr["dr"] = 0.02 + 0.01j
+    tarr["dl"] = -0.01 + 0.015j
+    arr.tarr = tarr
+    return arr
 
 
 @pytest.fixture(scope="module")
@@ -37,19 +61,200 @@ def asymmetric_image_pol(asymmetric_image):
     return im
 
 
-def _observe(im, array, ttype):
+def _observe(im, array, ttype="direct"):
     return im.observe(
         array, TINT, TADV, TSTART, TSTOP, BW,
         ampcal=True, phasecal=True, ttype=ttype, add_th_noise=False,
     )
 
 
-class TestSampleVisTtypeParity:
-    """sample_vis output agrees across ttype='direct' and ttype='nfft'.
+@pytest.fixture(scope="module")
+def obs(asymmetric_image, array):
+    """Noise-free Stokes observation used by most Jones tests."""
+    return _observe(asymmetric_image, array)
 
-    Same uv coverage, same image, same pulse: visibilities should agree to
-    finufft's accuracy floor (eps=1e-9 default).
-    """
+
+@pytest.fixture(scope="module")
+def obs_pol(asymmetric_image_pol, array):
+    return _observe(asymmetric_image_pol, array)
+
+
+@pytest.fixture(scope="module")
+def obs_asym(asymmetric_image, asymmetric_array):
+    """Observation against the asymmetric array (sefdr != sefdl, nonzero D)."""
+    return _observe(asymmetric_image, asymmetric_array)
+
+
+# ---------------------------------------------------------------------------
+# make_uvpoints
+# ---------------------------------------------------------------------------
+
+
+class TestMakeUvpoints:
+    """Coverage for obs_simulate.make_uvpoints (uv generation + sigma layout)."""
+
+    def test_stokes_dtype(self, array):
+        out = os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
+                                   TINT, TADV, TSTART, TSTOP, polrep="stokes")
+        assert out.dtype == np.dtype(ehc.DTPOL_STOKES)
+        assert set(out.dtype.names) >= {"vis", "qvis", "uvis", "vvis",
+                                        "sigma", "qsigma", "usigma", "vsigma"}
+
+    def test_circ_dtype(self, array):
+        out = os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
+                                   TINT, TADV, TSTART, TSTOP, polrep="circ")
+        assert out.dtype == np.dtype(ehc.DTPOL_CIRC)
+        assert set(out.dtype.names) >= {"rrvis", "llvis", "rlvis", "lrvis",
+                                        "rrsigma", "llsigma", "rlsigma", "lrsigma"}
+
+    def test_invalid_polrep_raises(self, array):
+        with pytest.raises(Exception, match="only 'stokes' and 'circ'"):
+            os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
+                                 TINT, TADV, TSTART, TSTOP, polrep="linear")
+
+    def test_baseline_ordering(self, array):
+        out = os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
+                                   TINT, TADV, TSTART, TSTOP)
+        order = {site: i for i, site in enumerate(array.tarr["site"])}
+        for row in out:
+            assert order[row["t1"]] < order[row["t2"]]
+
+    def test_stokes_sigma_layout(self, asymmetric_array):
+        """For circ: sig_iv = 0.5*sqrt(sig_rr^2 + sig_ll^2); sig_qu = 0.5*sqrt(sig_rl^2 + sig_lr^2)."""
+        out = os_sim.make_uvpoints(asymmetric_array, 17.761, -29.0, 230e9, BW,
+                                   TINT, TADV, TSTART, TSTOP, polrep="stokes")
+        row = out[0]
+        t1, t2 = row["t1"], row["t2"]
+        i1 = list(asymmetric_array.tarr["site"]).index(t1)
+        i2 = list(asymmetric_array.tarr["site"]).index(t2)
+        sefdr1 = asymmetric_array.tarr[i1]["sefdr"]
+        sefdl1 = asymmetric_array.tarr[i1]["sefdl"]
+        sefdr2 = asymmetric_array.tarr[i2]["sefdr"]
+        sefdl2 = asymmetric_array.tarr[i2]["sefdl"]
+        sig_rr = obsh.blnoise(sefdr1, sefdr2, TINT, BW)
+        sig_ll = obsh.blnoise(sefdl1, sefdl2, TINT, BW)
+        sig_rl = obsh.blnoise(sefdr1, sefdl2, TINT, BW)
+        sig_lr = obsh.blnoise(sefdl1, sefdr2, TINT, BW)
+        sig_iv = 0.5 * np.sqrt(sig_rr ** 2 + sig_ll ** 2)
+        sig_qu = 0.5 * np.sqrt(sig_rl ** 2 + sig_lr ** 2)
+        np.testing.assert_allclose(row["sigma"], sig_iv)
+        np.testing.assert_allclose(row["vsigma"], sig_iv)
+        np.testing.assert_allclose(row["qsigma"], sig_qu)
+        np.testing.assert_allclose(row["usigma"], sig_qu)
+
+    def test_circ_sigma_layout(self, asymmetric_array):
+        """For circ: sig1..4 = sig_rr, sig_ll, sig_rl, sig_lr (no mixing)."""
+        out = os_sim.make_uvpoints(asymmetric_array, 17.761, -29.0, 230e9, BW,
+                                   TINT, TADV, TSTART, TSTOP, polrep="circ")
+        row = out[0]
+        i1 = list(asymmetric_array.tarr["site"]).index(row["t1"])
+        i2 = list(asymmetric_array.tarr["site"]).index(row["t2"])
+        sefdr1 = asymmetric_array.tarr[i1]["sefdr"]
+        sefdl1 = asymmetric_array.tarr[i1]["sefdl"]
+        sefdr2 = asymmetric_array.tarr[i2]["sefdr"]
+        sefdl2 = asymmetric_array.tarr[i2]["sefdl"]
+        np.testing.assert_allclose(row["rrsigma"], obsh.blnoise(sefdr1, sefdr2, TINT, BW))
+        np.testing.assert_allclose(row["llsigma"], obsh.blnoise(sefdl1, sefdl2, TINT, BW))
+        np.testing.assert_allclose(row["rlsigma"], obsh.blnoise(sefdr1, sefdl2, TINT, BW))
+        np.testing.assert_allclose(row["lrsigma"], obsh.blnoise(sefdl1, sefdr2, TINT, BW))
+
+    def test_scalar_tau_applied(self, array):
+        out = os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
+                                   TINT, TADV, TSTART, TSTOP, tau=0.25)
+        assert np.all(out["tau1"] == 0.25)
+        assert np.all(out["tau2"] == 0.25)
+
+    def test_dict_tau_full_dict(self, array):
+        sites = list(array.tarr["site"])
+        tau = {s: 0.05 + 0.01 * i for i, s in enumerate(sites)}
+        out = os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
+                                   TINT, TADV, TSTART, TSTOP, tau=tau)
+        for row in out:
+            np.testing.assert_allclose(row["tau1"], tau[row["t1"]])
+            np.testing.assert_allclose(row["tau2"], tau[row["t2"]])
+
+    def test_dict_tau_partial_falls_back_per_baseline(self, array):
+        """Documented behavior: KeyError on either site falls both back to TAUDEF.
+
+        This is per the source: `try: tau1 = tau[site1]; tau2 = tau[site2] except KeyError:`.
+        Slightly surprising (one-missing-site doesn't preserve the other side), but
+        deliberate fallback. Pin it so any future change is intentional.
+        """
+        sites = list(array.tarr["site"])
+        tau = {s: 0.05 + 0.01 * i for i, s in enumerate(sites)}
+        del tau[sites[3]]   # drop LMT
+        out = os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
+                                   TINT, TADV, TSTART, TSTOP, tau=tau)
+        for row in out:
+            if sites[3] in (row["t1"], row["t2"]):
+                assert row["tau1"] == ehc.TAUDEF
+                assert row["tau2"] == ehc.TAUDEF
+            else:
+                np.testing.assert_allclose(row["tau1"], tau[row["t1"]])
+                np.testing.assert_allclose(row["tau2"], tau[row["t2"]])
+
+    def test_space_site_tau_zero(self, array):
+        """Space-based sites (xyz=0) get tau=0 regardless of input."""
+        arr = array.copy()
+        tarr = np.asarray(arr.tarr).copy()
+        tarr[0]["x"] = tarr[0]["y"] = tarr[0]["z"] = 0.0
+        arr.tarr = tarr
+        space_site = tarr[0]["site"]
+        out = os_sim.make_uvpoints(arr, 17.761, -29.0, 230e9, BW,
+                                   TINT, TADV, TSTART, TSTOP,
+                                   tau=0.25, no_elevcut_space=True)
+        space_rows = out[(out["t1"] == space_site) | (out["t2"] == space_site)]
+        assert len(space_rows) > 0
+        for row in space_rows:
+            if row["t1"] == space_site:
+                assert row["tau1"] == 0.0
+            if row["t2"] == space_site:
+                assert row["tau2"] == 0.0
+
+    def test_tstop_lt_tstart_wraps(self, array):
+        out = os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
+                                   TINT, TADV, 22.0, 2.0)
+        assert len(out) > 0
+        assert out["time"].min() >= 22.0
+        assert out["time"].max() < 26.0
+
+    def test_invalid_timetype_falls_back_to_utc(self, array, capsys):
+        out_bad = os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
+                                       TINT, TADV, TSTART, TSTOP, timetype="WAT")
+        captured = capsys.readouterr()
+        assert "Time Type Not Recognized" in captured.out
+        out_utc = os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
+                                       TINT, TADV, TSTART, TSTOP, timetype="UTC")
+        assert len(out_bad) == len(out_utc)
+        np.testing.assert_allclose(out_bad["u"], out_utc["u"])
+        np.testing.assert_allclose(out_bad["v"], out_utc["v"])
+
+    def test_no_mutual_visibilities_raises(self, array):
+        """Single-element 'array' produces no baselines -> Exception."""
+        single = array.copy()
+        single.tarr = np.asarray(array.tarr)[:1].copy()
+        with pytest.raises(Exception, match="No mutual visibilities"):
+            os_sim.make_uvpoints(single, 17.761, -29.0, 230e9, BW,
+                                 TINT, TADV, TSTART, TSTOP)
+
+    def test_warns_on_nonpositive_sefd(self, array, capsys):
+        bad = array.copy()
+        tarr = np.asarray(array.tarr).copy()
+        tarr[0]["sefdr"] = 0.0
+        bad.tarr = tarr
+        os_sim.make_uvpoints(bad, 17.761, -29.0, 230e9, BW,
+                             TINT, TADV, TSTART, TSTOP)
+        captured = capsys.readouterr()
+        assert "SEFDs are <= 0" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# sample_vis  (extends original direct-vs-nfft parity tests)
+# ---------------------------------------------------------------------------
+
+
+class TestSampleVisTtypeParity:
+    """sample_vis output agrees across ttype='direct' and ttype='nfft' (existing test)."""
 
     def test_stokes_i(self, asymmetric_image, array):
         obs_direct = _observe(asymmetric_image, array, "direct")
@@ -68,3 +273,608 @@ class TestSampleVisTtypeParity:
                 rtol=1e-6, atol=1e-9,
                 err_msg=f"direct vs nfft mismatch on {field}",
             )
+
+    def test_fast_matches_direct(self, asymmetric_image, array):
+        """ttype='fast' (FFT + interpolation) matches direct to a looser tolerance."""
+        obs_direct = _observe(asymmetric_image, array, "direct")
+        obs_fast = _observe(asymmetric_image, array, "fast")
+        np.testing.assert_allclose(
+            obs_fast.data["vis"], obs_direct.data["vis"],
+            rtol=1e-2, atol=5e-3,
+        )
+
+
+class TestSampleVisBranches:
+    """Direct coverage of sample_vis flags and error paths."""
+
+    def test_invalid_uv_shape_raises(self, asymmetric_image):
+        with pytest.raises(Exception, match="list of pairs"):
+            os_sim.sample_vis(asymmetric_image, np.zeros((10, 3)), ttype="direct")
+
+    def test_invalid_polrep_raises(self, asymmetric_image, obs):
+        uv = np.column_stack([obs.data["u"], obs.data["v"]])
+        with pytest.raises(Exception, match="only 'stokes' and 'circ'"):
+            os_sim.sample_vis(asymmetric_image, uv, polrep_obs="linear", ttype="direct")
+
+    def test_nfft_rejects_odd_dims(self, array):
+        odd = eh.image.make_empty(31, 200 * eh.RADPERUAS, 17.761, -29.0, rf=230e9)
+        odd = odd.add_gauss(1.0, (50 * eh.RADPERUAS, 50 * eh.RADPERUAS, 0, 0, 0))
+        with pytest.raises(Exception, match="odd image dimensions"):
+            os_sim.sample_vis(odd, np.array([[1e9, 1e9]]), ttype="nfft")
+
+    def test_polrep_obs_circ(self, asymmetric_image_pol, obs):
+        uv = np.column_stack([obs.data["u"], obs.data["v"]])
+        out_circ = os_sim.sample_vis(asymmetric_image_pol, uv,
+                                     polrep_obs="circ", ttype="direct", verbose=False)
+        out_stokes = os_sim.sample_vis(asymmetric_image_pol, uv,
+                                       polrep_obs="stokes", ttype="direct", verbose=False)
+        # circ order is RR, LL, RL, LR.  Relations:
+        #   RR = I + V,  LL = I - V,  RL = Q + iU,  LR = Q - iU
+        I, Q, U, V = out_stokes
+        np.testing.assert_allclose(out_circ[0], I + V, atol=1e-10)
+        np.testing.assert_allclose(out_circ[1], I - V, atol=1e-10)
+        np.testing.assert_allclose(out_circ[2], Q + 1j * U, atol=1e-10)
+        np.testing.assert_allclose(out_circ[3], Q - 1j * U, atol=1e-10)
+
+    def test_zero_empty_pol_true(self, asymmetric_image, obs):
+        """Stokes-I-only image: Q/U/V slots should be zero arrays with zero_empty_pol=True."""
+        uv = np.column_stack([obs.data["u"], obs.data["v"]])
+        out = os_sim.sample_vis(asymmetric_image, uv, ttype="direct",
+                                zero_empty_pol=True, verbose=False)
+        assert all(d is not None for d in out)
+        for d in out[1:]:
+            np.testing.assert_array_equal(d, 0.0)
+            assert d.shape == (len(uv),)
+
+    def test_zero_empty_pol_false(self, asymmetric_image, obs):
+        uv = np.column_stack([obs.data["u"], obs.data["v"]])
+        out = os_sim.sample_vis(asymmetric_image, uv, ttype="direct",
+                                zero_empty_pol=False, verbose=False)
+        assert out[0] is not None
+        for d in out[1:]:
+            assert d is None
+
+    def test_sgrscat_multiplies_by_kernel(self, asymmetric_image, obs):
+        uv = np.column_stack([obs.data["u"], obs.data["v"]])
+        clean = os_sim.sample_vis(asymmetric_image, uv,
+                                  ttype="direct", sgrscat=False, verbose=False)
+        scat = os_sim.sample_vis(asymmetric_image, uv,
+                                 ttype="direct", sgrscat=True, verbose=False)
+        ker = obsh.sgra_kernel_uv(asymmetric_image.rf, uv[:, 0], uv[:, 1])
+        np.testing.assert_allclose(scat[0], clean[0] * ker, atol=1e-12)
+
+    def test_image_pa_rotates_uv(self, asymmetric_image, obs):
+        """im.pa rotates the input uv before sampling: vis(uv; pa) == vis(R(pa)@uv; pa=0)."""
+        uv = np.column_stack([obs.data["u"], obs.data["v"]])
+        theta = np.pi / 5
+
+        im_pa = asymmetric_image.copy()
+        im_pa.pa = theta
+        out_pa = os_sim.sample_vis(im_pa, uv, ttype="direct", verbose=False)[0]
+
+        c, s = np.cos(theta), np.sin(theta)
+        uv_rot = np.column_stack([c * uv[:, 0] - s * uv[:, 1],
+                                  s * uv[:, 0] + c * uv[:, 1]])
+        out_pa0 = os_sim.sample_vis(asymmetric_image, uv_rot, ttype="direct", verbose=False)[0]
+        np.testing.assert_allclose(out_pa, out_pa0, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# make_jones
+# ---------------------------------------------------------------------------
+
+
+def _all_jones(jm):
+    """Flatten {site: {time: 2x2}} into an (Nsite*Ntime, 2, 2) array."""
+    out = []
+    for site_dict in jm.values():
+        for mat in site_dict.values():
+            out.append(mat)
+    return np.array(out)
+
+
+class TestMakeJones:
+    """Coverage for make_jones.  Defaults give identity; each flag perturbs it."""
+
+    def test_default_all_identity(self, obs):
+        jm = os_sim.make_jones(obs)
+        mats = _all_jones(jm)
+        expected = np.broadcast_to(np.eye(2), mats.shape)
+        np.testing.assert_allclose(mats, expected, atol=1e-12)
+
+    def test_default_keys_one_per_site(self, obs):
+        jm = os_sim.make_jones(obs)
+        assert set(jm.keys()) == set(obs.tarr["site"])
+        for site_dict in jm.values():
+            assert len(site_dict) > 0
+
+    def test_seed_reproducible(self, obs):
+        jm1 = os_sim.make_jones(obs, ampcal=False, phasecal=False, seed=42)
+        jm2 = os_sim.make_jones(obs, ampcal=False, phasecal=False, seed=42)
+        np.testing.assert_array_equal(_all_jones(jm1), _all_jones(jm2))
+
+    def test_seed_differs(self, obs):
+        jm1 = os_sim.make_jones(obs, ampcal=False, phasecal=False, seed=42)
+        jm2 = os_sim.make_jones(obs, ampcal=False, phasecal=False, seed=43)
+        assert not np.allclose(_all_jones(jm1), _all_jones(jm2))
+
+    def test_frcal_false_diagonal_with_phase(self, obs):
+        """frcal=False: diagonal unit-modulus phases; off-diagonals stay zero."""
+        jm = os_sim.make_jones(obs, frcal=False, seed=42)
+        mats = _all_jones(jm)
+        # off-diagonals still zero
+        np.testing.assert_allclose(mats[:, 0, 1], 0, atol=1e-12)
+        np.testing.assert_allclose(mats[:, 1, 0], 0, atol=1e-12)
+        # diagonals are unit modulus (no amp/opacity corruption)
+        np.testing.assert_allclose(np.abs(mats[:, 0, 0]), 1.0, atol=1e-12)
+        np.testing.assert_allclose(np.abs(mats[:, 1, 1]), 1.0, atol=1e-12)
+        # not identity for at least some entries (fr_elev varies in EHT2017)
+        assert not np.allclose(mats, np.broadcast_to(np.eye(2), mats.shape))
+
+    def test_ampcal_false_perturbs_diagonal(self, obs):
+        jm = os_sim.make_jones(obs, ampcal=False, seed=42)
+        mats = _all_jones(jm)
+        # off-diagonals still zero, but diagonal magnitudes != 1
+        np.testing.assert_allclose(mats[:, 0, 1], 0, atol=1e-12)
+        np.testing.assert_allclose(mats[:, 1, 0], 0, atol=1e-12)
+        assert not np.allclose(np.abs(mats[:, 0, 0]), 1.0)
+        assert not np.allclose(np.abs(mats[:, 1, 1]), 1.0)
+
+    def test_ampcal_false_neggains(self, obs):
+        jm = os_sim.make_jones(obs, ampcal=False, neggains=True, seed=42)
+        mats = _all_jones(jm)
+        assert np.all(np.abs(mats[:, 0, 0]) <= 1.0 + 1e-12)
+        assert np.all(np.abs(mats[:, 1, 1]) <= 1.0 + 1e-12)
+
+    def test_phasecal_false_unit_modulus_phases(self, obs):
+        jm = os_sim.make_jones(obs, phasecal=False, seed=42)
+        mats = _all_jones(jm)
+        # diagonals still unit modulus (no amp corruption)
+        np.testing.assert_allclose(np.abs(mats[:, 0, 0]), 1.0, atol=1e-12)
+        np.testing.assert_allclose(np.abs(mats[:, 1, 1]), 1.0, atol=1e-12)
+        # but not real-valued (phases are nontrivial)
+        assert np.max(np.abs(np.imag(mats[:, 0, 0]))) > 0.01
+
+    def test_phasecal_false_gaussian_branch(self, obs):
+        """phase_std>=0 selects the Gaussian branch (tighter spread)."""
+        jm_uniform = os_sim.make_jones(obs, phasecal=False, phase_std=-1, seed=42)
+        jm_narrow = os_sim.make_jones(obs, phasecal=False, phase_std=0.01, seed=42)
+        ph_u = np.angle(_all_jones(jm_uniform)[:, 0, 0])
+        ph_n = np.angle(_all_jones(jm_narrow)[:, 0, 0])
+        # Gaussian phase_std=0.01 should be far tighter than uniform [-pi,pi]
+        assert np.std(ph_n) < np.std(ph_u) / 10
+
+    def test_dcal_false_nonzero_offdiag(self, obs_asym):
+        """dcal=False: off-diagonals = dR*gainR, dL*gainL (here gain=1, fr=0, so = dR, dL)."""
+        jm = os_sim.make_jones(obs_asym, dcal=False, frcal=True, seed=42)
+        mats = _all_jones(jm)
+        # diagonals are still 1 (ampcal=True, phasecal=True)
+        np.testing.assert_allclose(np.abs(mats[:, 0, 0]), 1.0, atol=1e-12)
+        np.testing.assert_allclose(np.abs(mats[:, 1, 1]), 1.0, atol=1e-12)
+        # off-diagonals nonzero, since tarr['dr'] != 0 in asymmetric array
+        assert np.max(np.abs(mats[:, 0, 1])) > 0.001
+        assert np.max(np.abs(mats[:, 1, 0])) > 0.001
+
+    def test_rlgaincal_false_breaks_rl_symmetry(self, obs):
+        jm = os_sim.make_jones(obs, ampcal=False, rlgaincal=False,
+                               rlratio_std=0.1, seed=42)
+        mats = _all_jones(jm)
+        # gain_R != gain_L on every entry that ampcal=False touches
+        assert not np.allclose(np.abs(mats[:, 0, 0]), np.abs(mats[:, 1, 1]))
+
+    def test_opacitycal_false_attenuates(self, obs):
+        jm = os_sim.make_jones(obs, opacitycal=False, taup=0.0, seed=42)
+        mats = _all_jones(jm)
+        # opacity is amplitude-only, no phase: imaginary part 0
+        np.testing.assert_allclose(np.imag(mats[:, 0, 0]), 0, atol=1e-12)
+        # all amplitudes attenuated below 1
+        assert np.all(np.abs(mats[:, 0, 0]) <= 1.0 + 1e-12)
+        # at least some are noticeably attenuated
+        assert np.min(np.abs(mats[:, 0, 0])) < 0.99
+
+    def test_stabilize_scan_amp_constant_within_scan(self, obs):
+        """With stabilize_scan_amp=True, the gain is constant for all times in the same scan."""
+        jm = os_sim.make_jones(obs, ampcal=False, stabilize_scan_amp=True, seed=42)
+        scans = obs.scans
+        for site, site_dict in jm.items():
+            times = np.array(sorted(site_dict.keys()))
+            for sc_start, sc_end in scans:
+                mask = (times >= sc_start) & (times <= sc_end)
+                if mask.sum() < 2:
+                    continue
+                gains = np.array([site_dict[t][0, 0] for t in times[mask]])
+                np.testing.assert_allclose(gains, gains[0], atol=1e-12,
+                                           err_msg=f"site {site} scan {sc_start}-{sc_end}")
+                break   # one scan-with-multiple-times check per site is enough
+
+    def test_dict_kwargs_honored(self, obs):
+        """Per-site gainp dict is honored: site-specific noise level."""
+        sites = list(obs.tarr["site"])
+        gainp = {s: 0.1 for s in sites}
+        gainp[sites[0]] = 0.0   # one site has zero gain noise
+        jm = os_sim.make_jones(obs, ampcal=False, gainp=gainp, seed=42)
+        # The zero-noise site should still have constant log-gain (from gain_offset).
+        # Compare its gain variance to other sites' variance.
+        var_zero = np.var(np.abs([m[0, 0] for m in jm[sites[0]].values()]))
+        var_other = np.var(np.abs([m[0, 0] for m in jm[sites[1]].values()]))
+        assert var_zero < var_other
+
+    def test_gmst_timetype(self, obs):
+        """GMST path: should run without error and produce same shape."""
+        obs_gmst = obs.switch_timetype("GMST")
+        jm = os_sim.make_jones(obs_gmst, frcal=False, seed=42)
+        mats = _all_jones(jm)
+        assert mats.shape[1:] == (2, 2)
+        assert mats.shape[0] > 0
+
+    def test_caltable_path_writes_file(self, obs, tmp_path):
+        prefix = tmp_path / "cal"
+        os_sim.make_jones(obs, ampcal=False, dcal=False,
+                          caltable_path=str(prefix), seed=42)
+        # Caltable.save_txt creates a directory of per-site files
+        caldir = tmp_path / "cal_simdata_caltable"
+        assert caldir.exists()
+        files = list(caldir.iterdir())
+        assert len(files) > 0
+
+
+# ---------------------------------------------------------------------------
+# make_jones_inverse
+# ---------------------------------------------------------------------------
+
+
+class TestMakeJonesInverse:
+
+    def test_default_all_identity(self, obs):
+        jm = os_sim.make_jones_inverse(obs)
+        mats = _all_jones(jm)
+        expected = np.broadcast_to(np.eye(2), mats.shape)
+        np.testing.assert_allclose(mats, expected, atol=1e-12)
+
+    def test_frcal_false_phases_reverse_jones(self, obs):
+        """Forward and inverse have opposite-sign feed-rotation phases on each diagonal slot.
+
+        Forward [0,0] = exp(-i*fr); inverse [0,0] = exp(+i*fr).  Same slot, opposite phase.
+        """
+        jm = os_sim.make_jones(obs, frcal=False, seed=42)
+        jm_inv = os_sim.make_jones_inverse(obs, frcal=False)
+        for site in jm:
+            for time in jm[site]:
+                ph_fwd_00 = np.angle(jm[site][time][0, 0])
+                ph_inv_00 = np.angle(jm_inv[site][time][0, 0])
+                np.testing.assert_allclose(ph_inv_00, -ph_fwd_00, atol=1e-12)
+                ph_fwd_11 = np.angle(jm[site][time][1, 1])
+                ph_inv_11 = np.angle(jm_inv[site][time][1, 1])
+                np.testing.assert_allclose(ph_inv_11, -ph_fwd_11, atol=1e-12)
+
+    def test_inverse_opacity_amplitude(self, obs):
+        """opacitycal=False: amplitudes scale as 1/sqrt(exp(tau_eff)*exp(tau_eff)) = 1/exp(tau_eff)."""
+        jm_inv = os_sim.make_jones_inverse(obs, opacitycal=False)
+        mats = _all_jones(jm_inv)
+        np.testing.assert_allclose(np.imag(mats[:, 0, 0]), 0, atol=1e-12)
+        # off-diagonals still zero
+        np.testing.assert_allclose(mats[:, 0, 1], 0, atol=1e-12)
+        # amplitudes >= 1 (inverse of attenuation)
+        assert np.all(np.abs(mats[:, 0, 0]) >= 1.0 - 1e-12)
+        assert np.max(np.abs(mats[:, 0, 0])) > 1.01
+
+    def test_inverse_dcal_offdiagonal(self, obs_asym):
+        """dcal=False: |off-diagonals| = |dR/(1-dL*dR)|, |dL/(1-dL*dR)|.
+
+        Phases also pick up feed-rotation factors (the `frcal and not dcal` branch
+        applies a 2*fr correction even when frcal=True), so we test magnitudes.
+        """
+        jm_inv = os_sim.make_jones_inverse(obs_asym, dcal=False)
+        for site, site_dict in jm_inv.items():
+            i = list(obs_asym.tarr["site"]).index(site)
+            dR = obs_asym.tarr[i]["dr"]
+            dL = obs_asym.tarr[i]["dl"]
+            pref = 1.0 / (1.0 - dL * dR)
+            for mat in site_dict.values():
+                np.testing.assert_allclose(np.abs(mat[0, 1]), np.abs(pref * dR), atol=1e-12)
+                np.testing.assert_allclose(np.abs(mat[1, 0]), np.abs(pref * dL), atol=1e-12)
+
+    def test_inverse_actually_inverts(self, obs_asym):
+        """J^-1 @ J should be identity at every (site, time), within tolerance.
+
+        Test with frcal=False (the most-likely-to-have-sign-bug term)."""
+        jm = os_sim.make_jones(obs_asym, frcal=False, seed=42)
+        jm_inv = os_sim.make_jones_inverse(obs_asym, frcal=False)
+        for site in jm:
+            for time in jm[site]:
+                prod = jm_inv[site][time] @ jm[site][time]
+                np.testing.assert_allclose(prod, np.eye(2), atol=1e-10,
+                                           err_msg=f"site {site} time {time}")
+
+
+# ---------------------------------------------------------------------------
+# add_jones_and_noise
+# ---------------------------------------------------------------------------
+
+
+class TestAddJonesAndNoise:
+
+    def test_identity_preserves_vis(self, obs):
+        """All cal True, no thermal noise -> visibilities and sigmas unchanged."""
+        obsdat = os_sim.add_jones_and_noise(obs, add_th_noise=False,
+                                            verbose=False, seed=42)
+        np.testing.assert_allclose(obsdat["vis"], obs.data["vis"], atol=1e-12)
+        np.testing.assert_allclose(obsdat["sigma"], obs.data["sigma"], atol=1e-12)
+
+    def test_seed_reproducible_no_noise(self, obs):
+        """Without thermal noise, same seed -> identical output."""
+        o1 = os_sim.add_jones_and_noise(obs, add_th_noise=False, ampcal=False,
+                                        verbose=False, seed=42)
+        o2 = os_sim.add_jones_and_noise(obs, add_th_noise=False, ampcal=False,
+                                        verbose=False, seed=42)
+        np.testing.assert_array_equal(o1["vis"], o2["vis"])
+
+    def test_seed_differs_no_noise(self, obs):
+        o1 = os_sim.add_jones_and_noise(obs, add_th_noise=False, ampcal=False,
+                                        verbose=False, seed=42)
+        o2 = os_sim.add_jones_and_noise(obs, add_th_noise=False, ampcal=False,
+                                        verbose=False, seed=43)
+        assert not np.allclose(o1["vis"], o2["vis"])
+
+    def test_thermal_noise_residual_matches_sigma(self, obs):
+        """With add_th_noise, residual std should be ~sigma."""
+        obsdat = os_sim.add_jones_and_noise(obs, add_th_noise=True,
+                                            verbose=False, seed=42)
+        residual = obsdat["vis"] - obs.data["vis"]
+        ratio = np.std(residual.real) / np.mean(obsdat["sigma"])
+        assert 0.5 < ratio < 2.0
+
+    def test_ampcal_false_deviates_amplitude(self, obs):
+        out = os_sim.add_jones_and_noise(obs, add_th_noise=False, ampcal=False,
+                                         verbose=False, seed=42)
+        # phases preserved, amplitudes shifted
+        np.testing.assert_allclose(np.angle(out["vis"]),
+                                   np.angle(obs.data["vis"]), atol=1e-10)
+        assert not np.allclose(np.abs(out["vis"]), np.abs(obs.data["vis"]))
+
+    def test_phasecal_false_deviates_phase(self, obs):
+        out = os_sim.add_jones_and_noise(obs, add_th_noise=False, phasecal=False,
+                                         verbose=False, seed=42)
+        # amplitudes preserved, phases shifted
+        np.testing.assert_allclose(np.abs(out["vis"]),
+                                   np.abs(obs.data["vis"]), atol=1e-10)
+        assert not np.allclose(np.angle(out["vis"]), np.angle(obs.data["vis"]))
+
+    def test_recomputed_sigmas_match_asymmetric_sefds(self, asymmetric_image, asymmetric_array):
+        """Per-correlation sigmas after SEFD recomputation, on an array with sefdr != sefdl.
+
+        Pins the four SEFD-column pairings:
+            sig_rr = blnoise(sefdr1, sefdr2)
+            sig_ll = blnoise(sefdl1, sefdl2)
+            sig_rl = blnoise(sefdr1, sefdl2)
+            sig_lr = blnoise(sefdl1, sefdr2)
+
+        Catches the kind of bug where one of these uses the wrong SEFD column
+        (e.g. sig_ll using sefdr1 instead of sefdl1) — invisible when sefdr == sefdl.
+        """
+        obs_circ = _observe(asymmetric_image, asymmetric_array).switch_polrep("circ")
+        out = os_sim.add_jones_and_noise(obs_circ, add_th_noise=False,
+                                         verbose=False, seed=42)
+        arr = obs_circ.tarr
+        sites = list(arr["site"])
+        for row in out:
+            i1 = sites.index(row["t1"])
+            i2 = sites.index(row["t2"])
+            sefdr1, sefdl1 = arr[i1]["sefdr"], arr[i1]["sefdl"]
+            sefdr2, sefdl2 = arr[i2]["sefdr"], arr[i2]["sefdl"]
+            np.testing.assert_allclose(row["rrsigma"],
+                obsh.blnoise(sefdr1, sefdr2, row["tint"], obs_circ.bw))
+            np.testing.assert_allclose(row["llsigma"],
+                obsh.blnoise(sefdl1, sefdl2, row["tint"], obs_circ.bw))
+            np.testing.assert_allclose(row["rlsigma"],
+                obsh.blnoise(sefdr1, sefdl2, row["tint"], obs_circ.bw))
+            np.testing.assert_allclose(row["lrsigma"],
+                obsh.blnoise(sefdl1, sefdr2, row["tint"], obs_circ.bw))
+
+    def test_sefd_nonpositive_falls_back_to_sigmas(self, obs, capsys):
+        """SEFD<=0: code uses obs.data sigmas rather than recomputing.  Warning printed."""
+        obs_bad = obs.copy()
+        tarr = np.asarray(obs_bad.tarr).copy()
+        tarr[0]["sefdr"] = 0.0
+        obs_bad.tarr = tarr
+        out = os_sim.add_jones_and_noise(obs_bad, add_th_noise=False, verbose=True, seed=42)
+        captured = capsys.readouterr()
+        assert "SEFDs are <= 0" in captured.out
+        # Sigmas should equal the original obs sigmas (no recomputation)
+        np.testing.assert_allclose(out["sigma"], obs_bad.data["sigma"])
+
+    def test_caltable_path_propagates(self, obs, tmp_path):
+        prefix = tmp_path / "cal"
+        os_sim.add_jones_and_noise(obs, add_th_noise=False, ampcal=False,
+                                   caltable_path=str(prefix),
+                                   verbose=False, seed=42)
+        caldir = tmp_path / "cal_simdata_caltable"
+        assert caldir.exists()
+
+
+# ---------------------------------------------------------------------------
+# apply_jones_inverse
+# ---------------------------------------------------------------------------
+
+
+class TestApplyJonesInverse:
+
+    def test_identity_preserves_vis(self, obs):
+        out = os_sim.apply_jones_inverse(obs, verbose=False)
+        np.testing.assert_allclose(out["vis"], obs.data["vis"], atol=1e-12)
+        np.testing.assert_allclose(out["sigma"], obs.data["sigma"], atol=1e-12)
+
+    def test_roundtrip_with_frcal_only(self, obs):
+        """Corrupt with frcal=False (deterministic), then uncorrupt with frcal=False: identity."""
+        obs_corr = obs.copy()
+        obs_corr.data = os_sim.add_jones_and_noise(obs, add_th_noise=False, frcal=False,
+                                                   verbose=False, seed=42)
+        obs_back = obs_corr.copy()
+        obs_back.data = os_sim.apply_jones_inverse(obs_corr, frcal=False, verbose=False)
+        np.testing.assert_allclose(obs_back.data["vis"], obs.data["vis"], atol=1e-10)
+
+    def test_recomputed_sigmas_match_asymmetric_sefds(self, asymmetric_image, asymmetric_array):
+        """Same correlation-vs-SEFD layout check as in add_jones_and_noise.
+
+        With all cal flags True the inverse Jones matrices are identity and the
+        recomputed sigmas equal blnoise(sefd_a, sefd_b) directly per slot.
+        """
+        obs_circ = _observe(asymmetric_image, asymmetric_array).switch_polrep("circ")
+        out = os_sim.apply_jones_inverse(obs_circ, verbose=False)
+        arr = obs_circ.tarr
+        sites = list(arr["site"])
+        for row in out:
+            i1 = sites.index(row["t1"])
+            i2 = sites.index(row["t2"])
+            sefdr1, sefdl1 = arr[i1]["sefdr"], arr[i1]["sefdl"]
+            sefdr2, sefdl2 = arr[i2]["sefdr"], arr[i2]["sefdl"]
+            np.testing.assert_allclose(row["rrsigma"],
+                obsh.blnoise(sefdr1, sefdr2, row["tint"], obs_circ.bw))
+            np.testing.assert_allclose(row["llsigma"],
+                obsh.blnoise(sefdl1, sefdl2, row["tint"], obs_circ.bw))
+            np.testing.assert_allclose(row["rlsigma"],
+                obsh.blnoise(sefdr1, sefdl2, row["tint"], obs_circ.bw))
+            np.testing.assert_allclose(row["lrsigma"],
+                obsh.blnoise(sefdl1, sefdr2, row["tint"], obs_circ.bw))
+
+    def test_roundtrip_with_opacity_only(self, obs):
+        """taup=0 makes opacity attenuation deterministic; apply_jones_inverse inverts exactly."""
+        obs_corr = obs.copy()
+        obs_corr.data = os_sim.add_jones_and_noise(
+            obs, add_th_noise=False, opacitycal=False, taup=0.0,
+            verbose=False, seed=42,
+        )
+        obs_back = obs_corr.copy()
+        obs_back.data = os_sim.apply_jones_inverse(obs_corr, opacitycal=False, verbose=False)
+        np.testing.assert_allclose(obs_back.data["vis"], obs.data["vis"], atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# add_noise  (legacy path)
+# ---------------------------------------------------------------------------
+
+
+class TestAddNoiseLegacy:
+
+    def test_identity_preserves_vis(self, obs):
+        out = os_sim.add_noise(obs, add_th_noise=False, verbose=False, seed=42)
+        np.testing.assert_allclose(out["vis"], obs.data["vis"], atol=1e-12)
+        np.testing.assert_allclose(out["sigma"], obs.data["sigma"], atol=1e-12)
+
+    def test_seed_reproducible(self, obs):
+        o1 = os_sim.add_noise(obs, add_th_noise=False, ampcal=False,
+                              verbose=False, seed=42)
+        o2 = os_sim.add_noise(obs, add_th_noise=False, ampcal=False,
+                              verbose=False, seed=42)
+        np.testing.assert_array_equal(o1["vis"], o2["vis"])
+
+    def test_sigmat_raises(self, obs):
+        with pytest.raises(Exception, match="correlated gains not supported"):
+            os_sim.add_noise(obs, ampcal=False, sigmat=10.0, verbose=False, seed=42)
+
+    def test_caltable_path_prints_unsupported(self, obs, capsys, tmp_path):
+        os_sim.add_noise(obs, add_th_noise=False,
+                         caltable_path=str(tmp_path / "cal"),
+                         verbose=False, seed=42)
+        captured = capsys.readouterr()
+        assert "caltable saving not implemented" in captured.out
+
+    def test_ampcal_false_deviates_amplitude(self, obs):
+        out = os_sim.add_noise(obs, add_th_noise=False, ampcal=False,
+                               verbose=False, seed=42)
+        # legacy add_noise multiplies vis by a real gain factor: phases unchanged
+        np.testing.assert_allclose(np.angle(out["vis"]),
+                                   np.angle(obs.data["vis"]), atol=1e-10)
+        assert not np.allclose(np.abs(out["vis"]), np.abs(obs.data["vis"]))
+
+    def test_phasecal_false_deviates_phase(self, obs):
+        out = os_sim.add_noise(obs, add_th_noise=False, phasecal=False,
+                               verbose=False, seed=42)
+        np.testing.assert_allclose(np.abs(out["vis"]),
+                                   np.abs(obs.data["vis"]), atol=1e-10)
+        assert not np.allclose(np.angle(out["vis"]), np.angle(obs.data["vis"]))
+
+    def test_dict_gainp(self, obs):
+        sites = list(obs.tarr["site"])
+        gainp_dict = {s: 0.1 for s in sites}
+        gainp_dict[sites[0]] = 0.0
+        out_dict = os_sim.add_noise(obs, add_th_noise=False, ampcal=False,
+                                    gainp=gainp_dict, verbose=False, seed=42)
+        out_scalar = os_sim.add_noise(obs, add_th_noise=False, ampcal=False,
+                                      gainp=0.1, verbose=False, seed=42)
+        # The first site has zero gain noise in the dict -> at least some baselines differ.
+        assert not np.allclose(out_dict["vis"], out_scalar["vis"])
+
+    def test_stabilize_scan_amp_constant_within_scan(self, obs):
+        """With stabilize_scan_amp=True, identical times-in-scan yield identical gain factors,
+        so the |vis| ratio (corrupt/original) is constant within a scan on a given baseline."""
+        out = os_sim.add_noise(obs, add_th_noise=False, ampcal=False,
+                               stabilize_scan_amp=True, verbose=False, seed=42)
+        # Pick the first baseline (t1, t2)
+        d = obs.data
+        t1_pick = d["t1"][0]
+        t2_pick = d["t2"][0]
+        mask = (d["t1"] == t1_pick) & (d["t2"] == t2_pick)
+        ratios = np.abs(out["vis"][mask]) / np.abs(d["vis"][mask])
+        # Identify times that fall in the same scan
+        scans = obs.scans
+        for sc_start, sc_end in scans:
+            in_scan = (d["time"][mask] >= sc_start) & (d["time"][mask] <= sc_end)
+            if in_scan.sum() < 2:
+                continue
+            np.testing.assert_allclose(ratios[in_scan], ratios[in_scan][0],
+                                       rtol=1e-10)
+            break
+
+    def test_recomputed_sigmas_match_asymmetric_sefds_circ(self, asymmetric_image, asymmetric_array):
+        """Per-correlation sigmas after add_noise's SEFD recomputation, circ polrep.
+
+        With sefdr != sefdl, llsigma must use (sefdl1, sefdl2), not (sefdr1, sefdl2).
+        A wrong-SEFD-column bug in any of the four slots is caught directly here.
+        """
+        obs_circ = _observe(asymmetric_image, asymmetric_array).switch_polrep("circ")
+        out = os_sim.add_noise(obs_circ, add_th_noise=False, verbose=False, seed=42)
+        arr = obs_circ.tarr
+        sites = list(arr["site"])
+        for row in out:
+            i1 = sites.index(row["t1"])
+            i2 = sites.index(row["t2"])
+            sefdr1, sefdl1 = arr[i1]["sefdr"], arr[i1]["sefdl"]
+            sefdr2, sefdl2 = arr[i2]["sefdr"], arr[i2]["sefdl"]
+            np.testing.assert_allclose(row["rrsigma"],
+                obsh.blnoise(sefdr1, sefdr2, row["tint"], obs_circ.bw))
+            np.testing.assert_allclose(row["llsigma"],
+                obsh.blnoise(sefdl1, sefdl2, row["tint"], obs_circ.bw))
+            np.testing.assert_allclose(row["rlsigma"],
+                obsh.blnoise(sefdr1, sefdl2, row["tint"], obs_circ.bw))
+            np.testing.assert_allclose(row["lrsigma"],
+                obsh.blnoise(sefdl1, sefdr2, row["tint"], obs_circ.bw))
+
+    def test_recomputed_sigmas_match_asymmetric_sefds_stokes(self, obs_asym):
+        """Same as the circ-polrep test, but on stokes input: bug propagates through
+        sig_iv = 0.5*sqrt(sig_rr^2 + sig_ll^2) into both `sigma` and `vsigma`.
+        """
+        out = os_sim.add_noise(obs_asym, add_th_noise=False, verbose=False, seed=42)
+        arr = obs_asym.tarr
+        sites = list(arr["site"])
+        for row in out:
+            i1 = sites.index(row["t1"])
+            i2 = sites.index(row["t2"])
+            sefdr1, sefdl1 = arr[i1]["sefdr"], arr[i1]["sefdl"]
+            sefdr2, sefdl2 = arr[i2]["sefdr"], arr[i2]["sefdl"]
+            sig_rr = obsh.blnoise(sefdr1, sefdr2, row["tint"], obs_asym.bw)
+            sig_ll = obsh.blnoise(sefdl1, sefdl2, row["tint"], obs_asym.bw)
+            sig_rl = obsh.blnoise(sefdr1, sefdl2, row["tint"], obs_asym.bw)
+            sig_lr = obsh.blnoise(sefdl1, sefdr2, row["tint"], obs_asym.bw)
+            sig_iv = 0.5 * np.sqrt(sig_rr ** 2 + sig_ll ** 2)
+            sig_qu = 0.5 * np.sqrt(sig_rl ** 2 + sig_lr ** 2)
+            np.testing.assert_allclose(row["sigma"], sig_iv)
+            np.testing.assert_allclose(row["vsigma"], sig_iv)
+            np.testing.assert_allclose(row["qsigma"], sig_qu)
+            np.testing.assert_allclose(row["usigma"], sig_qu)
+
+    def test_thermal_noise_residual_matches_sigma(self, obs):
+        out = os_sim.add_noise(obs, add_th_noise=True, verbose=False, seed=42)
+        residual = out["vis"] - obs.data["vis"]
+        ratio = np.std(residual.real) / np.mean(out["sigma"])
+        assert 0.5 < ratio < 2.0

--- a/tests/test_obsdata.py
+++ b/tests/test_obsdata.py
@@ -374,6 +374,56 @@ def test_bllist_unique_baseline_per_chunk(obs_direct):
         assert len(pairs) == 1
 
 
+# Regression: np.array(list_of_recarrays, dtype=object) silently stacks into 2-D
+# when every scan has the same shape, dropping the recarray dtype and breaking
+# field-name indexing downstream (e.g. bispectra() -> tdata[0]['time']). See PR #186.
+
+def test_tlist_returns_1d_object_array_single_scan(obs_direct):
+    chunks = obs_direct.tlist(t_gather=1e9)  # lump all data into one scan
+    assert chunks.ndim == 1
+    assert len(chunks) == 1
+    assert chunks[0].dtype.names is not None
+    # Field-name indexing must not raise.
+    assert chunks[0]["time"].shape == (len(chunks[0]),)
+
+
+def test_tlist_returns_1d_object_array_uniform_scans(obs_direct):
+    # Synthesize an obs whose scans all have the same baseline count by
+    # restricting to one baseline that's present at every time.
+    obs = obs_direct.copy()
+    pair = (obs.data[0]["t1"], obs.data[0]["t2"])
+    mask = (obs.data["t1"] == pair[0]) & (obs.data["t2"] == pair[1])
+    obs.data = obs.data[mask]
+    chunks = obs.tlist()
+    assert len(chunks) > 1  # multiple scans
+    assert chunks.ndim == 1
+    assert chunks[0].dtype.names is not None
+    assert chunks[0]["time"].shape == (1,)
+
+
+def test_bllist_returns_1d_object_array(obs_direct):
+    # Restrict to the (ALMA, APEX)/(ALMA, SPT)/(APEX, SPT) triangle, whose
+    # baselines all share the same row count -- triggers the auto-stacking bug.
+    obs = obs_direct.copy()
+    triangle = {"ALMA", "APEX", "SPT"}
+    mask = np.array([row["t1"] in triangle and row["t2"] in triangle for row in obs.data])
+    obs.data = obs.data[mask]
+    chunks = obs.bllist()
+    assert chunks.ndim == 1
+    assert len(chunks) == 3
+    assert chunks[0].dtype.names is not None
+    assert chunks[0]["t1"].shape == (len(chunks[0]),)
+
+
+def test_bispectra_runs_when_scans_have_uniform_shape(obs_direct):
+    # Direct repro from PR #186: bispectra() does `tdata[0]['time']`, which
+    # raised when tlist() collapsed to 2-D.
+    obs = obs_direct.copy()
+    obs.data = obs.data[obs.data["time"] == obs.data[0]["time"]]
+    bs = obs.bispectra(mode="all", count="min")
+    assert len(bs) > 0
+
+
 # ---------------------------------------------------------------------------
 # Section 5: Unpacking (unpack, unpack_dat, unpack_bl)
 # ---------------------------------------------------------------------------

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -88,6 +88,76 @@ class TestRegularizerGradients:
         )
 
 
+class TestCenterOfMassRegularizer:
+    """`reg_cm` / `reggrad_cm` semantics on a full-grid imvec.
+
+    The COM constraint is `(sum(I*x))^2 + (sum(I*y))^2`, normalised. An
+    off-centre image yields a strictly larger penalty than the centred one,
+    and the analytic gradient must match a finite-difference reference.
+    """
+
+    @staticmethod
+    def _kw(im):
+        return dict(xdim=im.xdim, ydim=im.ydim, psize=im.psize,
+                    flux=im.total_flux(), norm_reg=True)
+
+    def test_off_center_image_more_positive_than_centered(self, gauss_im):
+        """Shifting the source off-centre makes the (positive) penalty strictly larger."""
+        mask = np.ones_like(gauss_im.imvec, dtype=bool)
+        arr = gauss_im.imvec.reshape(gauss_im.ydim, gauss_im.xdim)
+        shifted = np.roll(arr, gauss_im.xdim // 4, axis=1).flatten()
+        val_centered = ib.compute_regularizer_term(gauss_im.imvec, 'cm', mask,
+                                                   **self._kw(gauss_im))
+        val_off = ib.compute_regularizer_term(shifted, 'cm', mask,
+                                              **self._kw(gauss_im))
+        assert val_off > val_centered
+        assert val_off > 1e-6
+
+    def test_gradient_matches_finite_difference(self, gauss_im):
+        """Analytic reggrad_cm matches a central finite-difference gradient at sample pixels."""
+        mask = np.ones_like(gauss_im.imvec, dtype=bool)
+        kw = self._kw(gauss_im)
+        rng = np.random.default_rng(0)
+        imvec = gauss_im.imvec + 0.01 * rng.standard_normal(gauss_im.imvec.shape)
+        grad_analytic = ib.compute_regularizergrad_term(imvec, 'cm', mask, **kw)
+        h = 1e-6
+        sample_idx = rng.choice(imvec.size, size=10, replace=False)
+        for i in sample_idx:
+            ep = imvec.copy()
+            ep[i] += h
+            em = imvec.copy()
+            em[i] -= h
+            fd = (ib.compute_regularizer_term(ep, 'cm', mask, **kw)
+                  - ib.compute_regularizer_term(em, 'cm', mask, **kw)) / (2 * h)
+            np.testing.assert_allclose(grad_analytic[i], fd, rtol=1e-4, atol=1e-12)
+
+    def test_gradient_matches_finite_difference_partial_mask(self, gauss_im):
+        """Exercise the embed-pre / mask-post-slice path of reg_cm/reggrad_cm.
+
+        With a non-trivial mask, `reg_cm` calls `embed(imvec, mask, randomfloor=True)`
+        which (with default `clipfloor=0`) zero-fills masked positions deterministically.
+        The analytic gradient returned by `reggrad_cm` is length-nmask (post-slice),
+        and FD perturbations on the masked-only vector must agree.
+        """
+        full_mask = gauss_im.imvec > 0.1 * gauss_im.imvec.max()
+        assert not full_mask.all(), "test requires a partial (non-trivial) mask"
+        kw = self._kw(gauss_im)
+        rng = np.random.default_rng(1)
+        imvec_masked = gauss_im.imvec[full_mask] + 0.01 * rng.standard_normal(full_mask.sum())
+        grad_analytic = ib.compute_regularizergrad_term(imvec_masked, 'cm', full_mask, **kw)
+        assert grad_analytic.shape == (full_mask.sum(),), "gradient must be length-nmask"
+        h = 1e-6
+        sample_idx = rng.choice(imvec_masked.size, size=10, replace=False)
+        for i in sample_idx:
+            ep = imvec_masked.copy()
+            ep[i] += h
+            em = imvec_masked.copy()
+            em[i] -= h
+            fd = (ib.compute_regularizer_term(ep, 'cm', full_mask, **kw)
+                  - ib.compute_regularizer_term(em, 'cm', full_mask, **kw)) / (2 * h)
+            np.testing.assert_allclose(grad_analytic[i], fd, rtol=1e-4, atol=1e-12)
+
+
 def _reg_kwargs(rtype, norm_reg=True):
     """Return kwargs for regularizer/regularizergrad based on rtype."""
     kwargs = dict(


### PR DESCRIPTION
## Summary
- Merges `dev-backend` (through #266) into `dev-backend-mixpol`. `Obsdata.tlist`/`bllist` auto-merged cleanly.
- Fixes 3 mixpol regressions surfaced by the new dev-backend test suites:
  - `obs_simulate.make_jones` caltable write: `DTCAL` gained `dr`/`dl` in Phase 1 (#254), so the row must include all 5 fields.
  - `Array.remove_site`: `self.tkey[site]` raises `KeyError`, not `IndexError` — catch both so the informative message surfaces on a missing site.
  - `test_array.test_init_tarr_dtype_has_legacy_columns`: check `dtype.fields` (includes title aliases) rather than `dtype.names` (primary only).

## Test plan
- [x] Full test suite green: 1381 passed, 1 skipped, 1 xpassed.
- [x] CI on the PR.