### PR TITLE
'lin' polrep for Image/Movie/Model + pol_conventions module

### DIFF
--- a/docs/polarization_conventions.md
+++ b/docs/polarization_conventions.md
@@ -17,9 +17,15 @@ We work in the sky-tangent frame at the source, with the right-handed
 basis $(\hat e_X, \hat e_Y, \hat k)$ where $\hat k$ points from source
 to observer. The electric field of a monochromatic plane wave is
 
-$$\vec E(t) = \mathrm{Re}\,[E_X \hat e_X + E_Y \hat e_Y]\,e^{-i\omega t},$$
+$$\vec E(t) = \mathrm{Re}\,[E_X \hat e_X + E_Y \hat e_Y]\,e^{+i\omega t},$$
 
-with $E_X, E_Y$ complex analytic amplitudes. The "feed" of an antenna
+with $E_X, E_Y$ complex analytic amplitudes. We use the engineering /
+IEEE positive-frequency convention $e^{+i\omega t}$ standard in radio
+interferometry literature (e.g., TMS Ch. 4). The physics convention
+$e^{-i\omega t}$ would conjugate all complex amplitudes and flip the
+sign of $V$ in the §5 linear formulas; everything else is invariant.
+
+The "feed" of an antenna
 projects $\vec E$ onto a basis vector; the two pure-feed cases of
 interest are **linear** (samples $E_X, E_Y$ directly) and **circular**
 (samples $E_R, E_L$ — defined below).
@@ -31,16 +37,17 @@ Implemented at: convention statement in
 
 ## §2. Linear-circular basis transform — the convention choice (IAU/HBS)
 
-ehtim adopts the IAU / Hamaker-Bregman-Sault / CASA / AIPS convention:
+ehtim adopts the IAU / Hamaker-Bregman-Sault / CASA / AIPS convention
+under the §1 engineering time dependence $e^{+i\omega t}$:
 
-$$R = \frac{X - iY}{\sqrt 2}, \quad L = \frac{X + iY}{\sqrt 2}.$$
+$$R = \frac{X + iY}{\sqrt 2}, \quad L = \frac{X - iY}{\sqrt 2}.$$
 
 In matrix form, the basis-change matrix
 $M_{\mathrm{lin}\to\mathrm{circ}}$ acting on the column vector
 $(E_X, E_Y)^\top$ to produce $(E_R, E_L)^\top$ is
 
 $$M_{\mathrm{lin}\to\mathrm{circ}} = \frac{1}{\sqrt 2}
-  \begin{pmatrix} 1 & -i \\ 1 & +i \end{pmatrix}.$$
+  \begin{pmatrix} 1 & +i \\ 1 & -i \end{pmatrix}.$$
 
 It is unitary, so
 $M_{\mathrm{circ}\to\mathrm{lin}} = M_{\mathrm{lin}\to\mathrm{circ}}^\dagger$.
@@ -49,10 +56,11 @@ The IAU/HBS convention is the standard in radio interferometry
 calibration software (CASA, AIPS, DIFX) and is what AIPS POLTYA/POLTYB
 labels assume when they report an X/Y feed.
 
-The opposite choice ($R = (X+iY)/\sqrt 2$) is sometimes used in optics
-texts and pulsar literature; switching to it requires only changing
-the constant `BASIS_LIN_TO_CIRC` in `pol_conventions.py` (and the
-formulas in §5 below). The sign of $V$ flips under that change.
+Under the physics time convention $e^{-i\omega t}$ the same physical
+basis is written $R = (X - iY)/\sqrt 2$ (complex conjugates of the
+amplitudes). Switching to that convention requires changing the
+constant `BASIS_LIN_TO_CIRC` in `pol_conventions.py` and flipping the
+sign of $V$ in §5; §4 is unaffected.
 
 Implemented at: `ehtim/observing/pol_conventions.py:56-60`.
 
@@ -107,27 +115,53 @@ Four-component wrappers at `:176-186` (`circ_to_stokes`) and
 
 ## §5. Stokes from linear feeds
 
-Substituting the §2 basis transform into the §4 definitions gives the
-linear-feed analog. Starting from $R = (X - iY)/\sqrt 2$ and
-$L = (X + iY)/\sqrt 2$, the four circular correlations expand to
+Following §3, the linear correlator labels are
+$XX \equiv \langle E_X E_X^* \rangle$,
+$XY \equiv \langle E_X E_Y^* \rangle$,
+$YX \equiv \langle E_Y E_X^* \rangle$,
+$YY \equiv \langle E_Y E_Y^* \rangle$
+(first index un-conjugated, second conjugated). This labeling, together
+with §2, fixes the sign of $V$.
 
-$$RR = \tfrac{1}{2}[(XX + YY) + i(XY - YX)],$$
-$$LL = \tfrac{1}{2}[(XX + YY) - i(XY - YX)],$$
+Substituting the §2 basis transform into the §4 definitions gives the
+linear-feed analog. Starting from $R = (X + iY)/\sqrt 2$ and
+$L = (X - iY)/\sqrt 2$, the four circular correlations expand to
+
+$$RR = \tfrac{1}{2}[(XX + YY) - i(XY - YX)],$$
+$$LL = \tfrac{1}{2}[(XX + YY) + i(XY - YX)],$$
 $$RL = \tfrac{1}{2}[(XX - YY) + i(XY + YX)],$$
 $$LR = \tfrac{1}{2}[(XX - YY) - i(XY + YX)].$$
 
 Plugging into §4 yields the linear-feed Stokes formulas:
 
 $$\boxed{\,I = \tfrac{1}{2}(XX + YY), \quad Q = \tfrac{1}{2}(XX - YY), \quad
-       U = \tfrac{1}{2}(XY + YX), \quad V = +\tfrac{i}{2}(XY - YX).\,}$$
+       U = \tfrac{1}{2}(XY + YX), \quad V = -\tfrac{i}{2}(XY - YX).\,}$$
 
 Inverted (to derive linear correlations from Stokes):
 
-$$XX = I + Q, \quad YY = I - Q, \quad XY = U - iV, \quad YX = U + iV.$$
+$$XX = I + Q, \quad YY = I - Q, \quad XY = U + iV, \quad YX = U - iV.$$
 
-The **sign of V** depends on the §2 choice: under the opposite basis
-convention, $V \to -i(XY - YX)/2$ and accordingly $XY \to U + iV$,
-$YX \to U - iV$.
+The **sign of V** depends on the §1/§2 choice: under the physics
+convention ($e^{-i\omega t}$, $R = (X - iY)/\sqrt 2$), $V \to +i(XY -
+YX)/2$ and accordingly $XY \to U - iV$, $YX \to U + iV$. The circular
+formulas in §4 are invariant.
+
+### §5a. Comparison to Thompson, Moran & Swenson (3rd ed.)
+
+TMS Eq. 4.28 (engineering convention $e^{+j\omega t}$, matching our §1)
+gives the cross-hand linear correlations as
+
+$$\langle E_X E_Y^* \rangle = \tfrac{1}{2}(U + jV), \qquad
+  \langle E_Y E_X^* \rangle = \tfrac{1}{2}(U - jV),$$
+
+which agree in sign with ehtim's $XY = U + iV$, $YX = U - iV$. The
+remaining difference is a factor-of-2 normalization: TMS Eq. 4.28
+puts the $1/2$ on the Stokes side of every correlation (parallel and
+cross), whereas ehtim §5 puts the $1/2$ on the correlation side.
+Equivalently, $\text{(TMS Stokes)} = 2 \times \text{(ehtim Stokes)}$
+for all of $I, Q, U, V$. A data set written under TMS Eq. 4.28
+normalization must therefore have all four Stokes parameters rescaled
+by $\tfrac{1}{2}$ before being ingested into the ehtim pipeline.
 
 Implemented at: pair primitives in
 `ehtim/observing/pol_conventions.py:140-146` (`lin_to_stokes_diag`),

--- a/docs/polarization_conventions.md
+++ b/docs/polarization_conventions.md
@@ -96,8 +96,12 @@ $$Q = \tfrac{1}{2}(RL + LR), \quad U = \tfrac{i}{2}(LR - RL).$$
 These match ehtim's existing (pre-mixed-pol) circular-to-Stokes code
 and define what we mean by Stokes throughout the codebase.
 
-Implemented at: `ehtim/observing/pol_conventions.py:96-109`
-(`circ_to_stokes`) and `:111-124` (`stokes_to_circ`).
+Implemented at: pair primitives in
+`ehtim/observing/pol_conventions.py:108-115` (`circ_to_stokes_parallel`),
+`:117-126` (`circ_to_stokes_cross`), `:128-131`
+(`stokes_to_circ_parallel`), `:134-137` (`stokes_to_circ_cross`).
+Four-component wrappers at `:176-186` (`circ_to_stokes`) and
+`:188-198` (`stokes_to_circ`).
 
 ---
 
@@ -125,8 +129,12 @@ The **sign of V** depends on the §2 choice: under the opposite basis
 convention, $V \to -i(XY - YX)/2$ and accordingly $XY \to U + iV$,
 $YX \to U - iV$.
 
-Implemented at: `ehtim/observing/pol_conventions.py:126-139`
-(`lin_to_stokes`) and `:141-156` (`stokes_to_lin`).
+Implemented at: pair primitives in
+`ehtim/observing/pol_conventions.py:140-146` (`lin_to_stokes_diag`),
+`:149-158` (`lin_to_stokes_offdiag`), `:160-163`
+(`stokes_to_lin_diag`), `:166-169` (`stokes_to_lin_offdiag`).
+Four-component wrappers at `:200-210` (`lin_to_stokes`) and
+`:212-222` (`stokes_to_lin`).
 
 ---
 
@@ -195,9 +203,9 @@ sufficient for bit-identical migration of existing Obsdata behavior —
 but new code that mixes polreps in noise calculations should not
 assume independence.
 
-Implemented at: `ehtim/observing/pol_conventions.py:191-200`
-(`circ_to_stokes_sigma`), `:202-211` (`stokes_to_circ_sigma`),
-`:213-221` (`lin_to_stokes_sigma`), `:224-228` (`stokes_to_lin_sigma`).
+Implemented at: `ehtim/observing/pol_conventions.py:257-266`
+(`circ_to_stokes_sigma`), `:268-277` (`stokes_to_circ_sigma`),
+`:279-287` (`lin_to_stokes_sigma`), `:290-294` (`stokes_to_lin_sigma`).
 The covariance-aware version is not yet implemented; it will arrive
 when a downstream consumer needs it.
 
@@ -220,8 +228,8 @@ wrapper in `pol_conventions.py` is implemented as the two-step
 composition `lin_to_stokes` → `stokes_to_circ` to keep a single source
 of truth and make any future convention change a one-line edit.
 
-Implemented at: `ehtim/observing/pol_conventions.py:158-160`
-(`lin_to_circ`) and `:163-165` (`circ_to_lin`).
+Implemented at: `ehtim/observing/pol_conventions.py:224-226`
+(`lin_to_circ`) and `:229-231` (`circ_to_lin`).
 The cross-check is enforced by a round-trip test in
 `tests/test_pol_conventions.py`.
 
@@ -266,8 +274,8 @@ work. This module ships the per-station algebra so that downstream
 calibration code has a single home to call into.)
 
 Implemented at: scaffolding in
-`ehtim/observing/pol_conventions.py:244-264` (`jones_matrix`),
-`:266-271` (`invert_jones`), `:274-291`
+`ehtim/observing/pol_conventions.py:310-330` (`jones_matrix`),
+`:332-337` (`invert_jones`), `:340-357`
 (`apply_inverse_jones_to_coherency`).
 
 ---
@@ -295,7 +303,7 @@ EHT calibration pipeline. When the first consumer (full-Jones
 `applycal`) lands, verify against existing `pol_cal*` code in this
 repo — flip here if a sign mismatch is found.
 
-Implemented at: `ehtim/observing/pol_conventions.py:244-264`
+Implemented at: `ehtim/observing/pol_conventions.py:310-330`
 (`jones_matrix`).
 
 ---
@@ -311,7 +319,7 @@ When gains and D-terms are well-determined and the feed model is
 correct, $C^{ij}_{\text{corr}}$ recovers the true sky-domain coherency
 matrix up to noise.
 
-Implemented at: `ehtim/observing/pol_conventions.py:274-291`
+Implemented at: `ehtim/observing/pol_conventions.py:340-357`
 (`apply_inverse_jones_to_coherency`).
 
 ---

--- a/docs/polarization_conventions.md
+++ b/docs/polarization_conventions.md
@@ -1,0 +1,343 @@
+# Polarization conventions in ehtim
+
+This document is the authoritative reference for how ehtim represents
+polarization. All basis transforms and Jones-matrix utilities are
+implemented in
+[`ehtim/observing/pol_conventions.py`](../ehtim/observing/pol_conventions.py);
+this document derives the formulas and pins down the sign conventions.
+
+If you ever need to change a convention, change it in one place
+(`pol_conventions.py`) and update this document.
+
+---
+
+## §1. Coordinate frames and field definitions
+
+We work in the sky-tangent frame at the source, with the right-handed
+basis $(\hat e_X, \hat e_Y, \hat k)$ where $\hat k$ points from source
+to observer. The electric field of a monochromatic plane wave is
+
+$$\vec E(t) = \mathrm{Re}\,[E_X \hat e_X + E_Y \hat e_Y]\,e^{-i\omega t},$$
+
+with $E_X, E_Y$ complex analytic amplitudes. The "feed" of an antenna
+projects $\vec E$ onto a basis vector; the two pure-feed cases of
+interest are **linear** (samples $E_X, E_Y$ directly) and **circular**
+(samples $E_R, E_L$ — defined below).
+
+Implemented at: convention statement in
+`ehtim/observing/pol_conventions.py:18-43` (module docstring).
+
+---
+
+## §2. Linear-circular basis transform — the convention choice (IAU/HBS)
+
+ehtim adopts the IAU / Hamaker-Bregman-Sault / CASA / AIPS convention:
+
+$$R = \frac{X - iY}{\sqrt 2}, \quad L = \frac{X + iY}{\sqrt 2}.$$
+
+In matrix form, the basis-change matrix
+$M_{\mathrm{lin}\to\mathrm{circ}}$ acting on the column vector
+$(E_X, E_Y)^\top$ to produce $(E_R, E_L)^\top$ is
+
+$$M_{\mathrm{lin}\to\mathrm{circ}} = \frac{1}{\sqrt 2}
+  \begin{pmatrix} 1 & -i \\ 1 & +i \end{pmatrix}.$$
+
+It is unitary, so
+$M_{\mathrm{circ}\to\mathrm{lin}} = M_{\mathrm{lin}\to\mathrm{circ}}^\dagger$.
+
+The IAU/HBS convention is the standard in radio interferometry
+calibration software (CASA, AIPS, DIFX) and is what AIPS POLTYA/POLTYB
+labels assume when they report an X/Y feed.
+
+The opposite choice ($R = (X+iY)/\sqrt 2$) is sometimes used in optics
+texts and pulsar literature; switching to it requires only changing
+the constant `BASIS_LIN_TO_CIRC` in `pol_conventions.py` (and the
+formulas in §5 below). The sign of $V$ flips under that change.
+
+Implemented at: `ehtim/observing/pol_conventions.py:56-60`.
+
+---
+
+## §3. Visibility correlations
+
+For two stations $i, j$ with feeds $p, q$, the visibility is
+
+$$V^{ij}_{pq} = \langle s^p_i \, (s^q_j)^* \rangle,$$
+
+where $s^p_i$ is the complex analytic feed-signal at station $i$ feed
+$p$. With four pure-feed station pairs we have four correlations per
+baseline.
+
+The natural object is the $2\times 2$ **coherency matrix**
+
+$$C^{ij} = \begin{pmatrix} V^{ij}_{p_1 p_1} & V^{ij}_{p_1 p_2} \\
+                            V^{ij}_{p_2 p_1} & V^{ij}_{p_2 p_2} \end{pmatrix},$$
+
+where $(p_1, p_2)$ is either $(R, L)$ or $(X, Y)$ depending on the feed
+type of stations $i$ and $j$.
+
+ehtim stores the four entries of $C$ as separate columns
+(`rrvis/llvis/rlvis/lrvis` for circular, `xxvis/yyvis/xyvis/yxvis` for
+linear, or the generic `p1p1vis/p2p2vis/p1p2vis/p2p1vis` title aliases).
+
+Implemented at: dtype declarations in
+`ehtim/const_def.py:99-115` (DTPOL_CIRC, DTPOL_LIN).
+
+---
+
+## §4. Stokes from circular feeds
+
+The Stokes parameters $(I, Q, U, V)$ in the visibility domain are
+combinations of the four circular correlations:
+
+$$I = \tfrac{1}{2}(RR + LL), \quad V = \tfrac{1}{2}(RR - LL),$$
+$$Q = \tfrac{1}{2}(RL + LR), \quad U = \tfrac{i}{2}(LR - RL).$$
+
+These match ehtim's existing (pre-mixed-pol) circular-to-Stokes code
+and define what we mean by Stokes throughout the codebase.
+
+Implemented at: `ehtim/observing/pol_conventions.py:96-109`
+(`circ_to_stokes`) and `:111-124` (`stokes_to_circ`).
+
+---
+
+## §5. Stokes from linear feeds
+
+Substituting the §2 basis transform into the §4 definitions gives the
+linear-feed analog. Starting from $R = (X - iY)/\sqrt 2$ and
+$L = (X + iY)/\sqrt 2$, the four circular correlations expand to
+
+$$RR = \tfrac{1}{2}[(XX + YY) + i(XY - YX)],$$
+$$LL = \tfrac{1}{2}[(XX + YY) - i(XY - YX)],$$
+$$RL = \tfrac{1}{2}[(XX - YY) + i(XY + YX)],$$
+$$LR = \tfrac{1}{2}[(XX - YY) - i(XY + YX)].$$
+
+Plugging into §4 yields the linear-feed Stokes formulas:
+
+$$\boxed{\,I = \tfrac{1}{2}(XX + YY), \quad Q = \tfrac{1}{2}(XX - YY), \quad
+       U = \tfrac{1}{2}(XY + YX), \quad V = +\tfrac{i}{2}(XY - YX).\,}$$
+
+Inverted (to derive linear correlations from Stokes):
+
+$$XX = I + Q, \quad YY = I - Q, \quad XY = U - iV, \quad YX = U + iV.$$
+
+The **sign of V** depends on the §2 choice: under the opposite basis
+convention, $V \to -i(XY - YX)/2$ and accordingly $XY \to U + iV$,
+$YX \to U - iV$.
+
+Implemented at: `ehtim/observing/pol_conventions.py:126-139`
+(`lin_to_stokes`) and `:141-156` (`stokes_to_lin`).
+
+---
+
+## §6. Visibility sigmas
+
+Each visibility column has a paired sigma column (`rrsigma`/`xxsigma`/
+`sigma`/etc.) carrying a per-row $1\sigma$ thermal noise estimate, in
+the same units as the visibility itself. Sigmas are real and
+non-negative.
+
+For independent, complex-circular Gaussian noise on the input
+correlations, propagating the §4 and §5 linear combinations gives the
+per-component output sigmas:
+
+**circular → Stokes**
+
+$$\sigma_I = \sigma_V = \tfrac{1}{2}\sqrt{\sigma_{RR}^2 + \sigma_{LL}^2}, \quad
+  \sigma_Q = \sigma_U = \tfrac{1}{2}\sqrt{\sigma_{RL}^2 + \sigma_{LR}^2}.$$
+
+**Stokes → circular**
+
+$$\sigma_{RR} = \sigma_{LL} = \sqrt{\sigma_I^2 + \sigma_V^2}, \quad
+  \sigma_{RL} = \sigma_{LR} = \sqrt{\sigma_Q^2 + \sigma_U^2}.$$
+
+**linear → Stokes** (under the §2 IAU/HBS convention)
+
+$$\sigma_I = \sigma_Q = \tfrac{1}{2}\sqrt{\sigma_{XX}^2 + \sigma_{YY}^2}, \quad
+  \sigma_U = \sigma_V = \tfrac{1}{2}\sqrt{\sigma_{XY}^2 + \sigma_{YX}^2}.$$
+
+**Stokes → linear**
+
+$$\sigma_{XX} = \sigma_{YY} = \sqrt{\sigma_I^2 + \sigma_Q^2}, \quad
+  \sigma_{XY} = \sigma_{YX} = \sqrt{\sigma_U^2 + \sigma_V^2}.$$
+
+### Known limitation: cross-component covariance is dropped
+
+Each output component is a linear combination of (typically) two input
+components. The output components are therefore **correlated** even
+when the inputs are independent, but the formulas above record only
+marginal variances — the full output covariance has nonzero off-diagonal
+entries that we discard.
+
+Concrete consequences:
+
+- Round-trips do not recover the input sigmas exactly. For example,
+  $\sigma_I, \sigma_Q$ from `circ_to_stokes_sigma` followed by
+  `stokes_to_circ_sigma` returns
+  $\sqrt{\sigma_I^2 + \sigma_V^2} = \tfrac{1}{\sqrt 2}\sqrt{\sigma_{RR}^2 + \sigma_{LL}^2}$
+  for the recovered $\sigma_{RR}$, which differs from the true
+  $\sigma_{RR}$ unless $\sigma_{RR} = \sigma_{LL}$.
+- Per-baseline closures, weighted averages, and Bayesian likelihoods
+  that mix Stokes and feed-basis quantities will be slightly
+  miscalibrated if they treat the sigmas as independent across
+  components.
+
+The proper treatment propagates the full $4\times 4$ covariance
+matrix:
+
+$$\mathrm{Cov}_{\mathrm{out}} = M\,\mathrm{Cov}_{\mathrm{in}}\,M^\dagger,$$
+
+where $M$ is the $4\times 4$ basis-transform matrix on the visibility
+vector. This produces nonzero off-diagonal entries that downstream
+code can use when it cares. **No current ehtim consumer reads
+off-diagonal covariance**, so the per-component sigma transforms are
+sufficient for bit-identical migration of existing Obsdata behavior —
+but new code that mixes polreps in noise calculations should not
+assume independence.
+
+Implemented at: `ehtim/observing/pol_conventions.py:191-200`
+(`circ_to_stokes_sigma`), `:202-211` (`stokes_to_circ_sigma`),
+`:213-221` (`lin_to_stokes_sigma`), `:224-228` (`stokes_to_lin_sigma`).
+The covariance-aware version is not yet implemented; it will arrive
+when a downstream consumer needs it.
+
+---
+
+## §7. Cross-check: `lin → circ → stokes` vs direct `lin → stokes`
+
+The two compositions must agree by construction (basis transforms are
+linear). Concretely, starting from $(XX, YY, XY, YX)$:
+
+1. Apply §5 inverse → $(I, Q, U, V)$
+2. Apply §4 forward → $(RR, LL, RL, LR)$
+
+vs.
+
+1. Apply §5 (relations above) directly → $(RR, LL, RL, LR)$
+
+Both routes produce the same circular correlations. The `lin_to_circ`
+wrapper in `pol_conventions.py` is implemented as the two-step
+composition `lin_to_stokes` → `stokes_to_circ` to keep a single source
+of truth and make any future convention change a one-line edit.
+
+Implemented at: `ehtim/observing/pol_conventions.py:158-160`
+(`lin_to_circ`) and `:163-165` (`circ_to_lin`).
+The cross-check is enforced by a round-trip test in
+`tests/test_pol_conventions.py`.
+
+---
+
+## §8. Faraday rotation sign convention
+
+Faraday rotation of an EVPA $\chi$ by an amount $\phi(\nu)$ (the
+rotation measure times $\lambda^2$ minus the reference value) rotates
+$Q + iU$ as
+
+$$Q' + iU' = (Q + iU)\,e^{+2i\phi}.$$
+
+The sign $+2i\phi$ is the convention used in the EHT data pipeline and
+is consistent with the §2 basis choice. (Multifrequency Faraday-rotation
+work is tracked in `obsdata_multifreq_plan.md`; this section is a
+forward-pointer.)
+
+Implemented at: not yet — Faraday rotation lives in calibration code
+that this module does not own. When that code consolidates here,
+update.
+
+---
+
+## §9. Jones matrices
+
+A station's net response to an incident field $\vec E$ is a $2\times 2$
+complex matrix $J$ acting on the feed-basis vector:
+
+$$\begin{pmatrix} V_{p_1} \\ V_{p_2} \end{pmatrix}_{\text{observed}}
+  = J \begin{pmatrix} E_{p_1} \\ E_{p_2} \end{pmatrix}.$$
+
+For a baseline $(i, j)$ the observed coherency matrix is
+
+$$C^{ij}_{\text{obs}} = J_i \, C^{ij}_{\text{true}} \, J_j^\dagger,$$
+
+where $J_i, J_j$ are the per-station Jones matrices. Inverting gives
+the calibration formula in §11.
+
+(The full mixed-pol Jones treatment lives in Alex's mixed-pol imaging
+work. This module ships the per-station algebra so that downstream
+calibration code has a single home to call into.)
+
+Implemented at: scaffolding in
+`ehtim/observing/pol_conventions.py:244-264` (`jones_matrix`),
+`:266-271` (`invert_jones`), `:274-291`
+(`apply_inverse_jones_to_coherency`).
+
+---
+
+## §10. Jones factoring: $J = G \cdot (I + D)$
+
+ehtim factors a station's Jones matrix into a diagonal complex gain and
+a D-term cross-coupling matrix:
+
+$$J = G \cdot (I + D), \quad
+  G = \begin{pmatrix} g_{p_1} & 0 \\ 0 & g_{p_2} \end{pmatrix}, \quad
+  I + D = \begin{pmatrix} 1 & d_{p_1} \\ d_{p_2} & 1 \end{pmatrix}.$$
+
+Equivalently,
+
+$$J = \begin{pmatrix} g_{p_1} & g_{p_1} d_{p_1} \\
+                       g_{p_2} d_{p_2} & g_{p_2} \end{pmatrix}.$$
+
+The $d_{p_1}, d_{p_2}$ entries are the per-feed leakage of the
+*other* feed into this one (so $d_{p_1}$ is the leakage of $p_2$ into
+$p_1$).
+
+This factoring matches the convention used in CASA's polcal and in the
+EHT calibration pipeline. When the first consumer (full-Jones
+`applycal`) lands, verify against existing `pol_cal*` code in this
+repo — flip here if a sign mismatch is found.
+
+Implemented at: `ehtim/observing/pol_conventions.py:244-264`
+(`jones_matrix`).
+
+---
+
+## §11. Per-baseline visibility correction
+
+Given per-station Jones matrices $J_i, J_j$ and an observed coherency
+matrix $C^{ij}_{\text{obs}}$, the calibrated coherency is
+
+$$C^{ij}_{\text{corr}} = J_i^{-1} \, C^{ij}_{\text{obs}} \, (J_j^\dagger)^{-1}.$$
+
+When gains and D-terms are well-determined and the feed model is
+correct, $C^{ij}_{\text{corr}}$ recovers the true sky-domain coherency
+matrix up to noise.
+
+Implemented at: `ehtim/observing/pol_conventions.py:274-291`
+(`apply_inverse_jones_to_coherency`).
+
+---
+
+## §12. Polrep-specific Jones application
+
+The $2\times 2$ coherency matrix corresponds to different physical
+quantities depending on the feed types of the two stations:
+
+| Stations | $C_{11}$ | $C_{12}$ | $C_{21}$ | $C_{22}$ | polrep |
+|---|---|---|---|---|---|
+| circular–circular | $V_{RR}$ | $V_{RL}$ | $V_{LR}$ | $V_{LL}$ | `'circ'` |
+| linear–linear     | $V_{XX}$ | $V_{XY}$ | $V_{YX}$ | $V_{YY}$ | `'lin'`  |
+| circ–linear (i.e. station $i$ has circular feed, $j$ has linear) | $V_{RX}$ | $V_{RY}$ | $V_{LX}$ | $V_{LY}$ | `'mixed'` (per-baseline) |
+| stokes (sky-frame; only meaningful at calibrated-image level) | $I$ | $Q + iU$ | $Q - iU$ | $V$ | `'stokes'` |
+
+The Jones machinery in §9-§11 operates on the coherency matrix and is
+**polrep-agnostic** — it does not know which physical quantities are
+in each slot. The polrep is used only to label the slots when packing
+results back into ehtim's column-storage layout (`rrvis`/`xxvis`/etc.).
+
+For `'mixed'` polrep the slot interpretation varies per baseline, so
+the per-baseline `polbasis` field on the DTPOL_MIXED dtype carries the
+feed-pair label needed to route results correctly. This is set up in
+the schema layer (DTPOL_MIXED definition in `ehtim/const_def.py`)
+and consumed by Obsdata polrep-dispatching code.
+
+Implemented at: dispatch logic in `Obsdata.switch_polrep` and friends
+(forthcoming).

--- a/ehtim/__init__.py
+++ b/ehtim/__init__.py
@@ -6,57 +6,45 @@
 .. moduleauthor:: Andrew Chael (achael@outlook.com)
 
 """
-from __future__ import division
-from __future__ import print_function
-
-from builtins import str
-from builtins import range
-from builtins import object
-
-import ehtim.observing
-from ehtim.const_def import *
-from ehtim.modeling.modeling_utils import modeler_func
-import ehtim.imaging
-from ehtim.features import rex
-import ehtim.features
-from ehtim.plotting.summary_plots import *
-from ehtim.plotting.comparisons import *
-from ehtim.plotting.comp_plots import *
-from ehtim.plotting import comparisons
-from ehtim.plotting import comp_plots
-import ehtim.plotting
-from ehtim.calibrating.network_cal import network_cal as netcal
-from ehtim.calibrating.self_cal import self_cal as selfcal
-from ehtim.calibrating.pol_cal import *
-from ehtim.calibrating.pol_cal_new import *
-from ehtim.calibrating import pol_cal
-from ehtim.calibrating import network_cal
-from ehtim.calibrating import self_cal
-import ehtim.calibrating
-import ehtim.parloop
-import ehtim.caltable
-import ehtim.vex
-import ehtim.imager
-import ehtim.obsdata
-import ehtim.array
-import ehtim.movie
-import ehtim.image
-import ehtim.model
-import ehtim.survey
-
 
 # Use a non-colliding local name: the bare `warnings` name shadows the
 # `ehtim.warnings` submodule attribute and breaks `import ehtim.warnings as ehw`.
 import warnings as _stdlib_warnings
+from builtins import object, range, str
+
+import ehtim.array
+import ehtim.calibrating
+import ehtim.caltable
+import ehtim.features
+import ehtim.image
+import ehtim.imager
+import ehtim.imaging
+import ehtim.model
+import ehtim.movie
+import ehtim.obsdata
+import ehtim.observing
+import ehtim.parloop
+import ehtim.plotting
+import ehtim.survey
+import ehtim.vex
+from ehtim.calibrating import network_cal, pol_cal, self_cal
+from ehtim.calibrating.network_cal import network_cal as netcal
+from ehtim.calibrating.pol_cal import *
+from ehtim.calibrating.pol_cal_new import *
+from ehtim.calibrating.self_cal import self_cal as selfcal
+from ehtim.const_def import *
+from ehtim.features import rex
+from ehtim.modeling.modeling_utils import modeler_func
+from ehtim.plotting import comp_plots, comparisons
+from ehtim.plotting.comp_plots import *
+from ehtim.plotting.comparisons import *
+from ehtim.plotting.summary_plots import *
+
 _stdlib_warnings.filterwarnings(
     "ignore", message="numpy.dtype size changed, may indicate binary incompatibility.")
 
-# necessary to prevent hangs from astropy iers bug in astropy v 2.0.8
-#from astropy.utils import iers
-#iers.conf.auto_download = False
-
 try:
-    from importlib.metadata import metadata, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError, metadata
     _meta = metadata("ehtim")
     __version__ = _meta["Version"]
     __author__  = _meta["Author-email"]

--- a/ehtim/__init__.py
+++ b/ehtim/__init__.py
@@ -45,8 +45,10 @@ import ehtim.model
 import ehtim.survey
 
 
-import warnings
-warnings.filterwarnings(
+# Use a non-colliding local name: the bare `warnings` name shadows the
+# `ehtim.warnings` submodule attribute and breaks `import ehtim.warnings as ehw`.
+import warnings as _stdlib_warnings
+_stdlib_warnings.filterwarnings(
     "ignore", message="numpy.dtype size changed, may indicate binary incompatibility.")
 
 # necessary to prevent hangs from astropy iers bug in astropy v 2.0.8

--- a/ehtim/__init__.py
+++ b/ehtim/__init__.py
@@ -10,35 +10,39 @@
 # Use a non-colliding local name: the bare `warnings` name shadows the
 # `ehtim.warnings` submodule attribute and breaks `import ehtim.warnings as ehw`.
 import warnings as _stdlib_warnings
-from builtins import object, range, str
 
-import ehtim.array
-import ehtim.calibrating
-import ehtim.caltable
-import ehtim.features
-import ehtim.image
-import ehtim.imager
-import ehtim.imaging
-import ehtim.model
-import ehtim.movie
-import ehtim.obsdata
+# TODO: this import order is necessary to avoid circular imports
+# refactor in the future and remove * imports 
 import ehtim.observing
-import ehtim.parloop
+from ehtim.const_def import *
+from ehtim.modeling.modeling_utils import modeler_func
+import ehtim.imaging
+from ehtim.features import rex
+import ehtim.features
+from ehtim.plotting.summary_plots import *
+from ehtim.plotting.comparisons import *
+from ehtim.plotting.comp_plots import *
+from ehtim.plotting import comparisons
+from ehtim.plotting import comp_plots
 import ehtim.plotting
-import ehtim.survey
-import ehtim.vex
-from ehtim.calibrating import network_cal, pol_cal, self_cal
 from ehtim.calibrating.network_cal import network_cal as netcal
+from ehtim.calibrating.self_cal import self_cal as selfcal
 from ehtim.calibrating.pol_cal import *
 from ehtim.calibrating.pol_cal_new import *
-from ehtim.calibrating.self_cal import self_cal as selfcal
-from ehtim.const_def import *
-from ehtim.features import rex
-from ehtim.modeling.modeling_utils import modeler_func
-from ehtim.plotting import comp_plots, comparisons
-from ehtim.plotting.comp_plots import *
-from ehtim.plotting.comparisons import *
-from ehtim.plotting.summary_plots import *
+from ehtim.calibrating import pol_cal
+from ehtim.calibrating import network_cal
+from ehtim.calibrating import self_cal
+import ehtim.calibrating
+import ehtim.parloop
+import ehtim.caltable
+import ehtim.vex
+import ehtim.imager
+import ehtim.obsdata
+import ehtim.array
+import ehtim.movie
+import ehtim.image
+import ehtim.model
+import ehtim.survey
 
 _stdlib_warnings.filterwarnings(
     "ignore", message="numpy.dtype size changed, may indicate binary incompatibility.")

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -161,9 +161,9 @@ DTCAL = DTCAL_CIRC  # legacy alias
 DTSCANS = [('time', 'f8'), ('interval', 'f8'), ('startvis', 'f8'), ('endvis', 'f8')]
 
 
-# TODO (Phase 3b): the feed_dtype_for_polrep / feed_poldict / upgrade_*
-# helpers below should migrate to ehtim/observing/pol_conventions.py when
-# that module is created.
+# TODO: the feed_dtype_for_polrep / feed_poldict / upgrade_* helpers below
+# should migrate to ehtim/observing/pol_conventions.py (created in
+# MixPol Phase 3) when Obsdata.switch_polrep is wired up to it.
 
 def feed_dtype_for_polrep(polrep):
     """Return the DTPOL_* field-spec list for a given polrep."""
@@ -263,11 +263,14 @@ POLDICT_CIRC = {'vis1': 'rrvis', 'vis2': 'llvis', 'vis3': 'rlvis', 'vis4': 'lrvi
 POLDICT_LIN = {'vis1': 'xxvis', 'vis2': 'yyvis', 'vis3': 'xyvis', 'vis4': 'yxvis',
                'sigma1': 'xxsigma', 'sigma2': 'yysigma', 'sigma3': 'xysigma', 'sigma4': 'yxsigma'}
 vis_poldict = {'I': 'vis', 'Q': 'qvis', 'U': 'uvis', 'V': 'vvis',
-               'RR': 'rrvis', 'LL': 'llvis', 'RL': 'rlvis', 'LR': 'lrvis'}
+               'RR': 'rrvis', 'LL': 'llvis', 'RL': 'rlvis', 'LR': 'lrvis',
+               'XX': 'xxvis', 'YY': 'yyvis', 'XY': 'xyvis', 'YX': 'yxvis'}
 amp_poldict = {'I': 'amp', 'Q': 'qamp', 'U': 'uamp', 'V': 'vamp',
-               'RR': 'rramp', 'LL': 'llamp', 'RL': 'rlamp', 'LR': 'lramp'}
+               'RR': 'rramp', 'LL': 'llamp', 'RL': 'rlamp', 'LR': 'lramp',
+               'XX': 'xxamp', 'YY': 'yyamp', 'XY': 'xyamp', 'YX': 'yxamp'}
 sig_poldict = {'I': 'sigma', 'Q': 'qsigma', 'U': 'usigma', 'V': 'vsigma',
-               'RR': 'rrsigma', 'LL': 'llsigma', 'RL': 'rlsigma', 'LR': 'lrsigma'}
+               'RR': 'rrsigma', 'LL': 'llsigma', 'RL': 'rlsigma', 'LR': 'lrsigma',
+               'XX': 'xxsigma', 'YY': 'yysigma', 'XY': 'xysigma', 'YX': 'yxsigma'}
 
 # Observation fields for plotting and retrieving data
 FIELDS = ['time', 'time_utc', 'time_gmst',

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -570,8 +570,9 @@ class Image:
     def evec(self):
         """Return the E mode image vector"""
         if self.polrep == 'circ':
-            qvec = np.real(0.5 * (self.lrvec + self.rlvec))
-            uvec = np.real(0.5j * (self.lrvec - self.rlvec))
+            qvec_c, uvec_c = pol_conventions.circ_to_stokes_cross(self.rlvec, self.lrvec)
+            qvec = np.real(qvec_c)
+            uvec = np.real(uvec_c)
         elif self.polrep == 'stokes':
             qvec = self.qvec
             uvec = self.uvec
@@ -602,8 +603,9 @@ class Image:
         """Return the B mode image vector"""
 
         if self.polrep == 'circ':
-            qvec = np.real(0.5 * (self.lrvec + self.rlvec))
-            uvec = np.real(0.5j * (self.lrvec - self.rlvec))
+            qvec_c, uvec_c = pol_conventions.circ_to_stokes_cross(self.rlvec, self.lrvec)
+            qvec = np.real(qvec_c)
+            uvec = np.real(uvec_c)
         elif self.polrep == 'stokes':
             qvec = self.qvec
             uvec = self.uvec

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -36,6 +36,7 @@ import ehtim.io.load
 import ehtim.io.save
 import ehtim.observing.obs_helpers as obsh
 import ehtim.observing.obs_simulate as simobs
+import ehtim.observing.pol_conventions as pol_conventions
 import ehtim.observing.pulses as pulses
 
 # TODO : add time to all images
@@ -261,10 +262,10 @@ class Image:
             ivec = self._imdict['I']
         elif self.polrep == 'circ':
             if len(self.rrvec) != 0 and len(self.llvec) != 0:
-                ivec = 0.5 * (self.rrvec + self.llvec)
+                ivec, _ = pol_conventions.circ_to_stokes_parallel(self.rrvec, self.llvec)
         elif self.polrep == 'lin':
             if len(self.xxvec) != 0 and len(self.yyvec) != 0:
-                ivec = 0.5 * (self.xxvec + self.yyvec)
+                ivec, _ = pol_conventions.lin_to_stokes_diag(self.xxvec, self.yyvec)
 
         return ivec
 
@@ -284,10 +285,11 @@ class Image:
             qvec = self._imdict['Q']
         elif self.polrep == 'circ':
             if len(self.rlvec) != 0 and len(self.lrvec) != 0:
-                qvec = np.real(0.5 * (self.lrvec + self.rlvec))
+                qvec_c, _ = pol_conventions.circ_to_stokes_cross(self.rlvec, self.lrvec)
+                qvec = np.real(qvec_c)
         elif self.polrep == 'lin':
             if len(self.xxvec) != 0 and len(self.yyvec) != 0:
-                qvec = 0.5 * (self.xxvec - self.yyvec)
+                _, qvec = pol_conventions.lin_to_stokes_diag(self.xxvec, self.yyvec)
 
         return qvec
 
@@ -307,10 +309,12 @@ class Image:
             uvec = self._imdict['U']
         elif self.polrep == 'circ':
             if len(self.rlvec) != 0 and len(self.lrvec) != 0:
-                uvec = np.real(0.5j * (self.lrvec - self.rlvec))
+                _, uvec_c = pol_conventions.circ_to_stokes_cross(self.rlvec, self.lrvec)
+                uvec = np.real(uvec_c)
         elif self.polrep == 'lin':
             if len(self.xyvec) != 0 and len(self.yxvec) != 0:
-                uvec = np.real(0.5 * (self.xyvec + self.yxvec))
+                uvec_c, _ = pol_conventions.lin_to_stokes_offdiag(self.xyvec, self.yxvec)
+                uvec = np.real(uvec_c)
 
         return uvec
 
@@ -330,10 +334,11 @@ class Image:
             vvec = self._imdict['V']
         elif self.polrep == 'circ':
             if len(self.rrvec) != 0 and len(self.llvec) != 0:
-                vvec = 0.5 * (self.rrvec - self.llvec)
+                _, vvec = pol_conventions.circ_to_stokes_parallel(self.rrvec, self.llvec)
         elif self.polrep == 'lin':
             if len(self.xyvec) != 0 and len(self.yxvec) != 0:
-                vvec = np.real(0.5j * (self.xyvec - self.yxvec))
+                _, vvec_c = pol_conventions.lin_to_stokes_offdiag(self.xyvec, self.yxvec)
+                vvec = np.real(vvec_c)
 
         return vvec
 
@@ -354,7 +359,7 @@ class Image:
         elif self.polrep in ('stokes', 'lin'):
             # lin composes through the Stokes vec getters above.
             if len(self.ivec) != 0 and len(self.vvec) != 0:
-                rrvec = (self.ivec + self.vvec)
+                rrvec, _ = pol_conventions.stokes_to_circ_parallel(self.ivec, self.vvec)
 
         return rrvec
 
@@ -374,7 +379,7 @@ class Image:
             llvec = self._imdict['LL']
         elif self.polrep in ('stokes', 'lin'):
             if len(self.ivec) != 0 and len(self.vvec) != 0:
-                llvec = (self.ivec - self.vvec)
+                _, llvec = pol_conventions.stokes_to_circ_parallel(self.ivec, self.vvec)
 
         return llvec
 
@@ -394,7 +399,7 @@ class Image:
             rlvec = self._imdict['RL']
         elif self.polrep in ('stokes', 'lin'):
             if len(self.qvec) != 0 and len(self.uvec) != 0:
-                rlvec = (self.qvec + 1j * self.uvec)
+                rlvec, _ = pol_conventions.stokes_to_circ_cross(self.qvec, self.uvec)
 
         return rlvec
 
@@ -415,7 +420,7 @@ class Image:
             lrvec = self._imdict['LR']
         elif self.polrep in ('stokes', 'lin'):
             if len(self.qvec) != 0 and len(self.uvec) != 0:
-                lrvec = (self.qvec - 1j * self.uvec)
+                _, lrvec = pol_conventions.stokes_to_circ_cross(self.qvec, self.uvec)
 
         return lrvec
 
@@ -437,7 +442,7 @@ class Image:
             xxvec = self._imdict['XX']
         elif self.polrep in ('stokes', 'circ'):
             if len(self.ivec) != 0 and len(self.qvec) != 0:
-                xxvec = (self.ivec + self.qvec)
+                xxvec, _ = pol_conventions.stokes_to_lin_diag(self.ivec, self.qvec)
 
         return xxvec
 
@@ -456,7 +461,7 @@ class Image:
             yyvec = self._imdict['YY']
         elif self.polrep in ('stokes', 'circ'):
             if len(self.ivec) != 0 and len(self.qvec) != 0:
-                yyvec = (self.ivec - self.qvec)
+                _, yyvec = pol_conventions.stokes_to_lin_diag(self.ivec, self.qvec)
 
         return yyvec
 
@@ -475,7 +480,7 @@ class Image:
             xyvec = self._imdict['XY']
         elif self.polrep in ('stokes', 'circ'):
             if len(self.uvec) != 0 and len(self.vvec) != 0:
-                xyvec = (self.uvec - 1j * self.vvec)
+                xyvec, _ = pol_conventions.stokes_to_lin_offdiag(self.uvec, self.vvec)
 
         return xyvec
 
@@ -494,7 +499,7 @@ class Image:
             yxvec = self._imdict['YX']
         elif self.polrep in ('stokes', 'circ'):
             if len(self.uvec) != 0 and len(self.vvec) != 0:
-                yxvec = (self.uvec + 1j * self.vvec)
+                _, yxvec = pol_conventions.stokes_to_lin_offdiag(self.uvec, self.vvec)
 
         return yxvec
 

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -96,8 +96,8 @@ class Image:
 
         if len(image.shape) != 2:
             raise Exception("image must be a 2D numpy array")
-        if polrep not in ['stokes', 'circ']:
-            raise Exception("only 'stokes' and 'circ' are supported polreps!")
+        if polrep not in ['stokes', 'circ', 'lin']:
+            raise Exception("only 'stokes', 'circ', and 'lin' are supported polreps!")
 
         # Save the image vector
         imvec = image.flatten()
@@ -126,8 +126,19 @@ class Image:
                 self._imdict = {'RR': np.array([]), 'LL': imvec, 'RL': np.array([]), 'LR': np.array([])}
             else:
                 raise Exception("for polrep=='circ', pol_prim must be 'RR' or 'LL'!")
+
+        elif polrep == 'lin':
+            if pol_prim is None:
+                print("polrep is 'lin' and no pol_prim specified! Setting pol_prim='XX'")
+                pol_prim = 'XX'
+            if pol_prim == 'XX':
+                self._imdict = {'XX': imvec, 'YY': np.array([]), 'XY': np.array([]), 'YX': np.array([])}
+            elif pol_prim == 'YY':
+                self._imdict = {'XX': np.array([]), 'YY': imvec, 'XY': np.array([]), 'YX': np.array([])}
+            else:
+                raise Exception("for polrep=='lin', pol_prim must be 'XX' or 'YY'!")
         else:
-            raise Exception("polrep must be 'circ' or 'stokes'!")
+            raise Exception("polrep must be 'circ', 'lin', or 'stokes'!")
 
         # multifrequency spectral index, curvature arrays
         # TODO -- higher orders?
@@ -251,6 +262,9 @@ class Image:
         elif self.polrep == 'circ':
             if len(self.rrvec) != 0 and len(self.llvec) != 0:
                 ivec = 0.5 * (self.rrvec + self.llvec)
+        elif self.polrep == 'lin':
+            if len(self.xxvec) != 0 and len(self.yyvec) != 0:
+                ivec = 0.5 * (self.xxvec + self.yyvec)
 
         return ivec
 
@@ -271,6 +285,9 @@ class Image:
         elif self.polrep == 'circ':
             if len(self.rlvec) != 0 and len(self.lrvec) != 0:
                 qvec = np.real(0.5 * (self.lrvec + self.rlvec))
+        elif self.polrep == 'lin':
+            if len(self.xxvec) != 0 and len(self.yyvec) != 0:
+                qvec = 0.5 * (self.xxvec - self.yyvec)
 
         return qvec
 
@@ -291,6 +308,9 @@ class Image:
         elif self.polrep == 'circ':
             if len(self.rlvec) != 0 and len(self.lrvec) != 0:
                 uvec = np.real(0.5j * (self.lrvec - self.rlvec))
+        elif self.polrep == 'lin':
+            if len(self.xyvec) != 0 and len(self.yxvec) != 0:
+                uvec = np.real(0.5 * (self.xyvec + self.yxvec))
 
         return uvec
 
@@ -311,6 +331,9 @@ class Image:
         elif self.polrep == 'circ':
             if len(self.rrvec) != 0 and len(self.llvec) != 0:
                 vvec = 0.5 * (self.rrvec - self.llvec)
+        elif self.polrep == 'lin':
+            if len(self.xyvec) != 0 and len(self.yxvec) != 0:
+                vvec = np.real(0.5j * (self.xyvec - self.yxvec))
 
         return vvec
 
@@ -328,7 +351,8 @@ class Image:
         rrvec = np.array([])
         if self.polrep == 'circ':
             rrvec = self._imdict['RR']
-        elif self.polrep == 'stokes':
+        elif self.polrep in ('stokes', 'lin'):
+            # lin composes through the Stokes vec getters above.
             if len(self.ivec) != 0 and len(self.vvec) != 0:
                 rrvec = (self.ivec + self.vvec)
 
@@ -348,7 +372,7 @@ class Image:
         llvec = np.array([])
         if self.polrep == 'circ':
             llvec = self._imdict['LL']
-        elif self.polrep == 'stokes':
+        elif self.polrep in ('stokes', 'lin'):
             if len(self.ivec) != 0 and len(self.vvec) != 0:
                 llvec = (self.ivec - self.vvec)
 
@@ -368,7 +392,7 @@ class Image:
         rlvec = np.array([])
         if self.polrep == 'circ':
             rlvec = self._imdict['RL']
-        elif self.polrep == 'stokes':
+        elif self.polrep in ('stokes', 'lin'):
             if len(self.qvec) != 0 and len(self.uvec) != 0:
                 rlvec = (self.qvec + 1j * self.uvec)
 
@@ -389,10 +413,9 @@ class Image:
         lrvec = np.array([])
         if self.polrep == 'circ':
             lrvec = self._imdict['LR']
-        elif self.polrep == 'stokes':
+        elif self.polrep in ('stokes', 'lin'):
             if len(self.qvec) != 0 and len(self.uvec) != 0:
                 lrvec = (self.qvec - 1j * self.uvec)
-
 
         return lrvec
 
@@ -408,11 +431,87 @@ class Image:
         self._imdict['LR'] = vec
 
     @property
+    def xxvec(self):
+        xxvec = np.array([])
+        if self.polrep == 'lin':
+            xxvec = self._imdict['XX']
+        elif self.polrep in ('stokes', 'circ'):
+            if len(self.ivec) != 0 and len(self.qvec) != 0:
+                xxvec = (self.ivec + self.qvec)
+
+        return xxvec
+
+    @xxvec.setter
+    def xxvec(self, vec):
+        if len(vec) != self.xdim * self.ydim:
+            raise Exception("vec size is not consistent with xdim*ydim!")
+        if self.polrep != 'lin':
+            raise Exception("xxvec cannot be set unless self.polrep=='lin'")
+        self._imdict['XX'] = vec
+
+    @property
+    def yyvec(self):
+        yyvec = np.array([])
+        if self.polrep == 'lin':
+            yyvec = self._imdict['YY']
+        elif self.polrep in ('stokes', 'circ'):
+            if len(self.ivec) != 0 and len(self.qvec) != 0:
+                yyvec = (self.ivec - self.qvec)
+
+        return yyvec
+
+    @yyvec.setter
+    def yyvec(self, vec):
+        if len(vec) != self.xdim * self.ydim:
+            raise Exception("vec size is not consistent with xdim*ydim!")
+        if self.polrep != 'lin':
+            raise Exception("yyvec cannot be set unless self.polrep=='lin'")
+        self._imdict['YY'] = vec
+
+    @property
+    def xyvec(self):
+        xyvec = np.array([])
+        if self.polrep == 'lin':
+            xyvec = self._imdict['XY']
+        elif self.polrep in ('stokes', 'circ'):
+            if len(self.uvec) != 0 and len(self.vvec) != 0:
+                xyvec = (self.uvec - 1j * self.vvec)
+
+        return xyvec
+
+    @xyvec.setter
+    def xyvec(self, vec):
+        if len(vec) != self.xdim * self.ydim:
+            raise Exception("vec size is not consistent with xdim*ydim!")
+        if self.polrep != 'lin':
+            raise Exception("xyvec cannot be set unless self.polrep=='lin'")
+        self._imdict['XY'] = vec
+
+    @property
+    def yxvec(self):
+        yxvec = np.array([])
+        if self.polrep == 'lin':
+            yxvec = self._imdict['YX']
+        elif self.polrep in ('stokes', 'circ'):
+            if len(self.uvec) != 0 and len(self.vvec) != 0:
+                yxvec = (self.uvec + 1j * self.vvec)
+
+        return yxvec
+
+    @yxvec.setter
+    def yxvec(self, vec):
+        if len(vec) != self.xdim * self.ydim:
+            raise Exception("vec size is not consistent with xdim*ydim!")
+        if self.polrep != 'lin':
+            raise Exception("yxvec cannot be set unless self.polrep=='lin'")
+        self._imdict['YX'] = vec
+
+    @property
     def pvec(self):
         """Return the linear polarization magnitude for each pixel"""
         if self.polrep == 'circ':
             pvec = np.abs(self.rlvec)
-        elif self.polrep == 'stokes':
+        elif self.polrep in ('stokes', 'lin'):
             pvec = np.abs(self.qvec + 1j * self.uvec)
 
         return pvec
@@ -422,7 +521,7 @@ class Image:
         """Return the fractional linear polarization for each pixel"""
         if self.polrep == 'circ':
             mvec = 2 * np.abs(self.rlvec) / (self.rrvec + self.llvec)
-        elif self.polrep == 'stokes':
+        elif self.polrep in ('stokes', 'lin'):
             mvec = np.abs(self.qvec + 1j * self.uvec) / self.ivec
 
         return mvec
@@ -432,7 +531,7 @@ class Image:
         """Return the linear polarization angle for each pixel"""
         if self.polrep == 'circ':
             chivec = 0.5 * np.angle(self.rlvec / (self.rrvec + self.llvec))
-        elif self.polrep == 'stokes':
+        elif self.polrep in ('stokes', 'lin'):
             chivec = 0.5 * np.angle((self.qvec + 1j * self.uvec) / self.ivec)
 
         return chivec
@@ -532,6 +631,8 @@ class Image:
             pol = 'I'
         elif self.polrep == 'circ' and pol is None:
             pol = 'RR'
+        elif self.polrep == 'lin' and pol is None:
+            pol = 'XX'
 
         if pol.lower() == 'i':
             outvec = self.ivec
@@ -549,6 +650,14 @@ class Image:
             outvec = self.lrvec
         elif pol.lower() == 'rl':
             outvec = self.rlvec
+        elif pol.lower() == 'xx':
+            outvec = self.xxvec
+        elif pol.lower() == 'yy':
+            outvec = self.yyvec
+        elif pol.lower() == 'xy':
+            outvec = self.xyvec
+        elif pol.lower() == 'yx':
+            outvec = self.yxvec
         elif pol.lower() == 'p':
             outvec = self.pvec
         elif pol.lower() == 'm':
@@ -648,6 +757,16 @@ class Image:
             elif pol == 'LR':
                 self.lrvec = image.flatten()
 
+        elif self.polrep == 'lin':
+            if pol == 'XX':
+                self.xxvec = image.flatten()
+            elif pol == 'YY':
+                self.yyvec = image.flatten()
+            elif pol == 'XY':
+                self.xyvec = image.flatten()
+            elif pol == 'YX':
+                self.yxvec = image.flatten()
+
         return
 
     # TODO deprecated -- replace with generic add_pol_image
@@ -686,64 +805,36 @@ class Image:
         """Return a new image with the polarization representation changed
            Args:
                polrep_out (str):  the polrep of the output data
-               pol_prim_out (str): The default image: I,Q,U or V for Stokes, RR,LL,LR,RL for circ
+               pol_prim_out (str): The default image: I,Q,U,V for stokes,
+                                   RR,LL,LR,RL for circ, XX,YY,XY,YX for lin
 
            Returns:
                (Image): new Image object with potentially different polrep
         """
 
-        if polrep_out not in ['stokes', 'circ']:
-            raise Exception("polrep_out must be either 'stokes' or 'circ'")
+        if polrep_out not in ['stokes', 'circ', 'lin']:
+            raise Exception("polrep_out must be 'stokes', 'circ', or 'lin'")
         if pol_prim_out is None:
             if polrep_out == 'stokes':
                 pol_prim_out = 'I'
             elif polrep_out == 'circ':
                 pol_prim_out = 'RR'
+            elif polrep_out == 'lin':
+                pol_prim_out = 'XX'
 
         # Simply copy if the polrep is unchanged
         if polrep_out == self.polrep and pol_prim_out == self.pol_prim:
             return self.copy()
 
-        # Assemble a dictionary of new polarization vectors
+        # The cross-polrep ivec/qvec/.../xxvec/... accessors compose through
+        # the canonical pair for the source polrep, returning empty arrays
+        # when a transform cannot close. No source-polrep branches needed.
         if polrep_out == 'stokes':
-            if self.polrep == 'stokes':
-                imdict = {'I': self.ivec, 'Q': self.qvec, 'U': self.uvec, 'V': self.vvec}
-            else:
-                if len(self.rrvec) == 0 or len(self.llvec) == 0:
-                    ivec = np.array([])
-                    vvec = np.array([])
-                else:
-                    ivec = 0.5 * (self.rrvec + self.llvec)
-                    vvec = 0.5 * (self.rrvec - self.llvec)
-
-                if len(self.rlvec) == 0 or len(self.lrvec) == 0:
-                    qvec = np.array([])
-                    uvec = np.array([])
-                else:
-                    qvec = np.real(0.5 * (self.lrvec + self.rlvec))
-                    uvec = np.real(0.5j * (self.lrvec - self.rlvec))
-
-                imdict = {'I': ivec, 'Q': qvec, 'U': uvec, 'V': vvec}
-
+            imdict = {'I': self.ivec, 'Q': self.qvec, 'U': self.uvec, 'V': self.vvec}
         elif polrep_out == 'circ':
-            if self.polrep == 'circ':
-                imdict = {'RR': self.rrvec, 'LL': self.llvec, 'RL': self.rlvec, 'LR': self.lrvec}
-            else:
-                if len(self.ivec) == 0 or len(self.vvec) == 0:
-                    rrvec = np.array([])
-                    llvec = np.array([])
-                else:
-                    rrvec = (self.ivec + self.vvec)
-                    llvec = (self.ivec - self.vvec)
-
-                if len(self.qvec) == 0 or len(self.uvec) == 0:
-                    rlvec = np.array([])
-                    lrvec = np.array([])
-                else:
-                    rlvec = (self.qvec + 1j * self.uvec)
-                    lrvec = (self.qvec - 1j * self.uvec)
-
-                imdict = {'RR': rrvec, 'LL': llvec, 'RL': rlvec, 'LR': lrvec}
+            imdict = {'RR': self.rrvec, 'LL': self.llvec, 'RL': self.rlvec, 'LR': self.lrvec}
+        elif polrep_out == 'lin':
+            imdict = {'XX': self.xxvec, 'YY': self.yyvec, 'XY': self.xyvec, 'YX': self.yxvec}
 
         # Assemble the new image
         imvec = imdict[pol_prim_out]

--- a/ehtim/model.py
+++ b/ehtim/model.py
@@ -321,6 +321,8 @@ def get_const_polfac(model_type, params, pol):
             return params['cpol_frac']
         elif pol == 'P':
             return params['pol_frac'] * np.exp(1j * 2.0 * params['pol_evpa'])
+        # Non-stokes pols recurse on stokes via the stokes_to_circ / stokes_to_lin
+        # pair formulas in ehtim/observing/pol_conventions.py.
         elif pol == 'RR':
             return get_const_polfac(model_type, params, 'I') + get_const_polfac(model_type, params, 'V')
         elif pol == 'RL':
@@ -329,6 +331,14 @@ def get_const_polfac(model_type, params, pol):
             return get_const_polfac(model_type, params, 'Q') - 1j*get_const_polfac(model_type, params, 'U')
         elif pol == 'LL':
             return get_const_polfac(model_type, params, 'I') - get_const_polfac(model_type, params, 'V')
+        elif pol == 'XX':
+            return get_const_polfac(model_type, params, 'I') + get_const_polfac(model_type, params, 'Q')
+        elif pol == 'YY':
+            return get_const_polfac(model_type, params, 'I') - get_const_polfac(model_type, params, 'Q')
+        elif pol == 'XY':
+            return get_const_polfac(model_type, params, 'U') - 1j*get_const_polfac(model_type, params, 'V')
+        elif pol == 'YX':
+            return get_const_polfac(model_type, params, 'U') + 1j*get_const_polfac(model_type, params, 'V')
     except Exception:
         pass
 
@@ -483,7 +493,9 @@ def sample_1model_uv(u, v, model_type, params, pol='I', jonesdict=None):
         RLp = RL + LL * DR1 * np.exp( 2j*fr1) + RR * DL2 * np.exp( 2j*fr2) + LR * DR1 * DL2 * np.exp( 2j*(fr1+fr2))
         LRp = LR + RR * DL1 * np.exp(-2j*fr1) + LL * DR2 * np.exp(-2j*fr2) + RL * DL1 * DR2 * np.exp(-2j*(fr1+fr2))
         LLp = LL + LR * DL2 * np.exp( 2j*fr2) + RL * DL1 * np.exp(-2j*fr1) + RR * DL1 * DL2 * np.exp(-2j*(fr1-fr2))
-        # Return the specified polarization
+        # Return the specified polarization. Stokes / lin clauses follow the
+        # circ_to_stokes and stokes_to_lin (composed) formulas in
+        # ehtim/observing/pol_conventions.py.
         if   pol == 'RR': return RRp
         elif pol == 'RL': return RLp
         elif pol == 'LR': return LRp
@@ -493,9 +505,15 @@ def sample_1model_uv(u, v, model_type, params, pol='I', jonesdict=None):
         elif pol == 'U':  return 0.5j* (LRp - RLp)
         elif pol == 'V':  return 0.5 * (RRp - LLp)
         elif pol == 'P':  return RLp
+        elif pol == 'XX': return 0.5 * (RRp + LLp + LRp + RLp)
+        elif pol == 'YY': return 0.5 * (RRp + LLp - LRp - RLp)
+        elif pol == 'XY': return 0.5j * (LRp - RLp - RRp + LLp)
+        elif pol == 'YX': return 0.5j * (LRp - RLp + RRp - LLp)
         else:
             raise Exception('Polarization ' + pol + ' not recognized!')
 
+    # Non-stokes pols recurse on stokes via the stokes_to_circ / stokes_to_lin
+    # pair formulas in ehtim/observing/pol_conventions.py.
     if pol == 'Q':
         return 0.5 * (sample_1model_uv(u, v, model_type, params, pol='P') + np.conj(sample_1model_uv(-u, -v, model_type, params, pol='P')))
     elif pol == 'U':
@@ -510,6 +528,14 @@ def sample_1model_uv(u, v, model_type, params, pol='I', jonesdict=None):
         return sample_1model_uv(u, v, model_type, params, pol='Q') + 1j*sample_1model_uv(u, v, model_type, params, pol='U')
     elif pol == 'LR':
         return sample_1model_uv(u, v, model_type, params, pol='Q') - 1j*sample_1model_uv(u, v, model_type, params, pol='U')
+    elif pol == 'XX':
+        return sample_1model_uv(u, v, model_type, params, pol='I') + sample_1model_uv(u, v, model_type, params, pol='Q')
+    elif pol == 'YY':
+        return sample_1model_uv(u, v, model_type, params, pol='I') - sample_1model_uv(u, v, model_type, params, pol='Q')
+    elif pol == 'XY':
+        return sample_1model_uv(u, v, model_type, params, pol='U') - 1j*sample_1model_uv(u, v, model_type, params, pol='V')
+    elif pol == 'YX':
+        return sample_1model_uv(u, v, model_type, params, pol='U') + 1j*sample_1model_uv(u, v, model_type, params, pol='V')
     else:
         raise Exception('Polarization ' + pol + ' not implemented!')
 
@@ -649,7 +675,9 @@ def sample_1model_graduv_uv(u, v, model_type, params, pol='I', jonesdict=None):
         RLp = (RL + LL * DR1 * np.exp( 2j*fr1) + RR * DL2 * np.exp( 2j*fr2) + LR * DR1 * DL2 * np.exp( 2j*(fr1+fr2)))
         LRp = (LR + RR * DL1 * np.exp(-2j*fr1) + LL * DR2 * np.exp(-2j*fr2) + RL * DL1 * DR2 * np.exp(-2j*(fr1+fr2)))
         LLp = (LL + LR * DL2 * np.exp( 2j*fr2) + RL * DL1 * np.exp(-2j*fr1) + RR * DL1 * DL2 * np.exp(-2j*(fr1-fr2)))
-        # Return the specified polarization
+        # Return the specified polarization. Stokes / lin clauses follow the
+        # circ_to_stokes and stokes_to_lin (composed) formulas in
+        # ehtim/observing/pol_conventions.py.
         if   pol == 'RR': return RRp
         elif pol == 'RL': return RLp
         elif pol == 'LR': return LRp
@@ -659,9 +687,15 @@ def sample_1model_graduv_uv(u, v, model_type, params, pol='I', jonesdict=None):
         elif pol == 'U':  return 0.5j* (LRp - RLp)
         elif pol == 'V':  return 0.5 * (RRp - LLp)
         elif pol == 'P':  return RLp
+        elif pol == 'XX': return 0.5 * (RRp + LLp + LRp + RLp)
+        elif pol == 'YY': return 0.5 * (RRp + LLp - LRp - RLp)
+        elif pol == 'XY': return 0.5j * (LRp - RLp - RRp + LLp)
+        elif pol == 'YX': return 0.5j * (LRp - RLp + RRp - LLp)
         else:
             raise Exception('Polarization ' + pol + ' not recognized!')
 
+    # Non-stokes pols recurse on stokes via the stokes_to_circ / stokes_to_lin
+    # pair formulas in ehtim/observing/pol_conventions.py.
     if pol == 'Q':
         return 0.5 * (sample_1model_graduv_uv(u, v, model_type, params, pol='P') + np.conj(sample_1model_graduv_uv(-u, -v, model_type, params, pol='P')))
     elif pol == 'U':
@@ -676,6 +710,14 @@ def sample_1model_graduv_uv(u, v, model_type, params, pol='I', jonesdict=None):
         return sample_1model_graduv_uv(u, v, model_type, params, pol='Q') + 1j*sample_1model_graduv_uv(u, v, model_type, params, pol='U')
     elif pol == 'LR':
         return sample_1model_graduv_uv(u, v, model_type, params, pol='Q') - 1j*sample_1model_graduv_uv(u, v, model_type, params, pol='U')
+    elif pol == 'XX':
+        return sample_1model_graduv_uv(u, v, model_type, params, pol='I') + sample_1model_graduv_uv(u, v, model_type, params, pol='Q')
+    elif pol == 'YY':
+        return sample_1model_graduv_uv(u, v, model_type, params, pol='I') - sample_1model_graduv_uv(u, v, model_type, params, pol='Q')
+    elif pol == 'XY':
+        return sample_1model_graduv_uv(u, v, model_type, params, pol='U') - 1j*sample_1model_graduv_uv(u, v, model_type, params, pol='V')
+    elif pol == 'YX':
+        return sample_1model_graduv_uv(u, v, model_type, params, pol='U') + 1j*sample_1model_graduv_uv(u, v, model_type, params, pol='V')
     else:
         raise Exception('Polarization ' + pol + ' not implemented!')
 
@@ -919,7 +961,9 @@ def sample_1model_grad_leakage_uv_re(u, v, model_type, params, pol, site, hand, 
     LRp = RR * DL1mask * np.exp(-2j*fr1) + LL * DR2mask * np.exp(-2j*fr2) + RL * DL1mask * DR2 * np.exp(-2j*(fr1+fr2)) + RL * DL1 * DR2mask * np.exp(-2j*(fr1+fr2))
     LLp = LR * DL2mask * np.exp( 2j*fr2) + RL * DL1mask * np.exp(-2j*fr1) + RR * DL1mask * DL2 * np.exp(-2j*(fr1-fr2)) + RR * DL1 * DL2mask * np.exp(-2j*(fr1-fr2))
 
-    # Return the specified polarization
+    # Return the specified polarization. Stokes / lin clauses follow the
+    # circ_to_stokes and stokes_to_lin (composed) formulas in
+    # ehtim/observing/pol_conventions.py.
     if   pol == 'RR': return RRp
     elif pol == 'RL': return RLp
     elif pol == 'LR': return LRp
@@ -929,6 +973,10 @@ def sample_1model_grad_leakage_uv_re(u, v, model_type, params, pol, site, hand, 
     elif pol == 'U':  return 0.5j* (LRp - RLp)
     elif pol == 'V':  return 0.5 * (RRp - LLp)
     elif pol == 'P':  return RLp
+    elif pol == 'XX': return 0.5 * (RRp + LLp + LRp + RLp)
+    elif pol == 'YY': return 0.5 * (RRp + LLp - LRp - RLp)
+    elif pol == 'XY': return 0.5j * (LRp - RLp - RRp + LLp)
+    elif pol == 'YX': return 0.5j * (LRp - RLp + RRp - LLp)
     else:
         raise Exception('Polarization ' + pol + ' not recognized!')
 
@@ -961,7 +1009,9 @@ def sample_1model_grad_leakage_uv_im(u, v, model_type, params, pol, site, hand, 
     LRp = 1j*( RR * DL1mask * np.exp(-2j*fr1) - LL * DR2mask * np.exp(-2j*fr2) + RL * DL1mask * DR2 * np.exp(-2j*(fr1+fr2)) - RL * DL1 * DR2mask * np.exp(-2j*(fr1+fr2)))
     LLp = 1j*(-LR * DL2mask * np.exp( 2j*fr2) + RL * DL1mask * np.exp(-2j*fr1) + RR * DL1mask * DL2 * np.exp(-2j*(fr1-fr2)) - RR * DL1 * DL2mask * np.exp(-2j*(fr1-fr2)))
 
-    # Return the specified polarization
+    # Return the specified polarization. Stokes / lin clauses follow the
+    # circ_to_stokes and stokes_to_lin (composed) formulas in
+    # ehtim/observing/pol_conventions.py.
     if   pol == 'RR': return RRp
     elif pol == 'RL': return RLp
     elif pol == 'LR': return LRp
@@ -971,6 +1021,10 @@ def sample_1model_grad_leakage_uv_im(u, v, model_type, params, pol, site, hand, 
     elif pol == 'U':  return 0.5j* (LRp - RLp)
     elif pol == 'V':  return 0.5 * (RRp - LLp)
     elif pol == 'P':  return RLp
+    elif pol == 'XX': return 0.5 * (RRp + LLp + LRp + RLp)
+    elif pol == 'YY': return 0.5 * (RRp + LLp - LRp - RLp)
+    elif pol == 'XY': return 0.5j * (LRp - RLp - RRp + LLp)
+    elif pol == 'YX': return 0.5j * (LRp - RLp + RRp - LLp)
     else:
         raise Exception('Polarization ' + pol + ' not recognized!')
 
@@ -995,7 +1049,9 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
         RLp = (RL + LL * DR1 * np.exp( 2j*fr1) + RR * DL2 * np.exp( 2j*fr2) + LR * DR1 * DL2 * np.exp( 2j*(fr1+fr2)))
         LRp = (LR + RR * DL1 * np.exp(-2j*fr1) + LL * DR2 * np.exp(-2j*fr2) + RL * DL1 * DR2 * np.exp(-2j*(fr1+fr2)))
         LLp = (LL + LR * DL2 * np.exp( 2j*fr2) + RL * DL1 * np.exp(-2j*fr1) + RR * DL1 * DL2 * np.exp(-2j*(fr1-fr2)))
-        # Return the specified polarization
+        # Return the specified polarization. Stokes / lin clauses follow the
+        # circ_to_stokes and stokes_to_lin (composed) formulas in
+        # ehtim/observing/pol_conventions.py.
         if   pol == 'RR': grad = RRp
         elif pol == 'RL': grad = RLp
         elif pol == 'LR': grad = LRp
@@ -1005,6 +1061,10 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
         elif pol == 'U':  grad = 0.5j* (LRp - RLp)
         elif pol == 'V':  grad = 0.5 * (RRp - LLp)
         elif pol == 'P':  grad = RLp
+        elif pol == 'XX': grad = 0.5 * (RRp + LLp + LRp + RLp)
+        elif pol == 'YY': grad = 0.5 * (RRp + LLp - LRp - RLp)
+        elif pol == 'XY': grad = 0.5j * (LRp - RLp - RRp + LLp)
+        elif pol == 'YX': grad = 0.5j * (LRp - RLp + RRp - LLp)
         else:
             raise Exception('Polarization ' + pol + ' not recognized!')
         # If necessary, add the gradient components from the leakage terms
@@ -1016,6 +1076,8 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
 
         return grad
 
+    # Non-stokes pols recurse on stokes via the stokes_to_circ / stokes_to_lin
+    # pair formulas in ehtim/observing/pol_conventions.py.
     if pol == 'Q':
         return   0.5 * (sample_1model_grad_uv(u, v, model_type, params, pol='P', fit_pol=fit_pol, fit_cpol=fit_cpol) + np.conj(sample_1model_grad_uv(-u, -v, model_type, params, pol='P', fit_pol=fit_pol, fit_cpol=fit_cpol)))
     elif pol == 'U':
@@ -1030,6 +1092,14 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
         return sample_1model_grad_uv(u, v, model_type, params, pol='Q', fit_pol=fit_pol, fit_cpol=fit_cpol) + 1j*sample_1model_grad_uv(u, v, model_type, params, pol='U', fit_pol=fit_pol, fit_cpol=fit_cpol)
     elif pol == 'LR':
         return sample_1model_grad_uv(u, v, model_type, params, pol='Q', fit_pol=fit_pol, fit_cpol=fit_cpol) - 1j*sample_1model_grad_uv(u, v, model_type, params, pol='U', fit_pol=fit_pol, fit_cpol=fit_cpol)
+    elif pol == 'XX':
+        return sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=fit_pol, fit_cpol=fit_cpol) + sample_1model_grad_uv(u, v, model_type, params, pol='Q', fit_pol=fit_pol, fit_cpol=fit_cpol)
+    elif pol == 'YY':
+        return sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=fit_pol, fit_cpol=fit_cpol) - sample_1model_grad_uv(u, v, model_type, params, pol='Q', fit_pol=fit_pol, fit_cpol=fit_cpol)
+    elif pol == 'XY':
+        return sample_1model_grad_uv(u, v, model_type, params, pol='U', fit_pol=fit_pol, fit_cpol=fit_cpol) - 1j*sample_1model_grad_uv(u, v, model_type, params, pol='V', fit_pol=fit_pol, fit_cpol=fit_cpol)
+    elif pol == 'YX':
+        return sample_1model_grad_uv(u, v, model_type, params, pol='U', fit_pol=fit_pol, fit_cpol=fit_cpol) + 1j*sample_1model_grad_uv(u, v, model_type, params, pol='V', fit_pol=fit_pol, fit_cpol=fit_cpol)
     else:
         raise Exception('Polarization ' + pol + ' not implemented!')
 
@@ -1532,11 +1602,12 @@ class Model(object):
         """
 
         # Note: this currently does nothing, but it is put here for compatibility with functions such as selfcal
-        if polrep_out not in ['stokes','circ']:
-            raise Exception("polrep_out must be either 'stokes' or 'circ'")
+        if polrep_out not in ['stokes', 'circ', 'lin']:
+            raise Exception("polrep_out must be 'stokes', 'circ', or 'lin'")
         if pol_prim_out is None:
             if polrep_out=='stokes': pol_prim_out = 'I'
             elif polrep_out=='circ': pol_prim_out = 'RR'
+            elif polrep_out=='lin': pol_prim_out = 'XX'
 
         return self.copy()
 
@@ -2143,6 +2214,11 @@ class Model(object):
             obsdata['rlvis'] = self.sample_uv(obs.data['u'], obs.data['v'], pol='RL', jonesdict=jonesdict)
             obsdata['lrvis'] = self.sample_uv(obs.data['u'], obs.data['v'], pol='LR', jonesdict=jonesdict)
             obsdata['llvis'] = self.sample_uv(obs.data['u'], obs.data['v'], pol='LL', jonesdict=jonesdict)
+        elif obs.polrep=='lin':
+            obsdata['xxvis'] = self.sample_uv(obs.data['u'], obs.data['v'], pol='XX', jonesdict=jonesdict)
+            obsdata['yyvis'] = self.sample_uv(obs.data['u'], obs.data['v'], pol='YY', jonesdict=jonesdict)
+            obsdata['xyvis'] = self.sample_uv(obs.data['u'], obs.data['v'], pol='XY', jonesdict=jonesdict)
+            obsdata['yxvis'] = self.sample_uv(obs.data['u'], obs.data['v'], pol='YX', jonesdict=jonesdict)
 
         obs_no_noise = ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr,
                                              source=obs.source, mjd=obs.mjd, polrep=obs.polrep,

--- a/ehtim/model.py
+++ b/ehtim/model.py
@@ -14,6 +14,7 @@ import scipy.interpolate as interpolate
 import copy
 
 import ehtim.observing.obs_simulate as simobs
+import ehtim.observing.pol_conventions as pol_conventions
 import ehtim.observing.pulses
 
 from ehtim.const_def import *
@@ -323,22 +324,26 @@ def get_const_polfac(model_type, params, pol):
             return params['pol_frac'] * np.exp(1j * 2.0 * params['pol_evpa'])
         # Non-stokes pols recurse on stokes via the stokes_to_circ / stokes_to_lin
         # pair formulas in ehtim/observing/pol_conventions.py.
-        elif pol == 'RR':
-            return get_const_polfac(model_type, params, 'I') + get_const_polfac(model_type, params, 'V')
-        elif pol == 'RL':
-            return get_const_polfac(model_type, params, 'Q') + 1j*get_const_polfac(model_type, params, 'U')
-        elif pol == 'LR':
-            return get_const_polfac(model_type, params, 'Q') - 1j*get_const_polfac(model_type, params, 'U')
-        elif pol == 'LL':
-            return get_const_polfac(model_type, params, 'I') - get_const_polfac(model_type, params, 'V')
-        elif pol == 'XX':
-            return get_const_polfac(model_type, params, 'I') + get_const_polfac(model_type, params, 'Q')
-        elif pol == 'YY':
-            return get_const_polfac(model_type, params, 'I') - get_const_polfac(model_type, params, 'Q')
-        elif pol == 'XY':
-            return get_const_polfac(model_type, params, 'U') - 1j*get_const_polfac(model_type, params, 'V')
-        elif pol == 'YX':
-            return get_const_polfac(model_type, params, 'U') + 1j*get_const_polfac(model_type, params, 'V')
+        elif pol in ('RR', 'LL'):
+            rr, ll = pol_conventions.stokes_to_circ_parallel(
+                get_const_polfac(model_type, params, 'I'),
+                get_const_polfac(model_type, params, 'V'))
+            return rr if pol == 'RR' else ll
+        elif pol in ('RL', 'LR'):
+            rl, lr = pol_conventions.stokes_to_circ_cross(
+                get_const_polfac(model_type, params, 'Q'),
+                get_const_polfac(model_type, params, 'U'))
+            return rl if pol == 'RL' else lr
+        elif pol in ('XX', 'YY'):
+            xx, yy = pol_conventions.stokes_to_lin_diag(
+                get_const_polfac(model_type, params, 'I'),
+                get_const_polfac(model_type, params, 'Q'))
+            return xx if pol == 'XX' else yy
+        elif pol in ('XY', 'YX'):
+            xy, yx = pol_conventions.stokes_to_lin_offdiag(
+                get_const_polfac(model_type, params, 'U'),
+                get_const_polfac(model_type, params, 'V'))
+            return xy if pol == 'XY' else yx
     except Exception:
         pass
 
@@ -496,21 +501,17 @@ def sample_1model_uv(u, v, model_type, params, pol='I', jonesdict=None):
         # Return the specified polarization. Stokes / lin clauses follow the
         # circ_to_stokes and stokes_to_lin (composed) formulas in
         # ehtim/observing/pol_conventions.py.
-        if   pol == 'RR': return RRp
-        elif pol == 'RL': return RLp
-        elif pol == 'LR': return LRp
-        elif pol == 'LL': return LLp
-        elif pol == 'I':  return 0.5 * (RRp + LLp)
-        elif pol == 'Q':  return 0.5 * (LRp + RLp)
-        elif pol == 'U':  return 0.5j* (LRp - RLp)
-        elif pol == 'V':  return 0.5 * (RRp - LLp)
-        elif pol == 'P':  return RLp
-        elif pol == 'XX': return 0.5 * (RRp + LLp + LRp + RLp)
-        elif pol == 'YY': return 0.5 * (RRp + LLp - LRp - RLp)
-        elif pol == 'XY': return 0.5j * (LRp - RLp - RRp + LLp)
-        elif pol == 'YX': return 0.5j * (LRp - RLp + RRp - LLp)
-        else:
-            raise Exception('Polarization ' + pol + ' not recognized!')
+        if pol in ('RR', 'LL', 'RL', 'LR'):
+            return {'RR': RRp, 'LL': LLp, 'RL': RLp, 'LR': LRp}[pol]
+        if pol == 'P':
+            return RLp
+        if pol in ('I', 'Q', 'U', 'V'):
+            i_v, q_v, u_v, v_v = pol_conventions.circ_to_stokes(RRp, LLp, RLp, LRp)
+            return {'I': i_v, 'Q': q_v, 'U': u_v, 'V': v_v}[pol]
+        if pol in ('XX', 'YY', 'XY', 'YX'):
+            xx_v, yy_v, xy_v, yx_v = pol_conventions.circ_to_lin(RRp, LLp, RLp, LRp)
+            return {'XX': xx_v, 'YY': yy_v, 'XY': xy_v, 'YX': yx_v}[pol]
+        raise Exception('Polarization ' + pol + ' not recognized!')
 
     # Non-stokes pols recurse on stokes via the stokes_to_circ / stokes_to_lin
     # pair formulas in ehtim/observing/pol_conventions.py.
@@ -520,22 +521,26 @@ def sample_1model_uv(u, v, model_type, params, pol='I', jonesdict=None):
         return -0.5j * (sample_1model_uv(u, v, model_type, params, pol='P') - np.conj(sample_1model_uv(-u, -v, model_type, params, pol='P')))
     elif pol in ['I','V','P']:
         pass
-    elif pol == 'RR':
-        return sample_1model_uv(u, v, model_type, params, pol='I') + sample_1model_uv(u, v, model_type, params, pol='V')
-    elif pol == 'LL':
-        return sample_1model_uv(u, v, model_type, params, pol='I') - sample_1model_uv(u, v, model_type, params, pol='V')
-    elif pol == 'RL':
-        return sample_1model_uv(u, v, model_type, params, pol='Q') + 1j*sample_1model_uv(u, v, model_type, params, pol='U')
-    elif pol == 'LR':
-        return sample_1model_uv(u, v, model_type, params, pol='Q') - 1j*sample_1model_uv(u, v, model_type, params, pol='U')
-    elif pol == 'XX':
-        return sample_1model_uv(u, v, model_type, params, pol='I') + sample_1model_uv(u, v, model_type, params, pol='Q')
-    elif pol == 'YY':
-        return sample_1model_uv(u, v, model_type, params, pol='I') - sample_1model_uv(u, v, model_type, params, pol='Q')
-    elif pol == 'XY':
-        return sample_1model_uv(u, v, model_type, params, pol='U') - 1j*sample_1model_uv(u, v, model_type, params, pol='V')
-    elif pol == 'YX':
-        return sample_1model_uv(u, v, model_type, params, pol='U') + 1j*sample_1model_uv(u, v, model_type, params, pol='V')
+    elif pol in ('RR', 'LL'):
+        rr, ll = pol_conventions.stokes_to_circ_parallel(
+            sample_1model_uv(u, v, model_type, params, pol='I'),
+            sample_1model_uv(u, v, model_type, params, pol='V'))
+        return rr if pol == 'RR' else ll
+    elif pol in ('RL', 'LR'):
+        rl, lr = pol_conventions.stokes_to_circ_cross(
+            sample_1model_uv(u, v, model_type, params, pol='Q'),
+            sample_1model_uv(u, v, model_type, params, pol='U'))
+        return rl if pol == 'RL' else lr
+    elif pol in ('XX', 'YY'):
+        xx, yy = pol_conventions.stokes_to_lin_diag(
+            sample_1model_uv(u, v, model_type, params, pol='I'),
+            sample_1model_uv(u, v, model_type, params, pol='Q'))
+        return xx if pol == 'XX' else yy
+    elif pol in ('XY', 'YX'):
+        xy, yx = pol_conventions.stokes_to_lin_offdiag(
+            sample_1model_uv(u, v, model_type, params, pol='U'),
+            sample_1model_uv(u, v, model_type, params, pol='V'))
+        return xy if pol == 'XY' else yx
     else:
         raise Exception('Polarization ' + pol + ' not implemented!')
 
@@ -678,21 +683,17 @@ def sample_1model_graduv_uv(u, v, model_type, params, pol='I', jonesdict=None):
         # Return the specified polarization. Stokes / lin clauses follow the
         # circ_to_stokes and stokes_to_lin (composed) formulas in
         # ehtim/observing/pol_conventions.py.
-        if   pol == 'RR': return RRp
-        elif pol == 'RL': return RLp
-        elif pol == 'LR': return LRp
-        elif pol == 'LL': return LLp
-        elif pol == 'I':  return 0.5 * (RRp + LLp)
-        elif pol == 'Q':  return 0.5 * (LRp + RLp)
-        elif pol == 'U':  return 0.5j* (LRp - RLp)
-        elif pol == 'V':  return 0.5 * (RRp - LLp)
-        elif pol == 'P':  return RLp
-        elif pol == 'XX': return 0.5 * (RRp + LLp + LRp + RLp)
-        elif pol == 'YY': return 0.5 * (RRp + LLp - LRp - RLp)
-        elif pol == 'XY': return 0.5j * (LRp - RLp - RRp + LLp)
-        elif pol == 'YX': return 0.5j * (LRp - RLp + RRp - LLp)
-        else:
-            raise Exception('Polarization ' + pol + ' not recognized!')
+        if pol in ('RR', 'LL', 'RL', 'LR'):
+            return {'RR': RRp, 'LL': LLp, 'RL': RLp, 'LR': LRp}[pol]
+        if pol == 'P':
+            return RLp
+        if pol in ('I', 'Q', 'U', 'V'):
+            i_v, q_v, u_v, v_v = pol_conventions.circ_to_stokes(RRp, LLp, RLp, LRp)
+            return {'I': i_v, 'Q': q_v, 'U': u_v, 'V': v_v}[pol]
+        if pol in ('XX', 'YY', 'XY', 'YX'):
+            xx_v, yy_v, xy_v, yx_v = pol_conventions.circ_to_lin(RRp, LLp, RLp, LRp)
+            return {'XX': xx_v, 'YY': yy_v, 'XY': xy_v, 'YX': yx_v}[pol]
+        raise Exception('Polarization ' + pol + ' not recognized!')
 
     # Non-stokes pols recurse on stokes via the stokes_to_circ / stokes_to_lin
     # pair formulas in ehtim/observing/pol_conventions.py.
@@ -702,22 +703,26 @@ def sample_1model_graduv_uv(u, v, model_type, params, pol='I', jonesdict=None):
         return -0.5j * (sample_1model_graduv_uv(u, v, model_type, params, pol='P') - np.conj(sample_1model_graduv_uv(-u, -v, model_type, params, pol='P')))
     elif pol in ['I','V','P']:
         pass
-    elif pol == 'RR':
-        return sample_1model_graduv_uv(u, v, model_type, params, pol='I') + sample_1model_graduv_uv(u, v, model_type, params, pol='V')
-    elif pol == 'LL':
-        return sample_1model_graduv_uv(u, v, model_type, params, pol='I') - sample_1model_graduv_uv(u, v, model_type, params, pol='V')
-    elif pol == 'RL':
-        return sample_1model_graduv_uv(u, v, model_type, params, pol='Q') + 1j*sample_1model_graduv_uv(u, v, model_type, params, pol='U')
-    elif pol == 'LR':
-        return sample_1model_graduv_uv(u, v, model_type, params, pol='Q') - 1j*sample_1model_graduv_uv(u, v, model_type, params, pol='U')
-    elif pol == 'XX':
-        return sample_1model_graduv_uv(u, v, model_type, params, pol='I') + sample_1model_graduv_uv(u, v, model_type, params, pol='Q')
-    elif pol == 'YY':
-        return sample_1model_graduv_uv(u, v, model_type, params, pol='I') - sample_1model_graduv_uv(u, v, model_type, params, pol='Q')
-    elif pol == 'XY':
-        return sample_1model_graduv_uv(u, v, model_type, params, pol='U') - 1j*sample_1model_graduv_uv(u, v, model_type, params, pol='V')
-    elif pol == 'YX':
-        return sample_1model_graduv_uv(u, v, model_type, params, pol='U') + 1j*sample_1model_graduv_uv(u, v, model_type, params, pol='V')
+    elif pol in ('RR', 'LL'):
+        rr, ll = pol_conventions.stokes_to_circ_parallel(
+            sample_1model_graduv_uv(u, v, model_type, params, pol='I'),
+            sample_1model_graduv_uv(u, v, model_type, params, pol='V'))
+        return rr if pol == 'RR' else ll
+    elif pol in ('RL', 'LR'):
+        rl, lr = pol_conventions.stokes_to_circ_cross(
+            sample_1model_graduv_uv(u, v, model_type, params, pol='Q'),
+            sample_1model_graduv_uv(u, v, model_type, params, pol='U'))
+        return rl if pol == 'RL' else lr
+    elif pol in ('XX', 'YY'):
+        xx, yy = pol_conventions.stokes_to_lin_diag(
+            sample_1model_graduv_uv(u, v, model_type, params, pol='I'),
+            sample_1model_graduv_uv(u, v, model_type, params, pol='Q'))
+        return xx if pol == 'XX' else yy
+    elif pol in ('XY', 'YX'):
+        xy, yx = pol_conventions.stokes_to_lin_offdiag(
+            sample_1model_graduv_uv(u, v, model_type, params, pol='U'),
+            sample_1model_graduv_uv(u, v, model_type, params, pol='V'))
+        return xy if pol == 'XY' else yx
     else:
         raise Exception('Polarization ' + pol + ' not implemented!')
 
@@ -964,21 +969,17 @@ def sample_1model_grad_leakage_uv_re(u, v, model_type, params, pol, site, hand, 
     # Return the specified polarization. Stokes / lin clauses follow the
     # circ_to_stokes and stokes_to_lin (composed) formulas in
     # ehtim/observing/pol_conventions.py.
-    if   pol == 'RR': return RRp
-    elif pol == 'RL': return RLp
-    elif pol == 'LR': return LRp
-    elif pol == 'LL': return LLp
-    elif pol == 'I':  return 0.5 * (RRp + LLp)
-    elif pol == 'Q':  return 0.5 * (LRp + RLp)
-    elif pol == 'U':  return 0.5j* (LRp - RLp)
-    elif pol == 'V':  return 0.5 * (RRp - LLp)
-    elif pol == 'P':  return RLp
-    elif pol == 'XX': return 0.5 * (RRp + LLp + LRp + RLp)
-    elif pol == 'YY': return 0.5 * (RRp + LLp - LRp - RLp)
-    elif pol == 'XY': return 0.5j * (LRp - RLp - RRp + LLp)
-    elif pol == 'YX': return 0.5j * (LRp - RLp + RRp - LLp)
-    else:
-        raise Exception('Polarization ' + pol + ' not recognized!')
+    if pol in ('RR', 'LL', 'RL', 'LR'):
+        return {'RR': RRp, 'LL': LLp, 'RL': RLp, 'LR': LRp}[pol]
+    if pol == 'P':
+        return RLp
+    if pol in ('I', 'Q', 'U', 'V'):
+        i_v, q_v, u_v, v_v = pol_conventions.circ_to_stokes(RRp, LLp, RLp, LRp)
+        return {'I': i_v, 'Q': q_v, 'U': u_v, 'V': v_v}[pol]
+    if pol in ('XX', 'YY', 'XY', 'YX'):
+        xx_v, yy_v, xy_v, yx_v = pol_conventions.circ_to_lin(RRp, LLp, RLp, LRp)
+        return {'XX': xx_v, 'YY': yy_v, 'XY': xy_v, 'YX': yx_v}[pol]
+    raise Exception('Polarization ' + pol + ' not recognized!')
 
 def sample_1model_grad_leakage_uv_im(u, v, model_type, params, pol, site, hand, jonesdict):
     # Convenience function to calculate the gradient with respect to the imaginary part of a specified site/hand leakage
@@ -1012,21 +1013,17 @@ def sample_1model_grad_leakage_uv_im(u, v, model_type, params, pol, site, hand, 
     # Return the specified polarization. Stokes / lin clauses follow the
     # circ_to_stokes and stokes_to_lin (composed) formulas in
     # ehtim/observing/pol_conventions.py.
-    if   pol == 'RR': return RRp
-    elif pol == 'RL': return RLp
-    elif pol == 'LR': return LRp
-    elif pol == 'LL': return LLp
-    elif pol == 'I':  return 0.5 * (RRp + LLp)
-    elif pol == 'Q':  return 0.5 * (LRp + RLp)
-    elif pol == 'U':  return 0.5j* (LRp - RLp)
-    elif pol == 'V':  return 0.5 * (RRp - LLp)
-    elif pol == 'P':  return RLp
-    elif pol == 'XX': return 0.5 * (RRp + LLp + LRp + RLp)
-    elif pol == 'YY': return 0.5 * (RRp + LLp - LRp - RLp)
-    elif pol == 'XY': return 0.5j * (LRp - RLp - RRp + LLp)
-    elif pol == 'YX': return 0.5j * (LRp - RLp + RRp - LLp)
-    else:
-        raise Exception('Polarization ' + pol + ' not recognized!')
+    if pol in ('RR', 'LL', 'RL', 'LR'):
+        return {'RR': RRp, 'LL': LLp, 'RL': RLp, 'LR': LRp}[pol]
+    if pol == 'P':
+        return RLp
+    if pol in ('I', 'Q', 'U', 'V'):
+        i_v, q_v, u_v, v_v = pol_conventions.circ_to_stokes(RRp, LLp, RLp, LRp)
+        return {'I': i_v, 'Q': q_v, 'U': u_v, 'V': v_v}[pol]
+    if pol in ('XX', 'YY', 'XY', 'YX'):
+        xx_v, yy_v, xy_v, yx_v = pol_conventions.circ_to_lin(RRp, LLp, RLp, LRp)
+        return {'XX': xx_v, 'YY': yy_v, 'XY': xy_v, 'YX': yx_v}[pol]
+    raise Exception('Polarization ' + pol + ' not recognized!')
 
 def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_cpol=False, fit_leakage=False, jonesdict=None):
     # Gradient of the model for each model parameter 
@@ -1052,19 +1049,16 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
         # Return the specified polarization. Stokes / lin clauses follow the
         # circ_to_stokes and stokes_to_lin (composed) formulas in
         # ehtim/observing/pol_conventions.py.
-        if   pol == 'RR': grad = RRp
-        elif pol == 'RL': grad = RLp
-        elif pol == 'LR': grad = LRp
-        elif pol == 'LL': grad = LLp
-        elif pol == 'I':  grad = 0.5 * (RRp + LLp)
-        elif pol == 'Q':  grad = 0.5 * (LRp + RLp)
-        elif pol == 'U':  grad = 0.5j* (LRp - RLp)
-        elif pol == 'V':  grad = 0.5 * (RRp - LLp)
-        elif pol == 'P':  grad = RLp
-        elif pol == 'XX': grad = 0.5 * (RRp + LLp + LRp + RLp)
-        elif pol == 'YY': grad = 0.5 * (RRp + LLp - LRp - RLp)
-        elif pol == 'XY': grad = 0.5j * (LRp - RLp - RRp + LLp)
-        elif pol == 'YX': grad = 0.5j * (LRp - RLp + RRp - LLp)
+        if pol in ('RR', 'LL', 'RL', 'LR'):
+            grad = {'RR': RRp, 'LL': LLp, 'RL': RLp, 'LR': LRp}[pol]
+        elif pol == 'P':
+            grad = RLp
+        elif pol in ('I', 'Q', 'U', 'V'):
+            i_v, q_v, u_v, v_v = pol_conventions.circ_to_stokes(RRp, LLp, RLp, LRp)
+            grad = {'I': i_v, 'Q': q_v, 'U': u_v, 'V': v_v}[pol]
+        elif pol in ('XX', 'YY', 'XY', 'YX'):
+            xx_v, yy_v, xy_v, yx_v = pol_conventions.circ_to_lin(RRp, LLp, RLp, LRp)
+            grad = {'XX': xx_v, 'YY': yy_v, 'XY': xy_v, 'YX': yx_v}[pol]
         else:
             raise Exception('Polarization ' + pol + ' not recognized!')
         # If necessary, add the gradient components from the leakage terms
@@ -1084,22 +1078,26 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
         return -0.5j * (sample_1model_grad_uv(u, v, model_type, params, pol='P', fit_pol=fit_pol, fit_cpol=fit_cpol) - np.conj(sample_1model_grad_uv(-u, -v, model_type, params, pol='P', fit_pol=fit_pol, fit_cpol=fit_cpol)))
     elif pol in ['I','V','P']:
         pass
-    elif pol == 'RR':
-        return sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=fit_pol, fit_cpol=fit_cpol) + sample_1model_grad_uv(u, v, model_type, params, pol='V', fit_pol=fit_pol, fit_cpol=fit_cpol)
-    elif pol == 'LL':
-        return sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=fit_pol, fit_cpol=fit_cpol) - sample_1model_grad_uv(u, v, model_type, params, pol='V', fit_pol=fit_pol, fit_cpol=fit_cpol)
-    elif pol == 'RL':
-        return sample_1model_grad_uv(u, v, model_type, params, pol='Q', fit_pol=fit_pol, fit_cpol=fit_cpol) + 1j*sample_1model_grad_uv(u, v, model_type, params, pol='U', fit_pol=fit_pol, fit_cpol=fit_cpol)
-    elif pol == 'LR':
-        return sample_1model_grad_uv(u, v, model_type, params, pol='Q', fit_pol=fit_pol, fit_cpol=fit_cpol) - 1j*sample_1model_grad_uv(u, v, model_type, params, pol='U', fit_pol=fit_pol, fit_cpol=fit_cpol)
-    elif pol == 'XX':
-        return sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=fit_pol, fit_cpol=fit_cpol) + sample_1model_grad_uv(u, v, model_type, params, pol='Q', fit_pol=fit_pol, fit_cpol=fit_cpol)
-    elif pol == 'YY':
-        return sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=fit_pol, fit_cpol=fit_cpol) - sample_1model_grad_uv(u, v, model_type, params, pol='Q', fit_pol=fit_pol, fit_cpol=fit_cpol)
-    elif pol == 'XY':
-        return sample_1model_grad_uv(u, v, model_type, params, pol='U', fit_pol=fit_pol, fit_cpol=fit_cpol) - 1j*sample_1model_grad_uv(u, v, model_type, params, pol='V', fit_pol=fit_pol, fit_cpol=fit_cpol)
-    elif pol == 'YX':
-        return sample_1model_grad_uv(u, v, model_type, params, pol='U', fit_pol=fit_pol, fit_cpol=fit_cpol) + 1j*sample_1model_grad_uv(u, v, model_type, params, pol='V', fit_pol=fit_pol, fit_cpol=fit_cpol)
+    elif pol in ('RR', 'LL'):
+        rr, ll = pol_conventions.stokes_to_circ_parallel(
+            sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=fit_pol, fit_cpol=fit_cpol),
+            sample_1model_grad_uv(u, v, model_type, params, pol='V', fit_pol=fit_pol, fit_cpol=fit_cpol))
+        return rr if pol == 'RR' else ll
+    elif pol in ('RL', 'LR'):
+        rl, lr = pol_conventions.stokes_to_circ_cross(
+            sample_1model_grad_uv(u, v, model_type, params, pol='Q', fit_pol=fit_pol, fit_cpol=fit_cpol),
+            sample_1model_grad_uv(u, v, model_type, params, pol='U', fit_pol=fit_pol, fit_cpol=fit_cpol))
+        return rl if pol == 'RL' else lr
+    elif pol in ('XX', 'YY'):
+        xx, yy = pol_conventions.stokes_to_lin_diag(
+            sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=fit_pol, fit_cpol=fit_cpol),
+            sample_1model_grad_uv(u, v, model_type, params, pol='Q', fit_pol=fit_pol, fit_cpol=fit_cpol))
+        return xx if pol == 'XX' else yy
+    elif pol in ('XY', 'YX'):
+        xy, yx = pol_conventions.stokes_to_lin_offdiag(
+            sample_1model_grad_uv(u, v, model_type, params, pol='U', fit_pol=fit_pol, fit_cpol=fit_cpol),
+            sample_1model_grad_uv(u, v, model_type, params, pol='V', fit_pol=fit_pol, fit_cpol=fit_cpol))
+        return xy if pol == 'XY' else yx
     else:
         raise Exception('Polarization ' + pol + ' not implemented!')
 

--- a/ehtim/movie.py
+++ b/ehtim/movie.py
@@ -35,6 +35,7 @@ import ehtim.io.save
 import ehtim.io.load
 import ehtim.const_def as ehc
 import ehtim.observing.obs_helpers as obsh
+import ehtim.observing.pol_conventions as pol_conventions
 
 INTERPOLATION_KINDS = ['linear', 'nearest', 'zero', 'slinear',
                        'quadratic', 'cubic', 'previous', 'next']
@@ -169,6 +170,22 @@ class Movie(object):
             else:
                 raise Exception("for polrep=='circ', pol_prim must be 'RR' or 'LL'!")
 
+        elif polrep == 'lin':
+            if pol_prim is None:
+                print("polrep is 'lin' and no pol_prim specified! Setting pol_prim='XX'")
+                pol_prim = 'XX'
+            if pol_prim == 'XX':
+                self._movdict = {'XX': frames, 'YY': [], 'XY': [], 'YX': []}
+                self._fundict = {'XX': fun, 'YY': None, 'XY': None, 'YX': None}
+            elif pol_prim == 'YY':
+                self._movdict = {'XX': [], 'YY': frames, 'XY': [], 'YX': []}
+                self._fundict = {'XX': None, 'YY': fun, 'XY': None, 'YX': None}
+            else:
+                raise Exception("for polrep=='lin', pol_prim must be 'XX' or 'YY'!")
+
+        else:
+            raise Exception("polrep must be 'stokes', 'circ', or 'lin'!")
+
         self.pol_prim = pol_prim
 
         self.ra = float(ra)
@@ -197,23 +214,35 @@ class Movie(object):
                                          bounds_error=self.bounds_error, fill_value=fill_value)
         self._fundict[self.pol_prim] = fun
 
+    # Frame accessors are harmonized across polreps: each getter returns the
+    # stored frames when self.polrep matches the accessor's native basis, or
+    # computes them from the stored basis via pol_conventions when not.
+    # Setters keep their original polrep guard (you can only write into the
+    # storage basis); they also (re)build the matching _fundict interpolator.
+    # Cross-polrep reads do not populate _fundict; callers that need time
+    # interpolation in a different basis should switch_polrep first.
+
     @property
     def iframes(self):
-
-        if self.polrep != 'stokes':
-            raise Exception(
-                "iframes is not defined unless self.polrep=='stokes' -- try self.switch_polrep()")
-
-        frames = self._movdict['I']
+        frames = []
+        if self.polrep == 'stokes':
+            frames = self._movdict['I']
+        elif self.polrep == 'circ':
+            rr, ll = self.rrframes, self.llframes
+            if len(rr) != 0 and len(ll) != 0:
+                frames, _ = pol_conventions.circ_to_stokes_parallel(rr, ll)
+        elif self.polrep == 'lin':
+            xx, yy = self.xxframes, self.yyframes
+            if len(xx) != 0 and len(yy) != 0:
+                frames, _ = pol_conventions.lin_to_stokes_diag(xx, yy)
         return frames
 
     @iframes.setter
     def iframes(self, frames):
-
+        if self.polrep != 'stokes':
+            raise Exception("iframes can only be set when self.polrep=='stokes'")
         if len(frames[0]) != self.xdim*self.ydim:
             raise Exception("vec size is not consistent with xdim*ydim!")
-
-        # TODO -- more checks on the consistency of the imvec with the existing pol data???
         frames = np.array(frames)
         self._movdict['I'] = frames
         fill_value = (frames[0], frames[-1])
@@ -223,21 +252,26 @@ class Movie(object):
 
     @property
     def qframes(self):
-
-        if self.polrep != 'stokes':
-            raise Exception(
-                "qframes is not defined unless self.polrep=='stokes' -- try self.switch_polrep()")
-
-        frames = self._movdict['Q']
+        frames = []
+        if self.polrep == 'stokes':
+            frames = self._movdict['Q']
+        elif self.polrep == 'circ':
+            rl, lr = self.rlframes, self.lrframes
+            if len(rl) != 0 and len(lr) != 0:
+                q_c, _ = pol_conventions.circ_to_stokes_cross(rl, lr)
+                frames = np.real(q_c)
+        elif self.polrep == 'lin':
+            xx, yy = self.xxframes, self.yyframes
+            if len(xx) != 0 and len(yy) != 0:
+                _, frames = pol_conventions.lin_to_stokes_diag(xx, yy)
         return frames
 
     @qframes.setter
     def qframes(self, frames):
-
+        if self.polrep != 'stokes':
+            raise Exception("qframes can only be set when self.polrep=='stokes'")
         if len(frames[0]) != self.xdim*self.ydim:
             raise Exception("vec size is not consistent with xdim*ydim!")
-
-        # TODO -- more checks on the consistency of the imvec with the existing pol data???
         frames = np.array(frames)
         self._movdict['Q'] = frames
         fill_value = (frames[0], frames[-1])
@@ -247,22 +281,27 @@ class Movie(object):
 
     @property
     def uframes(self):
-
-        if self.polrep != 'stokes':
-            raise Exception(
-                "uframes is not defined unless self.polrep=='stokes' -- try self.switch_polrep()")
-
-        frames = self._movdict['U']
-
+        frames = []
+        if self.polrep == 'stokes':
+            frames = self._movdict['U']
+        elif self.polrep == 'circ':
+            rl, lr = self.rlframes, self.lrframes
+            if len(rl) != 0 and len(lr) != 0:
+                _, u_c = pol_conventions.circ_to_stokes_cross(rl, lr)
+                frames = np.real(u_c)
+        elif self.polrep == 'lin':
+            xy, yx = self.xyframes, self.yxframes
+            if len(xy) != 0 and len(yx) != 0:
+                u_c, _ = pol_conventions.lin_to_stokes_offdiag(xy, yx)
+                frames = np.real(u_c)
         return frames
 
     @uframes.setter
     def uframes(self, frames):
-
+        if self.polrep != 'stokes':
+            raise Exception("uframes can only be set when self.polrep=='stokes'")
         if len(frames[0]) != self.xdim*self.ydim:
             raise Exception("vec size is not consistent with xdim*ydim!")
-
-        # TODO -- more checks on the consistency of the imvec with the existing pol data???
         frames = np.array(frames)
         self._movdict['U'] = frames
         fill_value = (frames[0], frames[-1])
@@ -272,22 +311,26 @@ class Movie(object):
 
     @property
     def vframes(self):
-
-        if self.polrep != 'stokes':
-            raise Exception(
-                "vframes is not defined unless self.polrep=='stokes' -- try self.switch_polrep()")
-
-        frames = self._movdict['V']
-
+        frames = []
+        if self.polrep == 'stokes':
+            frames = self._movdict['V']
+        elif self.polrep == 'circ':
+            rr, ll = self.rrframes, self.llframes
+            if len(rr) != 0 and len(ll) != 0:
+                _, frames = pol_conventions.circ_to_stokes_parallel(rr, ll)
+        elif self.polrep == 'lin':
+            xy, yx = self.xyframes, self.yxframes
+            if len(xy) != 0 and len(yx) != 0:
+                _, v_c = pol_conventions.lin_to_stokes_offdiag(xy, yx)
+                frames = np.real(v_c)
         return frames
 
     @vframes.setter
     def vframes(self, frames):
-
+        if self.polrep != 'stokes':
+            raise Exception("vframes can only be set when self.polrep=='stokes'")
         if len(frames[0]) != self.xdim*self.ydim:
             raise Exception("vec size is not consistent with xdim*ydim!")
-
-        # TODO -- more checks on the consistency of the imvec with the existing pol data???
         frames = np.array(frames)
         self._movdict['V'] = frames
         fill_value = (frames[0], frames[-1])
@@ -297,21 +340,21 @@ class Movie(object):
 
     @property
     def rrframes(self):
-
-        if self.polrep != 'circ':
-            raise Exception(
-                "rrframes is not defined unless self.polrep=='circ' -- try self.switch_polrep()")
-
-        frames = self._movdict['RR']
+        frames = []
+        if self.polrep == 'circ':
+            frames = self._movdict['RR']
+        elif self.polrep in ('stokes', 'lin'):
+            i, v = self.iframes, self.vframes
+            if len(i) != 0 and len(v) != 0:
+                frames, _ = pol_conventions.stokes_to_circ_parallel(i, v)
         return frames
 
     @rrframes.setter
     def rrframes(self, frames):
-
+        if self.polrep != 'circ':
+            raise Exception("rrframes can only be set when self.polrep=='circ'")
         if len(frames[0]) != self.xdim*self.ydim:
             raise Exception("vec size is not consistent with xdim*ydim!")
-
-        # TODO -- more checks on the consistency of the imvec with the existing pol data???
         frames = np.array(frames)
         self._movdict['RR'] = frames
         fill_value = (frames[0], frames[-1])
@@ -321,21 +364,21 @@ class Movie(object):
 
     @property
     def llframes(self):
-
-        if self.polrep != 'circ':
-            raise Exception(
-                "llframes is not defined unless self.polrep=='circ' -- try self.switch_polrep()")
-
-        frames = self._movdict['LL']
+        frames = []
+        if self.polrep == 'circ':
+            frames = self._movdict['LL']
+        elif self.polrep in ('stokes', 'lin'):
+            i, v = self.iframes, self.vframes
+            if len(i) != 0 and len(v) != 0:
+                _, frames = pol_conventions.stokes_to_circ_parallel(i, v)
         return frames
 
     @llframes.setter
     def llframes(self, frames):
-
+        if self.polrep != 'circ':
+            raise Exception("llframes can only be set when self.polrep=='circ'")
         if len(frames[0]) != self.xdim*self.ydim:
             raise Exception("vec size is not consistent with xdim*ydim!")
-
-        # TODO -- more checks on the consistency of the imvec with the existing pol data???
         frames = np.array(frames)
         self._movdict['LL'] = frames
         fill_value = (frames[0], frames[-1])
@@ -344,22 +387,22 @@ class Movie(object):
         self._fundict['LL'] = fun
 
     @property
-    def rlvec(self):
-
-        if self.polrep != 'circ':
-            raise Exception(
-                "rlframes is not defined unless self.polrep=='circ' -- try self.switch_polrep()")
-
-        frames = self._movdict['RL']
+    def rlframes(self):
+        frames = []
+        if self.polrep == 'circ':
+            frames = self._movdict['RL']
+        elif self.polrep in ('stokes', 'lin'):
+            q, u = self.qframes, self.uframes
+            if len(q) != 0 and len(u) != 0:
+                frames, _ = pol_conventions.stokes_to_circ_cross(q, u)
         return frames
 
-    @rlvec.setter
-    def rlvec(self, frames):
-
+    @rlframes.setter
+    def rlframes(self, frames):
+        if self.polrep != 'circ':
+            raise Exception("rlframes can only be set when self.polrep=='circ'")
         if len(frames[0]) != self.xdim*self.ydim:
             raise Exception("vec size is not consistent with xdim*ydim!")
-
-        # TODO -- more checks on the consistency of the imvec with the existing pol data???
         frames = np.array(frames)
         self._movdict['RL'] = frames
         fill_value = (frames[0], frames[-1])
@@ -368,28 +411,152 @@ class Movie(object):
         self._fundict['RL'] = fun
 
     @property
-    def lrvec(self):
-
-        if self.polrep != 'circ':
-            raise Exception(
-                "lrframes is not defined unless self.polrep=='circ' -- try self.switch_polrep()")
-
-        frames = self._movdict['LR']
+    def lrframes(self):
+        frames = []
+        if self.polrep == 'circ':
+            frames = self._movdict['LR']
+        elif self.polrep in ('stokes', 'lin'):
+            q, u = self.qframes, self.uframes
+            if len(q) != 0 and len(u) != 0:
+                _, frames = pol_conventions.stokes_to_circ_cross(q, u)
         return frames
 
-    @lrvec.setter
-    def lrvec(self, frames):
-
+    @lrframes.setter
+    def lrframes(self, frames):
+        if self.polrep != 'circ':
+            raise Exception("lrframes can only be set when self.polrep=='circ'")
         if len(frames[0]) != self.xdim*self.ydim:
             raise Exception("vec size is not consistent with xdim*ydim!")
-
-        # TODO -- more checks on the consistency of the imvec with the existing pol data???
         frames = np.array(frames)
         self._movdict['LR'] = frames
         fill_value = (frames[0], frames[-1])
         fun = scipy.interpolate.interp1d(self.times, frames.T, kind=self.interp,
                                          bounds_error=self.bounds_error, fill_value=fill_value)
         self._fundict['LR'] = fun
+
+    # Pre-Phase-3 names rlvec / lrvec were inconsistent with the rest of
+    # Movie's "frames" naming and the rest of the codebase did not call them.
+    # Phase 3 renamed them to rlframes / lrframes; these shims raise so any
+    # surviving caller fails loudly with a migration message.
+    @property
+    def rlvec(self):
+        raise AttributeError(
+            "Movie.rlvec was renamed to Movie.rlframes in Phase 3 mixed-pol; "
+            "update the caller.")
+
+    @rlvec.setter
+    def rlvec(self, frames):
+        raise AttributeError(
+            "Movie.rlvec was renamed to Movie.rlframes in Phase 3 mixed-pol; "
+            "update the caller.")
+
+    @property
+    def lrvec(self):
+        raise AttributeError(
+            "Movie.lrvec was renamed to Movie.lrframes in Phase 3 mixed-pol; "
+            "update the caller.")
+
+    @lrvec.setter
+    def lrvec(self, frames):
+        raise AttributeError(
+            "Movie.lrvec was renamed to Movie.lrframes in Phase 3 mixed-pol; "
+            "update the caller.")
+
+    @property
+    def xxframes(self):
+        frames = []
+        if self.polrep == 'lin':
+            frames = self._movdict['XX']
+        elif self.polrep in ('stokes', 'circ'):
+            i, q = self.iframes, self.qframes
+            if len(i) != 0 and len(q) != 0:
+                frames, _ = pol_conventions.stokes_to_lin_diag(i, q)
+        return frames
+
+    @xxframes.setter
+    def xxframes(self, frames):
+        if self.polrep != 'lin':
+            raise Exception("xxframes can only be set when self.polrep=='lin'")
+        if len(frames[0]) != self.xdim*self.ydim:
+            raise Exception("vec size is not consistent with xdim*ydim!")
+        frames = np.array(frames)
+        self._movdict['XX'] = frames
+        fill_value = (frames[0], frames[-1])
+        fun = scipy.interpolate.interp1d(self.times, frames.T, kind=self.interp,
+                                         bounds_error=self.bounds_error, fill_value=fill_value)
+        self._fundict['XX'] = fun
+
+    @property
+    def yyframes(self):
+        frames = []
+        if self.polrep == 'lin':
+            frames = self._movdict['YY']
+        elif self.polrep in ('stokes', 'circ'):
+            i, q = self.iframes, self.qframes
+            if len(i) != 0 and len(q) != 0:
+                _, frames = pol_conventions.stokes_to_lin_diag(i, q)
+        return frames
+
+    @yyframes.setter
+    def yyframes(self, frames):
+        if self.polrep != 'lin':
+            raise Exception("yyframes can only be set when self.polrep=='lin'")
+        if len(frames[0]) != self.xdim*self.ydim:
+            raise Exception("vec size is not consistent with xdim*ydim!")
+        frames = np.array(frames)
+        self._movdict['YY'] = frames
+        fill_value = (frames[0], frames[-1])
+        fun = scipy.interpolate.interp1d(self.times, frames.T, kind=self.interp,
+                                         bounds_error=self.bounds_error, fill_value=fill_value)
+        self._fundict['YY'] = fun
+
+    @property
+    def xyframes(self):
+        frames = []
+        if self.polrep == 'lin':
+            frames = self._movdict['XY']
+        elif self.polrep in ('stokes', 'circ'):
+            u, v = self.uframes, self.vframes
+            if len(u) != 0 and len(v) != 0:
+                frames, _ = pol_conventions.stokes_to_lin_offdiag(u, v)
+        return frames
+
+    @xyframes.setter
+    def xyframes(self, frames):
+        if self.polrep != 'lin':
+            raise Exception("xyframes can only be set when self.polrep=='lin'")
+        if len(frames[0]) != self.xdim*self.ydim:
+            raise Exception("vec size is not consistent with xdim*ydim!")
+        frames = np.array(frames)
+        self._movdict['XY'] = frames
+        fill_value = (frames[0], frames[-1])
+        fun = scipy.interpolate.interp1d(self.times, frames.T, kind=self.interp,
+                                         bounds_error=self.bounds_error, fill_value=fill_value)
+        self._fundict['XY'] = fun
+
+    @property
+    def yxframes(self):
+        frames = []
+        if self.polrep == 'lin':
+            frames = self._movdict['YX']
+        elif self.polrep in ('stokes', 'circ'):
+            u, v = self.uframes, self.vframes
+            if len(u) != 0 and len(v) != 0:
+                _, frames = pol_conventions.stokes_to_lin_offdiag(u, v)
+        return frames
+
+    @yxframes.setter
+    def yxframes(self, frames):
+        if self.polrep != 'lin':
+            raise Exception("yxframes can only be set when self.polrep=='lin'")
+        if len(frames[0]) != self.xdim*self.ydim:
+            raise Exception("vec size is not consistent with xdim*ydim!")
+        frames = np.array(frames)
+        self._movdict['YX'] = frames
+        fill_value = (frames[0], frames[-1])
+        fun = scipy.interpolate.interp1d(self.times, frames.T, kind=self.interp,
+                                         bounds_error=self.bounds_error, fill_value=fill_value)
+        self._fundict['YX'] = fun
 
     def movie_args(self):
         """"Copy arguments for making a  new Movie into a list and dictonary
@@ -575,6 +742,49 @@ class Movie(object):
             self._movdict = {'RR': self.rrframes, 'LL': self.llframes,
                              'RL': self.rlframes, 'LR': self.lrframes}
             self._fundict = {'RR': rrfun, 'LL': llfun, 'RL': rlfun, 'LR': lrfun}
+
+        elif self.polrep == 'lin':
+            if pol == 'XX':
+                self.xxframes = [image.flatten() for image in movie]
+            elif pol == 'YY':
+                self.yyframes = [image.flatten() for image in movie]
+            elif pol == 'XY':
+                self.xyframes = [image.flatten() for image in movie]
+            elif pol == 'YX':
+                self.yxframes = [image.flatten() for image in movie]
+
+            if len(self.xxframes) > 0:
+                fill_value = (self.xxframes[0], self.xxframes[-1])
+                xxfun = scipy.interpolate.interp1d(self.times, self.xxframes.T, kind=self.interp,
+                                                   fill_value=fill_value,
+                                                   bounds_error=self.bounds_error)
+            else:
+                xxfun = None
+            if len(self.yyframes) > 0:
+                fill_value = (self.yyframes[0], self.yyframes[-1])
+                yyfun = scipy.interpolate.interp1d(self.times, self.yyframes.T, kind=self.interp,
+                                                   fill_value=fill_value,
+                                                   bounds_error=self.bounds_error)
+            else:
+                yyfun = None
+            if len(self.xyframes) > 0:
+                fill_value = (self.xyframes[0], self.xyframes[-1])
+                xyfun = scipy.interpolate.interp1d(self.times, self.xyframes.T, kind=self.interp,
+                                                   fill_value=fill_value,
+                                                   bounds_error=self.bounds_error)
+            else:
+                xyfun = None
+            if len(self.yxframes) > 0:
+                fill_value = (self.yxframes[0], self.yxframes[-1])
+                yxfun = scipy.interpolate.interp1d(self.times, self.yxframes.T, kind=self.interp,
+                                                   fill_value=fill_value,
+                                                   bounds_error=self.bounds_error)
+            else:
+                yxfun = None
+
+            self._movdict = {'XX': self.xxframes, 'YY': self.yyframes,
+                             'XY': self.xyframes, 'YX': self.yxframes}
+            self._fundict = {'XX': xxfun, 'YY': yyfun, 'XY': xyfun, 'YX': yxfun}
         return
 
     # TODO deprecated -- replace with generic add_pol_movie
@@ -616,72 +826,43 @@ class Movie(object):
 
            Args:
                polrep_out (str):  the polrep of the output data
-               pol_prim_out (str): The default movie: I,Q,U or V for Stokes,
-                                   RR,LL,LR,RL for Circular
+               pol_prim_out (str): The default movie: I,Q,U,V for stokes,
+                                   RR,LL,LR,RL for circ, XX,YY,XY,YX for lin
 
            Returns:
                (Movie): new movie object with potentially different polrep
         """
 
-        if polrep_out not in ['stokes', 'circ']:
-            raise Exception("polrep_out must be either 'stokes' or 'circ'")
+        if polrep_out not in ['stokes', 'circ', 'lin']:
+            raise Exception("polrep_out must be 'stokes', 'circ', or 'lin'")
         if pol_prim_out is None:
             if polrep_out == 'stokes':
                 pol_prim_out = 'I'
             elif polrep_out == 'circ':
                 pol_prim_out = 'RR'
+            elif polrep_out == 'lin':
+                pol_prim_out = 'XX'
 
         # Simply copy if the polrep is unchanged
         if polrep_out == self.polrep and pol_prim_out == self.pol_prim:
             return self.copy()
 
-        # Assemble a dictionary of new polarization vectors
-        framedim = (self.nframes, self.ydim, self.xdim)
+        # circ <-> lin goes through stokes (no direct path; plan Decision 7).
+        if (polrep_out, self.polrep) in [('circ', 'lin'), ('lin', 'circ')]:
+            return self.switch_polrep('stokes').switch_polrep(polrep_out, pol_prim_out)
+
+        # The cross-polrep accessors compose through the canonical pair for
+        # the source polrep, returning empty arrays when a transform cannot
+        # close.
         if polrep_out == 'stokes':
-            if self.polrep == 'stokes':
-                movdict = {'I': self.iframes, 'Q': self.qframes,
-                           'U': self.uframes, 'V': self.vframes}
-            else:
-                if len(self.rrframes) == 0 or len(self.llframes) == 0:
-                    iframes = []
-                    vframes = []
-                else:
-                    iframes = 0.5*(self.rrframes.reshape(framedim) +
-                                   self.llframes.reshape(framedim))
-                    vframes = 0.5*(self.rrframes.reshape(framedim) -
-                                   self.llframes.reshape(framedim))
-
-                if len(self.rlframes) == 0 or len(self.lrframes) == 0:
-                    qframes = []
-                    uframes = []
-                else:
-                    qframes = np.real(0.5*(self.lrframes.reshape(framedim) +
-                                           self.rlframes.reshape(framedim)))
-                    uframes = np.real(0.5j*(self.lrframes.reshape(framedim) -
-                                            self.rlframes.reshape(framedim)))
-
-                movdict = {'I': iframes, 'Q': qframes, 'U': uframes, 'V': vframes}
-
+            movdict = {'I': self.iframes, 'Q': self.qframes,
+                       'U': self.uframes, 'V': self.vframes}
         elif polrep_out == 'circ':
-            if self.polrep == 'circ':
-                movdict = {'RR': self.rrframes, 'LL': self.llframes,
-                           'RL': self.rlframes, 'LR': self.lrframes}
-            else:
-                if len(self.iframes) == 0 or len(self.vframes) == 0:
-                    rrframes = []
-                    llframes = []
-                else:
-                    rrframes = (self.iframes.reshape(framedim) + self.vframes.reshape(framedim))
-                    llframes = (self.iframes.reshape(framedim) - self.vframes.reshape(framedim))
-
-                if len(self.qframes) == 0 or len(self.uframes) == 0:
-                    rlframes = []
-                    lrframes = []
-                else:
-                    rlframes = (self.qframes.reshape(framedim) + 1j*self.uframes.reshape(framedim))
-                    lrframes = (self.qframes.reshape(framedim) - 1j*self.uframes.reshape(framedim))
-
-                movdict = {'RR': rrframes, 'LL': llframes, 'RL': rlframes, 'LR': lrframes}
+            movdict = {'RR': self.rrframes, 'LL': self.llframes,
+                       'RL': self.rlframes, 'LR': self.lrframes}
+        elif polrep_out == 'lin':
+            movdict = {'XX': self.xxframes, 'YY': self.yyframes,
+                       'XY': self.xyframes, 'YX': self.yxframes}
 
         # Assemble the new movie
         frames = movdict[pol_prim_out]
@@ -690,9 +871,11 @@ class Movie(object):
                             "%s with pol_prim_out=%s, \n" % (polrep_out, pol_prim_out) +
                             "output movie is not defined")
 
-        # Make new  movie with primary polarization
+        # The Movie constructor wants a list of 2D frames; the accessors
+        # return (nframes, xdim*ydim). Reshape primary + secondary.
+        framedim = (self.nframes, self.ydim, self.xdim)
         arglist, argdict = self.movie_args()
-        arglist[0] = frames
+        arglist[0] = frames.reshape(framedim)
         argdict['polrep'] = polrep_out
         argdict['pol_prim'] = pol_prim_out
         newmov = Movie(*arglist, **argdict)
@@ -703,8 +886,7 @@ class Movie(object):
                 continue
             polframes = movdict[pol]
             if len(polframes):
-                polframes = polframes.reshape((self.nframes, self.ydim, self.xdim))
-                newmov.add_pol_movie(polframes, pol)
+                newmov.add_pol_movie(polframes.reshape(framedim), pol)
 
         return newmov
 

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -42,6 +42,7 @@ import ehtim.image
 import ehtim.io.load
 import ehtim.io.save
 import ehtim.observing.obs_helpers as obsh
+import ehtim.observing.pol_conventions as pol_conventions
 import ehtim.statistics.dataframes as ehdf
 
 warnings.filterwarnings("ignore",
@@ -287,21 +288,16 @@ class Obsdata:
             rrmask = np.isnan(self.data['rrvis'])
             llmask = np.isnan(self.data['llvis'])
 
-            for f in np.dtype(ehc.DTPOL_STOKES).names:
-                if f in ['time', 'tint', 't1', 't2', 'tau1', 'tau2', 'u', 'v']:
-                    data[f] = self.data[f]
-                elif f == 'vis':
-                    data[f] = 0.5 * (self.data['rrvis'] + self.data['llvis'])
-                elif f == 'qvis':
-                    data[f] = 0.5 * (self.data['lrvis'] + self.data['rlvis'])
-                elif f == 'uvis':
-                    data[f] = 0.5j * (self.data['lrvis'] - self.data['rlvis'])
-                elif f == 'vvis':
-                    data[f] = 0.5 * (self.data['rrvis'] - self.data['llvis'])
-                elif f in ['sigma', 'vsigma']:
-                    data[f] = 0.5 * np.sqrt(self.data['rrsigma']**2 + self.data['llsigma']**2)
-                elif f in ['qsigma', 'usigma']:
-                    data[f] = 0.5 * np.sqrt(self.data['rlsigma']**2 + self.data['lrsigma']**2)
+            for f in ['time', 'tint', 't1', 't2', 'tau1', 'tau2', 'u', 'v']:
+                data[f] = self.data[f]
+            (data['vis'], data['qvis'],
+             data['uvis'], data['vvis']) = pol_conventions.circ_to_stokes(
+                self.data['rrvis'], self.data['llvis'],
+                self.data['rlvis'], self.data['lrvis'])
+            (data['sigma'], data['qsigma'],
+             data['usigma'], data['vsigma']) = pol_conventions.circ_to_stokes_sigma(
+                self.data['rrsigma'], self.data['llsigma'],
+                self.data['rlsigma'], self.data['lrsigma'])
 
             if allow_singlepol:
                 # In cases where only one polarization is present
@@ -316,21 +312,16 @@ class Obsdata:
             data = np.empty(len(self.data), dtype=ehc.DTPOL_CIRC)
             Vmask = np.isnan(self.data['vvis'])
 
-            for f in np.dtype(ehc.DTPOL_CIRC).names:
-                if f in ['time', 'tint', 't1', 't2', 'tau1', 'tau2', 'u', 'v']:
-                    data[f] = self.data[f]
-                elif f == 'rrvis':
-                    data[f] = (self.data['vis'] + self.data['vvis'])
-                elif f == 'llvis':
-                    data[f] = (self.data['vis'] - self.data['vvis'])
-                elif f == 'rlvis':
-                    data[f] = (self.data['qvis'] + 1j * self.data['uvis'])
-                elif f == 'lrvis':
-                    data[f] = (self.data['qvis'] - 1j * self.data['uvis'])
-                elif f in ['rrsigma', 'llsigma']:
-                    data[f] = np.sqrt(self.data['sigma']**2 + self.data['vsigma']**2)
-                elif f in ['rlsigma', 'lrsigma']:
-                    data[f] = np.sqrt(self.data['qsigma']**2 + self.data['usigma']**2)
+            for f in ['time', 'tint', 't1', 't2', 'tau1', 'tau2', 'u', 'v']:
+                data[f] = self.data[f]
+            (data['rrvis'], data['llvis'],
+             data['rlvis'], data['lrvis']) = pol_conventions.stokes_to_circ(
+                self.data['vis'], self.data['qvis'],
+                self.data['uvis'], self.data['vvis'])
+            (data['rrsigma'], data['llsigma'],
+             data['rlsigma'], data['lrsigma']) = pol_conventions.stokes_to_circ_sigma(
+                self.data['sigma'], self.data['qsigma'],
+                self.data['usigma'], self.data['vsigma'])
 
             if allow_singlepol:
                 # In cases where only Stokes I is present, copy it to a specified parallel-hand

--- a/ehtim/observing/pol_conventions.py
+++ b/ehtim/observing/pol_conventions.py
@@ -1,0 +1,293 @@
+# pol_conventions.py
+# Single home for polarization-basis transforms and Jones-matrix math.
+#
+#    Copyright (C) 2026 Andrew Chael
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Polarization basis transforms and Jones-matrix utilities.
+
+Convention (IAU / Hamaker-Bregman-Sault / CASA / AIPS):
+
+    R = (X - iY) / sqrt(2)
+    L = (X + iY) / sqrt(2)
+
+with the circular Stokes formulas:
+
+    I = (RR + LL) / 2,    V = (RR - LL) / 2
+    Q = (RL + LR) / 2,    U = i (LR - RL) / 2
+
+and the inverted linear-feed Stokes formulas:
+
+    I = (XX + YY) / 2,    Q = (XX - YY) / 2
+    U = (XY + YX) / 2,    V = +i (XY - YX) / 2
+
+The sign of V flips under the opposite basis choice
+(R = (X + iY) / sqrt(2)). Full derivation and worked examples live in
+``docs/polarization_conventions.md``.
+
+A ``MixedPolConventionWarning`` fires once per session on the first
+non-identity transform call.
+"""
+
+import warnings
+
+import numpy as np
+
+from ehtim.warnings import MixedPolConventionWarning
+
+# ---------------------------------------------------------------------------
+# Basis matrices
+# ---------------------------------------------------------------------------
+
+# Maps a feed-basis vector (X, Y) -> (R, L) under the IAU/HBS convention.
+# Rows indexed by (R, L); columns by (X, Y).
+BASIS_LIN_TO_CIRC = np.array([[1.0, -1.0j],
+                              [1.0, +1.0j]]) / np.sqrt(2.0)
+
+# Unitary inverse: maps (R, L) -> (X, Y).
+BASIS_CIRC_TO_LIN = BASIS_LIN_TO_CIRC.conj().T
+
+
+# ---------------------------------------------------------------------------
+# Session-level convention warning
+# ---------------------------------------------------------------------------
+
+_convention_warning_emitted = False
+
+
+def _maybe_warn_convention():
+    """Emit MixedPolConventionWarning at most once per session."""
+    global _convention_warning_emitted
+    if _convention_warning_emitted:
+        return
+    _convention_warning_emitted = True
+    warnings.warn(
+        "Polarization basis transform applied under the IAU/Hamaker-"
+        "Bregman-Sault convention (R = (X - iY)/sqrt(2)). This "
+        "transformation assumes ideal feeds (D = 0 or already "
+        "calibrated). See docs/polarization_conventions.md.",
+        category=MixedPolConventionWarning,
+        stacklevel=3,
+    )
+
+
+def _reset_convention_warning():
+    """Test helper: re-arm the once-per-session warning flag."""
+    global _convention_warning_emitted
+    _convention_warning_emitted = False
+
+
+# ---------------------------------------------------------------------------
+# Visibility transforms (vis only; sigmas handled by *_sigma helpers below)
+# ---------------------------------------------------------------------------
+
+def circ_to_stokes(rrvis, llvis, rlvis, lrvis):
+    """Convert circular-feed visibilities to Stokes visibilities.
+
+    Returns
+    -------
+    (vis, qvis, uvis, vvis) : tuple of ndarrays
+    """
+    _maybe_warn_convention()
+    vis = 0.5 * (rrvis + llvis)
+    qvis = 0.5 * (lrvis + rlvis)
+    uvis = 0.5j * (lrvis - rlvis)
+    vvis = 0.5 * (rrvis - llvis)
+    return vis, qvis, uvis, vvis
+
+
+def stokes_to_circ(vis, qvis, uvis, vvis):
+    """Convert Stokes visibilities to circular-feed visibilities.
+
+    Returns
+    -------
+    (rrvis, llvis, rlvis, lrvis) : tuple of ndarrays
+    """
+    _maybe_warn_convention()
+    rrvis = vis + vvis
+    llvis = vis - vvis
+    rlvis = qvis + 1.0j * uvis
+    lrvis = qvis - 1.0j * uvis
+    return rrvis, llvis, rlvis, lrvis
+
+
+def lin_to_stokes(xxvis, yyvis, xyvis, yxvis):
+    """Convert linear-feed visibilities to Stokes (IAU/HBS).
+
+    Returns
+    -------
+    (vis, qvis, uvis, vvis) : tuple of ndarrays
+    """
+    _maybe_warn_convention()
+    vis = 0.5 * (xxvis + yyvis)
+    qvis = 0.5 * (xxvis - yyvis)
+    uvis = 0.5 * (xyvis + yxvis)
+    vvis = 0.5j * (xyvis - yxvis)
+    return vis, qvis, uvis, vvis
+
+
+def stokes_to_lin(vis, qvis, uvis, vvis):
+    """Convert Stokes visibilities to linear-feed visibilities (IAU/HBS).
+
+    Inverse of ``lin_to_stokes``.
+
+    Returns
+    -------
+    (xxvis, yyvis, xyvis, yxvis) : tuple of ndarrays
+    """
+    _maybe_warn_convention()
+    xxvis = vis + qvis
+    yyvis = vis - qvis
+    xyvis = uvis - 1.0j * vvis
+    yxvis = uvis + 1.0j * vvis
+    return xxvis, yyvis, xyvis, yxvis
+
+
+def lin_to_circ(xxvis, yyvis, xyvis, yxvis):
+    """Convert linear-feed visibilities to circular-feed via Stokes."""
+    return stokes_to_circ(*lin_to_stokes(xxvis, yyvis, xyvis, yxvis))
+
+
+def circ_to_lin(rrvis, llvis, rlvis, lrvis):
+    """Convert circular-feed visibilities to linear-feed via Stokes."""
+    return stokes_to_lin(*circ_to_stokes(rrvis, llvis, rlvis, lrvis))
+
+
+# ---------------------------------------------------------------------------
+# Sigma propagation (quadrature, not linear)
+# ---------------------------------------------------------------------------
+#
+# TODO: these per-component sigma transforms are NOT invertible. The
+# basis transforms are linear combinations of the input visibilities, so
+# the output components are correlated even when the inputs are
+# independent — but we only return marginal variances per output
+# component, dropping the off-diagonal covariance terms. A
+# round-trip (e.g. stokes_to_circ_sigma then circ_to_stokes_sigma)
+# generally does not recover the input sigmas.
+#
+# Proper treatment needs a full 4x4 covariance matrix propagation:
+#     Cov_out = M @ Cov_in @ M^dagger
+# where M is the 4x4 transform matrix on the visibility vector. Migrate
+# callers to that when a downstream consumer cares about the cross
+# terms (uncertainty quantification, weighted closures, Bayesian
+# inference).
+#
+# Until then these helpers replicate the existing inline obsdata.py
+# behavior bit-for-bit, so the lossy independence assumption is
+# preserved across the migration.
+
+def circ_to_stokes_sigma(rrsigma, llsigma, rlsigma, lrsigma):
+    """Propagate circular-feed sigmas to Stokes sigmas.
+
+    sigma_I = sigma_V = 0.5 * sqrt(rrsigma^2 + llsigma^2)
+    sigma_Q = sigma_U = 0.5 * sqrt(rlsigma^2 + lrsigma^2)
+    """
+    iv = 0.5 * np.sqrt(rrsigma**2 + llsigma**2)
+    qu = 0.5 * np.sqrt(rlsigma**2 + lrsigma**2)
+    return iv, qu, qu, iv
+
+
+def stokes_to_circ_sigma(sigma, qsigma, usigma, vsigma):
+    """Propagate Stokes sigmas to circular-feed sigmas.
+
+    sigma_RR = sigma_LL = sqrt(sigma_I^2 + sigma_V^2)
+    sigma_RL = sigma_LR = sqrt(sigma_Q^2 + sigma_U^2)
+    """
+    rr_ll = np.sqrt(sigma**2 + vsigma**2)
+    rl_lr = np.sqrt(qsigma**2 + usigma**2)
+    return rr_ll, rr_ll, rl_lr, rl_lr
+
+
+def lin_to_stokes_sigma(xxsigma, yysigma, xysigma, yxsigma):
+    """Propagate linear-feed sigmas to Stokes sigmas.
+
+    sigma_I = sigma_Q = 0.5 * sqrt(xxsigma^2 + yysigma^2)
+    sigma_U = sigma_V = 0.5 * sqrt(xysigma^2 + yxsigma^2)
+    """
+    iq = 0.5 * np.sqrt(xxsigma**2 + yysigma**2)
+    uv = 0.5 * np.sqrt(xysigma**2 + yxsigma**2)
+    return iq, iq, uv, uv
+
+
+def stokes_to_lin_sigma(sigma, qsigma, usigma, vsigma):
+    """Propagate Stokes sigmas to linear-feed sigmas."""
+    xx_yy = np.sqrt(sigma**2 + qsigma**2)
+    xy_yx = np.sqrt(usigma**2 + vsigma**2)
+    return xx_yy, xx_yy, xy_yx, xy_yx
+
+
+# ---------------------------------------------------------------------------
+# Jones-matrix scaffolding
+# ---------------------------------------------------------------------------
+#
+# Factoring convention: J = G @ (I + D), where
+#
+#     G = diag(g_p1, g_p2)           (diagonal complex gains)
+#     I + D = [[1,    d_p1],
+#              [d_p2, 1   ]]         (D-term cross-coupling)
+#
+# Verify against existing pol_cal* code when the first consumer
+# (full-Jones applycal) lands.
+
+def jones_matrix(g_p1, g_p2, d_p1=0.0, d_p2=0.0):
+    """Build a 2x2 Jones matrix from per-feed gains and D-terms.
+
+    Parameters
+    ----------
+    g_p1, g_p2 : complex
+        Per-feed complex gains. Diagonal of G.
+    d_p1, d_p2 : complex, optional
+        Off-diagonal D-term cross-coupling. Default 0 (ideal feeds).
+
+    Returns
+    -------
+    J : (2, 2) complex ndarray
+        ``J = G @ (I + D)``.
+    """
+    G = np.array([[g_p1, 0.0],
+                  [0.0, g_p2]], dtype=complex)
+    IpD = np.array([[1.0, d_p1],
+                    [d_p2, 1.0]], dtype=complex)
+    return G @ IpD
+
+
+def invert_jones(J):
+    """Return the inverse of a Jones matrix.
+
+    Broadcasts over leading axes.
+    """
+    return np.linalg.inv(J)
+
+
+def apply_inverse_jones_to_coherency(V_obs, J1, J2):
+    """Apply the inverse Jones correction to an observed coherency matrix.
+
+    Computes ``V_corr = J1^{-1} @ V_obs @ (J2^dagger)^{-1}``.
+
+    Parameters
+    ----------
+    V_obs : (..., 2, 2) complex ndarray
+        Observed coherency matrix. Leading axes broadcast.
+    J1, J2 : (..., 2, 2) complex ndarray
+        Jones matrices at stations 1 and 2.
+
+    Returns
+    -------
+    V_corr : (..., 2, 2) complex ndarray
+    """
+    _maybe_warn_convention()
+    J1_inv = np.linalg.inv(J1)
+    J2_dagger_inv = np.linalg.inv(np.conjugate(np.swapaxes(J2, -1, -2)))
+    return J1_inv @ V_obs @ J2_dagger_inv

--- a/ehtim/observing/pol_conventions.py
+++ b/ehtim/observing/pol_conventions.py
@@ -90,79 +90,145 @@ def _reset_convention_warning():
 
 
 # ---------------------------------------------------------------------------
-# Visibility transforms (vis only; sigmas handled by *_sigma helpers below)
+# Pair-based polarization transforms (the primitives)
+# ---------------------------------------------------------------------------
+#
+# These transforms operate on the polarization basis itself, so they apply
+# uniformly to any quantity carried in that basis: visibilities, image
+# pixels, model parameters, etc. The basis transforms factor into pairs:
+#   - circ:  parallel-hand (RR, LL) <-> (I, V);  cross-hand (RL, LR) <-> (Q, U)
+#   - lin:   diagonal     (XX, YY) <-> (I, Q);   off-diagonal (XY, YX) <-> (U, V)
+#
+# Callers that need a single Stokes component (image/movie property
+# getters) call the relevant pair helper and discard one output. The
+# 4-in/4-out functions further down compose two pair calls and are
+# convenience wrappers for callers (like Obsdata.switch_polrep) that
+# want the full four-tuple.
+
+def circ_to_stokes_parallel(rr, ll):
+    """(I, V) from (RR, LL) parallel-hand pair.
+
+    Returns ``(0.5*(RR+LL), 0.5*(RR-LL))``.
+    """
+    _maybe_warn_convention()
+    return 0.5 * (rr + ll), 0.5 * (rr - ll)
+
+
+def circ_to_stokes_cross(rl, lr):
+    """(Q, U) from (RL, LR) cross-hand pair.
+
+    Returns ``(0.5*(LR+RL), 0.5j*(LR-RL))``. The outputs are complex;
+    image-domain callers should apply ``np.real()`` since the sky-domain
+    Q, U are real-valued.
+    """
+    _maybe_warn_convention()
+    return 0.5 * (lr + rl), 0.5j * (lr - rl)
+
+
+def stokes_to_circ_parallel(i, v):
+    """(RR, LL) from (I, V). Inverse of circ_to_stokes_parallel."""
+    _maybe_warn_convention()
+    return i + v, i - v
+
+
+def stokes_to_circ_cross(q, u):
+    """(RL, LR) from (Q, U). Inverse of circ_to_stokes_cross."""
+    _maybe_warn_convention()
+    return q + 1.0j * u, q - 1.0j * u
+
+
+def lin_to_stokes_diag(xx, yy):
+    """(I, Q) from (XX, YY) diagonal pair.
+
+    Returns ``(0.5*(XX+YY), 0.5*(XX-YY))``.
+    """
+    _maybe_warn_convention()
+    return 0.5 * (xx + yy), 0.5 * (xx - yy)
+
+
+def lin_to_stokes_offdiag(xy, yx):
+    """(U, V) from (XY, YX) off-diagonal pair.
+
+    Returns ``(0.5*(XY+YX), 0.5j*(XY-YX))``. The outputs are complex;
+    image-domain callers should apply ``np.real()`` since the sky-domain
+    U, V are real-valued.
+    """
+    _maybe_warn_convention()
+    return 0.5 * (xy + yx), 0.5j * (xy - yx)
+
+
+def stokes_to_lin_diag(i, q):
+    """(XX, YY) from (I, Q). Inverse of lin_to_stokes_diag."""
+    _maybe_warn_convention()
+    return i + q, i - q
+
+
+def stokes_to_lin_offdiag(u, v):
+    """(XY, YX) from (U, V). Inverse of lin_to_stokes_offdiag."""
+    _maybe_warn_convention()
+    return u - 1.0j * v, u + 1.0j * v
+
+
+# ---------------------------------------------------------------------------
+# 4-in/4-out polarization transforms (thin wrappers around the pair helpers)
 # ---------------------------------------------------------------------------
 
-def circ_to_stokes(rrvis, llvis, rlvis, lrvis):
-    """Convert circular-feed visibilities to Stokes visibilities.
+def circ_to_stokes(rr, ll, rl, lr):
+    """Convert all four circular-basis components to Stokes.
 
     Returns
     -------
-    (vis, qvis, uvis, vvis) : tuple of ndarrays
+    (i, q, u, v) : tuple of ndarrays
     """
-    _maybe_warn_convention()
-    vis = 0.5 * (rrvis + llvis)
-    qvis = 0.5 * (lrvis + rlvis)
-    uvis = 0.5j * (lrvis - rlvis)
-    vvis = 0.5 * (rrvis - llvis)
-    return vis, qvis, uvis, vvis
+    i, v = circ_to_stokes_parallel(rr, ll)
+    q, u = circ_to_stokes_cross(rl, lr)
+    return i, q, u, v
 
 
-def stokes_to_circ(vis, qvis, uvis, vvis):
-    """Convert Stokes visibilities to circular-feed visibilities.
+def stokes_to_circ(i, q, u, v):
+    """Convert all four Stokes components to circular basis.
 
     Returns
     -------
-    (rrvis, llvis, rlvis, lrvis) : tuple of ndarrays
+    (rr, ll, rl, lr) : tuple of ndarrays
     """
-    _maybe_warn_convention()
-    rrvis = vis + vvis
-    llvis = vis - vvis
-    rlvis = qvis + 1.0j * uvis
-    lrvis = qvis - 1.0j * uvis
-    return rrvis, llvis, rlvis, lrvis
+    rr, ll = stokes_to_circ_parallel(i, v)
+    rl, lr = stokes_to_circ_cross(q, u)
+    return rr, ll, rl, lr
 
 
-def lin_to_stokes(xxvis, yyvis, xyvis, yxvis):
-    """Convert linear-feed visibilities to Stokes (IAU/HBS).
+def lin_to_stokes(xx, yy, xy, yx):
+    """Convert all four linear-basis components to Stokes (IAU/HBS).
 
     Returns
     -------
-    (vis, qvis, uvis, vvis) : tuple of ndarrays
+    (i, q, u, v) : tuple of ndarrays
     """
-    _maybe_warn_convention()
-    vis = 0.5 * (xxvis + yyvis)
-    qvis = 0.5 * (xxvis - yyvis)
-    uvis = 0.5 * (xyvis + yxvis)
-    vvis = 0.5j * (xyvis - yxvis)
-    return vis, qvis, uvis, vvis
+    i, q = lin_to_stokes_diag(xx, yy)
+    u, v = lin_to_stokes_offdiag(xy, yx)
+    return i, q, u, v
 
 
-def stokes_to_lin(vis, qvis, uvis, vvis):
-    """Convert Stokes visibilities to linear-feed visibilities (IAU/HBS).
-
-    Inverse of ``lin_to_stokes``.
+def stokes_to_lin(i, q, u, v):
+    """Convert all four Stokes components to linear basis (IAU/HBS).
 
     Returns
     -------
-    (xxvis, yyvis, xyvis, yxvis) : tuple of ndarrays
+    (xx, yy, xy, yx) : tuple of ndarrays
     """
-    _maybe_warn_convention()
-    xxvis = vis + qvis
-    yyvis = vis - qvis
-    xyvis = uvis - 1.0j * vvis
-    yxvis = uvis + 1.0j * vvis
-    return xxvis, yyvis, xyvis, yxvis
+    xx, yy = stokes_to_lin_diag(i, q)
+    xy, yx = stokes_to_lin_offdiag(u, v)
+    return xx, yy, xy, yx
 
 
-def lin_to_circ(xxvis, yyvis, xyvis, yxvis):
-    """Convert linear-feed visibilities to circular-feed via Stokes."""
-    return stokes_to_circ(*lin_to_stokes(xxvis, yyvis, xyvis, yxvis))
+def lin_to_circ(xx, yy, xy, yx):
+    """Convert linear-basis components to circular basis via Stokes."""
+    return stokes_to_circ(*lin_to_stokes(xx, yy, xy, yx))
 
 
-def circ_to_lin(rrvis, llvis, rlvis, lrvis):
-    """Convert circular-feed visibilities to linear-feed via Stokes."""
-    return stokes_to_lin(*circ_to_stokes(rrvis, llvis, rlvis, lrvis))
+def circ_to_lin(rr, ll, rl, lr):
+    """Convert circular-basis components to linear basis via Stokes."""
+    return stokes_to_lin(*circ_to_stokes(rr, ll, rl, lr))
 
 
 # ---------------------------------------------------------------------------

--- a/ehtim/observing/pol_conventions.py
+++ b/ehtim/observing/pol_conventions.py
@@ -18,24 +18,25 @@
 
 """Polarization basis transforms and Jones-matrix utilities.
 
-Convention (IAU / Hamaker-Bregman-Sault / CASA / AIPS):
+Convention (IAU / Hamaker-Bregman-Sault / CASA / AIPS, engineering
+time dependence ``exp(+i omega t)`` as in TMS Ch. 4):
 
-    R = (X - iY) / sqrt(2)
-    L = (X + iY) / sqrt(2)
+    R = (X + iY) / sqrt(2)
+    L = (X - iY) / sqrt(2)
 
 with the circular Stokes formulas:
 
     I = (RR + LL) / 2,    V = (RR - LL) / 2
     Q = (RL + LR) / 2,    U = i (LR - RL) / 2
 
-and the inverted linear-feed Stokes formulas:
+and the linear-feed Stokes formulas:
 
     I = (XX + YY) / 2,    Q = (XX - YY) / 2
-    U = (XY + YX) / 2,    V = +i (XY - YX) / 2
+    U = (XY + YX) / 2,    V = -i (XY - YX) / 2
 
 The sign of V flips under the opposite basis choice
-(R = (X + iY) / sqrt(2)). Full derivation and worked examples live in
-``docs/polarization_conventions.md``.
+(R = (X - iY) / sqrt(2), physics convention). Full derivation and
+worked examples live in ``docs/polarization_conventions.md``.
 
 A ``MixedPolConventionWarning`` fires once per session on the first
 non-identity transform call.
@@ -51,10 +52,15 @@ from ehtim.warnings import MixedPolConventionWarning
 # Basis matrices
 # ---------------------------------------------------------------------------
 
-# Maps a feed-basis vector (X, Y) -> (R, L) under the IAU/HBS convention.
+# Maps a feed-basis vector (X, Y) -> (R, L) under the IAU/HBS convention
+# with the engineering / IEEE time-dependence convention exp(+i omega t)
+# used throughout radio interferometry (cf. TMS Ch. 4). Under this
+# convention R = (X + iY)/sqrt(2), L = (X - iY)/sqrt(2).
 # Rows indexed by (R, L); columns by (X, Y).
-BASIS_LIN_TO_CIRC = np.array([[1.0, -1.0j],
-                              [1.0, +1.0j]]) / np.sqrt(2.0)
+# Reference only: the pair transforms below currently use the explicit
+# arithmetic forms.
+BASIS_LIN_TO_CIRC = np.array([[1.0, +1.0j],
+                              [1.0, -1.0j]]) / np.sqrt(2.0)
 
 # Unitary inverse: maps (R, L) -> (X, Y).
 BASIS_CIRC_TO_LIN = BASIS_LIN_TO_CIRC.conj().T
@@ -75,7 +81,7 @@ def _maybe_warn_convention():
     _convention_warning_emitted = True
     warnings.warn(
         "Polarization basis transform applied under the IAU/Hamaker-"
-        "Bregman-Sault convention (R = (X - iY)/sqrt(2)). This "
+        "Bregman-Sault convention (R = (X + iY)/sqrt(2)). This "
         "transformation assumes ideal feeds (D = 0 or already "
         "calibrated). See docs/polarization_conventions.md.",
         category=MixedPolConventionWarning,
@@ -149,12 +155,12 @@ def lin_to_stokes_diag(xx, yy):
 def lin_to_stokes_offdiag(xy, yx):
     """(U, V) from (XY, YX) off-diagonal pair.
 
-    Returns ``(0.5*(XY+YX), 0.5j*(XY-YX))``. The outputs are complex;
+    Returns ``(0.5*(XY+YX), 0.5j*(YX-XY))``. The outputs are complex;
     image-domain callers should apply ``np.real()`` since the sky-domain
     U, V are real-valued.
     """
     _maybe_warn_convention()
-    return 0.5 * (xy + yx), 0.5j * (xy - yx)
+    return 0.5 * (xy + yx), 0.5j * (yx - xy)
 
 
 def stokes_to_lin_diag(i, q):
@@ -166,7 +172,7 @@ def stokes_to_lin_diag(i, q):
 def stokes_to_lin_offdiag(u, v):
     """(XY, YX) from (U, V). Inverse of lin_to_stokes_offdiag."""
     _maybe_warn_convention()
-    return u - 1.0j * v, u + 1.0j * v
+    return u + 1.0j * v, u - 1.0j * v
 
 
 # ---------------------------------------------------------------------------
@@ -332,7 +338,8 @@ def jones_matrix(g_p1, g_p2, d_p1=0.0, d_p2=0.0):
 def invert_jones(J):
     """Return the inverse of a Jones matrix.
 
-    Broadcasts over leading axes.
+    Broadcasts over leading axes. Reference only: ``apply_inverse_jones_to_coherency``
+    currently inlines ``np.linalg.inv``.
     """
     return np.linalg.inv(J)
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -354,6 +354,109 @@ def test_switch_polrep_raises_if_output_pol_missing(gauss_im):
         gauss_im.switch_polrep("circ", "RR")
 
 
+# ---------------------------------------------------------------------------
+# Section 5b: lin polrep (Phase 3)
+# ---------------------------------------------------------------------------
+
+
+def test_init_lin_default_pol_prim_is_xx():
+    im = eh.image.Image(np.zeros((4, 4)), 1e-10, 17.761, -29.0, polrep="lin")
+    assert im.polrep == "lin"
+    assert im.pol_prim == "XX"
+
+
+def test_init_lin_pol_prim_yy():
+    im = eh.image.Image(np.zeros((4, 4)), 1e-10, 17.761, -29.0,
+                        polrep="lin", pol_prim="YY")
+    assert im.pol_prim == "YY"
+
+
+def test_init_lin_rejects_bad_pol_prim():
+    with pytest.raises(Exception, match="pol_prim"):
+        eh.image.Image(np.zeros((4, 4)), 1e-10, 17.761, -29.0,
+                       polrep="lin", pol_prim="XY")
+
+
+def test_switch_polrep_stokes_to_lin_roundtrip(gauss_im_pol):
+    rt = gauss_im_pol.switch_polrep("lin").switch_polrep("stokes")
+    for vec in ("ivec", "qvec", "uvec", "vvec"):
+        np.testing.assert_allclose(
+            getattr(rt, vec), getattr(gauss_im_pol, vec), atol=1e-12,
+        )
+
+
+def test_switch_polrep_stokes_to_lin_formulae(gauss_im_pol):
+    out = gauss_im_pol.switch_polrep("lin")
+    np.testing.assert_allclose(out.xxvec,
+                               gauss_im_pol.ivec + gauss_im_pol.qvec, atol=1e-12)
+    np.testing.assert_allclose(out.yyvec,
+                               gauss_im_pol.ivec - gauss_im_pol.qvec, atol=1e-12)
+    np.testing.assert_allclose(out.xyvec,
+                               gauss_im_pol.uvec - 1j * gauss_im_pol.vvec, atol=1e-12)
+    np.testing.assert_allclose(out.yxvec,
+                               gauss_im_pol.uvec + 1j * gauss_im_pol.vvec, atol=1e-12)
+
+
+def test_switch_polrep_circ_to_lin_matches_two_step(gauss_im_pol):
+    """circ -> lin composes through stokes (Decision 7)."""
+    im_circ = gauss_im_pol.switch_polrep("circ")
+    direct = im_circ.switch_polrep("lin")
+    two_step = im_circ.switch_polrep("stokes").switch_polrep("lin")
+    for vec in ("xxvec", "yyvec", "xyvec", "yxvec"):
+        np.testing.assert_allclose(
+            getattr(direct, vec), getattr(two_step, vec), atol=1e-12,
+        )
+
+
+def test_cross_convention_stokes_recovered_via_both_paths(gauss_im_pol):
+    """Stokes from circ and Stokes from lin agree (basis-transform unitarity)."""
+    im_c = gauss_im_pol.switch_polrep("circ")
+    im_l = gauss_im_pol.switch_polrep("lin")
+    for vec in ("ivec", "qvec", "uvec", "vvec"):
+        np.testing.assert_allclose(getattr(im_c, vec), getattr(im_l, vec),
+                                   atol=1e-12)
+
+
+def test_lin_image_xxvec_setter_writes_storage():
+    im = eh.image.Image(np.ones((4, 4)), 1e-10, 17.761, -29.0,
+                        polrep="lin", pol_prim="XX")
+    new_xx = np.arange(16.0)
+    im.xxvec = new_xx
+    np.testing.assert_array_equal(im.xxvec, new_xx)
+
+
+def test_lin_image_xxvec_setter_rejects_wrong_polrep(gauss_im):
+    with pytest.raises(Exception, match="lin"):
+        gauss_im.xxvec = np.zeros(gauss_im.xdim * gauss_im.ydim)
+
+
+def test_stokes_image_xxvec_computes_from_iq(gauss_im_pol):
+    """xxvec on a stokes image computes I+Q via pol_conventions."""
+    np.testing.assert_allclose(gauss_im_pol.xxvec,
+                               gauss_im_pol.ivec + gauss_im_pol.qvec, atol=1e-12)
+
+
+def test_stokes_image_xyvec_computes_complex(gauss_im_pol):
+    """xyvec on a stokes image is U - iV (complex)."""
+    np.testing.assert_allclose(gauss_im_pol.xyvec,
+                               gauss_im_pol.uvec - 1j * gauss_im_pol.vvec,
+                               atol=1e-12)
+
+
+def test_lin_image_round_trip_preserves_qvec(gauss_im_pol):
+    """Set Q via stokes, round-trip through lin, recover Q from xxvec/yyvec."""
+    im_l = gauss_im_pol.switch_polrep("lin")
+    q_recovered = 0.5 * (im_l.xxvec - im_l.yyvec)
+    np.testing.assert_allclose(q_recovered, gauss_im_pol.qvec, atol=1e-12)
+
+
+def test_add_pol_image_lin_supports_yy():
+    im = eh.image.Image(np.ones((4, 4)), 1e-10, 17.761, -29.0, polrep="lin")
+    yy = np.arange(16.0).reshape(4, 4)
+    im.add_pol_image(yy, "YY")
+    np.testing.assert_array_equal(im.yyvec, yy.flatten())
+
+
 def test_orth_chi_flips_qu_signs(gauss_im_pol):
     im = gauss_im_pol.orth_chi()
     np.testing.assert_array_equal(im.qvec, -gauss_im_pol.qvec)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -392,9 +392,9 @@ def test_switch_polrep_stokes_to_lin_formulae(gauss_im_pol):
     np.testing.assert_allclose(out.yyvec,
                                gauss_im_pol.ivec - gauss_im_pol.qvec, atol=1e-12)
     np.testing.assert_allclose(out.xyvec,
-                               gauss_im_pol.uvec - 1j * gauss_im_pol.vvec, atol=1e-12)
-    np.testing.assert_allclose(out.yxvec,
                                gauss_im_pol.uvec + 1j * gauss_im_pol.vvec, atol=1e-12)
+    np.testing.assert_allclose(out.yxvec,
+                               gauss_im_pol.uvec - 1j * gauss_im_pol.vvec, atol=1e-12)
 
 
 def test_switch_polrep_circ_to_lin_matches_two_step(gauss_im_pol):
@@ -437,9 +437,9 @@ def test_stokes_image_xxvec_computes_from_iq(gauss_im_pol):
 
 
 def test_stokes_image_xyvec_computes_complex(gauss_im_pol):
-    """xyvec on a stokes image is U - iV (complex)."""
+    """xyvec on a stokes image is U + iV (complex, engineering convention)."""
     np.testing.assert_allclose(gauss_im_pol.xyvec,
-                               gauss_im_pol.uvec - 1j * gauss_im_pol.vvec,
+                               gauss_im_pol.uvec + 1j * gauss_im_pol.vvec,
                                atol=1e-12)
 
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -24,7 +24,13 @@ def test_init_requires_2d_array():
 
 def test_init_rejects_bad_polrep():
     with pytest.raises(Exception, match="polrep"):
-        eh.image.Image(np.zeros((4, 4)), 1e-10, 17.761, -29.0, polrep="lin")
+        eh.image.Image(np.zeros((4, 4)), 1e-10, 17.761, -29.0, polrep="bogus")
+
+
+def test_init_accepts_lin_polrep():
+    im = eh.image.Image(np.zeros((4, 4)), 1e-10, 17.761, -29.0, polrep="lin")
+    assert im.polrep == "lin"
+    assert im.pol_prim == "XX"
 
 
 def test_init_rejects_bad_pol_prim_stokes():
@@ -310,7 +316,7 @@ def test_copy_pol_images_brings_q_u_v(gauss_im, gauss_im_pol):
 
 def test_switch_polrep_invalid_raises(gauss_im):
     with pytest.raises(Exception, match="polrep_out"):
-        gauss_im.switch_polrep("lin")
+        gauss_im.switch_polrep("bogus")
 
 
 def test_switch_polrep_noop_returns_copy(gauss_im):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -105,7 +105,7 @@ def test_get_const_polfac_xy_from_stokes(polarized_gauss_params):
     u_factor = get_const_polfac(mt, params, "U")
     v_factor = get_const_polfac(mt, params, "V")
     xy_factor = get_const_polfac(mt, params, "XY")
-    assert np.isclose(xy_factor, u_factor - 1j * v_factor)
+    assert np.isclose(xy_factor, u_factor + 1j * v_factor)
 
 
 def test_get_const_polfac_yx_from_stokes(polarized_gauss_params):
@@ -113,7 +113,7 @@ def test_get_const_polfac_yx_from_stokes(polarized_gauss_params):
     u_factor = get_const_polfac(mt, params, "U")
     v_factor = get_const_polfac(mt, params, "V")
     yx_factor = get_const_polfac(mt, params, "YX")
-    assert np.isclose(yx_factor, u_factor + 1j * v_factor)
+    assert np.isclose(yx_factor, u_factor - 1j * v_factor)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,195 @@
+"""Tests for ehtim.model.Model.
+
+Focused on Phase 3 mixed-pol additions:
+- Model.switch_polrep accepts polrep='lin'
+- sample_1model_uv produces lin-basis visibilities consistent with
+  pol_conventions.stokes_to_lin and pol_conventions.circ_to_lin
+- get_const_polfac dispatches XX/YY/XY/YX
+
+Note: Model.sample_uv and Model.observe_same_nonoise both flow through
+sample_model_uv (model.py:1467, 1470), which uses np.sum(generator) —
+removed in numpy 2.0. That bug pre-dates Phase 3 and is out of scope
+here; the affected end-to-end paths are marked xfail and tested at the
+module-level entry point sample_1model_uv instead.
+"""
+
+import numpy as np
+import pytest
+
+import ehtim as eh
+from ehtim.model import get_const_polfac, sample_1model_uv
+from ehtim.observing import pol_conventions as pc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def polarized_gauss_params():
+    return ("circ_gauss",
+            {"F0": 1.0, "FWHM": 20 * eh.RADPERUAS, "x0": 0.0, "y0": 0.0,
+             "pol_frac": 0.1, "pol_evpa": 0.3, "cpol_frac": 0.05})
+
+
+@pytest.fixture
+def uv_grid():
+    u = np.array([1e9, 2e9, 3e9, 4e9])
+    v = np.array([0.0, 5e8, 1e9, -5e8])
+    return u, v
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning():
+    pc._reset_convention_warning()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Model.switch_polrep
+# ---------------------------------------------------------------------------
+
+
+def test_switch_polrep_lin_accepted():
+    """Phase 3 widening: 'lin' is a valid polrep_out.
+
+    Note: Model.switch_polrep is intentionally a no-op (returns self.copy()),
+    so the polrep on the output isn't actually changed — the test only
+    asserts that validation accepts 'lin' and the call doesn't raise.
+    """
+    mod = eh.model.Model(ra=0, dec=0)
+    out = mod.switch_polrep("lin")  # must not raise
+    assert isinstance(out, eh.model.Model)
+
+
+def test_switch_polrep_bogus_raises():
+    mod = eh.model.Model(ra=0, dec=0)
+    with pytest.raises(Exception, match="polrep_out"):
+        mod.switch_polrep("bogus")
+
+
+# ---------------------------------------------------------------------------
+# get_const_polfac dispatches XX/YY/XY/YX
+# ---------------------------------------------------------------------------
+
+
+def test_get_const_polfac_xx_from_stokes(polarized_gauss_params):
+    mt, params = polarized_gauss_params
+    i_factor = get_const_polfac(mt, params, "I")
+    q_factor = get_const_polfac(mt, params, "Q")
+    xx_factor = get_const_polfac(mt, params, "XX")
+    assert np.isclose(xx_factor, i_factor + q_factor)
+
+
+def test_get_const_polfac_yy_from_stokes(polarized_gauss_params):
+    mt, params = polarized_gauss_params
+    i_factor = get_const_polfac(mt, params, "I")
+    q_factor = get_const_polfac(mt, params, "Q")
+    yy_factor = get_const_polfac(mt, params, "YY")
+    assert np.isclose(yy_factor, i_factor - q_factor)
+
+
+def test_get_const_polfac_xy_from_stokes(polarized_gauss_params):
+    mt, params = polarized_gauss_params
+    u_factor = get_const_polfac(mt, params, "U")
+    v_factor = get_const_polfac(mt, params, "V")
+    xy_factor = get_const_polfac(mt, params, "XY")
+    assert np.isclose(xy_factor, u_factor - 1j * v_factor)
+
+
+def test_get_const_polfac_yx_from_stokes(polarized_gauss_params):
+    mt, params = polarized_gauss_params
+    u_factor = get_const_polfac(mt, params, "U")
+    v_factor = get_const_polfac(mt, params, "V")
+    yx_factor = get_const_polfac(mt, params, "YX")
+    assert np.isclose(yx_factor, u_factor + 1j * v_factor)
+
+
+# ---------------------------------------------------------------------------
+# sample_1model_uv XX/YY/XY/YX clauses
+# ---------------------------------------------------------------------------
+
+
+def test_sample_1model_xx_matches_stokes_to_lin(polarized_gauss_params, uv_grid):
+    mt, params = polarized_gauss_params
+    u, v = uv_grid
+    I = sample_1model_uv(u, v, mt, params, pol="I")
+    Q = sample_1model_uv(u, v, mt, params, pol="Q")
+    XX = sample_1model_uv(u, v, mt, params, pol="XX")
+    XX_e, _ = pc.stokes_to_lin_diag(I, Q)
+    np.testing.assert_allclose(XX, XX_e, atol=1e-12)
+
+
+def test_sample_1model_yy_matches_stokes_to_lin(polarized_gauss_params, uv_grid):
+    mt, params = polarized_gauss_params
+    u, v = uv_grid
+    I = sample_1model_uv(u, v, mt, params, pol="I")
+    Q = sample_1model_uv(u, v, mt, params, pol="Q")
+    YY = sample_1model_uv(u, v, mt, params, pol="YY")
+    _, YY_e = pc.stokes_to_lin_diag(I, Q)
+    np.testing.assert_allclose(YY, YY_e, atol=1e-12)
+
+
+def test_sample_1model_xy_matches_stokes_to_lin(polarized_gauss_params, uv_grid):
+    mt, params = polarized_gauss_params
+    u, v = uv_grid
+    U = sample_1model_uv(u, v, mt, params, pol="U")
+    V = sample_1model_uv(u, v, mt, params, pol="V")
+    XY = sample_1model_uv(u, v, mt, params, pol="XY")
+    XY_e, _ = pc.stokes_to_lin_offdiag(U, V)
+    np.testing.assert_allclose(XY, XY_e, atol=1e-12)
+
+
+def test_sample_1model_yx_matches_stokes_to_lin(polarized_gauss_params, uv_grid):
+    mt, params = polarized_gauss_params
+    u, v = uv_grid
+    U = sample_1model_uv(u, v, mt, params, pol="U")
+    V = sample_1model_uv(u, v, mt, params, pol="V")
+    YX = sample_1model_uv(u, v, mt, params, pol="YX")
+    _, YX_e = pc.stokes_to_lin_offdiag(U, V)
+    np.testing.assert_allclose(YX, YX_e, atol=1e-12)
+
+
+def test_sample_1model_lin_matches_circ_via_pol_conventions(
+    polarized_gauss_params, uv_grid,
+):
+    """Cross-check: lin sampling equals circ sampling routed through pol_conventions."""
+    mt, params = polarized_gauss_params
+    u, v = uv_grid
+    RR = sample_1model_uv(u, v, mt, params, pol="RR")
+    LL = sample_1model_uv(u, v, mt, params, pol="LL")
+    RL = sample_1model_uv(u, v, mt, params, pol="RL")
+    LR = sample_1model_uv(u, v, mt, params, pol="LR")
+    XX_e, YY_e, XY_e, YX_e = pc.circ_to_lin(RR, LL, RL, LR)
+    XX = sample_1model_uv(u, v, mt, params, pol="XX")
+    YY = sample_1model_uv(u, v, mt, params, pol="YY")
+    XY = sample_1model_uv(u, v, mt, params, pol="XY")
+    YX = sample_1model_uv(u, v, mt, params, pol="YX")
+    np.testing.assert_allclose(XX, XX_e, atol=1e-12)
+    np.testing.assert_allclose(YY, YY_e, atol=1e-12)
+    np.testing.assert_allclose(XY, XY_e, atol=1e-12)
+    np.testing.assert_allclose(YX, YX_e, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Model.observe_same_nonoise lin path
+# ---------------------------------------------------------------------------
+# Pre-existing model.py:1470 uses np.sum(generator), removed in numpy 2.0.
+# Once that's fixed, the xfail below should flip to passing on a lin obs.
+
+
+@pytest.mark.xfail(reason="model.py:1470 np.sum(generator) numpy 2.0 incompat", strict=True)
+def test_observe_same_nonoise_produces_lin_obsdata(polarized_gauss_params, uv_grid):
+    mt, params = polarized_gauss_params
+    mod = eh.model.Model(ra=0, dec=0)
+    mod = mod.add_circ_gauss(F0=params["F0"], FWHM=params["FWHM"],
+                             pol_frac=params["pol_frac"],
+                             pol_evpa=params["pol_evpa"],
+                             cpol_frac=params["cpol_frac"])
+    arr = eh.array.load_txt("arrays/EHT2025.txt")
+    obs = arr.obsdata(ra=0, dec=0, rf=230e9, bw=4e9,
+                      tint=10, tadv=600, tstart=0, tstop=4, polrep="lin")
+    out = mod.observe_same_nonoise(obs)
+    assert out.polrep == "lin"
+    assert "xxvis" in out.data.dtype.fields

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,11 +6,22 @@ Focused on Phase 3 mixed-pol additions:
   pol_conventions.stokes_to_lin and pol_conventions.circ_to_lin
 - get_const_polfac dispatches XX/YY/XY/YX
 
-Note: Model.sample_uv and Model.observe_same_nonoise both flow through
-sample_model_uv (model.py:1467, 1470), which uses np.sum(generator) —
-removed in numpy 2.0. That bug pre-dates Phase 3 and is out of scope
-here; the affected end-to-end paths are marked xfail and tested at the
-module-level entry point sample_1model_uv instead.
+Two pre-Phase-3 Model issues constrain what this file can test directly;
+both are tracked as future-cleanup TODOs separate from this PR:
+
+1. Model.switch_polrep is intentionally a no-op — it validates the
+   request and returns `self.copy()`, leaving the polrep unchanged.
+   Worse, Model.__init__ hardcodes `self.polrep = 'stokes'` regardless
+   of the `polrep=` constructor argument (model.py:1548). The polrep
+   slot on a Model is therefore always 'stokes' in practice. We test
+   only that switch_polrep('lin') doesn't raise, not that the output
+   actually carries the new polrep.
+
+2. Model.sample_uv and Model.observe_same_nonoise both flow through
+   sample_model_uv (model.py:1467, 1470), which uses
+   `np.sum(generator)` — removed in numpy 2.0. Affected end-to-end
+   paths are marked xfail and tested at the module-level entry point
+   sample_1model_uv instead.
 """
 
 import numpy as np

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -31,7 +31,6 @@ import ehtim as eh
 from ehtim.model import get_const_polfac, sample_1model_uv
 from ehtim.observing import pol_conventions as pc
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -14,7 +14,6 @@ import pytest
 import ehtim as eh
 from ehtim.observing import pol_conventions as pc
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -107,7 +107,7 @@ def test_stokes_movie_xxframes_computes_from_iq(stokes_movie_pol):
 
 def test_stokes_movie_xyframes_complex_from_uv(stokes_movie_pol):
     xy = stokes_movie_pol.xyframes
-    expected = stokes_movie_pol.uframes - 1j * stokes_movie_pol.vframes
+    expected = stokes_movie_pol.uframes + 1j * stokes_movie_pol.vframes
     np.testing.assert_allclose(xy, expected, atol=1e-12)
 
 

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -1,0 +1,248 @@
+"""Tests for ehtim.movie.Movie.
+
+Focused on Phase 3 mixed-pol additions:
+- polrep='lin' construction and round-trips
+- harmonized cross-polrep frame accessors (computed on demand for any source)
+- xxframes/yyframes/xyframes/yxframes accessors
+- rlvec/lrvec deprecation shims (renamed to rlframes/lrframes)
+- setter polrep guards remain (only the storage basis is writable)
+"""
+
+import numpy as np
+import pytest
+
+import ehtim as eh
+from ehtim.observing import pol_conventions as pc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_N = 8
+_T = 4
+
+
+def _gaussian_2d(scale=1.0):
+    coords = np.arange(_N * _N)
+    return scale * np.exp(-((coords - _N * _N / 2.0) ** 2) / 100.0).reshape(_N, _N)
+
+
+@pytest.fixture
+def times():
+    return np.linspace(0.0, 1.0, _T)
+
+
+@pytest.fixture
+def frames_I():
+    return [_gaussian_2d(1 + 0.1 * t) for t in range(_T)]
+
+
+@pytest.fixture
+def stokes_movie_pol(times, frames_I):
+    """Stokes movie with all four pols populated."""
+    mov = eh.movie.Movie(frames_I, times, 1e-10, 0.0, 0.0, polrep="stokes")
+    mov.add_pol_movie([0.10 * f for f in frames_I], "Q")
+    mov.add_pol_movie([0.05 * f for f in frames_I], "U")
+    mov.add_pol_movie([0.02 * f for f in frames_I], "V")
+    return mov
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning():
+    pc._reset_convention_warning()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_init_stokes_default(times, frames_I):
+    mov = eh.movie.Movie(frames_I, times, 1e-10, 0.0, 0.0)
+    assert mov.polrep == "stokes"
+    assert mov.pol_prim == "I"
+
+
+def test_init_lin_default_pol_prim_is_xx(times, frames_I):
+    mov = eh.movie.Movie(frames_I, times, 1e-10, 0.0, 0.0, polrep="lin")
+    assert mov.polrep == "lin"
+    assert mov.pol_prim == "XX"
+
+
+def test_init_lin_pol_prim_yy(times, frames_I):
+    mov = eh.movie.Movie(frames_I, times, 1e-10, 0.0, 0.0,
+                         polrep="lin", pol_prim="YY")
+    assert mov.pol_prim == "YY"
+
+
+def test_init_lin_rejects_bad_pol_prim(times, frames_I):
+    with pytest.raises(Exception, match="pol_prim"):
+        eh.movie.Movie(frames_I, times, 1e-10, 0.0, 0.0,
+                       polrep="lin", pol_prim="XY")
+
+
+def test_init_unknown_polrep_raises(times, frames_I):
+    with pytest.raises(Exception, match="polrep"):
+        eh.movie.Movie(frames_I, times, 1e-10, 0.0, 0.0, polrep="bogus")
+
+
+# ---------------------------------------------------------------------------
+# Harmonized cross-polrep frame accessors (the big behavior change)
+# ---------------------------------------------------------------------------
+
+
+def test_stokes_movie_rrframes_computes_from_iv(stokes_movie_pol):
+    """Pre-Phase-3 this would raise; now it computes I+V."""
+    rr = stokes_movie_pol.rrframes
+    expected = stokes_movie_pol.iframes + stokes_movie_pol.vframes
+    np.testing.assert_allclose(rr, expected, atol=1e-12)
+
+
+def test_stokes_movie_xxframes_computes_from_iq(stokes_movie_pol):
+    xx = stokes_movie_pol.xxframes
+    expected = stokes_movie_pol.iframes + stokes_movie_pol.qframes
+    np.testing.assert_allclose(xx, expected, atol=1e-12)
+
+
+def test_stokes_movie_xyframes_complex_from_uv(stokes_movie_pol):
+    xy = stokes_movie_pol.xyframes
+    expected = stokes_movie_pol.uframes - 1j * stokes_movie_pol.vframes
+    np.testing.assert_allclose(xy, expected, atol=1e-12)
+
+
+def test_circ_movie_iframes_computes(stokes_movie_pol):
+    mov_c = stokes_movie_pol.switch_polrep("circ")
+    np.testing.assert_allclose(mov_c.iframes,
+                               0.5 * (mov_c.rrframes + mov_c.llframes),
+                               atol=1e-12)
+
+
+def test_lin_movie_qframes_computes(stokes_movie_pol):
+    mov_l = stokes_movie_pol.switch_polrep("lin")
+    np.testing.assert_allclose(mov_l.qframes,
+                               0.5 * (mov_l.xxframes - mov_l.yyframes),
+                               atol=1e-12)
+
+
+def test_cross_polrep_read_does_not_populate_fundict(stokes_movie_pol):
+    """Cross-polrep reads compute on demand; they don't materialize _fundict."""
+    _ = stokes_movie_pol.rrframes  # cross-polrep computation
+    assert stokes_movie_pol._fundict["I"] is not None  # storage interp lives
+    # circ-side _fundict keys don't even exist on a stokes movie
+    assert "RR" not in stokes_movie_pol._fundict
+
+
+# ---------------------------------------------------------------------------
+# Setters retain their polrep guard
+# ---------------------------------------------------------------------------
+
+
+def test_iframes_setter_rejects_non_stokes(stokes_movie_pol):
+    mov_c = stokes_movie_pol.switch_polrep("circ")
+    with pytest.raises(Exception, match="stokes"):
+        mov_c.iframes = mov_c._movdict["RR"]
+
+
+def test_xxframes_setter_rejects_non_lin(stokes_movie_pol):
+    with pytest.raises(Exception, match="lin"):
+        stokes_movie_pol.xxframes = stokes_movie_pol._movdict["I"]
+
+
+def test_rrframes_setter_rejects_non_circ(stokes_movie_pol):
+    with pytest.raises(Exception, match="circ"):
+        stokes_movie_pol.rrframes = stokes_movie_pol._movdict["I"]
+
+
+# ---------------------------------------------------------------------------
+# switch_polrep round-trips through all three polreps
+# ---------------------------------------------------------------------------
+
+
+def test_stokes_to_circ_to_stokes_roundtrip(stokes_movie_pol):
+    rt = stokes_movie_pol.switch_polrep("circ").switch_polrep("stokes")
+    for attr in ("iframes", "qframes", "uframes", "vframes"):
+        np.testing.assert_allclose(getattr(rt, attr),
+                                   getattr(stokes_movie_pol, attr), atol=1e-12)
+
+
+def test_stokes_to_lin_to_stokes_roundtrip(stokes_movie_pol):
+    rt = stokes_movie_pol.switch_polrep("lin").switch_polrep("stokes")
+    for attr in ("iframes", "qframes", "uframes", "vframes"):
+        np.testing.assert_allclose(getattr(rt, attr),
+                                   getattr(stokes_movie_pol, attr), atol=1e-12)
+
+
+def test_circ_to_lin_via_stokes_composition(stokes_movie_pol):
+    mov_c = stokes_movie_pol.switch_polrep("circ")
+    direct = mov_c.switch_polrep("lin")
+    two_step = mov_c.switch_polrep("stokes").switch_polrep("lin")
+    for attr in ("xxframes", "yyframes", "xyframes", "yxframes"):
+        np.testing.assert_allclose(getattr(direct, attr),
+                                   getattr(two_step, attr), atol=1e-12)
+
+
+def test_lin_movie_xxframes_consistent_with_circ_movie(stokes_movie_pol):
+    """Cross-polrep accessors give the same physics from circ and lin sources."""
+    mov_c = stokes_movie_pol.switch_polrep("circ")
+    mov_l = stokes_movie_pol.switch_polrep("lin")
+    np.testing.assert_allclose(mov_c.xxframes, mov_l.xxframes, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# rlvec / lrvec deprecation shims
+# ---------------------------------------------------------------------------
+
+
+def test_rlvec_getter_raises_with_migration_message(stokes_movie_pol):
+    mov_c = stokes_movie_pol.switch_polrep("circ")
+    with pytest.raises(AttributeError, match="rlframes"):
+        _ = mov_c.rlvec
+
+
+def test_rlvec_setter_raises_with_migration_message(stokes_movie_pol):
+    mov_c = stokes_movie_pol.switch_polrep("circ")
+    with pytest.raises(AttributeError, match="rlframes"):
+        mov_c.rlvec = []
+
+
+def test_lrvec_getter_raises_with_migration_message(stokes_movie_pol):
+    mov_c = stokes_movie_pol.switch_polrep("circ")
+    with pytest.raises(AttributeError, match="lrframes"):
+        _ = mov_c.lrvec
+
+
+def test_rlframes_works_after_rename(stokes_movie_pol):
+    """rlframes is the new canonical name (was rlvec)."""
+    mov_c = stokes_movie_pol.switch_polrep("circ")
+    rl = mov_c.rlframes
+    expected = mov_c.qframes + 1j * mov_c.uframes
+    np.testing.assert_allclose(rl, expected, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# add_pol_movie for lin pols
+# ---------------------------------------------------------------------------
+
+
+def test_add_pol_movie_lin_yy(times, frames_I):
+    mov = eh.movie.Movie(frames_I, times, 1e-10, 0.0, 0.0, polrep="lin")
+    yy_frames = [0.5 * f for f in frames_I]
+    mov.add_pol_movie(yy_frames, "YY")
+    np.testing.assert_allclose(
+        mov.yyframes,
+        np.array([f.flatten() for f in yy_frames]),
+        atol=1e-12,
+    )
+
+
+def test_add_pol_movie_lin_xy_complex(times, frames_I):
+    mov = eh.movie.Movie(frames_I, times, 1e-10, 0.0, 0.0, polrep="lin")
+    xy_frames = [0.3 * f * 1j for f in frames_I]
+    mov.add_pol_movie(xy_frames, "XY")
+    np.testing.assert_allclose(
+        mov.xyframes,
+        np.array([f.flatten() for f in xy_frames]),
+        atol=1e-12,
+    )

--- a/tests/test_pol_conventions.py
+++ b/tests/test_pol_conventions.py
@@ -1,0 +1,260 @@
+"""Tests for ehtim/observing/pol_conventions.py.
+
+Covers:
+* the pair-based primitives and their 4-in/4-out wrappers
+* round-trips and cross-convention consistency
+* sigma propagation (matches existing inline obsdata.py behavior)
+* Jones-matrix scaffolding (identity, round-trip with small D-terms)
+* MixedPolConventionWarning fires exactly once per session
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+from ehtim.observing import pol_conventions as pc
+from ehtim.warnings import MixedPolConventionWarning
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning():
+    """Re-arm the once-per-session warning flag for each test."""
+    pc._reset_convention_warning()
+    yield
+    pc._reset_convention_warning()
+
+
+# ---------------------------------------------------------------------------
+# Pair-based primitives
+# ---------------------------------------------------------------------------
+
+
+def test_circ_to_stokes_parallel_returns_pair():
+    rr = np.array([1.0 + 0j, 2.0 + 0j])
+    ll = np.array([0.8 + 0j, 1.6 + 0j])
+    i, v = pc.circ_to_stokes_parallel(rr, ll)
+    np.testing.assert_allclose(i, [0.9, 1.8])
+    np.testing.assert_allclose(v, [0.1, 0.2])
+
+
+def test_circ_to_stokes_cross_returns_complex():
+    rl = np.array([0.05 + 0.02j])
+    lr = np.array([0.05 - 0.02j])
+    q, u = pc.circ_to_stokes_cross(rl, lr)
+    np.testing.assert_allclose(q, [0.05 + 0j])
+    np.testing.assert_allclose(u, [0.02 + 0j])
+
+
+def test_circ_parallel_roundtrip():
+    rr, ll = 1.0 + 0.1j, 0.9 - 0.1j
+    i, v = pc.circ_to_stokes_parallel(rr, ll)
+    rr2, ll2 = pc.stokes_to_circ_parallel(i, v)
+    assert np.isclose(rr2, rr) and np.isclose(ll2, ll)
+
+
+def test_circ_cross_roundtrip():
+    rl, lr = 0.05 + 0.02j, 0.05 - 0.02j
+    q, u = pc.circ_to_stokes_cross(rl, lr)
+    rl2, lr2 = pc.stokes_to_circ_cross(q, u)
+    assert np.isclose(rl2, rl) and np.isclose(lr2, lr)
+
+
+def test_lin_diag_roundtrip():
+    xx, yy = 1.5 + 0j, 0.5 + 0j
+    i, q = pc.lin_to_stokes_diag(xx, yy)
+    xx2, yy2 = pc.stokes_to_lin_diag(i, q)
+    assert np.isclose(xx2, xx) and np.isclose(yy2, yy)
+
+
+def test_lin_offdiag_roundtrip():
+    xy, yx = 0.3 - 0.2j, 0.3 + 0.2j
+    u, v = pc.lin_to_stokes_offdiag(xy, yx)
+    xy2, yx2 = pc.stokes_to_lin_offdiag(u, v)
+    assert np.isclose(xy2, xy) and np.isclose(yx2, yx)
+
+
+# ---------------------------------------------------------------------------
+# 4-in/4-out wrappers compose to the same as paired calls
+# ---------------------------------------------------------------------------
+
+
+def test_circ_to_stokes_wrapper_equals_pair_calls():
+    rr, ll, rl, lr = 1.0 + 0.1j, 0.9 + 0j, 0.05 + 0.02j, 0.05 - 0.02j
+    i_w, q_w, u_w, v_w = pc.circ_to_stokes(rr, ll, rl, lr)
+    i_p, v_p = pc.circ_to_stokes_parallel(rr, ll)
+    q_p, u_p = pc.circ_to_stokes_cross(rl, lr)
+    assert (i_w, q_w, u_w, v_w) == (i_p, q_p, u_p, v_p)
+
+
+def test_stokes_to_circ_wrapper_equals_pair_calls():
+    i, q, u, v = 1.0 + 0j, 0.05 + 0j, -0.02 + 0j, 0.1 + 0j
+    rr_w, ll_w, rl_w, lr_w = pc.stokes_to_circ(i, q, u, v)
+    rr_p, ll_p = pc.stokes_to_circ_parallel(i, v)
+    rl_p, lr_p = pc.stokes_to_circ_cross(q, u)
+    assert (rr_w, ll_w, rl_w, lr_w) == (rr_p, ll_p, rl_p, lr_p)
+
+
+def test_lin_to_stokes_wrapper_equals_pair_calls():
+    xx, yy, xy, yx = 1.5 + 0j, 0.5 + 0j, 0.3 - 0.2j, 0.3 + 0.2j
+    i_w, q_w, u_w, v_w = pc.lin_to_stokes(xx, yy, xy, yx)
+    i_p, q_p = pc.lin_to_stokes_diag(xx, yy)
+    u_p, v_p = pc.lin_to_stokes_offdiag(xy, yx)
+    assert (i_w, q_w, u_w, v_w) == (i_p, q_p, u_p, v_p)
+
+
+def test_stokes_to_lin_wrapper_equals_pair_calls():
+    i, q, u, v = 1.0 + 0j, 0.5 + 0j, 0.3 + 0j, 0.2 + 0j
+    xx_w, yy_w, xy_w, yx_w = pc.stokes_to_lin(i, q, u, v)
+    xx_p, yy_p = pc.stokes_to_lin_diag(i, q)
+    xy_p, yx_p = pc.stokes_to_lin_offdiag(u, v)
+    assert (xx_w, yy_w, xy_w, yx_w) == (xx_p, yy_p, xy_p, yx_p)
+
+
+# ---------------------------------------------------------------------------
+# Cross-convention: stokes -> circ vs stokes -> lin produce the same physics
+# ---------------------------------------------------------------------------
+
+
+def test_circ_lin_consistency_via_stokes():
+    """Known Stokes -> circ vs Stokes -> lin -> circ must agree."""
+    i, q, u, v = 1.0 + 0j, 0.5 + 0j, 0.3 + 0j, 0.2 + 0j
+    rr, ll, rl, lr = pc.stokes_to_circ(i, q, u, v)
+    xx, yy, xy, yx = pc.stokes_to_lin(i, q, u, v)
+    rr2, ll2, rl2, lr2 = pc.lin_to_circ(xx, yy, xy, yx)
+    assert np.isclose(rr, rr2) and np.isclose(ll, ll2)
+    assert np.isclose(rl, rl2) and np.isclose(lr, lr2)
+
+
+def test_circ_to_lin_via_composition():
+    """circ_to_lin = stokes_to_lin(circ_to_stokes(...))."""
+    rr, ll, rl, lr = 1.2 + 0.1j, 0.8 - 0.1j, 0.05 + 0.02j, 0.05 - 0.02j
+    xx, yy, xy, yx = pc.circ_to_lin(rr, ll, rl, lr)
+    xx_e, yy_e, xy_e, yx_e = pc.stokes_to_lin(*pc.circ_to_stokes(rr, ll, rl, lr))
+    assert np.isclose(xx, xx_e) and np.isclose(yy, yy_e)
+    assert np.isclose(xy, xy_e) and np.isclose(yx, yx_e)
+
+
+# ---------------------------------------------------------------------------
+# IAU/HBS convention check via a known Stokes vector
+# ---------------------------------------------------------------------------
+
+
+def test_known_stokes_to_lin_iau_convention():
+    """For I=1, Q=0, U=0, V=0 we expect XX=YY=1, XY=YX=0."""
+    xx, yy, xy, yx = pc.stokes_to_lin(1.0 + 0j, 0 + 0j, 0 + 0j, 0 + 0j)
+    assert np.isclose(xx, 1.0) and np.isclose(yy, 1.0)
+    assert np.isclose(xy, 0.0) and np.isclose(yx, 0.0)
+
+
+def test_known_stokes_q_only_to_lin():
+    """For I=0, Q=1, U=0, V=0 we expect XX=1, YY=-1, XY=YX=0."""
+    xx, yy, xy, yx = pc.stokes_to_lin(0 + 0j, 1.0 + 0j, 0 + 0j, 0 + 0j)
+    assert np.isclose(xx, 1.0) and np.isclose(yy, -1.0)
+    assert np.isclose(xy, 0.0) and np.isclose(yx, 0.0)
+
+
+def test_known_stokes_v_only_to_lin_iau_sign():
+    """For pure V=1, IAU/HBS gives XY=-i, YX=+i; XX=YY=0."""
+    xx, yy, xy, yx = pc.stokes_to_lin(0 + 0j, 0 + 0j, 0 + 0j, 1.0 + 0j)
+    assert np.isclose(xx, 0.0) and np.isclose(yy, 0.0)
+    assert np.isclose(xy, -1.0j) and np.isclose(yx, +1.0j)
+
+
+# ---------------------------------------------------------------------------
+# Sigma propagation matches the existing inline obsdata.py formulas
+# ---------------------------------------------------------------------------
+
+
+def test_circ_to_stokes_sigma():
+    s_iv_e = 0.5 * np.sqrt(0.1**2 + 0.1**2)
+    s_qu_e = 0.5 * np.sqrt(0.2**2 + 0.2**2)
+    si, sq, su, sv = pc.circ_to_stokes_sigma(0.1, 0.1, 0.2, 0.2)
+    assert np.isclose(si, s_iv_e) and np.isclose(sv, s_iv_e)
+    assert np.isclose(sq, s_qu_e) and np.isclose(su, s_qu_e)
+
+
+def test_stokes_to_circ_sigma():
+    rr_e = np.sqrt(0.1**2 + 0.05**2)
+    rl_e = np.sqrt(0.2**2 + 0.2**2)
+    sr, sl, srl, slr = pc.stokes_to_circ_sigma(0.1, 0.2, 0.2, 0.05)
+    assert np.isclose(sr, rr_e) and np.isclose(sl, rr_e)
+    assert np.isclose(srl, rl_e) and np.isclose(slr, rl_e)
+
+
+def test_lin_to_stokes_sigma_mirrors_circ_pattern():
+    """Same structure as circ_to_stokes_sigma but on (XX,YY) and (XY,YX)."""
+    si, sq, su, sv = pc.lin_to_stokes_sigma(0.1, 0.1, 0.2, 0.2)
+    assert np.isclose(si, 0.5 * np.sqrt(0.02))
+    assert np.isclose(sq, 0.5 * np.sqrt(0.02))
+    assert np.isclose(su, 0.5 * np.sqrt(0.08))
+    assert np.isclose(sv, 0.5 * np.sqrt(0.08))
+
+
+# ---------------------------------------------------------------------------
+# Jones-matrix scaffolding
+# ---------------------------------------------------------------------------
+
+
+def test_jones_identity_with_unit_gains():
+    J = pc.jones_matrix(1.0 + 0j, 1.0 + 0j, 0, 0)
+    np.testing.assert_allclose(J, np.eye(2))
+
+
+def test_jones_d_terms_off_diagonal():
+    """J = G(I + D); with G=I and small D, J has D's off-diagonals."""
+    J = pc.jones_matrix(1.0 + 0j, 1.0 + 0j, d_p1=0.05 + 0.01j, d_p2=-0.03 + 0.02j)
+    np.testing.assert_allclose(J, np.array([[1.0, 0.05 + 0.01j],
+                                            [-0.03 + 0.02j, 1.0]]))
+
+
+def test_apply_inverse_jones_identity_preserves_vis():
+    V = np.array([[1.0 + 0j, 0.05 + 0j], [0.05 + 0j, 0.8 + 0j]])
+    J = np.eye(2, dtype=complex)
+    V_corr = pc.apply_inverse_jones_to_coherency(V, J, J)
+    np.testing.assert_allclose(V_corr, V)
+
+
+def test_apply_inverse_jones_roundtrip_small_dterms():
+    """V_obs = J1 V_true J2^dag; apply_inverse recovers V_true."""
+    V_true = np.array([[1.0 + 0j, 0.05 + 0.02j],
+                       [0.05 - 0.02j, 0.8 + 0j]])
+    J1 = pc.jones_matrix(1.05 + 0.01j, 0.97 - 0.02j, 0.03, -0.02)
+    J2 = pc.jones_matrix(0.98 - 0.01j, 1.02 + 0.02j, -0.01, 0.04)
+    V_obs = J1 @ V_true @ J2.conj().T
+    V_recovered = pc.apply_inverse_jones_to_coherency(V_obs, J1, J2)
+    np.testing.assert_allclose(V_recovered, V_true, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# MixedPolConventionWarning fires exactly once per session
+# ---------------------------------------------------------------------------
+
+
+def test_warning_fires_on_first_transform():
+    pc._reset_convention_warning()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", category=MixedPolConventionWarning)
+        pc.circ_to_stokes_parallel(1.0 + 0j, 0.9 + 0j)
+    assert any(issubclass(w.category, MixedPolConventionWarning) for w in caught)
+
+
+def test_warning_only_fires_once_per_session():
+    pc._reset_convention_warning()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", category=MixedPolConventionWarning)
+        pc.circ_to_stokes_parallel(1.0 + 0j, 0.9 + 0j)
+        pc.lin_to_stokes_diag(1.5 + 0j, 0.5 + 0j)  # second non-identity transform
+        pc.stokes_to_lin_offdiag(0.3 + 0j, 0.2 + 0j)  # third
+    fired = [w for w in caught if issubclass(w.category, MixedPolConventionWarning)]
+    assert len(fired) == 1
+
+
+def test_warning_fires_from_jones_application():
+    pc._reset_convention_warning()
+    V = np.eye(2, dtype=complex)
+    J = np.eye(2, dtype=complex)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", category=MixedPolConventionWarning)
+        pc.apply_inverse_jones_to_coherency(V, J, J)
+    assert any(issubclass(w.category, MixedPolConventionWarning) for w in caught)

--- a/tests/test_pol_conventions.py
+++ b/tests/test_pol_conventions.py
@@ -135,6 +135,31 @@ def test_circ_to_lin_via_composition():
     assert np.isclose(xy, xy_e) and np.isclose(yx, yx_e)
 
 
+def test_basis_matrix_consistent_with_circ_lin_stokes_formulas():
+    """BASIS_LIN_TO_CIRC must give the same Stokes whether you go
+    (X,Y) -> Stokes via §5, or (X,Y) -> (R,L) -> Stokes via §4.
+
+    Regression test for the convention bug where §2 declared one basis
+    but §4 / §5 implemented the opposite (pre-fix, lin_to_stokes_offdiag
+    had V with the wrong sign relative to BASIS_LIN_TO_CIRC).
+    """
+    # Pure +U linear wave (45 deg, in phase) — the discriminating case.
+    EX, EY = 1.0 + 0j, 1.0 + 0j
+    XX, YY = EX * np.conj(EX), EY * np.conj(EY)
+    XY, YX = EX * np.conj(EY), EY * np.conj(EX)
+    I_lin, Q_lin, U_lin, V_lin = pc.lin_to_stokes(XX, YY, XY, YX)
+
+    ER, EL = pc.BASIS_LIN_TO_CIRC @ np.array([EX, EY])
+    RR, LL = ER * np.conj(ER), EL * np.conj(EL)
+    RL, LR = ER * np.conj(EL), EL * np.conj(ER)
+    I_cir, Q_cir, U_cir, V_cir = pc.circ_to_stokes(RR, LL, RL, LR)
+
+    assert np.isclose(I_lin, I_cir)
+    assert np.isclose(Q_lin, Q_cir)
+    assert np.isclose(U_lin, U_cir)
+    assert np.isclose(V_lin, V_cir)
+
+
 # ---------------------------------------------------------------------------
 # IAU/HBS convention check via a known Stokes vector
 # ---------------------------------------------------------------------------
@@ -155,10 +180,10 @@ def test_known_stokes_q_only_to_lin():
 
 
 def test_known_stokes_v_only_to_lin_iau_sign():
-    """For pure V=1, IAU/HBS gives XY=-i, YX=+i; XX=YY=0."""
+    """For pure V=1, IAU/HBS (engineering) gives XY=+i, YX=-i; XX=YY=0."""
     xx, yy, xy, yx = pc.stokes_to_lin(0 + 0j, 0 + 0j, 0 + 0j, 1.0 + 0j)
     assert np.isclose(xx, 0.0) and np.isclose(yy, 0.0)
-    assert np.isclose(xy, -1.0j) and np.isclose(yx, +1.0j)
+    assert np.isclose(xy, +1.0j) and np.isclose(yx, -1.0j)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- **New module** `ehtim/observing/pol_conventions.py` — basis transforms, sigma propagation, and Jones-matrix scaffolding. Factored into 8 pair-based primitives (parallel/cross for circ, diag/offdiag for lin) with 4-in/4-out
  wrappers on top.
- **New doc** `docs/polarization_conventions.md` (§1-§12) — convention statement (IAU/HBS), derivations, sign tables, Jones formalism. Each section cites the implementing line range in `pol_conventions.py`.
- **`Image`, `Movie`, `Model`** widen to accept `polrep='lin'` with `pol_prim ∈ {XX, YY}`. All cross-polrep accessors (ivec from circ, rrvec from stokes, xxvec from anything, etc.) compose on demand via
  `pol_conventions`.
- **`Obsdata.switch_polrep`** now calls `pol_conventions.circ_to_stokes` / `stokes_to_circ` (numerically bit-identical to the previous inline math).
- **`Movie` harmonization** — every frame accessor (`iframes`, `qframes`,`rrframes`, etc., all 12 incl. lin) now computes on demand for any source polrep. Pre-Phase-3 they raised on wrong polrep. Setters keep their
  storage-basis guard. - **`Movie.rlvec` / `lrvec` renamed** to `rlframes` / `lrframes` (consistent with `iframes`/`rrframes`/etc.). Old names raise `AttributeError` with a migration message. No in-tree callers used
  these on Movie objects.
- **`Model.observe_same_nonoise`** and the 9 `sample_uv*` dispatch sites gain XX/YY/XY/YX clauses.
- **`const_def.py`** `vis_poldict` / `amp_poldict` / `sig_poldict` extended with XX/YY/XY/YX entries.

## Why

- Provides the sky-model side of mixed-pol observations so linear-feed
  Obsdata (coming in Phase 4) has something to image against.
- Centralizes basis-transform math in one place so future convention
  changes are a single-file edit.
- Movie accessor harmonization gives the class a uniform shape that
  matches `Image`'s long-standing pattern.

## Known issues called out in `tests/test_model.py` header

- `Model.__init__` hardcodes `self.polrep = 'stokes'` regardless of the
  `polrep=` constructor argument, and `Model.switch_polrep` is 
  a no-op. The polrep slot on a Model is always 'stokes' in practice.
- `Model.sample_uv` / `observe_same_nonoise` go through `sample_model_uv`
  (model.py:1467, 1470) which uses `np.sum(generator)`, removed in numpy
  2.0. The end-to-end lin path is marked `xfail(strict=True)`/ 

Both are out of scope here.

## Design points worth discussing

1. **Jones factoring `J = G·(I+D)`** in `pol_conventions.jones_matrix` — per plan Open Question 4, verify against existing `pol_cal*` code when Phase 5 (Caltable rewrite) lands; this PR ships the scaffolding ahead
   of its first consumer.
2. **Per-component sigma propagation** drops cross-component covariance. Documented as a known limitation in `pol_conventions.py` and `docs/polarization_conventions.md` §6. Matches existing inline`Obsdata` behavior bit-for-bit, so no regression — but new code that mixes polreps in noise calcs should be aware.