### PR TITLE
Support the latest stable packages (NumPy 2 / SciPy 1.17 / Python 3.11-3.12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/coverage_status.md
+++ b/docs/coverage_status.md
@@ -1,0 +1,68 @@
+# Test coverage inventory
+
+Per-module test status, to track what still needs filling out before pushing to `dev`
+(requested in the #271 review). Coverage measured on the full suite at the latest stack
+(`pytest --cov=ehtim`), `dev-backend` + #271. Numbers are whole-module line coverage.
+
+A module can be well covered without a `test_<module>.py` of its own (e.g. `imager_utils`
+is exercised by `test_chisquared`/`test_gradients`/`test_regularizers`/`test_imager_e2e`).
+
+## Well covered (>70%) — leave as is
+
+| Module | Cover | Exercised by |
+|---|---|---|
+| `imaging/imager_backend.py` | 96% | `test_imager_backend` |
+| `imaging/imager_utils.py` | 96% | `test_chisquared`, `test_gradients`, `test_regularizers`, `test_imager_e2e` |
+| `const_def.py` | 90% | (constants; incidental) |
+| `imaging/pol_imager_utils.py` | 89% | `test_imager_e2e`, `test_gradients` |
+| `observing/obs_simulate.py` | 84% | `test_obs_simulate` |
+| `imager.py` | 80% | `test_imager_*` |
+| `obsdata.py` | 72% | `test_obsdata` |
+
+## Partial (have a test file, but thin) — fill out next
+
+| Module | Cover | Test file | Gap |
+|---|---|---|---|
+| `diagnostics.py` | 67% | `test_diagnostics` | minor |
+| `image.py` | 63% | `test_image` | plotting/display + transform branches |
+| `array.py` | 57% | `test_array` | satellite/ephemeris paths |
+| `features/rex.py` | 49% | `test_rex` | only the interp/profile path is covered; plotting + `FindProfiles*` untested |
+| `model.py` | 22% | `test_model` | only mring build + dispatch (parked low-priority per 2026-05-21) |
+| `movie.py` | 21% | `test_movie` | only merge + HDF5 round-trip; frame ops/plotting untested |
+| `imaging/starwarps.py` | 13% | `test_starwarps` | heritage; rect-image + smoke only |
+| `imaging/dynamical_imaging.py` | 10% | `test_dynamical_imaging` | heritage; rect-image + smoke only |
+
+`observing/obs_helpers.py` (52%), `scattering/stochastic_optics.py` (59%, via `test_scattering`),
+`io/load.py` (36%) + `io/save.py` (24%, via `test_io`) sit between these tiers.
+
+## No dedicated tests — candidates for new suites
+
+Highest value (core, actively developed):
+
+| Module | Cover | Note |
+|---|---|---|
+| `caltable.py` | 12% | calibration tables; MixPol Phase 4 rewrites this — worth a suite first |
+| `calibrating/self_cal.py` | 8% | |
+| `calibrating/network_cal.py` | 10% | |
+| `calibrating/pol_cal.py` / `pol_cal_new.py` | 5% / 7% | MixPol Phase 4 territory |
+| `calibrating/polgains_cal.py` | 14% | |
+| `statistics/dataframes.py` / `stats.py` | 24% / 29% | `test_averaging` (PR #252) will lift these once it lands |
+
+Lower priority:
+
+| Module | Cover | Note |
+|---|---|---|
+| `plotting/summary_plots.py` | 2% | large; needs Agg-backend render/save smoke tests |
+| `plotting/comp_plots.py` / `comparisons.py` | 9% / 15% | Alex's interactive-plotting PR (#269) is separate |
+| `vex.py` | 10% | VEX schedule parsing |
+| `survey.py` | 10% | paramsurvey wrapper |
+| `modeling/modeling_utils.py` | 6% | parked "don't touch" (2026-05-21); revisit with a dedicated owner |
+| `parloop.py` (27%), `observing/pulses.py` (40%), `calibrating/cal_helpers.py` (27%) | | small |
+
+## Effectively dead / not worth testing now
+
+| Module | Cover | Note |
+|---|---|---|
+| `imaging/clean.py` | 0% | unused ~6 yrs; slated to move to `scripts/` |
+| `imaging/linearize_energy.py` | 0% | niche |
+| `imaging/patch_prior.py` | 0% | niche |

--- a/ehtim/calibrating/pol_cal.py
+++ b/ehtim/calibrating/pol_cal.py
@@ -17,21 +17,16 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
-
-import numpy as np
-import scipy.optimize as opt
-import matplotlib.pyplot as plt
 import time
 
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy.optimize as opt
+
+import ehtim.const_def as ehc
 import ehtim.imaging.imager_utils as iu
 import ehtim.observing.obs_simulate as simobs
-import ehtim.const_def as ehc
 
 MAXIT = 1000  # maximum number of iterations in pol-cal minimizer
 
@@ -236,7 +231,7 @@ def leakage_cal(obs, im=None, sites=[], leakage_tol=.1, pol_fit=['RL', 'LR'], dt
     print("Minimizing...")
     res = opt.minimize(errfunc, Dpar_guess, method=minimizer_method, options=optdict)
     print(errfunc(Dpar_guess),errfunc(res.x))
-    
+
     # get solution
     D_fit = res.x.astype(np.float64).view(dtype=np.complex128)  # all the D-terms (complex)
 
@@ -264,18 +259,17 @@ def leakage_cal(obs, im=None, sites=[], leakage_tol=.1, pol_fit=['RL', 'LR'], dt
                                      im_circ, D_fit*0, inverse=inverse)
             chisq_new = chisq_total(obs.switch_polrep('circ').data, im_circ, D_fit, inverse=inverse)
 
-        print("Original chi-squared: {:.4f}".format(chisq_orig))
-        print("New chi-squared: {:.4f}\n".format(chisq_new))
+        print(f"Original chi-squared: {chisq_orig:.4f}")
+        print(f"New chi-squared: {chisq_new:.4f}\n")
         for isite in range(len(sites)):
             print(sites[isite])
-            print('   D_R: {:.4f}'.format(D_fit[2*isite]))
-            print('   D_L: {:.4f}\n'.format(D_fit[2*isite+1]))
+            print(f'   D_R: {D_fit[2*isite]:.4f}')
+            print(f'   D_L: {D_fit[2*isite+1]:.4f}\n')
         if const_fpol:
-            print('Source Fractional Polarization Magnitude: {:.4f}'.format(np.abs(D_fit[-2])))
-            print('Source Fractional Polarization EVPA [deg]: {:.4f}\n'.format(
-                90./np.pi*np.angle(D_fit[-2])))
+            print(f'Source Fractional Polarization Magnitude: {np.abs(D_fit[-2]):.4f}')
+            print(f'Source Fractional Polarization EVPA [deg]: {90./np.pi*np.angle(D_fit[-2]):.4f}\n')
             if inverse:
-                print('Source Fractional Circular Polarization: {:.4f}'.format(np.real(D_fit[-1])))
+                print(f'Source Fractional Circular Polarization: {np.real(D_fit[-1]):.4f}')
 
     tstop = time.time()
     print("\nleakage_cal time: %f s" % (tstop - tstart))

--- a/ehtim/calibrating/pol_cal.py
+++ b/ehtim/calibrating/pol_cal.py
@@ -385,11 +385,11 @@ def plot_leakage(obs, sites=[], axis=False, rangex=False, rangey=False,
 
     # label and save
     if axislabels:
-        x.set_xlabel('Re[$D$] (\%)')
-        x.set_ylabel('Im[$D$] (\%)')
+        x.set_xlabel(r'Re[$D$] (\%)')
+        x.set_ylabel(r'Im[$D$] (\%)')
     if legend:
         legend1 = plt.legend([l[0] for l in plot_points], tarr['site'], ncol=1, loc=1)
-        plt.legend(plot_points[0], ['$D_R$ (\%)', '$D_L$ (\%)'], loc=4)
+        plt.legend(plot_points[0], [r'$D_R$ (\%)', r'$D_L$ (\%)'], loc=4)
         plt.gca().add_artist(legend1)
     if export_pdf != "":  # and not axis:
         fig.savefig(export_pdf, bbox_inches='tight')

--- a/ehtim/features/rex.py
+++ b/ehtim/features/rex.py
@@ -104,7 +104,9 @@ class Profiles(object):
 
         self.xs = np.arange(im.xdim)*im.psize/ehc.RADPERUAS
         self.ys = np.arange(im.ydim)*im.psize/ehc.RADPERUAS
-        self.interp = scipy.interpolate.interp2d(self.ys, self.xs, self.imarr, kind=interptype)
+        self.interp = scipy.interpolate.RegularGridInterpolator(
+            (self.ys, self.xs), self.imarr,
+            method=interptype, bounds_error=False, fill_value=None)
 
         self.profiles = np.array(profs)
         self.profilesQ = np.array(profsQ)
@@ -724,13 +726,14 @@ def compute_ring_profile(im, x0, y0, title="",
     ys = np.arange(im.ydim)*im.psize/ehc.RADPERUAS
 
     # TODO: test fiducial images with linear?
-    interp = scipy.interpolate.interp2d(ys, xs, imarr, kind=interptype)
+    interp = scipy.interpolate.RegularGridInterpolator(
+        (ys, xs), imarr, method=interptype, bounds_error=False, fill_value=None)
 
     def ringVals(theta):
         xxs = x0 - rs*np.sin(theta)
         yys = y0 + rs*np.cos(theta)
 
-        vals = [interp(xxs[i], yys[i])[0] for i in np.arange(len(rs))]
+        vals = interp(np.column_stack([yys, xxs]))
         return vals
 
     profs = []
@@ -744,21 +747,23 @@ def compute_ring_profile(im, x0, y0, title="",
     if len(im.qvec) > 0 and len(im.uvec > 0) and pol_profs:
         qarr = im.qvec.reshape(im.ydim, im.xdim)[::-1] * factor  # in brightness temperature K
         uarr = im.uvec.reshape(im.ydim, im.xdim)[::-1] * factor  # in brightness temperature K
-        interpQ = scipy.interpolate.interp2d(ys, xs, qarr, kind=interptype)
-        interpU = scipy.interpolate.interp2d(ys, xs, uarr, kind=interptype)
+        interpQ = scipy.interpolate.RegularGridInterpolator(
+            (ys, xs), qarr, method=interptype, bounds_error=False, fill_value=None)
+        interpU = scipy.interpolate.RegularGridInterpolator(
+            (ys, xs), uarr, method=interptype, bounds_error=False, fill_value=None)
 
         def ringValsQ(theta):
             xxs = x0 - rs*np.sin(theta)
             yys = y0 + rs*np.cos(theta)
 
-            vals = [interpQ(xxs[i], yys[i])[0] for i in np.arange(len(rs))]
+            vals = interpQ(np.column_stack([yys, xxs]))
             return vals
 
         def ringValsU(theta):
             xxs = x0 - rs*np.sin(theta)
             yys = y0 + rs*np.cos(theta)
 
-            vals = [interpU(xxs[i], yys[i])[0] for i in np.arange(len(rs))]
+            vals = interpU(np.column_stack([yys, xxs]))
             return vals
 
         for j in range(nrays):
@@ -793,16 +798,15 @@ def findCenter(im,
     ys = np.arange(im.ydim)*im.psize/ehc.RADPERUAS
 
     # TODO: test fiducial images with linear?
-    #iminterp = scipy.interpolate.interp2d(ys, xs, imarr, kind='cubic')
-    iminterp = scipy.interpolate.interp2d(ys, xs, imarr, kind='linear')
-    #iminterp = scipy.interpolate.RegularGridInterpolator((ys,xs),imarr)
+    iminterp = scipy.interpolate.RegularGridInterpolator(
+        (ys, xs), imarr, method='linear', bounds_error=False, fill_value=None)
     def objFunc(pos):
         (x0, y0) = pos
         diameters = []
         for j in range(nrays_search):
             xxs = x0 - rs*np.sin(thetas[j])
             yys = y0 + rs*np.cos(thetas[j])
-            prof = np.array([iminterp(xxs[i], yys[i])[0] for i in np.arange(len(rs))])
+            prof = iminterp(np.column_stack([yys, xxs]))
             
             args = np.argsort(prof)
             pkpos = args[-1]

--- a/ehtim/features/rex.py
+++ b/ehtim/features/rex.py
@@ -16,29 +16,23 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
-
-import os
 import glob
-import matplotlib.pyplot as plt
-import numpy as np
-import astropy.io.fits as fits
+import os
 import subprocess
 
+import astropy.io.fits as fits
+import matplotlib.pyplot as plt
+import numpy as np
 import scipy.interpolate
 import scipy.optimize
 import scipy.stats
 from astropy.stats import median_absolute_deviation
 
-from ehtim.image import load_image
+import ehtim.const_def as ehc
 import ehtim.imaging.dynamical_imaging as di
 import ehtim.parloop as ploop
-import ehtim.const_def as ehc
+from ehtim.image import load_image
 
 ###################################################################################################
 # Parameters
@@ -73,9 +67,9 @@ POSTPROCDIR = '.'  # default postprocessing directory
 ###################################################################################################
 
 
-class Profiles(object):
+class Profiles:
 
-    def __init__(self, im, x0, y0, profs, thetas, rmin=RMIN, rmax=RMAX, 
+    def __init__(self, im, x0, y0, profs, thetas, rmin=RMIN, rmax=RMAX,
                  interptype='cubic',flux_norm=NORMFLUX,
                  profsQ=[], profsU=[]):
 
@@ -384,27 +378,27 @@ class Profiles(object):
 
     def plot_img(self, postprocdir=POSTPROCDIR, save_png=False):
         plt.figure()
-        
+
         fovx = self.im.fovx()/ehc.RADPERUAS
         fovy = self.im.fovy()/ehc.RADPERUAS
         xsplot = self.xs - fovx/2.
         ysplot = self.ys - fovy/2.
         x0plot = self.x0 - fovx/2.
         y0plot = self.y0 - fovy/2.
-        
+
         plt.pcolormesh(xsplot,ysplot,self.imarr,cmap='afmhot')
-        plt.contour(xsplot,ysplot, self.imarr, colors='k',levels=5)        
-        
+        plt.contour(xsplot,ysplot, self.imarr, colors='k',levels=5)
+
         plt.xlabel(r"-RA ($\mu$as)")
         plt.ylabel(r"Dec ($\mu$as)")
-      
+
         plt.plot(x0plot,y0plot, 'r*', markersize=20)
 
         thetas = np.linspace(0, 2*np.pi, 100)
         plt.plot(x0plot+ np.cos(thetas) * self.RingSize1[0]/2,
                  y0plot + np.sin(thetas) * self.RingSize1[0]/2,
                  'r-', markersize=1)
-                         
+
         #plt.axes().set_aspect('equal', 'datalim')
 
         if save_png:
@@ -494,7 +488,7 @@ class Profiles(object):
         xticks = (360/imarr.shape[1])*xticklabels
 
         yticks = np.floor(np.arange(0, imarr.shape[0], imarr.shape[0]/5)).astype(int)
-        yticklabels = ["%0.0f" % r for r in self.rs[yticks]]
+        yticklabels = [f"{r:0.0f}" for r in self.rs[yticks]]
 
         if not xticklabel:
             xticklabels = []
@@ -772,7 +766,7 @@ def compute_ring_profile(im, x0, y0, title="",
             valsU = ringValsU(thetas[j])
             profsU.append(valsU)
 
-    
+
     profiles = Profiles(im, x0, y0, profs, thetas, rmin=rmin, rmax=rmax, interptype=interptype,
                         flux_norm=flux_norm,profsQ=profsQ, profsU=profsU)
 
@@ -807,7 +801,7 @@ def findCenter(im,
             xxs = x0 - rs*np.sin(thetas[j])
             yys = y0 + rs*np.cos(thetas[j])
             prof = iminterp(np.column_stack([yys, xxs]))
-            
+
             args = np.argsort(prof)
             pkpos = args[-1]
             pk = rs[pkpos]
@@ -815,12 +809,12 @@ def findCenter(im,
             if pkpos > 0 and pkpos < nrs_search-1:
                 vals = [prof[pkpos-1], prof[pkpos], prof[pkpos+1]]
                 pk, vpk = quad_interp_radius(pk, dr, vals)
-            
+
             diameters.append(2*np.abs(pk))
-                    
+
         # ring size
         mean,std = (np.mean(diameters), np.std(diameters))
-        
+
         if mean < rmin_search or mean > rmax_search:
             return np.inf
         else:
@@ -848,7 +842,7 @@ def FindProfile(im, blur=0, pol_profs=False,
                 flux_norm=NORMFLUX,center=False):
     """find the best ring profile for an image object and save results
     """
-    
+
     im_raw = im.copy()
     # blur image if requested
     if blur > 0:
@@ -856,7 +850,7 @@ def FindProfile(im, blur=0, pol_profs=False,
 
     # center image and regrid to uniform pixel size and fox
     if center:
-        im = di.center_core(im_raw) # TODO -- why isn't this working? 
+        im = di.center_core(im_raw) # TODO -- why isn't this working?
     else:
         im = im_raw
 
@@ -882,16 +876,16 @@ def FindProfile(im, blur=0, pol_profs=False,
                      rmin_search=rmin_search,  rmax_search=rmax_search,
                      nrays_search=nrays_search, nrs_search=nrs_search,
                      fov_search=fov_search, n_search=n_search, flux_norm=flux_norm)
-                     
+
     # compute profiles using the original (regridded, flux centroid centered) image
     print("compute profile")
     pp = compute_ring_profile(im, res[0], res[1], nrs=nrs, nrays=nrays,
                               rmin=rmin, rmax=rmax, flux_norm=flux_norm,
                               pol_profs=pol_profs)
-    pp.calc_meanprof_and_stats()  
-    
-    return pp    
-                       
+    pp.calc_meanprof_and_stats()
+
+    return pp
+
 def FindProfileSingle(imname, postprocdir,
                       save_files=False, blur=0, aipscc=False, tag='',
                       rerun=True, return_pp=True,
@@ -916,7 +910,7 @@ def FindProfileSingle(imname, postprocdir,
         im_raw = load_image(imname, aipscc=aipscc)
 
         # calculate profile
-        pp = FindProfile(im, blur=blur, 
+        pp = FindProfile(im_raw, blur=blur,
                          imsize=imsize, npix=npix, rmin=rmin, rmax=rmax, nrays=nrays, nrs=nrs,
                          rmin_search=rmin_search, rmax_search=rmax_search,
                          nrays_search=nrays_search, nrs_search=nrs_search,
@@ -938,8 +932,8 @@ def FindProfileSingle(imname, postprocdir,
                 os.remove(txtname)
 
             f = open(txtname, 'a')
-            f.write('ring_x0 ' + str(res[0]) + '\n')
-            f.write('ring_y0 ' + str(res[1]) + '\n')
+            f.write('ring_x0 ' + str(pp.x0) + '\n')
+            f.write('ring_y0 ' + str(pp.y0) + '\n')
 
             f.write('ring_diameter ' + str(pp.RingSize1[0]) + '\n')
             f.write('ring_diameter_sigma ' + str(pp.RingSize1[1]) + '\n')

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -24,10 +24,9 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.interpolate
-import scipy.ndimage as filt
+import scipy.ndimage as ndi
 import scipy.optimize as opt
 import scipy.signal
-from scipy import ndimage as ndi
 
 import ehtim.const_def as ehc
 import ehtim.imaging.pol_imager_utils as polutils
@@ -1602,7 +1601,7 @@ class Image:
             sigma = fwhmp / (2. * np.sqrt(2. * np.log(2.)))
             if np.any(np.imag(imarr) != 0):
                 return blur(np.real(imarr), sigma) + 1j * blur(np.imag(imarr), sigma)
-            imarr_blur = filt.gaussian_filter(imarr, (sigma, sigma))
+            imarr_blur = ndi.gaussian_filter(imarr, (sigma, sigma))
             return imarr_blur
 
         def blur_butter(imarr, size):

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -23,9 +23,8 @@ import math
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
-import numpy.matlib as matlib
 import scipy.interpolate
-import scipy.ndimage.filters as filt
+import scipy.ndimage as filt
 import scipy.optimize as opt
 import scipy.signal
 from scipy import ndimage as ndi
@@ -1356,7 +1355,7 @@ class Image:
         def rot_imvec(imvec):
             if np.any(np.imag(imvec) != 0):
                 return rot_imvec(np.real(imvec)) + 1j * rot_imvec(np.imag(imvec))
-            imarr_rot = scipy.ndimage.interpolation.rotate(imvec.reshape((self.ydim, self.xdim)),
+            imarr_rot = ndi.rotate(imvec.reshape((self.ydim, self.xdim)),
                                                            angle * 180.0 / np.pi, reshape=False,
                                                            order=order, mode='constant',
                                                            cval=0.0, prefilter=True)
@@ -4114,7 +4113,7 @@ class Image:
             dynamic_range = dynamic_range * np.ones(len(im_list) + 1)
 
         if not isinstance(shift, np.ndarray) and not isinstance(shift, bool):
-            shift = matlib.repmat(shift, len(im_list), 1)
+            shift = np.tile(shift, (len(im_list), 1))
 
         psize = self.psize
         max_fov = np.max([self.xdim * self.psize, self.ydim * self.psize])

--- a/ehtim/imaging/dynamical_imaging.py
+++ b/ehtim/imaging/dynamical_imaging.py
@@ -31,7 +31,7 @@ from multiprocessing import Pool, cpu_count
 import matplotlib.pyplot as plt
 import numpy as np
 import requests
-import scipy.ndimage as filt
+import scipy.ndimage as ndi
 import scipy.optimize as opt
 import scipy.signal
 
@@ -335,7 +335,7 @@ def blur_im_list(im_List, fwhm_x, fwhm_t):
     sigma_t = fwhm_t / (2. * np.sqrt(2. * np.log(2.)))
 
     arr = np.array([im.imvec.reshape(im.ydim, im.xdim) for im in im_List])
-    arr = filt.gaussian_filter(arr, (sigma_t, sigma_x, sigma_x))
+    arr = ndi.gaussian_filter(arr, (sigma_t, sigma_x, sigma_x))
 
     ret = []
     for j in range(len(im_List)):

--- a/ehtim/imaging/dynamical_imaging.py
+++ b/ehtim/imaging/dynamical_imaging.py
@@ -31,7 +31,7 @@ from multiprocessing import Pool, cpu_count
 import matplotlib.pyplot as plt
 import numpy as np
 import requests
-import scipy.ndimage.filters as filt
+import scipy.ndimage as filt
 import scipy.optimize as opt
 import scipy.signal
 

--- a/ehtim/imaging/starwarps.py
+++ b/ehtim/imaging/starwarps.py
@@ -1273,24 +1273,24 @@ def applyImageWarp(im, theta, init_x, init_y, flowbasis_x, flowbasis_y, initThet
 
             vec_x = flow_x_new[1,i] - flow_x_new[0,i]
             vec_y = flow_y_new[1,i] - flow_y_new[0,i]
-            from_pts = np.row_stack( (from_pts, np.array( [ flow_x_new[0,i]-vec_x, flow_y_new[0,i]-vec_y ] ) ) )
+            from_pts = np.vstack( (from_pts, np.array( [ flow_x_new[0,i]-vec_x, flow_y_new[0,i]-vec_y ] ) ) )
             im_pts = np.concatenate( ( im_pts, np.array([0.0]) ), axis = 0 )
 
             vec_x = flow_x_new[im.ydim-2,i] - flow_x_new[im.ydim-1,i]
             vec_y = flow_y_new[im.ydim-2,i] - flow_y_new[im.ydim-1,i]
-            from_pts = np.row_stack( (from_pts, np.array( [ flow_x_new[im.ydim-1,i]-vec_x, flow_y_new[im.ydim-1,i]-vec_y ] ) ) )
+            from_pts = np.vstack( (from_pts, np.array( [ flow_x_new[im.ydim-1,i]-vec_x, flow_y_new[im.ydim-1,i]-vec_y ] ) ) )
             im_pts = np.concatenate( ( im_pts, np.array([0.0]) ), axis = 0 )
         # add padding on the y axis
         for i in range(0,im.ydim):
 
             vec_x = flow_x_new[i,1] - flow_x_new[i,0]
             vec_y = flow_y_new[i,1] - flow_y_new[i,0]
-            from_pts = np.row_stack( (from_pts, np.array( [ flow_x_new[i,0]-vec_x, flow_y_new[i,0]-vec_y ] ) ) )
+            from_pts = np.vstack( (from_pts, np.array( [ flow_x_new[i,0]-vec_x, flow_y_new[i,0]-vec_y ] ) ) )
             im_pts = np.concatenate( ( im_pts, np.array([0.0]) ), axis = 0 )
 
             vec_x = flow_x_new[i,im.xdim-2] - flow_x_new[i,im.xdim-1]
             vec_y = flow_y_new[i,im.xdim-2] - flow_y_new[i,im.xdim-1]
-            from_pts = np.row_stack( (from_pts, np.array( [ flow_x_new[i,im.xdim-1]-vec_x, flow_y_new[i,im.xdim-1]-vec_y ] ) ) )
+            from_pts = np.vstack( (from_pts, np.array( [ flow_x_new[i,im.xdim-1]-vec_x, flow_y_new[i,im.xdim-1]-vec_y ] ) ) )
             im_pts = np.concatenate( ( im_pts, np.array([0.0]) ), axis = 0 )
 
     #npixels = flowbasis_x.shape[0]*flowbasis_x.shape[1]

--- a/ehtim/io/save.py
+++ b/ehtim/io/save.py
@@ -194,14 +194,14 @@ def save_mov_hdf5(mov, fname, mjd=False):
         if mjd is False:
             mjd = mov.mjd
 
-        head.attrs['mjd'] = np.string_(str(mjd))
-        head.attrs['psize'] = np.string_(str(mov.psize))
-        head.attrs['source'] = np.string_(str(mov.source))
-        head.attrs['ra'] = np.string_(str(mov.ra))
-        head.attrs['dec'] = np.string_(str(mov.dec))
-        head.attrs['rf'] = np.string_(str(mov.rf))
-        head.attrs['polrep'] = np.string_(str(mov.polrep))
-        head.attrs['pol_prim'] = np.string_(str(mov.pol_prim))
+        head.attrs['mjd'] = np.bytes_(str(mjd))
+        head.attrs['psize'] = np.bytes_(str(mov.psize))
+        head.attrs['source'] = np.bytes_(str(mov.source))
+        head.attrs['ra'] = np.bytes_(str(mov.ra))
+        head.attrs['dec'] = np.bytes_(str(mov.dec))
+        head.attrs['rf'] = np.bytes_(str(mov.rf))
+        head.attrs['polrep'] = np.bytes_(str(mov.polrep))
+        head.attrs['pol_prim'] = np.bytes_(str(mov.pol_prim))
 
         name = 'times'
         times = mov.times

--- a/ehtim/model.py
+++ b/ehtim/model.py
@@ -1810,7 +1810,7 @@ class Model(object):
         if beta_list is None:
             beta_list = [0.0]
         out.models.append('mring')
-        out.params.append({'F0':F0,'d':d,'beta_list':np.array(beta_list, dtype=np.complex_),'beta_list_pol':np.array(beta_list_pol, dtype=np.complex_),'beta_list_cpol':np.array(beta_list_cpol, dtype=np.complex_),'x0':x0,'y0':y0})
+        out.params.append({'F0':F0,'d':d,'beta_list':np.array(beta_list, dtype=np.complex128),'beta_list_pol':np.array(beta_list_pol, dtype=np.complex128),'beta_list_cpol':np.array(beta_list_cpol, dtype=np.complex128),'x0':x0,'y0':y0})
         return out
 
     def add_stretched_mring(self, F0 = 1.0, d = 50.*RADPERUAS, x0 = 0.0, y0 = 0.0, beta_list = None, beta_list_pol = None, beta_list_cpol = None, stretch = 1.0, stretch_PA = 0.0):
@@ -1838,7 +1838,7 @@ class Model(object):
         if beta_list is None:
             beta_list = [0.0]
         out.models.append('stretched_mring')
-        out.params.append({'F0':F0,'d':d,'beta_list':np.array(beta_list, dtype=np.complex_),'beta_list_pol':np.array(beta_list_pol, dtype=np.complex_),'beta_list_cpol':np.array(beta_list_cpol, dtype=np.complex_),'x0':x0,'y0':y0,'stretch':stretch,'stretch_PA':stretch_PA})
+        out.params.append({'F0':F0,'d':d,'beta_list':np.array(beta_list, dtype=np.complex128),'beta_list_pol':np.array(beta_list_pol, dtype=np.complex128),'beta_list_cpol':np.array(beta_list_cpol, dtype=np.complex128),'x0':x0,'y0':y0,'stretch':stretch,'stretch_PA':stretch_PA})
         return out
 
     def add_thick_mring(self, F0 = 1.0, d = 50.*RADPERUAS, alpha = 10.*RADPERUAS, x0 = 0.0, y0 = 0.0, beta_list = None, beta_list_pol = None, beta_list_cpol = None):
@@ -1866,7 +1866,7 @@ class Model(object):
         if beta_list is None:
             beta_list = [0.0]
         out.models.append('thick_mring')
-        out.params.append({'F0':F0,'d':d,'beta_list':np.array(beta_list, dtype=np.complex_),'beta_list_pol':np.array(beta_list_pol, dtype=np.complex_),'beta_list_cpol':np.array(beta_list_cpol, dtype=np.complex_),'alpha':alpha,'x0':x0,'y0':y0})
+        out.params.append({'F0':F0,'d':d,'beta_list':np.array(beta_list, dtype=np.complex128),'beta_list_pol':np.array(beta_list_pol, dtype=np.complex128),'beta_list_cpol':np.array(beta_list_cpol, dtype=np.complex128),'alpha':alpha,'x0':x0,'y0':y0})
         return out
 
     def add_thick_mring_floor(self, F0 = 1.0, d = 50.*RADPERUAS, alpha = 10.*RADPERUAS, ff=0.0, x0 = 0.0, y0 = 0.0, beta_list = None, beta_list_pol = None, beta_list_cpol = None):
@@ -1896,7 +1896,7 @@ class Model(object):
         if beta_list is None:
             beta_list = [0.0]
         out.models.append('thick_mring_floor')
-        out.params.append({'F0':F0,'d':d,'beta_list':np.array(beta_list, dtype=np.complex_),'beta_list_pol':np.array(beta_list_pol, dtype=np.complex_),'beta_list_cpol':np.array(beta_list_cpol, dtype=np.complex_),'alpha':alpha,'x0':x0,'y0':y0,'ff':ff})
+        out.params.append({'F0':F0,'d':d,'beta_list':np.array(beta_list, dtype=np.complex128),'beta_list_pol':np.array(beta_list_pol, dtype=np.complex128),'beta_list_cpol':np.array(beta_list_cpol, dtype=np.complex128),'alpha':alpha,'x0':x0,'y0':y0,'ff':ff})
         return out
 
     def add_thick_mring_Gfloor(self, F0 = 1.0, d = 50.*RADPERUAS, alpha = 10.*RADPERUAS, ff=0.0, FWHM = 50.*RADPERUAS, x0 = 0.0, y0 = 0.0, beta_list = None, beta_list_pol = None, beta_list_cpol = None):
@@ -1927,7 +1927,7 @@ class Model(object):
         if beta_list is None:
             beta_list = [0.0]
         out.models.append('thick_mring_Gfloor')
-        out.params.append({'F0':F0,'d':d,'beta_list':np.array(beta_list, dtype=np.complex_),'beta_list_pol':np.array(beta_list_pol, dtype=np.complex_),'beta_list_cpol':np.array(beta_list_cpol, dtype=np.complex_),'alpha':alpha,'x0':x0,'y0':y0,'ff':ff,'FWHM':FWHM})
+        out.params.append({'F0':F0,'d':d,'beta_list':np.array(beta_list, dtype=np.complex128),'beta_list_pol':np.array(beta_list_pol, dtype=np.complex128),'beta_list_cpol':np.array(beta_list_cpol, dtype=np.complex128),'alpha':alpha,'x0':x0,'y0':y0,'ff':ff,'FWHM':FWHM})
         return out
 
     def add_stretched_thick_mring(self, F0 = 1.0, d = 50.*RADPERUAS, alpha = 10.*RADPERUAS, x0 = 0.0, y0 = 0.0, beta_list = None, beta_list_pol = None, beta_list_cpol = None, stretch = 1.0, stretch_PA = 0.0):
@@ -1957,7 +1957,7 @@ class Model(object):
         if beta_list is None:
             beta_list = [0.0]
         out.models.append('stretched_thick_mring')
-        out.params.append({'F0':F0,'d':d,'beta_list':np.array(beta_list, dtype=np.complex_),'beta_list_pol':np.array(beta_list_pol, dtype=np.complex_),'beta_list_cpol':np.array(beta_list_cpol, dtype=np.complex_),'alpha':alpha,'x0':x0,'y0':y0,'stretch':stretch,'stretch_PA':stretch_PA})
+        out.params.append({'F0':F0,'d':d,'beta_list':np.array(beta_list, dtype=np.complex128),'beta_list_pol':np.array(beta_list_pol, dtype=np.complex128),'beta_list_cpol':np.array(beta_list_cpol, dtype=np.complex128),'alpha':alpha,'x0':x0,'y0':y0,'stretch':stretch,'stretch_PA':stretch_PA})
         return out
 
     def add_stretched_thick_mring_floor(self, F0 = 1.0, d = 50.*RADPERUAS, alpha = 10.*RADPERUAS, ff=0.0, x0 = 0.0, y0 = 0.0, beta_list = None, beta_list_pol = None, beta_list_cpol = None, stretch = 1.0, stretch_PA = 0.0):
@@ -1987,7 +1987,7 @@ class Model(object):
         if beta_list is None:
             beta_list = [0.0]
         out.models.append('stretched_thick_mring_floor')
-        out.params.append({'F0':F0,'d':d,'beta_list':np.array(beta_list, dtype=np.complex_),'beta_list_pol':np.array(beta_list_pol, dtype=np.complex_),'beta_list_cpol':np.array(beta_list_cpol, dtype=np.complex_),'alpha':alpha,'x0':x0,'y0':y0,'stretch':stretch,'stretch_PA':stretch_PA,'ff':ff})
+        out.params.append({'F0':F0,'d':d,'beta_list':np.array(beta_list, dtype=np.complex128),'beta_list_pol':np.array(beta_list_pol, dtype=np.complex128),'beta_list_cpol':np.array(beta_list_cpol, dtype=np.complex128),'alpha':alpha,'x0':x0,'y0':y0,'stretch':stretch,'stretch_PA':stretch_PA,'ff':ff})
         return out
 
     def sample_xy(self, x, y, psize=1.*RADPERUAS, pol='I'):

--- a/ehtim/model.py
+++ b/ehtim/model.py
@@ -1,28 +1,31 @@
 # model.py
 # an interferometric model class
 
-from __future__ import division
-from __future__ import print_function
-from builtins import str
-from builtins import range
-from builtins import object
-
-import numpy as np
-import scipy.special as sps
-import scipy.integrate as integrate
-import scipy.interpolate as interpolate
 import copy
 
+import numpy as np
+import scipy.integrate as integrate
+import scipy.interpolate as interpolate
+import scipy.special as sps
+
+#from ehtim.modeling.modeling_utils import *
+import ehtim.image as image
 import ehtim.observing.obs_simulate as simobs
 import ehtim.observing.pulses
-
-from ehtim.const_def import *
-from ehtim.observing.obs_helpers import *
-#from ehtim.modeling.modeling_utils import *
-
-import ehtim.image as image
-
-from ehtim.const_def import *
+from ehtim.const_def import (
+    DEC_DEFAULT,
+    DTERMPDEF,
+    ELEV_HIGH,
+    ELEV_LOW,
+    GAINPDEF,
+    MJD_DEFAULT,
+    PULSE_DEFAULT,
+    RA_DEFAULT,
+    RADPERUAS,
+    RF_DEFAULT,
+    SOURCE_DEFAULT,
+    TAUDEF,
+)
 
 LINE_THICKNESS = 2 # Thickness of 1D models on the image, in pixels
 FOV_DEFAULT = 100.*RADPERUAS
@@ -52,7 +55,7 @@ def model_params(model_type, model_params=None, fit_pol=False, fit_cpol=False):
             if model_type.find('mring') == -1:
                 params.append('pol_frac')
                 params.append('pol_evpa')
-            else:            
+            else:
                 for j in range(-(len(model_params['beta_list_pol'])-1)//2,(len(model_params['beta_list_pol'])+1)//2):
                     params.append('betapol' + str(j) + complex_labels[0])
                     params.append('betapol' + str(j) + complex_labels[1])
@@ -115,19 +118,19 @@ def model_params(model_type, model_params=None, fit_pol=False, fit_cpol=False):
         params.append('stretch')
         params.append('stretch_PA')
     elif model_type == 'thick_mring':
-        params = ['F0','d','alpha','x0','y0']            
+        params = ['F0','d','alpha','x0','y0']
         for j in range(len(model_params['beta_list'])):
             params.append('beta' + str(j+1) + complex_labels[0])
             params.append('beta' + str(j+1) + complex_labels[1])
         add_pol()
     elif model_type == 'thick_mring_floor':
-        params = ['F0','d','alpha','ff','x0','y0']            
+        params = ['F0','d','alpha','ff','x0','y0']
         for j in range(len(model_params['beta_list'])):
             params.append('beta' + str(j+1) + complex_labels[0])
             params.append('beta' + str(j+1) + complex_labels[1])
         add_pol()
     elif model_type == 'thick_mring_Gfloor':
-        params = ['F0','d','alpha','ff','FWHM','x0','y0']            
+        params = ['F0','d','alpha','ff','FWHM','x0','y0']
         for j in range(len(model_params['beta_list'])):
             params.append('beta' + str(j+1) + complex_labels[0])
             params.append('beta' + str(j+1) + complex_labels[1])
@@ -150,7 +153,7 @@ def model_params(model_type, model_params=None, fit_pol=False, fit_cpol=False):
         params.append('stretch')
         params.append('stretch_PA')
     else:
-        print('Model ' + model_init.models[j] + ' not recognized.')
+        print('Model ' + model_type + ' not recognized.')
         params = []
 
     return params
@@ -166,13 +169,13 @@ def default_prior(model_type,model_params=None,fit_pol=False,fit_cpol=False):
     elif COMPLEX_BASIS == 'abs-arg':
         complex_labels = ['_abs','_arg']
         # Note: angle range here must match np.angle(). Need to properly define wrapped distributions
-        complex_priors  = [{'prior_type':'flat','min':0.0,'max':0.5}, {'prior_type':'flat','min':-np.pi, 'max':np.pi}] 
-        complex_priors2 = [{'prior_type':'flat','min':0.0,'max':1.0}, {'prior_type':'flat','min':-np.pi, 'max':np.pi}] 
+        complex_priors  = [{'prior_type':'flat','min':0.0,'max':0.5}, {'prior_type':'flat','min':-np.pi, 'max':np.pi}]
+        complex_priors2 = [{'prior_type':'flat','min':0.0,'max':1.0}, {'prior_type':'flat','min':-np.pi, 'max':np.pi}]
     else:
         raise Exception('COMPLEX_BASIS ' + COMPLEX_BASIS + ' not recognized!')
 
-    prior = {'F0':{'prior_type':'none','transform':'log'}, 
-             'x0':{'prior_type':'none'}, 
+    prior = {'F0':{'prior_type':'none','transform':'log'},
+             'x0':{'prior_type':'none'},
              'y0':{'prior_type':'none'}}
     if model_type == 'point':
         pass
@@ -187,7 +190,7 @@ def default_prior(model_type,model_params=None,fit_pol=False,fit_cpol=False):
     elif model_type == 'blurred_disk':
         prior['d'] = {'prior_type':'positive','transform':'log'}
         prior['alpha'] = {'prior_type':'positive','transform':'log'}
-    elif model_type == 'crescent': 
+    elif model_type == 'crescent':
         prior['d'] = {'prior_type':'positive','transform':'log'}
         prior['fr'] = {'prior_type':'flat','min':0,'max':1}
         prior['fo'] = {'prior_type':'flat','min':0,'max':1}
@@ -271,7 +274,7 @@ def default_prior(model_type,model_params=None,fit_pol=False,fit_cpol=False):
         if model_type.find('mring') == -1:
             prior['pol_frac'] = {'prior_type':'flat','min':0.0,'max':1.0}
             prior['pol_evpa'] = {'prior_type':'flat','min':0.0,'max':np.pi}
-        else:            
+        else:
             for j in range(-(len(model_params['beta_list_pol'])-1)//2,(len(model_params['beta_list_pol'])+1)//2):
                 prior['betapol' + str(j) + complex_labels[0]] = complex_priors2[0]
                 prior['betapol' + str(j) + complex_labels[1]] = complex_priors2[1]
@@ -334,7 +337,7 @@ def get_const_polfac(model_type, params, pol):
 
     return 0.0
 
-def sample_1model_xy(x, y, model_type, params, psize=1.*RADPERUAS, pol='I'):   
+def sample_1model_xy(x, y, model_type, params, psize=1.*RADPERUAS, pol='I'):
     if pol == 'Q':
         return np.real(sample_1model_xy(x, y, model_type, params, psize=psize, pol='P'))
     elif pol == 'U':
@@ -348,18 +351,18 @@ def sample_1model_xy(x, y, model_type, params, psize=1.*RADPERUAS, pol='I'):
         val = params['F0'] * (np.abs( x - params['x0']) < psize/2.0) * (np.abs( y - params['y0']) < psize/2.0)
     elif model_type == 'circ_gauss':
         sigma = params['FWHM'] / (2. * np.sqrt(2. * np.log(2.)))
-        val = (params['F0']*psize**2 * 4.0 * np.log(2.)/(np.pi * params['FWHM']**2) * 
+        val = (params['F0']*psize**2 * 4.0 * np.log(2.)/(np.pi * params['FWHM']**2) *
                np.exp(-((x - params['x0'])**2 + (y - params['y0'])**2)/(2*sigma**2)))
     elif model_type == 'gauss':
         sigma_maj = params['FWHM_maj'] / (2. * np.sqrt(2. * np.log(2.)))
         sigma_min = params['FWHM_min'] / (2. * np.sqrt(2. * np.log(2.)))
         cth = np.cos(params['PA'])
         sth = np.sin(params['PA'])
-        val = (params['F0']*psize**2 * 4.0 * np.log(2.)/(np.pi * params['FWHM_maj'] * params['FWHM_min']) * 
+        val = (params['F0']*psize**2 * 4.0 * np.log(2.)/(np.pi * params['FWHM_maj'] * params['FWHM_min']) *
                np.exp(-((y - params['y0'])*np.cos(params['PA']) + (x - params['x0'])*np.sin(params['PA']))**2/(2*sigma_maj**2) +
                       -((x - params['x0'])*np.cos(params['PA']) - (y - params['y0'])*np.sin(params['PA']))**2/(2*sigma_min**2)))
     elif model_type == 'disk':
-        val = params['F0']*psize**2/(np.pi*params['d']**2/4.) * (np.sqrt((x - params['x0'])**2 + (y - params['y0'])**2) < params['d']/2.0) 
+        val = params['F0']*psize**2/(np.pi*params['d']**2/4.) * (np.sqrt((x - params['x0'])**2 + (y - params['y0'])**2) < params['d']/2.0)
     elif model_type == 'blurred_disk':
         # Note: the exact form of a blurred disk requires numeric integration
 
@@ -367,12 +370,12 @@ def sample_1model_xy(x, y, model_type, params, psize=1.*RADPERUAS, pol='I'):
         I_peak = 4.0/(np.pi*params['d']**2) * (1.0 - 2.0**(-params['d']**2/params['alpha']**2))
 
         # Constant prefactor
-        prefac = 32.0 * np.log(2.0)/(np.pi * params['alpha']**2 * params['d']**2) 
+        prefac = 32.0 * np.log(2.0)/(np.pi * params['alpha']**2 * params['d']**2)
 
         def f(r):
-            return integrate.quad(lambda rp: 
-                prefac * rp * np.exp( -4.0 * np.log(2.0)/params['alpha']**2 * (r**2 + rp**2 - 2.0*r * rp) ) 
-                * sps.ive(0, 8.0*np.log(2.0) * r * rp/params['alpha']**2), 
+            return integrate.quad(lambda rp:
+                prefac * rp * np.exp( -4.0 * np.log(2.0)/params['alpha']**2 * (r**2 + rp**2 - 2.0*r * rp) )
+                * sps.ive(0, 8.0*np.log(2.0) * r * rp/params['alpha']**2),
                 0, params['d']/2.0, limit=1000, epsabs=I_peak/1e9, epsrel=1.0e-6)[0]
         f=np.vectorize(f)
         r = np.sqrt((x - params['x0'])**2 + (y - params['y0'])**2)
@@ -382,7 +385,7 @@ def sample_1model_xy(x, y, model_type, params, psize=1.*RADPERUAS, pol='I'):
             r_min = np.min(r)
             r_max = np.max(r)
             r_list = np.linspace(r_min, r_max, int((r_max-r_min)/(params['alpha']) * 20))
-            if len(r_list) < len(np.ravel(r))/2 and len(r) > 100: 
+            if len(r_list) < len(np.ravel(r))/2 and len(r) > 100:
                 f = interpolate.interp1d(r_list, f(r_list), kind='cubic')
         val = params['F0'] * psize**2 * f(r)
     elif model_type == 'crescent':
@@ -393,7 +396,7 @@ def sample_1model_xy(x, y, model_type, params, psize=1.*RADPERUAS, pol='I'):
         r = params['d'] / 2.
         params0 = {'F0': 1.0/(1.0-(1-ff)*fr**2)*params['F0'],   'd':params['d'],    'x0': params['x0'], 'y0': params['y0']}
         params1 = {'F0': (1-ff)*fr**2/(1.0-(1-ff)*fr**2)*params['F0'], 'd':params['d']*fr, 'x0': params['x0'] + r*(1-fr)*fo*np.sin(phi), 'y0': params['y0'] + r*(1-fr)*fo*np.cos(phi)}
-        val =  sample_1model_xy(x, y, 'disk', params0, psize=psize, pol=pol) 
+        val =  sample_1model_xy(x, y, 'disk', params0, psize=psize, pol=pol)
         val -= sample_1model_xy(x, y, 'disk', params1, psize=psize, pol=pol)
     elif model_type == 'blurred_crescent':
         phi = params['phi']
@@ -403,7 +406,7 @@ def sample_1model_xy(x, y, model_type, params, psize=1.*RADPERUAS, pol='I'):
         r = params['d'] / 2.
         params0 = {'F0': 1.0/(1.0-(1-ff)*fr**2)*params['F0'],   'd':params['d'], 'alpha':params['alpha'], 'x0': params['x0'], 'y0': params['y0']}
         params1 = {'F0': (1-ff)*fr**2/(1.0-(1-ff)*fr**2)*params['F0'], 'd':params['d']*fr, 'alpha':params['alpha'], 'x0': params['x0'] + r*(1-fr)*fo*np.sin(phi), 'y0': params['y0'] + r*(1-fr)*fo*np.cos(phi)}
-        val =  sample_1model_xy(x, y, 'blurred_disk', params0, psize=psize, pol=pol) 
+        val =  sample_1model_xy(x, y, 'blurred_disk', params0, psize=psize, pol=pol)
         val -= sample_1model_xy(x, y, 'blurred_disk', params1, psize=psize, pol=pol)
     elif model_type == 'ring':
         val = (params['F0']*psize**2/(np.pi*params['d']*psize*LINE_THICKNESS)
@@ -414,7 +417,7 @@ def sample_1model_xy(x, y, model_type, params, psize=1.*RADPERUAS, pol='I'):
         z = 4.*np.log(2.) * r * params['d']/params['alpha']**2
         val = (params['F0']*psize**2 * 4.0 * np.log(2.)/(np.pi * params['alpha']**2)
                 * np.exp(-4.*np.log(2.)/params['alpha']**2*(r**2 + params['d']**2/4.) + z)
-                * sps.ive(0, z)) 
+                * sps.ive(0, z))
     elif model_type == 'mring':
         phi = np.angle((y - params['y0']) + 1j*(x - params['x0']))
         if pol == 'I':
@@ -484,15 +487,24 @@ def sample_1model_uv(u, v, model_type, params, pol='I', jonesdict=None):
         LRp = LR + RR * DL1 * np.exp(-2j*fr1) + LL * DR2 * np.exp(-2j*fr2) + RL * DL1 * DR2 * np.exp(-2j*(fr1+fr2))
         LLp = LL + LR * DL2 * np.exp( 2j*fr2) + RL * DL1 * np.exp(-2j*fr1) + RR * DL1 * DL2 * np.exp(-2j*(fr1-fr2))
         # Return the specified polarization
-        if   pol == 'RR': return RRp
-        elif pol == 'RL': return RLp
-        elif pol == 'LR': return LRp
-        elif pol == 'LL': return LLp
-        elif pol == 'I':  return 0.5 * (RRp + LLp)
-        elif pol == 'Q':  return 0.5 * (LRp + RLp)
-        elif pol == 'U':  return 0.5j* (LRp - RLp)
-        elif pol == 'V':  return 0.5 * (RRp - LLp)
-        elif pol == 'P':  return RLp
+        if   pol == 'RR':
+            return RRp
+        elif pol == 'RL':
+            return RLp
+        elif pol == 'LR':
+            return LRp
+        elif pol == 'LL':
+            return LLp
+        elif pol == 'I':
+            return 0.5 * (RRp + LLp)
+        elif pol == 'Q':
+            return 0.5 * (LRp + RLp)
+        elif pol == 'U':
+            return 0.5j* (LRp - RLp)
+        elif pol == 'V':
+            return 0.5 * (RRp - LLp)
+        elif pol == 'P':
+            return RLp
         else:
             raise Exception('Polarization ' + pol + ' not recognized!')
 
@@ -516,28 +528,28 @@ def sample_1model_uv(u, v, model_type, params, pol='I', jonesdict=None):
     if model_type == 'point':
         val = params['F0'] * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))
     elif model_type == 'circ_gauss':
-        val = (params['F0'] 
+        val = (params['F0']
                * np.exp(-np.pi**2/(4.*np.log(2.)) * (u**2 + v**2) * params['FWHM']**2)
-               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) 
+               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))
     elif model_type == 'gauss':
         u_maj = u*np.sin(params['PA']) + v*np.cos(params['PA'])
         u_min = u*np.cos(params['PA']) - v*np.sin(params['PA'])
-        val = (params['F0'] 
+        val = (params['F0']
                * np.exp(-np.pi**2/(4.*np.log(2.)) * ((u_maj * params['FWHM_maj'])**2 + (u_min * params['FWHM_min'])**2))
-               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) 
+               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))
     elif model_type == 'disk':
         z = np.pi * params['d'] * (u**2 + v**2)**0.5
         #Add a small offset to avoid issues with division by zero
         z += (z == 0.0) * 1e-10
-        val = (params['F0'] * 2.0/z * sps.jv(1, z) 
-               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) 
+        val = (params['F0'] * 2.0/z * sps.jv(1, z)
+               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))
     elif model_type == 'blurred_disk':
         z = np.pi * params['d'] * (u**2 + v**2)**0.5
         #Add a small offset to avoid issues with division by zero
         z += (z == 0.0) * 1e-10
-        val = (params['F0'] * 2.0/z * sps.jv(1, z) 
+        val = (params['F0'] * 2.0/z * sps.jv(1, z)
                * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))
-               * np.exp(-(np.pi * params['alpha'] * (u**2 + v**2)**0.5)**2/(4. * np.log(2.)))) 
+               * np.exp(-(np.pi * params['alpha'] * (u**2 + v**2)**0.5)**2/(4. * np.log(2.))))
     elif model_type == 'crescent':
         phi = params['phi']
         fr = params['fr']
@@ -546,7 +558,7 @@ def sample_1model_uv(u, v, model_type, params, pol='I', jonesdict=None):
         r = params['d'] / 2.
         params0 = {'F0': 1.0/(1.0-(1-ff)*fr**2)*params['F0'],   'd':params['d'],    'x0': params['x0'], 'y0': params['y0']}
         params1 = {'F0': (1-ff)*fr**2/(1.0-(1-ff)*fr**2)*params['F0'], 'd':params['d']*fr, 'x0': params['x0'] + r*(1-fr)*fo*np.sin(phi), 'y0': params['y0'] + r*(1-fr)*fo*np.cos(phi)}
-        val =  sample_1model_uv(u, v, 'disk', params0, pol=pol, jonesdict=jonesdict) 
+        val =  sample_1model_uv(u, v, 'disk', params0, pol=pol, jonesdict=jonesdict)
         val -= sample_1model_uv(u, v, 'disk', params1, pol=pol, jonesdict=jonesdict)
     elif model_type == 'blurred_crescent':
         phi = params['phi']
@@ -556,17 +568,17 @@ def sample_1model_uv(u, v, model_type, params, pol='I', jonesdict=None):
         r = params['d'] / 2.
         params0 = {'F0': 1.0/(1.0-(1-ff)*fr**2)*params['F0'],   'd':params['d'], 'alpha':params['alpha'], 'x0': params['x0'], 'y0': params['y0']}
         params1 = {'F0': (1-ff)*fr**2/(1.0-(1-ff)*fr**2)*params['F0'], 'd':params['d']*fr, 'alpha':params['alpha'], 'x0': params['x0'] + r*(1-fr)*fo*np.sin(phi), 'y0': params['y0'] + r*(1-fr)*fo*np.cos(phi)}
-        val =  sample_1model_uv(u, v, 'blurred_disk', params0, pol=pol, jonesdict=jonesdict) 
-        val -= sample_1model_uv(u, v, 'blurred_disk', params1, pol=pol, jonesdict=jonesdict) 
+        val =  sample_1model_uv(u, v, 'blurred_disk', params0, pol=pol, jonesdict=jonesdict)
+        val -= sample_1model_uv(u, v, 'blurred_disk', params1, pol=pol, jonesdict=jonesdict)
     elif model_type == 'ring':
         z = np.pi * params['d'] * (u**2 + v**2)**0.5
-        val = (params['F0'] * sps.jv(0, z) 
-               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) 
+        val = (params['F0'] * sps.jv(0, z)
+               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))
     elif model_type == 'thick_ring':
         z = np.pi * params['d'] * (u**2 + v**2)**0.5
-        val = (params['F0'] * sps.jv(0, z) 
+        val = (params['F0'] * sps.jv(0, z)
                * np.exp(-(np.pi * params['alpha'] * (u**2 + v**2)**0.5)**2/(4. * np.log(2.)))
-               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) 
+               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))
     elif model_type == 'mring':
         phi = np.angle(v + 1j*u)
         # Flip the baseline sign to match eht-imaging conventions
@@ -574,11 +586,11 @@ def sample_1model_uv(u, v, model_type, params, pol='I', jonesdict=None):
         z = np.pi * params['d'] * (u**2 + v**2)**0.5
 
         if pol == 'I':
-            beta_factor = (sps.jv(0, z) 
+            beta_factor = (sps.jv(0, z)
                + np.sum([params['beta_list'][m-1]          * sps.jv( m, z) * np.exp( 1j * m * (phi - np.pi/2.)) for m in range(1,len(params['beta_list'])+1)],axis=0)
                + np.sum([np.conj(params['beta_list'][m-1]) * sps.jv(-m, z) * np.exp(-1j * m * (phi - np.pi/2.)) for m in range(1,len(params['beta_list'])+1)],axis=0))
         elif pol == 'V' and len(params['beta_list_cpol']) > 0:
-            beta_factor = (np.real(params['beta_list_cpol'][0]) * sps.jv(0, z) 
+            beta_factor = (np.real(params['beta_list_cpol'][0]) * sps.jv(0, z)
                + np.sum([params['beta_list_cpol'][m]          * sps.jv( m, z) * np.exp( 1j * m * (phi - np.pi/2.)) for m in range(1,len(params['beta_list_cpol']))],axis=0)
                + np.sum([np.conj(params['beta_list_cpol'][m]) * sps.jv(-m, z) * np.exp(-1j * m * (phi - np.pi/2.)) for m in range(1,len(params['beta_list_cpol']))],axis=0))
         elif pol == 'P' and len(params['beta_list_pol']) > 0:
@@ -595,11 +607,11 @@ def sample_1model_uv(u, v, model_type, params, pol='I', jonesdict=None):
         z = np.pi * params['d'] * (u**2 + v**2)**0.5
 
         if pol == 'I':
-            beta_factor = (sps.jv(0, z) 
+            beta_factor = (sps.jv(0, z)
                + np.sum([params['beta_list'][m-1]          * sps.jv( m, z) * np.exp( 1j * m * (phi - np.pi/2.)) for m in range(1,len(params['beta_list'])+1)],axis=0)
                + np.sum([np.conj(params['beta_list'][m-1]) * sps.jv(-m, z) * np.exp(-1j * m * (phi - np.pi/2.)) for m in range(1,len(params['beta_list'])+1)],axis=0))
         elif pol == 'V' and len(params['beta_list_cpol']) > 0:
-            beta_factor = (np.real(params['beta_list_cpol'][0]) * sps.jv(0, z) 
+            beta_factor = (np.real(params['beta_list_cpol'][0]) * sps.jv(0, z)
                + np.sum([params['beta_list_cpol'][m]          * sps.jv( m, z) * np.exp( 1j * m * (phi - np.pi/2.)) for m in range(1,len(params['beta_list_cpol']))],axis=0)
                + np.sum([np.conj(params['beta_list_cpol'][m]) * sps.jv(-m, z) * np.exp(-1j * m * (phi - np.pi/2.)) for m in range(1,len(params['beta_list_cpol']))],axis=0))
         elif pol == 'P' and len(params['beta_list_pol']) > 0:
@@ -610,7 +622,7 @@ def sample_1model_uv(u, v, model_type, params, pol='I', jonesdict=None):
 
         val = (params['F0'] * beta_factor
                * np.exp(-(np.pi * params['alpha'] * (u**2 + v**2)**0.5)**2/(4. * np.log(2.)))
-               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) 
+               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))
     elif model_type == 'thick_mring_floor':
         val  = (1.0 - params['ff']) * sample_1model_uv(u, v, 'thick_mring', params, pol=pol, jonesdict=jonesdict)
         val += params['ff'] * sample_1model_uv(u, v, 'blurred_disk', params, pol=pol, jonesdict=jonesdict)
@@ -618,10 +630,10 @@ def sample_1model_uv(u, v, model_type, params, pol='I', jonesdict=None):
         val  = (1.0 - params['ff']) * sample_1model_uv(u, v, 'thick_mring', params, pol=pol, jonesdict=jonesdict)
         val += params['ff'] * sample_1model_uv(u, v, 'circ_gauss', params, pol=pol, jonesdict=jonesdict)
     elif model_type[:9] == 'stretched':
-        params_stretch = params.copy()        
+        params_stretch = params.copy()
         params_stretch['x0'] = 0.0
         params_stretch['y0'] = 0.0
-        val = sample_1model_uv(*stretch_uv(u,v,params), model_type[10:], params_stretch, pol=pol) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])) 
+        val = sample_1model_uv(*stretch_uv(u,v,params), model_type[10:], params_stretch, pol=pol) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))
     else:
         print('Model ' + model_type + ' not recognized!')
         val = 0.0
@@ -650,15 +662,24 @@ def sample_1model_graduv_uv(u, v, model_type, params, pol='I', jonesdict=None):
         LRp = (LR + RR * DL1 * np.exp(-2j*fr1) + LL * DR2 * np.exp(-2j*fr2) + RL * DL1 * DR2 * np.exp(-2j*(fr1+fr2)))
         LLp = (LL + LR * DL2 * np.exp( 2j*fr2) + RL * DL1 * np.exp(-2j*fr1) + RR * DL1 * DL2 * np.exp(-2j*(fr1-fr2)))
         # Return the specified polarization
-        if   pol == 'RR': return RRp
-        elif pol == 'RL': return RLp
-        elif pol == 'LR': return LRp
-        elif pol == 'LL': return LLp
-        elif pol == 'I':  return 0.5 * (RRp + LLp)
-        elif pol == 'Q':  return 0.5 * (LRp + RLp)
-        elif pol == 'U':  return 0.5j* (LRp - RLp)
-        elif pol == 'V':  return 0.5 * (RRp - LLp)
-        elif pol == 'P':  return RLp
+        if   pol == 'RR':
+            return RRp
+        elif pol == 'RL':
+            return RLp
+        elif pol == 'LR':
+            return LRp
+        elif pol == 'LL':
+            return LLp
+        elif pol == 'I':
+            return 0.5 * (RRp + LLp)
+        elif pol == 'Q':
+            return 0.5 * (LRp + RLp)
+        elif pol == 'U':
+            return 0.5j* (LRp - RLp)
+        elif pol == 'V':
+            return 0.5 * (RRp - LLp)
+        elif pol == 'P':
+            return RLp
         else:
             raise Exception('Polarization ' + pol + ' not recognized!')
 
@@ -680,37 +701,37 @@ def sample_1model_graduv_uv(u, v, model_type, params, pol='I', jonesdict=None):
         raise Exception('Polarization ' + pol + ' not implemented!')
 
     vis = sample_1model_uv(u, v, model_type, params, jonesdict=jonesdict)
-    if model_type == 'point': 
+    if model_type == 'point':
         val = np.array([ 1j * 2.0 * np.pi * params['x0'] * vis,
                           1j * 2.0 * np.pi * params['y0'] * vis])
-    elif model_type == 'circ_gauss': 
+    elif model_type == 'circ_gauss':
         val = np.array([ (1j * 2.0 * np.pi * params['x0'] - params['FWHM']**2 * np.pi**2 * u/(2. * np.log(2.))) * vis,
-                          (1j * 2.0 * np.pi * params['y0'] - params['FWHM']**2 * np.pi**2 * v/(2. * np.log(2.))) * vis])                          
-    elif model_type == 'gauss': 
+                          (1j * 2.0 * np.pi * params['y0'] - params['FWHM']**2 * np.pi**2 * v/(2. * np.log(2.))) * vis])
+    elif model_type == 'gauss':
         u_maj = u*np.sin(params['PA']) + v*np.cos(params['PA'])
         u_min = u*np.cos(params['PA']) - v*np.sin(params['PA'])
         val = np.array([ (1j * 2.0 * np.pi * params['x0'] - params['FWHM_maj']**2 * np.pi**2 * u_maj/(2. * np.log(2.)) * np.sin(params['PA']) - params['FWHM_min']**2 * np.pi**2 * u_min/(2. * np.log(2.)) * np.cos(params['PA'])) * vis,
-                          (1j * 2.0 * np.pi * params['y0'] - params['FWHM_maj']**2 * np.pi**2 * u_maj/(2. * np.log(2.)) * np.cos(params['PA']) + params['FWHM_min']**2 * np.pi**2 * u_min/(2. * np.log(2.)) * np.sin(params['PA'])) * vis])       
-    elif model_type == 'disk': 
+                          (1j * 2.0 * np.pi * params['y0'] - params['FWHM_maj']**2 * np.pi**2 * u_maj/(2. * np.log(2.)) * np.cos(params['PA']) + params['FWHM_min']**2 * np.pi**2 * u_min/(2. * np.log(2.)) * np.sin(params['PA'])) * vis])
+    elif model_type == 'disk':
         # Take care of the degenerate origin point by a small offset
         #v += (u==0.)*(v==0.)*1e-10
         uvdist = (u**2 + v**2 + (u==0.)*(v==0.)*1e-10)**0.5
         z = np.pi * params['d'] * uvdist
         bessel_deriv = 0.5 * (sps.jv( 0, z) - sps.jv( 2, z))
-        val = np.array([  (1j * 2.0 * np.pi * params['x0'] - u/uvdist**2) * vis 
+        val = np.array([  (1j * 2.0 * np.pi * params['x0'] - u/uvdist**2) * vis
                             + params['F0'] * 2./z * np.pi * params['d'] * u/uvdist * bessel_deriv * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])),
-                          (1j * 2.0 * np.pi * params['y0'] - v/uvdist**2) * vis 
+                          (1j * 2.0 * np.pi * params['y0'] - v/uvdist**2) * vis
                             + params['F0'] * 2./z * np.pi * params['d'] * v/uvdist * bessel_deriv * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])) ])
-    elif model_type == 'blurred_disk': 
+    elif model_type == 'blurred_disk':
         # Take care of the degenerate origin point by a small offset
         #u += (u==0.)*(v==0.)*1e-10
         uvdist = (u**2 + v**2 + (u==0.)*(v==0.)*1e-10)**0.5
         z = np.pi * params['d'] * uvdist
         blur = np.exp(-(np.pi * params['alpha'] * (u**2 + v**2)**0.5)**2/(4. * np.log(2.)))
         bessel_deriv = 0.5 * (sps.jv( 0, z) - sps.jv( 2, z))
-        val = np.array([ (1j * 2.0 * np.pi * params['x0'] - u/uvdist**2 - params['alpha']**2 * np.pi**2 * u/(2. * np.log(2.))) * vis 
+        val = np.array([ (1j * 2.0 * np.pi * params['x0'] - u/uvdist**2 - params['alpha']**2 * np.pi**2 * u/(2. * np.log(2.))) * vis
                             + params['F0'] * 2./z * np.pi * params['d'] * u/uvdist * bessel_deriv * blur * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])),
-                         (1j * 2.0 * np.pi * params['y0'] - v/uvdist**2 - params['alpha']**2 * np.pi**2 * v/(2. * np.log(2.))) * vis 
+                         (1j * 2.0 * np.pi * params['y0'] - v/uvdist**2 - params['alpha']**2 * np.pi**2 * v/(2. * np.log(2.))) * vis
                             + params['F0'] * 2./z * np.pi * params['d'] * v/uvdist * bessel_deriv * blur * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])) ])
     elif model_type == 'crescent':
         phi = params['phi']
@@ -720,7 +741,7 @@ def sample_1model_graduv_uv(u, v, model_type, params, pol='I', jonesdict=None):
         r = params['d'] / 2.
         params0 = {'F0': 1.0/(1.0-(1-ff)*fr**2)*params['F0'],   'd':params['d'],    'x0': params['x0'], 'y0': params['y0']}
         params1 = {'F0': (1-ff)*fr**2/(1.0-(1-ff)*fr**2)*params['F0'], 'd':params['d']*fr, 'x0': params['x0'] + r*(1-fr)*fo*np.sin(phi), 'y0': params['y0'] + r*(1-fr)*fo*np.cos(phi)}
-        val =  sample_1model_graduv_uv(u, v, 'disk', params0, pol=pol, jonesdict=jonesdict) 
+        val =  sample_1model_graduv_uv(u, v, 'disk', params0, pol=pol, jonesdict=jonesdict)
         val -= sample_1model_graduv_uv(u, v, 'disk', params1, pol=pol, jonesdict=jonesdict)
     elif model_type == 'blurred_crescent':
         phi = params['phi']
@@ -730,37 +751,37 @@ def sample_1model_graduv_uv(u, v, model_type, params, pol='I', jonesdict=None):
         r = params['d'] / 2.
         params0 = {'F0': 1.0/(1.0-(1-ff)*fr**2)*params['F0'],   'd':params['d'], 'alpha':params['alpha'], 'x0': params['x0'], 'y0': params['y0']}
         params1 = {'F0': (1-ff)*fr**2/(1.0-(1-ff)*fr**2)*params['F0'], 'd':params['d']*fr, 'alpha':params['alpha'], 'x0': params['x0'] + r*(1-fr)*fo*np.sin(phi), 'y0': params['y0'] + r*(1-fr)*fo*np.cos(phi)}
-        val =  sample_1model_graduv_uv(u, v, 'blurred_disk', params0, pol=pol, jonesdict=jonesdict) 
-        val -= sample_1model_graduv_uv(u, v, 'blurred_disk', params1, pol=pol, jonesdict=jonesdict) 
+        val =  sample_1model_graduv_uv(u, v, 'blurred_disk', params0, pol=pol, jonesdict=jonesdict)
+        val -= sample_1model_graduv_uv(u, v, 'blurred_disk', params1, pol=pol, jonesdict=jonesdict)
     elif model_type == 'ring':
         # Take care of the degenerate origin point by a small offset
         u += (u==0.)*(v==0.)*1e-10
         uvdist = (u**2 + v**2 + (u==0.)*(v==0.)*1e-10)**0.5
         z = np.pi * params['d'] * uvdist
-        val = np.array([ 1j * 2.0 * np.pi * params['x0'] * vis 
+        val = np.array([ 1j * 2.0 * np.pi * params['x0'] * vis
                             - params['F0'] * np.pi*params['d']*u/uvdist * sps.jv(1, z) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])),
-                          1j * 2.0 * np.pi * params['y0'] * vis 
+                          1j * 2.0 * np.pi * params['y0'] * vis
                             - params['F0'] * np.pi*params['d']*v/uvdist * sps.jv(1, z) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])) ])
     elif model_type == 'thick_ring':
         uvdist = (u**2 + v**2)**0.5
         #Add a small offset to avoid issues with division by zero
         uvdist += (uvdist == 0.0) * 1e-10
         z = np.pi * params['d'] * uvdist
-        val = np.array([ (1j * 2.0 * np.pi * params['x0'] - params['alpha']**2 * np.pi**2 * u/(2. * np.log(2.))) * vis 
-                        - params['F0'] * np.pi*params['d']*u/uvdist * sps.jv(1, z) 
+        val = np.array([ (1j * 2.0 * np.pi * params['x0'] - params['alpha']**2 * np.pi**2 * u/(2. * np.log(2.))) * vis
+                        - params['F0'] * np.pi*params['d']*u/uvdist * sps.jv(1, z)
                                 * np.exp(-(np.pi * params['alpha'] * (u**2 + v**2)**0.5)**2/(4. * np.log(2.))) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])),
-                          (1j * 2.0 * np.pi * params['y0'] - params['alpha']**2 * np.pi**2 * v/(2. * np.log(2.))) * vis 
+                          (1j * 2.0 * np.pi * params['y0'] - params['alpha']**2 * np.pi**2 * v/(2. * np.log(2.))) * vis
                         - params['F0'] * np.pi*params['d']*v/uvdist * sps.jv(1, z) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))
                                 * np.exp(-(np.pi * params['alpha'] * (u**2 + v**2)**0.5)**2/(4. * np.log(2.))) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])) ])
-    elif model_type == 'mring': 
+    elif model_type == 'mring':
         # Take care of the degenerate origin point by a small offset
         u += (u==0.)*(v==0.)*1e-10
         phi = np.angle(v + 1j*u)
         # Flip the baseline sign to match eht-imaging conventions
         phi += np.pi
         uvdist = (u**2 + v**2 + (u==0.)*(v==0.)*1e-10)**0.5
-        dphidu =  v/uvdist**2 
-        dphidv = -u/uvdist**2 
+        dphidu =  v/uvdist**2
+        dphidv = -u/uvdist**2
         z = np.pi * params['d'] * uvdist
 
         if pol == 'I':
@@ -797,11 +818,11 @@ def sample_1model_graduv_uv(u, v, model_type, params, pol='I', jonesdict=None):
         else:
             beta_factor_u = beta_factor_v = 0.0
 
-        val = np.array([ 
-                 1j * 2.0 * np.pi * params['x0'] * vis 
+        val = np.array([
+                 1j * 2.0 * np.pi * params['x0'] * vis
                     + params['F0'] * beta_factor_u
                     * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])),
-                 1j * 2.0 * np.pi * params['y0'] * vis 
+                 1j * 2.0 * np.pi * params['y0'] * vis
                     + params['F0'] * beta_factor_v
                     * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])) ])
     elif model_type == 'thick_mring':
@@ -849,12 +870,12 @@ def sample_1model_graduv_uv(u, v, model_type, params, pol='I', jonesdict=None):
         else:
             beta_factor_u = beta_factor_v = 0.0
 
-        val = np.array([ 
-                 (1j * 2.0 * np.pi * params['x0'] - params['alpha']**2 * np.pi**2 * u/(2. * np.log(2.))) * vis 
+        val = np.array([
+                 (1j * 2.0 * np.pi * params['x0'] - params['alpha']**2 * np.pi**2 * u/(2. * np.log(2.))) * vis
                     + params['F0'] * beta_factor_u
                     * np.exp(-(np.pi * params['alpha'] * (u**2 + v**2)**0.5)**2/(4. * np.log(2.)))
                     * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])),
-                 (1j * 2.0 * np.pi * params['y0'] - params['alpha']**2 * np.pi**2 * v/(2. * np.log(2.))) * vis 
+                 (1j * 2.0 * np.pi * params['y0'] - params['alpha']**2 * np.pi**2 * v/(2. * np.log(2.))) * vis
                     + params['F0'] * beta_factor_v
                     * np.exp(-(np.pi * params['alpha'] * (u**2 + v**2)**0.5)**2/(4. * np.log(2.)))
                     * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])) ])
@@ -867,11 +888,11 @@ def sample_1model_graduv_uv(u, v, model_type, params, pol='I', jonesdict=None):
     elif model_type[:9] == 'stretched':
         # Take care of the degenerate origin point by a small offset
         u += (u==0.)*(v==0.)*1e-10
-        params_stretch = params.copy()        
+        params_stretch = params.copy()
         params_stretch['x0'] = 0.0
         params_stretch['y0'] = 0.0
         (u_stretch, v_stretch) = stretch_uv(u,v,params)
-        
+
         # First calculate the gradient of the unshifted but stretched image
         grad0 = sample_1model_graduv_uv(u_stretch, v_stretch, model_type[10:], params_stretch, pol=pol) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))
         grad  = grad0.copy() * 0.0
@@ -881,11 +902,11 @@ def sample_1model_graduv_uv(u, v, model_type, params, pol='I', jonesdict=None):
                   + grad0[0] * ((params['stretch'] - 1.0) * np.cos(params['stretch_PA']) * np.sin(params['stretch_PA'])))
 
         # Add the gradient term from the shift
-        vis = sample_1model_uv(u_stretch, v_stretch, model_type[10:], params_stretch, jonesdict=jonesdict) 
-        grad[0] += vis * 1j * 2.0 * np.pi * params['x0'] * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])) 
-        grad[1] += vis * 1j * 2.0 * np.pi * params['y0'] * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])) 
+        vis = sample_1model_uv(u_stretch, v_stretch, model_type[10:], params_stretch, jonesdict=jonesdict)
+        grad[0] += vis * 1j * 2.0 * np.pi * params['x0'] * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))
+        grad[1] += vis * 1j * 2.0 * np.pi * params['y0'] * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))
 
-        val = grad              
+        val = grad
     else:
         print('Model ' + model_type + ' not recognized!')
         val = 0.0
@@ -920,15 +941,24 @@ def sample_1model_grad_leakage_uv_re(u, v, model_type, params, pol, site, hand, 
     LLp = LR * DL2mask * np.exp( 2j*fr2) + RL * DL1mask * np.exp(-2j*fr1) + RR * DL1mask * DL2 * np.exp(-2j*(fr1-fr2)) + RR * DL1 * DL2mask * np.exp(-2j*(fr1-fr2))
 
     # Return the specified polarization
-    if   pol == 'RR': return RRp
-    elif pol == 'RL': return RLp
-    elif pol == 'LR': return LRp
-    elif pol == 'LL': return LLp
-    elif pol == 'I':  return 0.5 * (RRp + LLp)
-    elif pol == 'Q':  return 0.5 * (LRp + RLp)
-    elif pol == 'U':  return 0.5j* (LRp - RLp)
-    elif pol == 'V':  return 0.5 * (RRp - LLp)
-    elif pol == 'P':  return RLp
+    if   pol == 'RR':
+        return RRp
+    elif pol == 'RL':
+        return RLp
+    elif pol == 'LR':
+        return LRp
+    elif pol == 'LL':
+        return LLp
+    elif pol == 'I':
+        return 0.5 * (RRp + LLp)
+    elif pol == 'Q':
+        return 0.5 * (LRp + RLp)
+    elif pol == 'U':
+        return 0.5j* (LRp - RLp)
+    elif pol == 'V':
+        return 0.5 * (RRp - LLp)
+    elif pol == 'P':
+        return RLp
     else:
         raise Exception('Polarization ' + pol + ' not recognized!')
 
@@ -962,20 +992,29 @@ def sample_1model_grad_leakage_uv_im(u, v, model_type, params, pol, site, hand, 
     LLp = 1j*(-LR * DL2mask * np.exp( 2j*fr2) + RL * DL1mask * np.exp(-2j*fr1) + RR * DL1mask * DL2 * np.exp(-2j*(fr1-fr2)) - RR * DL1 * DL2mask * np.exp(-2j*(fr1-fr2)))
 
     # Return the specified polarization
-    if   pol == 'RR': return RRp
-    elif pol == 'RL': return RLp
-    elif pol == 'LR': return LRp
-    elif pol == 'LL': return LLp
-    elif pol == 'I':  return 0.5 * (RRp + LLp)
-    elif pol == 'Q':  return 0.5 * (LRp + RLp)
-    elif pol == 'U':  return 0.5j* (LRp - RLp)
-    elif pol == 'V':  return 0.5 * (RRp - LLp)
-    elif pol == 'P':  return RLp
+    if   pol == 'RR':
+        return RRp
+    elif pol == 'RL':
+        return RLp
+    elif pol == 'LR':
+        return LRp
+    elif pol == 'LL':
+        return LLp
+    elif pol == 'I':
+        return 0.5 * (RRp + LLp)
+    elif pol == 'Q':
+        return 0.5 * (LRp + RLp)
+    elif pol == 'U':
+        return 0.5j* (LRp - RLp)
+    elif pol == 'V':
+        return 0.5 * (RRp - LLp)
+    elif pol == 'P':
+        return RLp
     else:
         raise Exception('Polarization ' + pol + ' not recognized!')
 
 def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_cpol=False, fit_leakage=False, jonesdict=None):
-    # Gradient of the model for each model parameter 
+    # Gradient of the model for each model parameter
 
     if jonesdict is not None:
         # Define the various lists
@@ -996,19 +1035,28 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
         LRp = (LR + RR * DL1 * np.exp(-2j*fr1) + LL * DR2 * np.exp(-2j*fr2) + RL * DL1 * DR2 * np.exp(-2j*(fr1+fr2)))
         LLp = (LL + LR * DL2 * np.exp( 2j*fr2) + RL * DL1 * np.exp(-2j*fr1) + RR * DL1 * DL2 * np.exp(-2j*(fr1-fr2)))
         # Return the specified polarization
-        if   pol == 'RR': grad = RRp
-        elif pol == 'RL': grad = RLp
-        elif pol == 'LR': grad = LRp
-        elif pol == 'LL': grad = LLp
-        elif pol == 'I':  grad = 0.5 * (RRp + LLp)
-        elif pol == 'Q':  grad = 0.5 * (LRp + RLp)
-        elif pol == 'U':  grad = 0.5j* (LRp - RLp)
-        elif pol == 'V':  grad = 0.5 * (RRp - LLp)
-        elif pol == 'P':  grad = RLp
+        if   pol == 'RR':
+            grad = RRp
+        elif pol == 'RL':
+            grad = RLp
+        elif pol == 'LR':
+            grad = LRp
+        elif pol == 'LL':
+            grad = LLp
+        elif pol == 'I':
+            grad = 0.5 * (RRp + LLp)
+        elif pol == 'Q':
+            grad = 0.5 * (LRp + RLp)
+        elif pol == 'U':
+            grad = 0.5j* (LRp - RLp)
+        elif pol == 'V':
+            grad = 0.5 * (RRp - LLp)
+        elif pol == 'P':
+            grad = RLp
         else:
             raise Exception('Polarization ' + pol + ' not recognized!')
         # If necessary, add the gradient components from the leakage terms
-        # Each leakage term has two corresponding gradient terms: d/dRe and d/dIm. 
+        # Each leakage term has two corresponding gradient terms: d/dRe and d/dIm.
         if fit_leakage:
             # 'leakage_fit' is a list of tuples [site, 'R' or 'L'] denoting the fitted leakage terms
             for (site, hand) in jonesdict['leakage_fit']:
@@ -1043,44 +1091,44 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
         val = np.array([ 1.0/params['F0'] * gauss,
                          -np.pi**2/(2.*np.log(2.)) * (u**2 + v**2) * params['FWHM'] * gauss,
                           1j * 2.0 * np.pi * u * gauss,
-                          1j * 2.0 * np.pi * v * gauss])                          
+                          1j * 2.0 * np.pi * v * gauss])
     elif model_type == 'gauss': # F0, FWHM_maj, FWHM_min, PA, x0, y0
         u_maj = u*np.sin(params['PA']) + v*np.cos(params['PA'])
         u_min = u*np.cos(params['PA']) - v*np.sin(params['PA'])
-        vis = (params['F0'] 
+        vis = (params['F0']
                * np.exp(-np.pi**2/(4.*np.log(2.)) * ((u_maj * params['FWHM_maj'])**2 + (u_min * params['FWHM_min'])**2))
-               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) 
+               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))
         val = np.array([ 1.0/params['F0'] * vis,
                          -np.pi**2/(2.*np.log(2.)) * params['FWHM_maj'] * u_maj**2 * vis,
                          -np.pi**2/(2.*np.log(2.)) * params['FWHM_min'] * u_min**2 * vis,
                          -np.pi**2/(2.*np.log(2.)) * (params['FWHM_maj']**2 - params['FWHM_min']**2) * u_maj * u_min * vis,
                           1j * 2.0 * np.pi * u * vis,
-                          1j * 2.0 * np.pi * v * vis])    
+                          1j * 2.0 * np.pi * v * vis])
     elif model_type == 'disk': # F0, d, x0, y0
         z = np.pi * params['d'] * (u**2 + v**2)**0.5
         #Add a small offset to avoid issues with division by zero
         z += (z == 0.0) * 1e-10
-        vis = (params['F0'] * 2.0/z * sps.jv(1, z) 
-               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) 
+        vis = (params['F0'] * 2.0/z * sps.jv(1, z)
+               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))
         val = np.array([ 1.0/params['F0'] * vis,
                          -(params['F0'] * 2.0/z * sps.jv(2, z) * np.pi * (u**2 + v**2)**0.5 * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) ,
                           1j * 2.0 * np.pi * u * vis,
-                          1j * 2.0 * np.pi * v * vis]) 
+                          1j * 2.0 * np.pi * v * vis])
     elif model_type == 'blurred_disk': # F0, d, alpha, x0, y0
         z = np.pi * params['d'] * (u**2 + v**2)**0.5
         #Add a small offset to avoid issues with division by zero
         z += (z == 0.0) * 1e-10
         blur = np.exp(-(np.pi * params['alpha'] * (u**2 + v**2)**0.5)**2/(4. * np.log(2.)))
-        vis = (params['F0'] * 2.0/z * sps.jv(1, z) 
+        vis = (params['F0'] * 2.0/z * sps.jv(1, z)
                * blur
-               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) 
+               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))
         val = np.array([ 1.0/params['F0'] * vis,
                          -params['F0'] * 2.0/z * sps.jv(2, z) * np.pi * (u**2 + v**2)**0.5 * blur * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])),
                          -np.pi**2 * (u**2 + v**2) * params['alpha']/(2.*np.log(2.)) * vis,
                           1j * 2.0 * np.pi * u * vis,
-                          1j * 2.0 * np.pi * v * vis])  
+                          1j * 2.0 * np.pi * v * vis])
     elif model_type == 'crescent': #['F0','d', 'fr', 'fo', 'phi','x0','y0']
-        phi = params['phi'] 
+        phi = params['phi']
         fr = params['fr']
         fo = params['fo']
         ff = params['ff']
@@ -1101,20 +1149,20 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
         grad.append( grad0[1] - fr*grad1[1] - 0.5 * (1.0 - fr) * fo * (np.sin(phi) * grad1[2] + np.cos(phi) * grad1[3])  )
 
         # fr
-        grad.append( 2.0*params['F0']*(1-ff)*fr/(1.0 - (1-ff)*fr**2)**2 * (grad0[0] - grad1[0]) - params['d']*grad1[1] + r * fo * (np.sin(phi) * grad1[2] + np.cos(phi) * grad1[3]) ) 
+        grad.append( 2.0*params['F0']*(1-ff)*fr/(1.0 - (1-ff)*fr**2)**2 * (grad0[0] - grad1[0]) - params['d']*grad1[1] + r * fo * (np.sin(phi) * grad1[2] + np.cos(phi) * grad1[3]) )
 
         # fo
-        grad.append( -r * (1-fr) * (np.sin(phi) * grad1[2] + np.cos(phi) * grad1[3]) ) 
+        grad.append( -r * (1-fr) * (np.sin(phi) * grad1[2] + np.cos(phi) * grad1[3]) )
 
         # ff
-        grad.append( -params['F0']*fr**2/(1.0 - (1-ff)*fr**2)**2 * (grad0[0] - grad1[0]) ) 
+        grad.append( -params['F0']*fr**2/(1.0 - (1-ff)*fr**2)**2 * (grad0[0] - grad1[0]) )
 
         # phi
-        grad.append( -r*(1-fr)*fo* (np.cos(phi) * grad1[2] - np.sin(phi) * grad1[3]) ) 
+        grad.append( -r*(1-fr)*fo* (np.cos(phi) * grad1[2] - np.sin(phi) * grad1[3]) )
 
         # x0, y0
-        grad.append( grad0[2] - grad1[2] ) 
-        grad.append( grad0[3] - grad1[3] ) 
+        grad.append( grad0[2] - grad1[2] )
+        grad.append( grad0[3] - grad1[3] )
 
         val = np.array(grad)
     elif model_type == 'blurred_crescent': #['F0','d','alpha','fr', 'fo', 'phi','x0','y0']
@@ -1139,44 +1187,44 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
         grad.append( grad0[1] - fr*grad1[1] - 0.5 * (1.0 - fr) * fo * (np.sin(phi) * grad1[3] + np.cos(phi) * grad1[4])  )
 
         # alpha
-        grad.append( grad0[2] - grad1[2] ) 
+        grad.append( grad0[2] - grad1[2] )
 
         # fr
-        grad.append( 2.0*params['F0']*(1-ff)*fr/(1.0 - (1-ff)*fr**2)**2 * (grad0[0] - grad1[0]) - params['d']*grad1[1] + r * fo * (np.sin(phi) * grad1[3] + np.cos(phi) * grad1[4]) ) 
+        grad.append( 2.0*params['F0']*(1-ff)*fr/(1.0 - (1-ff)*fr**2)**2 * (grad0[0] - grad1[0]) - params['d']*grad1[1] + r * fo * (np.sin(phi) * grad1[3] + np.cos(phi) * grad1[4]) )
 
         # fo
-        grad.append( -r * (1-fr) * (np.sin(phi) * grad1[3] + np.cos(phi) * grad1[4]) ) 
+        grad.append( -r * (1-fr) * (np.sin(phi) * grad1[3] + np.cos(phi) * grad1[4]) )
 
         # ff
-        grad.append( -params['F0']*fr**2/(1.0 - (1-ff)*fr**2)**2 * (grad0[0] - grad1[0]) ) 
+        grad.append( -params['F0']*fr**2/(1.0 - (1-ff)*fr**2)**2 * (grad0[0] - grad1[0]) )
 
         # phi
-        grad.append( -r*(1-fr)*fo* (np.cos(phi) * grad1[3] - np.sin(phi) * grad1[4]) ) 
+        grad.append( -r*(1-fr)*fo* (np.cos(phi) * grad1[3] - np.sin(phi) * grad1[4]) )
 
         # x0, y0
-        grad.append( grad0[3] - grad1[3] ) 
-        grad.append( grad0[4] - grad1[4] ) 
+        grad.append( grad0[3] - grad1[3] )
+        grad.append( grad0[4] - grad1[4] )
 
         val = np.array(grad)
 
     elif model_type == 'ring': # F0, d, x0, y0
         z = np.pi * params['d'] * (u**2 + v**2)**0.5
-        val = np.array([ sps.jv(0, z) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])), 
-                -np.pi * (u**2 + v**2)**0.5 * params['F0'] * sps.jv(1, z) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])), 
-                 2.0 * np.pi * 1j * u * params['F0'] * sps.jv(0, z) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])), 
+        val = np.array([ sps.jv(0, z) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])),
+                -np.pi * (u**2 + v**2)**0.5 * params['F0'] * sps.jv(1, z) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])),
+                 2.0 * np.pi * 1j * u * params['F0'] * sps.jv(0, z) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])),
                  2.0 * np.pi * 1j * v * params['F0'] * sps.jv(0, z) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))])
     elif model_type == 'thick_ring': # F0, d, alpha, x0, y0
         z = np.pi * params['d'] * (u**2 + v**2)**0.5
-        vis = (params['F0'] * sps.jv(0, z) 
+        vis = (params['F0'] * sps.jv(0, z)
                * np.exp(-(np.pi * params['alpha'] * (u**2 + v**2)**0.5)**2/(4. * np.log(2.)))
-               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) 
+               * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))
         val = np.array([ 1.0/params['F0'] * vis,
-                         -(params['F0'] * np.pi * (u**2 + v**2)**0.5 * sps.jv(1, z) 
+                         -(params['F0'] * np.pi * (u**2 + v**2)**0.5 * sps.jv(1, z)
                             * np.exp(-(np.pi * params['alpha'] * (u**2 + v**2)**0.5)**2/(4. * np.log(2.)))
                             * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))),
                          -np.pi**2 * (u**2 + v**2) * params['alpha']/(2.*np.log(2.)) * vis,
                           1j * 2.0 * np.pi * u * vis,
-                          1j * 2.0 * np.pi * v * vis])    
+                          1j * 2.0 * np.pi * v * vis])
     elif model_type in ['mring','thick_mring']: # F0, d, [alpha], x0, y0, beta1_re/abs, beta1_im/arg, beta2_re/abs, beta2_im/arg, ...
         phi = np.angle(v + 1j*u)
         # Flip the baseline sign to match eht-imaging conventions
@@ -1191,21 +1239,21 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
         # Only one of the beta_lists will affect the measurement and have non-zero gradients. Figure out which:
         # These are for the derivatives wrt diameter
         if pol == 'I':
-            beta_factor = (-np.pi * uvdist * sps.jv(1, z) 
+            beta_factor = (-np.pi * uvdist * sps.jv(1, z)
                + np.sum([params['beta_list'][m-1]          * 0.5 * (sps.jv( m-1, z)  - sps.jv(  m+1, z)) * np.pi * uvdist * np.exp( 1j * m * (phi - np.pi/2.)) for m in range(1,len(params['beta_list'])+1)],axis=0)
                + np.sum([np.conj(params['beta_list'][m-1]) * 0.5 * (sps.jv( -m-1, z) - sps.jv( -m+1, z)) * np.pi * uvdist * np.exp(-1j * m * (phi - np.pi/2.)) for m in range(1,len(params['beta_list'])+1)],axis=0))
         elif pol == 'P' and len(params['beta_list_pol']) > 0:
             num_coeff = len(params['beta_list_pol'])
             beta_factor = np.sum([params['beta_list_pol'][m + (num_coeff-1)//2] * 0.5 * (sps.jv( m-1, z)  - sps.jv(  m+1, z)) * np.pi * uvdist * np.exp( 1j * m * (phi - np.pi/2.)) for m in range(-(num_coeff-1)//2,(num_coeff+1)//2)],axis=0)
         elif pol == 'V' and len(params['beta_list_cpol']) > 0:
-            beta_factor = (-np.pi * uvdist * sps.jv(1, z) * np.real(params['beta_list_cpol'][0]) 
+            beta_factor = (-np.pi * uvdist * sps.jv(1, z) * np.real(params['beta_list_cpol'][0])
                + np.sum([params['beta_list_cpol'][m]          * 0.5 * (sps.jv( m-1, z)  - sps.jv(  m+1, z)) * np.pi * uvdist * np.exp( 1j * m * (phi - np.pi/2.)) for m in range(1,len(params['beta_list_cpol']))],axis=0)
                + np.sum([np.conj(params['beta_list_cpol'][m]) * 0.5 * (sps.jv( -m-1, z) - sps.jv( -m+1, z)) * np.pi * uvdist * np.exp(-1j * m * (phi - np.pi/2.)) for m in range(1,len(params['beta_list_cpol']))],axis=0))
         else:
             beta_factor = 0.0
-            
+
         vis  = sample_1model_uv(u, v, model_type, params, pol=pol, jonesdict=jonesdict)
-        grad = [ 1.0/params['F0'] * vis, 
+        grad = [ 1.0/params['F0'] * vis,
                  (params['F0'] * alpha_factor * beta_factor * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))]
         if model_type == 'thick_mring':
             grad.append(-np.pi**2/(2.*np.log(2)) * uvdist**2 * params['alpha'] * vis)
@@ -1213,14 +1261,14 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
         grad.append(1j * 2.0 * np.pi * v * vis)
 
         if pol=='I':
-            # Add derivatives of the beta terms 
+            # Add derivatives of the beta terms
             for m in range(1,len(params['beta_list'])+1):
                 beta_grad_re =      params['F0'] * alpha_factor * (
-                   sps.jv( m, z) * np.exp( 1j * m * (phi - np.pi/2.)) + sps.jv(-m, z) * np.exp(-1j * m * (phi - np.pi/2.)) 
-                   * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) 
+                   sps.jv( m, z) * np.exp( 1j * m * (phi - np.pi/2.)) + sps.jv(-m, z) * np.exp(-1j * m * (phi - np.pi/2.))
+                   * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))
                 beta_grad_im = 1j * params['F0'] * alpha_factor * (
-                   sps.jv( m, z) * np.exp( 1j * m * (phi - np.pi/2.)) - sps.jv(-m, z) * np.exp(-1j * m * (phi - np.pi/2.)) 
-                   * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) 
+                   sps.jv( m, z) * np.exp( 1j * m * (phi - np.pi/2.)) - sps.jv(-m, z) * np.exp(-1j * m * (phi - np.pi/2.))
+                   * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))
                 if COMPLEX_BASIS == 're-im':
                     grad.append(beta_grad_re)
                     grad.append(beta_grad_im)
@@ -1235,10 +1283,10 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
             [grad.append(np.zeros_like(grad[0])) for _ in range(2*len(params['beta_list']))]
 
         if pol=='P' and fit_pol:
-            # Add derivatives of the beta_pol terms 
+            # Add derivatives of the beta_pol terms
             num_coeff = len(params['beta_list_pol'])
             for m in range(-(num_coeff-1)//2,(num_coeff+1)//2):
-                beta_grad_re = params['F0'] * alpha_factor * sps.jv( m, z) * np.exp( 1j * m * (phi - np.pi/2.)) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])) 
+                beta_grad_re = params['F0'] * alpha_factor * sps.jv( m, z) * np.exp( 1j * m * (phi - np.pi/2.)) * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))
                 beta_grad_im = 1j * beta_grad_re
                 if COMPLEX_BASIS == 're-im':
                     grad.append(beta_grad_re)
@@ -1254,21 +1302,21 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
             [grad.append(np.zeros_like(grad[0])) for _ in range(2*len(params['beta_list_pol']))]
 
         if pol=='V' and fit_cpol:
-            # Add derivatives of the beta_cpol terms 
+            # Add derivatives of the beta_cpol terms
             num_coeff = len(params['beta_list_cpol']) - 1
-            
+
             # First do the beta0 mode (real)
-            beta_grad_re = params['F0'] * alpha_factor * sps.jv( 0, z)  
+            beta_grad_re = params['F0'] * alpha_factor * sps.jv( 0, z)
             grad.append(beta_grad_re)
 
             # Now do the remaining modes (complex)
             for m in range(1,num_coeff+1):
                 beta_grad_re =      params['F0'] * alpha_factor * (
-                   sps.jv( m, z) * np.exp( 1j * m * (phi - np.pi/2.)) + sps.jv(-m, z) * np.exp(-1j * m * (phi - np.pi/2.)) 
-                   * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) 
+                   sps.jv( m, z) * np.exp( 1j * m * (phi - np.pi/2.)) + sps.jv(-m, z) * np.exp(-1j * m * (phi - np.pi/2.))
+                   * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))
                 beta_grad_im = 1j * params['F0'] * alpha_factor * (
-                   sps.jv( m, z) * np.exp( 1j * m * (phi - np.pi/2.)) - sps.jv(-m, z) * np.exp(-1j * m * (phi - np.pi/2.)) 
-                   * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))) 
+                   sps.jv( m, z) * np.exp( 1j * m * (phi - np.pi/2.)) - sps.jv(-m, z) * np.exp(-1j * m * (phi - np.pi/2.))
+                   * np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0'])))
                 if COMPLEX_BASIS == 're-im':
                     grad.append(beta_grad_re)
                     grad.append(beta_grad_im)
@@ -1317,9 +1365,9 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
         # gauss: F0, [d, alpha] FWHM, x0, y0
 
         grad = []
-        grad.append(grad_mring[0] + grad_gauss[0]) # Here are derivatives for F0 
+        grad.append(grad_mring[0] + grad_gauss[0]) # Here are derivatives for F0
 
-        # Here are derivatives for d, and alpha 
+        # Here are derivatives for d, and alpha
         grad.append(grad_mring[1])
         grad.append(grad_mring[2])
 
@@ -1357,7 +1405,7 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
 
         # Now calculate the gradient with respect to stretch and stretch PA
         grad_uv = sample_1model_graduv_uv(u_stretch, v_stretch, model_type[10:], params_stretch, pol=pol)
-        grad_stretch = grad_uv.copy() * 0.0 
+        grad_stretch = grad_uv.copy() * 0.0
         grad_stretch[0] = ( grad_uv[0] * (u * np.sin(params['stretch_PA'])**2 + v * np.sin(params['stretch_PA']) * np.cos(params['stretch_PA']))
                           + grad_uv[1] * (v * np.cos(params['stretch_PA'])**2 + u * np.sin(params['stretch_PA']) * np.cos(params['stretch_PA'])))
         grad_stretch[0] *= np.exp(1j * 2.0 * np.pi * (u * params['x0'] + v * params['y0']))
@@ -1394,10 +1442,10 @@ def sample_1model_grad_uv(u, v, model_type, params, pol='I', fit_pol=False, fit_
     return grad
 
 def sample_model_xy(models, params, x, y, psize=1.*RADPERUAS, pol='I'):
-    return np.sum(sample_1model_xy(x, y, models[j], params[j], psize=psize,pol=pol) for j in range(len(models)))
+    return sum(sample_1model_xy(x, y, models[j], params[j], psize=psize, pol=pol) for j in range(len(models)))
 
 def sample_model_uv(models, params, u, v, pol='I', jonesdict=None):
-    return np.sum(sample_1model_uv(u, v, models[j], params[j], pol=pol, jonesdict=jonesdict) for j in range(len(models)))
+    return sum(sample_1model_uv(u, v, models[j], params[j], pol=pol, jonesdict=jonesdict) for j in range(len(models)))
 
 def sample_model_graduv_uv(models, params, u, v, pol='I', jonesdict=None):
     # Gradient of a sum of models wrt (u,v)
@@ -1405,7 +1453,7 @@ def sample_model_graduv_uv(models, params, u, v, pol='I', jonesdict=None):
 
 def sample_model_grad_uv(models, params, u, v, pol='I', fit_pol=False, fit_cpol=False, fit_leakage=False, jonesdict=None):
     # Gradient of a sum of models for each parameter
-    if fit_leakage == False:
+    if not fit_leakage:
         return np.concatenate([sample_1model_grad_uv(u, v, models[j], params[j], pol=pol, fit_pol=fit_pol, fit_cpol=fit_cpol, fit_leakage=fit_leakage, jonesdict=jonesdict) for j in range(len(models))])
     else:
         # Need to sum the leakage contributions
@@ -1452,10 +1500,10 @@ def blur_circ_1model(model_type, params, fwhm):
         params_blur['alpha'] = fwhm
     else:
         raise Exception("A blurred " + model_type + " is not yet a supported model!")
-    
+
     return {'model_type':model_type_blur, 'params':params_blur}
 
-class Model(object):
+class Model:
     """A model with analytic representations in the image and visibility domains.
 
        Attributes:
@@ -1535,8 +1583,10 @@ class Model(object):
         if polrep_out not in ['stokes','circ']:
             raise Exception("polrep_out must be either 'stokes' or 'circ'")
         if pol_prim_out is None:
-            if polrep_out=='stokes': pol_prim_out = 'I'
-            elif polrep_out=='circ': pol_prim_out = 'RR'
+            if polrep_out=='stokes':
+                pol_prim_out = 'I'
+            elif polrep_out=='circ':
+                pol_prim_out = 'RR'
 
         return self.copy()
 
@@ -1796,15 +1846,18 @@ class Model(object):
                d (float): The diameter (radians)
                x0 (float): The x-coordinate (radians)
                y0 (float): The y-coordinate (radians)
-               beta_list (list): List of complex Fourier coefficients, [beta_1, beta_2, ...]. 
+               beta_list (list): List of complex Fourier coefficients, [beta_1, beta_2, ...].
                                  Negative indices are determined by the condition beta_{-m} = beta_m*.
-                                 Indices are all scaled by F0 = beta_0, so they are dimensionless. 
+                                 Indices are all scaled by F0 = beta_0, so they are dimensionless.
            Returns:
                 (Model): Updated Model
         """
-        if beta_list is None: beta_list = []
-        if beta_list_pol is None: beta_list_pol = []
-        if beta_list_cpol is None: beta_list_cpol = []
+        if beta_list is None:
+            beta_list = []
+        if beta_list_pol is None:
+            beta_list_pol = []
+        if beta_list_cpol is None:
+            beta_list_cpol = []
 
         out = self.copy()
         if beta_list is None:
@@ -1822,17 +1875,20 @@ class Model(object):
                d (float): The diameter (radians)
                x0 (float): The x-coordinate (radians)
                y0 (float): The y-coordinate (radians)
-               beta_list (list): List of complex Fourier coefficients, [beta_1, beta_2, ...]. 
+               beta_list (list): List of complex Fourier coefficients, [beta_1, beta_2, ...].
                                  Negative indices are determined by the condition beta_{-m} = beta_m*.
-                                 Indices are all scaled by F0 = beta_0, so they are dimensionless. 
+                                 Indices are all scaled by F0 = beta_0, so they are dimensionless.
                stretch (float): The stretch to apply (1.0 = no stretch)
                stretch_PA (float): Position angle of the stretch, east of north (radians)
            Returns:
                 (Model): Updated Model
         """
-        if beta_list is None: beta_list = []
-        if beta_list_pol is None: beta_list_pol = []
-        if beta_list_cpol is None: beta_list_cpol = []
+        if beta_list is None:
+            beta_list = []
+        if beta_list_pol is None:
+            beta_list_pol = []
+        if beta_list_cpol is None:
+            beta_list_cpol = []
 
         out = self.copy()
         if beta_list is None:
@@ -1852,15 +1908,18 @@ class Model(object):
                alpha (float): The ring thickness (FWHM of Gaussian convolution) (radians)
                x0 (float): The x-coordinate (radians)
                y0 (float): The y-coordinate (radians)
-               beta_list (list): List of complex Fourier coefficients, [beta_1, beta_2, ...]. 
+               beta_list (list): List of complex Fourier coefficients, [beta_1, beta_2, ...].
                                  Negative indices are determined by the condition beta_{-m} = beta_m*.
-                                 Indices are all scaled by F0 = beta_0, so they are dimensionless. 
+                                 Indices are all scaled by F0 = beta_0, so they are dimensionless.
            Returns:
                 (Model): Updated Model
         """
-        if beta_list is None: beta_list = []
-        if beta_list_pol is None: beta_list_pol = []
-        if beta_list_cpol is None: beta_list_cpol = []
+        if beta_list is None:
+            beta_list = []
+        if beta_list_pol is None:
+            beta_list_pol = []
+        if beta_list_cpol is None:
+            beta_list_cpol = []
 
         out = self.copy()
         if beta_list is None:
@@ -1882,15 +1941,18 @@ class Model(object):
                x0 (float): The x-coordinate (radians)
                y0 (float): The y-coordinate (radians)
                ff (float): The fraction of the total flux in the floor
-               beta_list (list): List of complex Fourier coefficients, [beta_1, beta_2, ...]. 
+               beta_list (list): List of complex Fourier coefficients, [beta_1, beta_2, ...].
                                  Negative indices are determined by the condition beta_{-m} = beta_m*.
-                                 Indices are all scaled by F0 = beta_0, so they are dimensionless. 
+                                 Indices are all scaled by F0 = beta_0, so they are dimensionless.
            Returns:
                 (Model): Updated Model
         """
-        if beta_list is None: beta_list = []
-        if beta_list_pol is None: beta_list_pol = []
-        if beta_list_cpol is None: beta_list_cpol = []
+        if beta_list is None:
+            beta_list = []
+        if beta_list_pol is None:
+            beta_list_pol = []
+        if beta_list_cpol is None:
+            beta_list_cpol = []
 
         out = self.copy()
         if beta_list is None:
@@ -1913,15 +1975,18 @@ class Model(object):
                x0 (float): The x-coordinate (radians)
                y0 (float): The y-coordinate (radians)
                ff (float): The fraction of the total flux in the floor
-               beta_list (list): List of complex Fourier coefficients, [beta_1, beta_2, ...]. 
+               beta_list (list): List of complex Fourier coefficients, [beta_1, beta_2, ...].
                                  Negative indices are determined by the condition beta_{-m} = beta_m*.
-                                 Indices are all scaled by F0 = beta_0, so they are dimensionless. 
+                                 Indices are all scaled by F0 = beta_0, so they are dimensionless.
            Returns:
                 (Model): Updated Model
         """
-        if beta_list is None: beta_list = []
-        if beta_list_pol is None: beta_list_pol = []
-        if beta_list_cpol is None: beta_list_cpol = []
+        if beta_list is None:
+            beta_list = []
+        if beta_list_pol is None:
+            beta_list_pol = []
+        if beta_list_cpol is None:
+            beta_list_cpol = []
 
         out = self.copy()
         if beta_list is None:
@@ -1941,17 +2006,20 @@ class Model(object):
                alpha (float): The ring thickness (FWHM of Gaussian convolution) (radians)
                x0 (float): The x-coordinate (radians)
                y0 (float): The y-coordinate (radians)
-               beta_list (list): List of complex Fourier coefficients, [beta_1, beta_2, ...]. 
+               beta_list (list): List of complex Fourier coefficients, [beta_1, beta_2, ...].
                                  Negative indices are determined by the condition beta_{-m} = beta_m*.
-                                 Indices are all scaled by F0 = beta_0, so they are dimensionless. 
+                                 Indices are all scaled by F0 = beta_0, so they are dimensionless.
                stretch (float): The stretch to apply (1.0 = no stretch)
                stretch_PA (float): Position angle of the stretch, east of north (radians)
            Returns:
                 (Model): Updated Model
         """
-        if beta_list is None: beta_list = []
-        if beta_list_pol is None: beta_list_pol = []
-        if beta_list_cpol is None: beta_list_cpol = []
+        if beta_list is None:
+            beta_list = []
+        if beta_list_pol is None:
+            beta_list_pol = []
+        if beta_list_cpol is None:
+            beta_list_cpol = []
 
         out = self.copy()
         if beta_list is None:
@@ -1971,17 +2039,20 @@ class Model(object):
                alpha (float): The ring thickness (FWHM of Gaussian convolution) (radians)
                x0 (float): The x-coordinate (radians)
                y0 (float): The y-coordinate (radians)
-               beta_list (list): List of complex Fourier coefficients, [beta_1, beta_2, ...]. 
+               beta_list (list): List of complex Fourier coefficients, [beta_1, beta_2, ...].
                                  Negative indices are determined by the condition beta_{-m} = beta_m*.
-                                 Indices are all scaled by F0 = beta_0, so they are dimensionless. 
+                                 Indices are all scaled by F0 = beta_0, so they are dimensionless.
                stretch (float): The stretch to apply (1.0 = no stretch)
                stretch_PA (float): Position angle of the stretch, east of north (radians)
            Returns:
                 (Model): Updated Model
         """
-        if beta_list is None: beta_list = []
-        if beta_list_pol is None: beta_list_pol = []
-        if beta_list_cpol is None: beta_list_cpol = []
+        if beta_list is None:
+            beta_list = []
+        if beta_list_pol is None:
+            beta_list_pol = []
+        if beta_list_cpol is None:
+            beta_list_cpol = []
 
         out = self.copy()
         if beta_list is None:
@@ -1999,7 +2070,7 @@ class Model(object):
 
            Returns:
                (float): Image brightness (Jy/radian^2)
-        """  
+        """
         return sample_model_xy(self.models, self.params, x, y, psize=psize, pol=pol)
 
     def sample_uv(self, u, v, polrep_obs='Stokes', pol='I', jonesdict=None):
@@ -2011,7 +2082,7 @@ class Model(object):
 
            Returns:
                (complex): complex visibility (Jy)
-        """   
+        """
         return sample_model_uv(self.models, self.params, u, v, pol=pol, jonesdict=jonesdict)
 
     def sample_graduv_uv(self, u, v, pol='I', jonesdict=None):
@@ -2023,7 +2094,7 @@ class Model(object):
 
            Returns:
                (complex): complex visibility (Jy)
-        """   
+        """
         return sample_model_graduv_uv(self.models, self.params, u, v, pol=pol, jonesdict=jonesdict)
 
     def sample_grad_uv(self, u, v, pol='I', fit_pol=False, fit_cpol=False, fit_leakage=False, jonesdict=None):
@@ -2035,7 +2106,7 @@ class Model(object):
 
            Returns:
                (complex): complex visibility (Jy)
-        """   
+        """
         return sample_model_grad_uv(self.models, self.params, u, v, pol=pol, fit_pol=fit_pol, fit_cpol=fit_cpol, fit_leakage=fit_leakage, jonesdict=jonesdict)
 
     def centroid(self, pol=None):
@@ -2049,17 +2120,17 @@ class Model(object):
                (np.array): centroid positions (x0,y0) in radians
         """
 
-        if pol is None: pol=self.pol_prim
-        if not (pol in list(self._imdict.keys())):
-            raise Exception("for polrep==%s, pol must be in " % 
-                             self.polrep + ",".join(list(self._imdict.keys())))
+        if pol is None:
+            pol=self.pol_prim
+        if pol not in list(self._imdict.keys()):
+            raise Exception(f"for polrep=={self.polrep}, pol must be in " + ",".join(list(self._imdict.keys())))
 
         return np.real(self.sample_graduv_uv(0,0)/(2.*np.pi*1j))/self.total_flux()
 
     def default_prior(self,fit_pol=False,fit_cpol=False):
-        return [default_prior(self.models[j],self.params[j],fit_pol=fit_pol,fit_cpol=fit_cpol) for j in range(self.N_models())]        
+        return [default_prior(self.models[j],self.params[j],fit_pol=fit_pol,fit_cpol=fit_cpol) for j in range(self.N_models())]
 
-    def display(self, fov=FOV_DEFAULT, npix=NPIX_DEFAULT, polrep='stokes', pol_prim=None, pulse=PULSE_DEFAULT, time=0., **kwargs):        
+    def display(self, fov=FOV_DEFAULT, npix=NPIX_DEFAULT, polrep='stokes', pol_prim=None, pulse=PULSE_DEFAULT, time=0., **kwargs):
         return self.make_image(fov, npix, polrep, pol_prim, pulse, time).display(**kwargs)
 
     def make_image(self, fov, npix, polrep='stokes', pol_prim=None, pulse=PULSE_DEFAULT, time=0.):
@@ -2090,7 +2161,7 @@ class Model(object):
         outim = image.Image(imarr, pdim, self.ra, self.dec,
                       polrep=polrep, pol_prim=pol_prim,
                       rf=self.rf, source=self.source, mjd=self.mjd, time=time, pulse=pulse)
-        
+
         return self.image_same(outim)
 
     def image_same(self, im):
@@ -2101,14 +2172,14 @@ class Model(object):
 
            Returns:
                (Image): image of the model
-        """        
+        """
         out = im.copy()
         xlist = np.arange(0,-im.xdim,-1)*im.psize + (im.psize*im.xdim)/2.0 - im.psize/2.0
         ylist = np.arange(0,-im.ydim,-1)*im.psize + (im.psize*im.ydim)/2.0 - im.psize/2.0
 
         x_grid, y_grid = np.meshgrid(xlist, ylist)
-        imarr = self.sample_xy(x_grid, y_grid, im.psize)    
-        out.imvec = imarr.flatten() # Change this to init with image_args 
+        imarr = self.sample_xy(x_grid, y_grid, im.psize)
+        out.imvec = imarr.flatten() # Change this to init with image_args
 
         # Add the remaining polarizations
         for pol in ['Q','U','V']:
@@ -2120,7 +2191,7 @@ class Model(object):
         """Observe the model on the same baselines as an existing observation, without noise.
 
            Args:
-               obs (Obsdata): the existing observation 
+               obs (Obsdata): the existing observation
 
            Returns:
                (Obsdata): an observation object with no noise
@@ -2153,27 +2224,27 @@ class Model(object):
         return obs_no_noise
 
     def observe_same(self, obs_in, add_th_noise=True, sgrscat=False, ttype=False, # Note: sgrscat and ttype are kept for consistency with comp_plots
-                           opacitycal=True, ampcal=True, phasecal=True, 
+                           opacitycal=True, ampcal=True, phasecal=True,
                            dcal=True, frcal=True, rlgaincal=True,
                            stabilize_scan_phase=False, stabilize_scan_amp=False, neggains=False,
                            jones=False, inv_jones=False,
                            tau=TAUDEF, taup=GAINPDEF,
                            gain_offset=GAINPDEF, gainp=GAINPDEF,
-                           dterm_offset=DTERMPDEF,                            
+                           dterm_offset=DTERMPDEF,
                            rlratio_std=0.,rlphase_std=0.,
                            caltable_path=None, seed=False, **kwargs):
 
         """Observe the image on the same baselines as an existing observation object and add noise.
 
            Args:
-               obs_in (Obsdata): the existing observation 
+               obs_in (Obsdata): the existing observation
 
                add_th_noise (bool): if True, baseline-dependent thermal noise is added
                opacitycal (bool): if False, time-dependent gaussian errors are added to opacities
                ampcal (bool): if False, time-dependent gaussian errors are added to station gains
                phasecal (bool): if False, time-dependent station-based random phases are added
-               frcal (bool): if False, feed rotation angle terms are added to Jones matrices. 
-               dcal (bool): if False, time-dependent gaussian errors added to D-terms. 
+               frcal (bool): if False, feed rotation angle terms are added to Jones matrices.
+               dcal (bool): if False, time-dependent gaussian errors added to D-terms.
 
                stabilize_scan_phase (bool): if True, random phase errors are constant over scans
                stabilize_scan_amp (bool): if True, random amplitude errors are constant over scans
@@ -2181,15 +2252,15 @@ class Model(object):
                                 meaning that you have overestimated your telescope's performance
 
 
-               jones (bool): if True, uses Jones matrix to apply mis-calibration effects 
-               inv_jones (bool): if True, applies estimated inverse Jones matrix 
+               jones (bool): if True, uses Jones matrix to apply mis-calibration effects
+               inv_jones (bool): if True, applies estimated inverse Jones matrix
                                  (not including random terms) to a priori calibrate data
 
-               tau (float): the base opacity at all sites, 
+               tau (float): the base opacity at all sites,
                             or a dict giving one opacity per site
                taup (float): the fractional std. dev. of the random error on the opacities
                gainp (float): the fractional std. dev. of the random error on the gains
-                              or a dict giving one std. dev. per site      
+                              or a dict giving one std. dev. per site
 
                gain_offset (float): the base gain offset at all sites,
                                     or a dict giving one gain offset per site
@@ -2197,10 +2268,10 @@ class Model(object):
                                     or a dict giving one std. dev. per site
 
                rlratio_std (float): the fractional std. dev. of the R/L gain offset
-                                    or a dict giving one std. dev. per site                                          
-               rlphase_std (float): std. dev. of R/L phase offset, 
                                     or a dict giving one std. dev. per site
-                                    a negative value samples from uniform                                          
+               rlphase_std (float): std. dev. of R/L phase offset,
+                                    or a dict giving one std. dev. per site
+                                    a negative value samples from uniform
 
                caltable_path (string): The path and prefix of a saved caltable
 
@@ -2210,7 +2281,7 @@ class Model(object):
                (Obsdata): an observation object
         """
 
-        if seed!=False:
+        if seed:
             np.random.seed(seed=seed)
 
         obs = self.observe_same_nonoise(obs_in, **kwargs)
@@ -2219,10 +2290,10 @@ class Model(object):
         if jones:
             obsdata = simobs.add_jones_and_noise(obs, add_th_noise=add_th_noise,
                                                  opacitycal=opacitycal, ampcal=ampcal,
-                                                 phasecal=phasecal, dcal=dcal, frcal=frcal, 
+                                                 phasecal=phasecal, dcal=dcal, frcal=frcal,
                                                  rlgaincal=rlgaincal,
                                                  stabilize_scan_phase=stabilize_scan_phase,
-                                                 stabilize_scan_amp=stabilize_scan_amp, 
+                                                 stabilize_scan_amp=stabilize_scan_amp,
                                                  neggains=neggains,
                                                  gainp=gainp, taup=taup, gain_offset=gain_offset,
                                                  dterm_offset=dterm_offset,
@@ -2231,12 +2302,12 @@ class Model(object):
 
             obs =  ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr,
                                          source=obs.source, mjd=obs.mjd, polrep=obs_in.polrep,
-                                         ampcal=ampcal, phasecal=phasecal, opacitycal=opacitycal, 
+                                         ampcal=ampcal, phasecal=phasecal, opacitycal=opacitycal,
                                          dcal=dcal, frcal=frcal,
                                          timetype=obs.timetype, scantable=obs.scans)
 
             if inv_jones:
-                obsdata = simobs.apply_jones_inverse(obs, 
+                obsdata = simobs.apply_jones_inverse(obs,
                                                      opacitycal=opacitycal, dcal=dcal, frcal=frcal)
 
                 obs =  ehtim.obsdata.Obsdata(obs.ra, obs.dec, obs.rf, obs.bw, obsdata, obs.tarr,
@@ -2248,7 +2319,7 @@ class Model(object):
 
 
         # No Jones Matrices, Add noise the old way
-        # NOTE There is an asymmetry here - in the old way, we don't offer the ability to *not*  
+        # NOTE There is an asymmetry here - in the old way, we don't offer the ability to *not*
         # unscale estimated noise.
         else:
 
@@ -2273,9 +2344,9 @@ class Model(object):
     def observe(self, array, tint, tadv, tstart, tstop, bw,
                       mjd=None, timetype='UTC', polrep_obs=None,
                       elevmin=ELEV_LOW, elevmax=ELEV_HIGH,
-                      no_elevcut_space=False,                      
+                      no_elevcut_space=False,
                       fix_theta_GMST=False, add_th_noise=True,
-                      opacitycal=True, ampcal=True, phasecal=True, 
+                      opacitycal=True, ampcal=True, phasecal=True,
                       dcal=True, frcal=True, rlgaincal=True,
                       stabilize_scan_phase=False, stabilize_scan_amp=False,
                       jones=False, inv_jones=False,
@@ -2299,30 +2370,30 @@ class Model(object):
                elevmin (float): station minimum elevation in degrees
                elevmax (float): station maximum elevation in degrees
                no_elevcut_space (bool): if True, do not apply elevation cut to orbiters
-           
+
                polrep_obs (str): 'stokes' or 'circ' sets the data polarimetric representation
 
-               fix_theta_GMST (bool): if True, stops earth rotation to sample fixed u,v 
+               fix_theta_GMST (bool): if True, stops earth rotation to sample fixed u,v
                sgrscat (bool): if True, the visibilites will be blurred by the Sgr A*  kernel
-               add_th_noise (bool): if True, baseline-dependent thermal noise is added 
+               add_th_noise (bool): if True, baseline-dependent thermal noise is added
                opacitycal (bool): if False, time-dependent gaussian errors are added to opacities
                ampcal (bool): if False, time-dependent gaussian errors are added to station gains
-               phasecal (bool): if False, time-dependent station-based random phases are added 
-               frcal (bool): if False, feed rotation angle terms are added to Jones matrices. 
-               dcal (bool): if False, time-dependent gaussian errors added to Jones matrices D-terms. 
+               phasecal (bool): if False, time-dependent station-based random phases are added
+               frcal (bool): if False, feed rotation angle terms are added to Jones matrices.
+               dcal (bool): if False, time-dependent gaussian errors added to Jones matrices D-terms.
 
                stabilize_scan_phase (bool): if True, random phase errors are constant over scans
                stabilize_scan_amp (bool): if True, random amplitude errors are constant over scans
-               jones (bool): if True, uses Jones matrix to apply mis-calibration effects 
+               jones (bool): if True, uses Jones matrix to apply mis-calibration effects
                              otherwise uses old formalism without D-terms
-               inv_jones (bool): if True, applies estimated inverse Jones matrix 
+               inv_jones (bool): if True, applies estimated inverse Jones matrix
                                  (not including random terms) to calibrate data
 
-               tau (float): the base opacity at all sites, 
+               tau (float): the base opacity at all sites,
                             or a dict giving one opacity per site
                taup (float): the fractional std. dev. of the random error on the opacities
                gainp (float): the fractional std. dev. of the random error on the gains
-                              or a dict giving one std. dev. per site      
+                              or a dict giving one std. dev. per site
 
                gain_offset (float): the base gain offset at all sites,
                                     or a dict giving one gain offset per site
@@ -2330,10 +2401,10 @@ class Model(object):
                                     or a dict giving one std. dev. per site
 
                rlratio_std (float): the fractional std. dev. of the R/L gain offset
-                                    or a dict giving one std. dev. per site                                          
-               rlphase_std (float): std. dev. of R/L phase offset, 
                                     or a dict giving one std. dev. per site
-                                    a negative value samples from uniform                                          
+               rlphase_std (float): std. dev. of R/L phase offset,
+                                    or a dict giving one std. dev. per site
+                                    a negative value samples from uniform
 
                seed (int): seeds the random component of noise added. DO NOT set to 0!
 
@@ -2344,18 +2415,18 @@ class Model(object):
         # Generate empty observation
         print("Generating empty observation file . . . ")
 
-        if mjd == None:
+        if mjd is None:
             mjd = self.mjd
         if polrep_obs is None:
             polrep_obs=self.polrep
 
-        obs = array.obsdata(self.ra, self.dec, self.rf, bw, tint, tadv, tstart, tstop, mjd=mjd, 
-                            polrep=polrep_obs, tau=tau, timetype=timetype, 
-                            elevmin=elevmin, elevmax=elevmax, 
+        obs = array.obsdata(self.ra, self.dec, self.rf, bw, tint, tadv, tstart, tstop, mjd=mjd,
+                            polrep=polrep_obs, tau=tau, timetype=timetype,
+                            elevmin=elevmin, elevmax=elevmax,
                             no_elevcut_space=no_elevcut_space, fix_theta_GMST=fix_theta_GMST)
 
         # Observe on the same baselines as the empty observation and add noise
-        obs = self.observe_same(obs, add_th_noise=add_th_noise, 
+        obs = self.observe_same(obs, add_th_noise=add_th_noise,
                                      opacitycal=opacitycal,ampcal=ampcal,
                                      phasecal=phasecal,dcal=dcal,
                                      frcal=frcal, rlgaincal=rlgaincal,
@@ -2378,10 +2449,10 @@ class Model(object):
         time = self.time
         mjd += (time/24.)
 
-        head = ("SRC: %s \n" % self.source +
-                "RA: " + obshelp.rastring(self.ra) + "\n" + 
+        head = (f"SRC: {self.source} \n" +
+                "RA: " + obshelp.rastring(self.ra) + "\n" +
                 "DEC: " + obshelp.decstring(self.dec) + "\n" +
-                "MJD: %.6f \n" % (float(mjd)) +  
+                f"MJD: {float(mjd):.6f} \n" +
                 "RF: %.4f GHz" % (self.rf/1e9))
         # Models
         out = []
@@ -2392,7 +2463,7 @@ class Model(object):
 
     def load_txt(self,filename):
         lines = open(filename).read().splitlines()
-        
+
         src = ' '.join(lines[0].split()[2:])
         ra = lines[1].split()
         self.ra = float(ra[2]) + float(ra[4])/60.0 + float(ra[6])/3600.0

--- a/ehtim/modeling/modeling_utils.py
+++ b/ehtim/modeling/modeling_utils.py
@@ -1951,7 +1951,7 @@ def chisqgrad_cphase_diag(model, uv, clphase_diag, sigma, pol='I', fit_pol=False
         term3 = np.dot(np.dot((np.sin(clphase_diag_measured-clphase_diag_samples)/(clphase_diag_sigma**2.0)),(tform_mats[iA]/i3)),i3_grad.T)
         deriv += -2.0*np.imag(term1 + term2 + term3)
 
-    deriv *= 1.0/np.float(len(np.concatenate(clphase_diag)))
+    deriv *= 1.0/float(len(np.concatenate(clphase_diag)))
 
     return deriv
 
@@ -2079,7 +2079,7 @@ def chisqgrad_logcamp_diag(model, uv, log_clamp_diag, sigma, pol='I', fit_pol=Fa
         term4 = np.dot(np.dot(((log_clamp_diag_measured-log_clamp_diag_samples)/(log_clamp_diag_sigma**2.0)),(tform_mats[iA]/i4)),i4_grad.T)
         deriv += -2.0*np.real(term1 + term2 - term3 - term4)
 
-    deriv *= 1.0/np.float(len(np.concatenate(log_clamp_diag)))
+    deriv *= 1.0/float(len(np.concatenate(log_clamp_diag)))
 
     return deriv
 

--- a/ehtim/movie.py
+++ b/ehtim/movie.py
@@ -16,25 +16,20 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
-
-from builtins import str
-from builtins import range
-from builtins import object
 
 import string
+
 import numpy as np
 import scipy.interpolate
 import scipy.ndimage as filt
 
-import ehtim.image
-import ehtim.obsdata
-import ehtim.observing.obs_simulate as simobs
-import ehtim.io.save
-import ehtim.io.load
 import ehtim.const_def as ehc
+import ehtim.image
+import ehtim.io.load
+import ehtim.io.save
+import ehtim.obsdata
 import ehtim.observing.obs_helpers as obsh
+import ehtim.observing.obs_simulate as simobs
 
 INTERPOLATION_KINDS = ['linear', 'nearest', 'zero', 'slinear',
                        'quadratic', 'cubic', 'previous', 'next']
@@ -44,7 +39,7 @@ INTERPOLATION_KINDS = ['linear', 'nearest', 'zero', 'slinear',
 ###################################################################################################
 
 
-class Movie(object):
+class Movie:
 
     """A polarimetric movie (in units of Jy/pixel).
 
@@ -105,7 +100,7 @@ class Movie(object):
         if len(frames) != len(times):
             raise Exception("len(frames) != len(times) !")
 
-        if not (interp in INTERPOLATION_KINDS):
+        if interp not in INTERPOLATION_KINDS:
             raise Exception(
                 "'interp' must be a valid argument for scipy.interpolate.interp1d: " +
                 string.join(INTERPOLATION_KINDS))
@@ -473,7 +468,7 @@ class Movie(object):
         return mov
 
     def add_pol_movie(self, movie, pol):
-        """Add another movie polarization. 
+        """Add another movie polarization.
 
            Args:
                movie (list): list of 2D frames (possibly complex) in a Jy/pixel array
@@ -486,9 +481,8 @@ class Movie(object):
             raise Exception("new pol in add_pol_movie is the same as pol_prim!")
         if np.any(np.array([image.shape != (self.ydim, self.xdim) for image in movie])):
             raise Exception("add_pol_movie image shapes incompatible with primary image!")
-        if not (pol in list(self._movdict.keys())):
-            raise Exception("for polrep==%s, pol in add_pol_movie must be in " %
-                            self.polrep + ",".join(list(self._movdict.keys())))
+        if pol not in list(self._movdict.keys()):
+            raise Exception(f"for polrep=={self.polrep}, pol in add_pol_movie must be in " + ",".join(list(self._movdict.keys())))
 
         if self.polrep == 'stokes':
             if pol == 'I':
@@ -687,7 +681,7 @@ class Movie(object):
         frames = movdict[pol_prim_out]
         if len(frames) == 0:
             raise Exception("switch_polrep to " +
-                            "%s with pol_prim_out=%s, \n" % (polrep_out, pol_prim_out) +
+                            f"{polrep_out} with pol_prim_out={pol_prim_out}, \n" +
                             "output movie is not defined")
 
         # Make new  movie with primary polarization
@@ -817,8 +811,7 @@ class Movie(object):
                 # print ("time %f before movie start time %f" % (time, self.start_hr))
                 # print ("returning constant frame 0! \n")
             else:
-                raise Exception("time %f must be in the range %f - %f" %
-                                (time, self.start_hr, self.stop_hr))
+                raise Exception(f"time {time:f} must be in the range {self.start_hr:f} - {self.stop_hr:f}")
 
         if (time > self.stop_hr):
             if not(self.bounds_error):
@@ -826,8 +819,7 @@ class Movie(object):
                 # print ("time %f after movie stop time %f" % (time, self.stop_hr))
                 # print ("returning constant frame -1! \n")
             else:
-                raise Exception("time %f must be in the range %f - %f" %
-                                (time, self.start_hr, self.stop_hr))
+                raise Exception(f"time {time:f} must be in the range {self.start_hr:f} - {self.stop_hr:f}")
 
         # interpolate the imvec to the given time
         imvec = self._fundict[self.pol_prim](time)
@@ -861,7 +853,7 @@ class Movie(object):
         """
 
         if n < 0 or n >= len(self.frames):
-            raise Exception("n must be in the range 0 - %i" % self.nframes)
+            raise Exception(f"n must be in the range 0 - {int(self.nframes)}")
 
         time = self.times[n]
 
@@ -960,8 +952,8 @@ class Movie(object):
 
         return movie_blur
 
-    def observe_same_nonoise(self, obs, repeat=False, sgrscat=False, 
-                             ttype="nfft", fft_pad_factor=2, 
+    def observe_same_nonoise(self, obs, repeat=False, sgrscat=False,
+                             ttype="nfft", fft_pad_factor=2,
                              zero_empty_pol=True, verbose=True):
         """Observe the movie on the same baselines as an existing observation
            without adding noise.
@@ -989,9 +981,10 @@ class Movie(object):
             raise Exception("Movie frequency is not the same as observation frequency!")
 
         if ttype == 'direct' or ttype == 'fast' or ttype == 'nfft':
-            if verbose: print("Producing clean visibilities from movie with " + ttype + " FT . . . ")
+            if verbose:
+                print("Producing clean visibilities from movie with " + ttype + " FT . . . ")
         else:
-            raise Exception("ttype=%s, options for ttype are 'direct', 'fast', 'nfft'" % ttype)
+            raise Exception(f"ttype={ttype}, options for ttype are 'direct', 'fast', 'nfft'")
 
         # Get data
         obslist = obs.tlist()
@@ -1000,22 +993,22 @@ class Movie(object):
 
         if (obstimes < self.start_hr).any():
             if repeat:
-                print("Some observation times before movie start time %f" % self.start_hr)
+                print(f"Some observation times before movie start time {self.start_hr:f}")
                 print("Looping movie before start\n")
             elif not(self.bounds_error):
-                print("Some observation times before movie start time %f" % self.start_hr)
+                print(f"Some observation times before movie start time {self.start_hr:f}")
                 print("bounds_error is  False:  using constant frame 0 before start_hr! \n")
             else:
-                raise Exception("Some observation times before movie start time %f" % self.start_hr)
+                raise Exception(f"Some observation times before movie start time {self.start_hr:f}")
         if (obstimes > self.stop_hr).any():
             if repeat:
-                print("Some observation times after movie stop time %f" % self.stop_hr)
+                print(f"Some observation times after movie stop time {self.stop_hr:f}")
                 print("Looping movie after stop\n")
             elif not(self.bounds_error):
-                print("Some observation times after movie stop time %f" % self.stop_hr)
+                print(f"Some observation times after movie stop time {self.stop_hr:f}")
                 print("bounds_error is  False:  using constant frame -1 after stop_hr! \n")
             else:
-                raise Exception("Some observation times after movie stop time %f" % self.stop_hr)
+                raise Exception(f"Some observation times after movie stop time {self.stop_hr:f}")
 
         # Observe nearest frame
         obsdata_out = []
@@ -1031,8 +1024,7 @@ class Movie(object):
                     if repeat:
                         time = self.start_hr + np.mod(time - self.start_hr, self.duration)
                     else:
-                        raise Exception("Obs time %f outside movie range %f--%f" %
-                                        (time, self.start_hr, self.stop_hr))
+                        raise Exception(f"Obs time {time:f} outside movie range {self.start_hr:f}--{self.stop_hr:f}")
 
             # Get the frame visibilities
             uv = obsh.recarr_to_ndarr(obsdata[['u', 'v']], 'f8')
@@ -1040,8 +1032,7 @@ class Movie(object):
             try:
                 im = self.get_image(time)
             except ValueError:
-                raise Exception("Interpolation error for time %f: movie range %f--%f" %
-                                (time, self.start_hr, self.stop_hr))
+                raise Exception(f"Interpolation error for time {time:f}: movie range {self.start_hr:f}--{self.stop_hr:f}")
 
             data = simobs.sample_vis(im, uv, sgrscat=sgrscat, polrep_obs=obs.polrep,
                                      ttype=ttype, fft_pad_factor=fft_pad_factor,
@@ -1051,16 +1042,16 @@ class Movie(object):
             # Put visibilities into the obsdata
             if obs.polrep == 'stokes':
                 obsdata['vis'] = data[0]
-                if not(data[1] is None):
+                if data[1] is not None:
                     obsdata['qvis'] = data[1]
                     obsdata['uvis'] = data[2]
                     obsdata['vvis'] = data[3]
 
             elif obs.polrep == 'circ':
                 obsdata['rrvis'] = data[0]
-                if not(data[1] is None):
+                if data[1] is not None:
                     obsdata['llvis'] = data[1]
-                if not(data[2] is None):
+                if data[2] is not None:
                     obsdata['rlvis'] = data[2]
                     obsdata['lrvis'] = data[3]
 
@@ -1089,7 +1080,7 @@ class Movie(object):
                      stabilize_scan_phase=False, stabilize_scan_amp=False,
                      neggains=False,
                      taup=ehc.GAINPDEF,
-                     gain_offset=ehc.GAINPDEF, gainp=ehc.GAINPDEF, 
+                     gain_offset=ehc.GAINPDEF, gainp=ehc.GAINPDEF,
                      dterm_offset=ehc.DTERMPDEF,
                      rlratio_std=0.,rlphase_std=0.,
                      caltable_path=None, seed=False, sigmat=None, verbose=True):
@@ -1119,7 +1110,7 @@ class Movie(object):
 
                taup (float): the fractional std. dev. of the random error on the opacities
                gainp (float): the fractional std. dev. of the random error on the gains
-                              or a dict giving one std. dev. per site      
+                              or a dict giving one std. dev. per site
 
                gain_offset (float): the base gain offset at all sites,
                                     or a dict giving one gain offset per site
@@ -1127,11 +1118,11 @@ class Movie(object):
                                     or a dict giving one std. dev. per site
 
                rlratio_std (float): the fractional std. dev. of the R/L gain offset
-                                    or a dict giving one std. dev. per site                                          
-               rlphase_std (float): std. dev. of R/L phase offset, 
                                     or a dict giving one std. dev. per site
-                                    a negative value samples from uniform                                          
-                                    
+               rlphase_std (float): std. dev. of R/L phase offset,
+                                    or a dict giving one std. dev. per site
+                                    a negative value samples from uniform
+
                caltable_path (string): If not None, path and prefix for saving the applied caltable
                seed (int): seeds the random component of the noise terms. DO NOT set to 0!
                sigmat (float): temporal std for a Gaussian Process used to generate gain noise.
@@ -1192,7 +1183,7 @@ class Movie(object):
                 print('WARNING: the caltable is only saved if you apply noise with a Jones Matrix')
 
             obsdata = simobs.add_noise(obs, add_th_noise=add_th_noise,
-                                       opacitycal=opacitycal, ampcal=ampcal, phasecal=phasecal, 
+                                       opacitycal=opacitycal, ampcal=ampcal, phasecal=phasecal,
                                        stabilize_scan_phase=stabilize_scan_phase,
                                        stabilize_scan_amp=stabilize_scan_amp,
                                        neggains=neggains,
@@ -1220,7 +1211,7 @@ class Movie(object):
                 stabilize_scan_phase=False, stabilize_scan_amp=False,
                 neggains=False,
                 tau=ehc.TAUDEF, taup=ehc.GAINPDEF,
-                gain_offset=ehc.GAINPDEF, gainp=ehc.GAINPDEF, 
+                gain_offset=ehc.GAINPDEF, gainp=ehc.GAINPDEF,
                 dterm_offset=ehc.DTERMPDEF,
                 rlratio_std=0.,rlphase_std=0.,
                 caltable_path=None, seed=False, sigmat=None, verbose=True):
@@ -1241,7 +1232,7 @@ class Movie(object):
                elevmin (float): station minimum elevation in degrees
                elevmax (float): station maximum elevation in degrees
                no_elevcut_space (bool): if True, do not apply elevation cut to orbiters
-           
+
                ttype (str): "fast", "nfft" or "dtft"
                fft_pad_factor (float): zero pad the image to fft_pad_factor * image size in the FFT
                fix_theta_GMST (bool): if True, stops earth rotation to sample fixed u,v
@@ -1267,7 +1258,7 @@ class Movie(object):
                tau (float): the base opacity at all sites, or a dict giving one opacity per site
                taup (float): the fractional std. dev. of the random error on the opacities
                gainp (float): the fractional std. dev. of the random error on the gains
-                              or a dict giving one std. dev. per site      
+                              or a dict giving one std. dev. per site
 
                gain_offset (float): the base gain offset at all sites,
                                     or a dict giving one gain offset per site
@@ -1275,10 +1266,10 @@ class Movie(object):
                                     or a dict giving one std. dev. per site
 
                rlratio_std (float): the fractional std. dev. of the R/L gain offset
-                                    or a dict giving one std. dev. per site                                          
-               rlphase_std (float): std. dev. of R/L phase offset, 
                                     or a dict giving one std. dev. per site
-                                    a negative value samples from uniform                                          
+               rlphase_std (float): std. dev. of R/L phase offset,
+                                    or a dict giving one std. dev. per site
+                                    a negative value samples from uniform
 
 
                caltable_path (string): If not None, path and prefix for saving the applied caltable
@@ -1293,7 +1284,8 @@ class Movie(object):
         """
 
         # Generate empty observation
-        if verbose: print("Generating empty observation file . . . ")
+        if verbose:
+            print("Generating empty observation file . . . ")
         if mjd is None:
             mjd = self.mjd
         if polrep_obs is None:
@@ -1307,7 +1299,7 @@ class Movie(object):
                             fix_theta_GMST=fix_theta_GMST)
 
         # Observe on the same baselines as the empty observation and add noise
-        obs = self.observe_same(obs, repeat=repeat, 
+        obs = self.observe_same(obs, repeat=repeat,
                                 ttype=ttype, fft_pad_factor=fft_pad_factor,
                                 sgrscat=sgrscat,
                                 add_th_noise=add_th_noise,
@@ -1319,7 +1311,7 @@ class Movie(object):
                                 stabilize_scan_amp=stabilize_scan_amp,
                                 neggains=neggains,
                                 taup=taup,
-                                gain_offset=gain_offset, gainp=gainp, 
+                                gain_offset=gain_offset, gainp=gainp,
                                 dterm_offset=dterm_offset,
                                 rlratio_std=rlratio_std,rlphase_std=rlphase_std,
                                 caltable_path=caltable_path, seed=seed, sigmat=sigmat,
@@ -1329,7 +1321,7 @@ class Movie(object):
 
     def observe_vex(self, vex, source, synchronize_start=True, t_int=0.0,
                     polrep_obs=None, ttype='nfft', fft_pad_factor=2,
-                    fix_theta_GMST=False, 
+                    fix_theta_GMST=False,
                     sgrscat=False, add_th_noise=True,
                     jones=False, inv_jones=False,
                     opacitycal=True, ampcal=True, phasecal=True,
@@ -1337,7 +1329,7 @@ class Movie(object):
                     stabilize_scan_phase=False, stabilize_scan_amp=False,
                     neggains=False,
                     tau=ehc.TAUDEF, taup=ehc.GAINPDEF,
-                    gain_offset=ehc.GAINPDEF, gainp=ehc.GAINPDEF, 
+                    gain_offset=ehc.GAINPDEF, gainp=ehc.GAINPDEF,
                     dterm_offset=ehc.DTERMPDEF,
                     caltable_path=None, seed=False, sigmat=None, verbose=True):
         """Generate baselines from a vex file and observe the movie.
@@ -1512,8 +1504,8 @@ class Movie(object):
 
         import matplotlib
         matplotlib.use('agg')
-        import matplotlib.pyplot as plt
         import matplotlib.animation as animation
+        import matplotlib.pyplot as plt
 
         if self.polrep != 'stokes':
             raise Exception("export_mp4 requires self.polrep=='stokes' -- try self.switch_polrep()")
@@ -1603,12 +1595,12 @@ class Movie(object):
 
         def update_img(n):
             if verbose:
-                print("processing frame {0} of {1}".format(n, len(self.frames)*frame_pad_factor))
+                print(f"processing frame {n} of {len(self.frames)*frame_pad_factor}")
             plt_im.set_data(im_data(n))
 
             if label_time:
                 time = self.times[n]
-                time_str = ("%02d:%02d:%02d" % (int(time), (time*60) % 60, (time*3600) % 60))
+                time_str = f"{int(time):02}:{int(time * 60 % 60):02}:{int(time * 3600 % 60):02}"
                 fig.suptitle(time_str)
 
             return plt_im
@@ -1646,8 +1638,8 @@ def export_multipanel_mp4(input_list, out='movie.mp4', start_hr=None, stop_hr=No
     """
     import matplotlib
     matplotlib.use('agg')
-    import matplotlib.pyplot as plt
     import matplotlib.animation as animation
+    import matplotlib.pyplot as plt
 
     if start_hr is None:
         try:
@@ -1661,7 +1653,7 @@ def export_multipanel_mp4(input_list, out='movie.mp4', start_hr=None, stop_hr=No
         except ValueError:
             raise Exception("no movies in input_list!")
 
-    print("%s will have %i frames in the  range %f-%f hr" % (out, nframes, start_hr, stop_hr))
+    print(f"{out} will have {int(nframes)} frames in the  range {start_hr:f}-{stop_hr:f} hr")
 
     ncols = int(np.ceil(len(input_list)/nrows))
     suptitle_space = 0.6  # inches
@@ -1734,7 +1726,7 @@ def export_multipanel_mp4(input_list, out='movie.mp4', start_hr=None, stop_hr=No
 
     def update_img(n):
         if verbose:
-            print("processing frame {0} of {1}".format(n, len(im_List_Set[0])))
+            print(f"processing frame {n} of {len(im_List_Set[0])}")
         i = 0
         for y in range(nrows):
             for x in range(ncols):
@@ -1748,7 +1740,7 @@ def export_multipanel_mp4(input_list, out='movie.mp4', start_hr=None, stop_hr=No
             fig.suptitle('MJD: ' + str(im_List_Set[0][n].mjd))
         else:
             time = im_List_Set[0][n].time
-            time_str = ("%d:%02d.%02d" % (int(time), (time*60) % 60, (time*3600) % 60))
+            time_str = f"{int(time)}:{int(time * 60 % 60):02}.{int(time * 3600 % 60):02}"
             fig.suptitle(time_str)
 
         return
@@ -1774,8 +1766,8 @@ def merge_im_list(imlist, framedur=-1, interp=ehc.INTERP_DEFAULT, bounds_error=e
     framelist = []
     nframes = len(imlist)
 
-    print("\nMerging %i frames from MJD %i %.2f hr to MJD %i %.2f hr" % (
-        nframes, imlist[0].mjd, imlist[0].time, imlist[-1].mjd, imlist[-1].time))
+    print(f"\nMerging {nframes} frames from MJD {imlist[0].mjd} {imlist[0].time:.2f} hr "
+          f"to MJD {imlist[-1].mjd} {imlist[-1].time:.2f} hr")
 
     for i in range(nframes):
         im = imlist[i]
@@ -1796,23 +1788,23 @@ def merge_im_list(imlist, framedur=-1, interp=ehc.INTERP_DEFAULT, bounds_error=e
             times = [hour0]
         else:
             if (im.polrep != polrep0):
-                raise Exception("polrep of image %i != polrep of image 0!" % i)
+                raise Exception(f"polrep of image {int(i)} != polrep of image 0!")
             if (im.psize != psize0):
-                raise Exception("psize of image %i != psize of image 0!" % i)
+                raise Exception(f"psize of image {int(i)} != psize of image 0!")
             if (im.xdim != xdim0):
-                raise Exception("xdim of image %i != xdim of image 0!" % i)
+                raise Exception(f"xdim of image {int(i)} != xdim of image 0!")
             if (im.ydim != ydim0):
-                raise Exception("ydim of image %i != ydim of image 0!" % i)
+                raise Exception(f"ydim of image {int(i)} != ydim of image 0!")
             if (im.ra != ra0):
-                raise Exception("RA of image %i != RA of image 0!" % i)
+                raise Exception(f"RA of image {int(i)} != RA of image 0!")
             if (im.dec != dec0):
-                raise Exception("DEC of image %i != DEC of image 0!" % i)
+                raise Exception(f"DEC of image {int(i)} != DEC of image 0!")
             if (im.rf != rf0):
-                raise Exception("rf of image %i != rf of image 0!" % i)
+                raise Exception(f"rf of image {int(i)} != rf of image 0!")
             if (im.source != src0):
-                raise Exception("source of image %i != src of image 0!" % i)
+                raise Exception(f"source of image {int(i)} != src of image 0!")
             if (im.mjd < mjd0):
-                raise Exception("mjd of image %i < mjd of image 0!" % i)
+                raise Exception(f"mjd of image {int(i)} < mjd of image 0!")
 
             hour = im.time
             if im.mjd > mjd0:
@@ -1831,7 +1823,7 @@ def merge_im_list(imlist, framedur=-1, interp=ehc.INTERP_DEFAULT, bounds_error=e
             else:
                 if movdict[pol]:
                     raise Exception("all frames in merge_im_list must have the same pol layout: " +
-                                    "error in  frame %i" % i)
+                                    f"error in  frame {int(i)}")
 
     # assume equispaced with a given framedur instead of reading the individual image times
     if framedur != -1:

--- a/ehtim/movie.py
+++ b/ehtim/movie.py
@@ -26,7 +26,7 @@ from builtins import object
 import string
 import numpy as np
 import scipy.interpolate
-import scipy.ndimage.filters as filt
+import scipy.ndimage as filt
 
 import ehtim.image
 import ehtim.obsdata

--- a/ehtim/movie.py
+++ b/ehtim/movie.py
@@ -21,7 +21,7 @@ import string
 
 import numpy as np
 import scipy.interpolate
-import scipy.ndimage as filt
+import scipy.ndimage as ndi
 
 import ehtim.const_def as ehc
 import ehtim.image
@@ -932,7 +932,7 @@ class Movie:
         sigma_x_pol = fwhm_x_pol / self.psize / (2. * np.sqrt(2. * np.log(2.)))
 
         arr = np.array([im.imvec.reshape(self.ydim, self.xdim) for im in frames])
-        arr = filt.gaussian_filter(arr, (sigma_t, sigma_x, sigma_x))
+        arr = ndi.gaussian_filter(arr, (sigma_t, sigma_x, sigma_x))
 
         # Make a new blurred movie
         arglist, argdict = self.movie_args()
@@ -947,7 +947,7 @@ class Movie:
 
             if len(polframes):
                 arr = np.array([imvec.reshape(self.ydim, self.xdim) for imvec in polframes])
-                arr = filt.gaussian_filter(arr, (sigma_t, sigma_x_pol, sigma_x_pol))
+                arr = ndi.gaussian_filter(arr, (sigma_t, sigma_x_pol, sigma_x_pol))
                 movie_blur.add_pol_movie(arr, pol)
 
         return movie_blur

--- a/ehtim/plotting/comp_plots.py
+++ b/ehtim/plotting/comp_plots.py
@@ -22,7 +22,6 @@ import itertools as it
 
 import matplotlib.pyplot as plt
 import numpy as np
-import numpy.matlib as matlib
 
 import ehtim.const_def as ehc
 from ehtim.obsdata import merge_obs
@@ -215,7 +214,7 @@ def plot_cphase_compare(obslist, imlist, site1, site2, site3,
         obslist = [obslist]
 
     if len(cphases) == 0:
-        cphases = matlib.repmat([], len(obslist), 1)
+        cphases = np.tile([], (len(obslist), 1))
 
     if len(cphases) != len(obslist):
         raise Exception("cphases list must be same length as obslist!")
@@ -299,7 +298,7 @@ def plot_camp_compare(obslist, imlist, site1, site2, site3, site4,
         obslist = [obslist]
 
     if len(camps) == 0:
-        camps = matlib.repmat([], len(obslist), 1)
+        camps = np.tile([], (len(obslist), 1))
 
     if len(camps) != len(obslist):
         raise Exception("camps list must be same length as obslist!")

--- a/ehtim/plotting/summary_plots.py
+++ b/ehtim/plotting/summary_plots.py
@@ -239,20 +239,20 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
                 ha='left', va='center', transform=ax.transAxes)
         ax.text(.23, .5, "%0.0f GHz" % (im_or_mov.rf/1.e9), fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.23, .3, "%0.1f $\mu$as" % (im_display.fovx()/ehc.RADPERUAS), fontsize=fs,
+        ax.text(.23, .3, r"%0.1f $\mu$as" % (im_display.fovx()/ehc.RADPERUAS), fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
         ax.text(.23, .1, "%0.2f Jy" % flux, fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
 
-        ax.text(.5, .9, "$\chi^2_{vis}$", fontsize=fs,
+        ax.text(.5, .9, r"$\chi^2_{vis}$", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.5, .7, "$\chi^2_{amp}$", fontsize=fs,
+        ax.text(.5, .7, r"$\chi^2_{amp}$", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.5, .5, "$\chi^2_{cphase}$", fontsize=fs,
+        ax.text(.5, .5, r"$\chi^2_{cphase}$", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.5, .3, "$\chi^2_{log camp}$", fontsize=fs,
+        ax.text(.5, .3, r"$\chi^2_{log camp}$", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.5, .1, "$\chi^2_{camp}$", fontsize=fs,
+        ax.text(.5, .1, r"$\chi^2_{camp}$", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
 
         ax.text(.72, .9, "%0.2f" % chi2vis, fontsize=fs,
@@ -470,7 +470,7 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
                                  ebar=ebar, markersize=MARKERSIZE)
         # modify the labels
         ax.set_title('Calibrated Visiblity Amplitudes')
-        ax.set_xlabel('u-v distance (G$\lambda$)')
+        ax.set_xlabel(r'u-v distance (G$\lambda$)')
         ax.set_xlim([0, 1.e10])
         ax.set_xticks([0, 2.e9, 4.e9, 6.e9, 8.e9, 10.e9])
         ax.set_xticklabels(["0", "2", "4", "6", "8", "10"])
@@ -1025,18 +1025,18 @@ def imgsum_pol(im, obs, obs_uncal, outname,
                 ha='left', va='center', transform=ax.transAxes)
         ax.text(.23, .5, "%0.0f GHz" % (im.rf/1.e9), fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.23, .3, "%0.1f $\mu$as" % (im.fovx()/ehc.RADPERUAS), fontsize=fs,
+        ax.text(.23, .3, r"%0.1f $\mu$as" % (im.fovx()/ehc.RADPERUAS), fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
         ax.text(.23, .1, "%0.2f Jy" % flux, fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
 
-        ax.text(.5, .9, "$\chi^2_{m}$", fontsize=fs,
+        ax.text(.5, .9, r"$\chi^2_{m}$", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.5, .7, "$\chi^2_{P}$", fontsize=fs,
+        ax.text(.5, .7, r"$\chi^2_{P}$", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.5, .5, "$\chi^2_{Q}$", fontsize=fs,
+        ax.text(.5, .5, r"$\chi^2_{Q}$", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.5, .3, "$\chi^2_{U}$", fontsize=fs,
+        ax.text(.5, .3, r"$\chi^2_{U}$", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
 
         ax.text(.72, .9, "%0.2f" % chi2m, fontsize=fs,
@@ -1510,7 +1510,7 @@ def _display_img(im, beamparams=None, scale='linear', gamma=0.5, cbar_lims=False
     imvec = imvec * factor
 
     imarr = (imvec).reshape(im.ydim, im.xdim)
-    unit = 'mJy/$\mu$ as$^2$'
+    unit = r'mJy/$\mu$ as$^2$'
     if scale == 'log':
         if (imarr < 0.0).any():
             print('clipping values less than 0')
@@ -1561,7 +1561,7 @@ def _display_img(im, beamparams=None, scale='linear', gamma=0.5, cbar_lims=False
     start = im.xdim * roughfactor / 3.0  # select the start location
     end = start + fov_scale/fov_uas * im.xdim  # determine the end location
     plt.plot([start, end], [im.ydim-start, im.ydim-start], color="white", lw=1)  # plot line
-    plt.text(x=(start+end)/2.0, y=im.ydim-start-im.ydim/20, s=str(fov_scale) + " $\mu$as",
+    plt.text(x=(start+end)/2.0, y=im.ydim-start-im.ydim/20, s=str(fov_scale) + r" $\mu$as",
              color="white", ha="center", va="center",
              fontsize=int(1.2*fontsize), fontweight='bold')
 
@@ -1719,7 +1719,7 @@ def _display_img_pol(im, beamparams=None, scale='linear', gamma=0.5, cbar_lims=F
         end = start + fov_scale/fov_uas * im.xdim
         # determine the end location based on the size of the bar
         plt.plot([start, end], [im.ydim-start, im.ydim-start], color="white", lw=1)  # plot line
-        plt.text(x=(start+end)/2.0, y=im.ydim-start-im.ydim/20, s=str(fov_scale) + " $\mu$as",
+        plt.text(x=(start+end)/2.0, y=im.ydim-start-im.ydim/20, s=str(fov_scale) + r" $\mu$as",
                  color="white", ha="center", va="center",
                  fontsize=int(1.2*fontsize), fontweight='bold')
 

--- a/ehtim/plotting/summary_plots.py
+++ b/ehtim/plotting/summary_plots.py
@@ -18,26 +18,23 @@
 
 # TODO add systematic noise to individual closure quantities?
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
-
-import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib.gridspec as gridspec
-from matplotlib.backends.backend_pdf import PdfPages
 import datetime
 
-from ehtim.plotting.comp_plots import plotall_obs_compare
-from ehtim.plotting.comp_plots import plot_bl_obs_compare
-from ehtim.plotting.comp_plots import plot_cphase_obs_compare
-from ehtim.plotting.comp_plots import plot_camp_obs_compare
-from ehtim.calibrating.self_cal import self_cal as selfcal
-from ehtim.calibrating.pol_cal import leakage_cal, plot_leakage
+import matplotlib.gridspec as gridspec
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+
 import ehtim.const_def as ehc
+from ehtim.calibrating.pol_cal import leakage_cal, plot_leakage
+from ehtim.calibrating.self_cal import self_cal as selfcal
+from ehtim.plotting.comp_plots import (
+    plot_bl_obs_compare,
+    plot_camp_obs_compare,
+    plot_cphase_obs_compare,
+    plotall_obs_compare,
+)
 
 FONTSIZE = 22
 WSPACE = 0.8
@@ -117,12 +114,12 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
             snrcut_dict[key] = snrcut
 
     with PdfPages(outname) as pdf:
-        titlestr = 'Summary Sheet for %s on MJD %s' % (im_or_mov.source, im_or_mov.mjd)
+        titlestr = f'Summary Sheet for {im_or_mov.source} on MJD {im_or_mov.mjd}'
 
         # pdf metadata
         d = pdf.infodict()
         d['Title'] = title
-        d['Author'] = u'EHT Team 1'
+        d['Author'] = 'EHT Team 1'
         d['Subject'] = titlestr
         d['CreationDate'] = datetime.datetime.today()
         d['ModDate'] = datetime.datetime.today()
@@ -150,7 +147,7 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
             # TODO --- ok to always extrapolate?
             if force_extrapolate:
                 im_or_mov.reset_interp(bounds_error=False)
-        elif hasattr(im_or_mov, 'make_image'):      
+        elif hasattr(im_or_mov, 'make_image'):
             im_display = im_or_mov.make_image(obs.res() * 10., 512)
         else:
             im_display = im_or_mov.copy()
@@ -214,11 +211,11 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
         chi2camp_uncal = obs_uncal.chisq(im_or_mov, dtype='camp', ttype=ttype, systematic_noise=0,
                                          maxset=maxset, snrcut=snrcut_dict['camp'])
 
-        print("chi^2 vis: %0.2f %0.2f" % (chi2vis, chi2vis_uncal))
-        print("chi^2 amp: %0.2f %0.2f" % (chi2amp, chi2amp_uncal))
-        print("chi^2 cphase: %0.2f %0.2f" % (chi2cphase, chi2cphase_uncal))
-        print("chi^2 logcamp: %0.2f %0.2f" % (chi2logcamp, chi2logcamp_uncal))
-        print("chi^2 camp: %0.2f %0.2f" % (chi2logcamp, chi2logcamp_uncal))
+        print(f"chi^2 vis: {chi2vis:0.2f} {chi2vis_uncal:0.2f}")
+        print(f"chi^2 amp: {chi2amp:0.2f} {chi2amp_uncal:0.2f}")
+        print(f"chi^2 cphase: {chi2cphase:0.2f} {chi2cphase_uncal:0.2f}")
+        print(f"chi^2 logcamp: {chi2logcamp:0.2f} {chi2logcamp_uncal:0.2f}")
+        print(f"chi^2 camp: {chi2logcamp:0.2f} {chi2logcamp_uncal:0.2f}")
 
         fs = int(1*fontsize)
         fs2 = int(.8*fontsize)
@@ -233,15 +230,15 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
         ax.text(.05, .1, "FLUX:", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
 
-        ax.text(.23, .9, "%s" % im_or_mov.source, fontsize=fs,
+        ax.text(.23, .9, f"{im_or_mov.source}", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.23, .7, "%i" % im_or_mov.mjd, fontsize=fs,
+        ax.text(.23, .7, f"{int(im_or_mov.mjd)}", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.23, .5, "%0.0f GHz" % (im_or_mov.rf/1.e9), fontsize=fs,
+        ax.text(.23, .5, f"{im_or_mov.rf / 1000000000.0:0.0f} GHz", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.23, .3, r"%0.1f $\mu$as" % (im_display.fovx()/ehc.RADPERUAS), fontsize=fs,
+        ax.text(.23, .3, rf"{im_display.fovx() / ehc.RADPERUAS:0.1f} $\mu$as", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.23, .1, "%0.2f Jy" % flux, fontsize=fs,
+        ax.text(.23, .1, f"{flux:0.2f} Jy", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
 
         ax.text(.5, .9, r"$\chi^2_{vis}$", fontsize=fs,
@@ -255,26 +252,26 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
         ax.text(.5, .1, r"$\chi^2_{camp}$", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
 
-        ax.text(.72, .9, "%0.2f" % chi2vis, fontsize=fs,
+        ax.text(.72, .9, f"{chi2vis:0.2f}", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.72, .7, "%0.2f" % chi2amp, fontsize=fs,
+        ax.text(.72, .7, f"{chi2amp:0.2f}", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.72, .5, "%0.2f" % chi2cphase, fontsize=fs,
+        ax.text(.72, .5, f"{chi2cphase:0.2f}", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.72, .3, "%0.2f" % chi2logcamp, fontsize=fs,
+        ax.text(.72, .3, f"{chi2logcamp:0.2f}", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.72, .1, "%0.2f" % chi2camp, fontsize=fs,
+        ax.text(.72, .1, f"{chi2camp:0.2f}", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
 
-        ax.text(.85, .9, "(%0.2f)" % chi2vis_uncal, fontsize=fs2,
+        ax.text(.85, .9, f"({chi2vis_uncal:0.2f})", fontsize=fs2,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.85, .7, "(%0.2f)" % chi2amp_uncal, fontsize=fs2,
+        ax.text(.85, .7, f"({chi2amp_uncal:0.2f})", fontsize=fs2,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.85, .5, "(%0.2f)" % chi2cphase_uncal, fontsize=fs2,
+        ax.text(.85, .5, f"({chi2cphase_uncal:0.2f})", fontsize=fs2,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.85, .3, "(%0.2f)" % chi2logcamp, fontsize=fs2,
+        ax.text(.85, .3, f"({chi2logcamp:0.2f})", fontsize=fs2,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.85, .1, "(%0.2f)" % chi2camp_uncal, fontsize=fs2,
+        ax.text(.85, .1, f"({chi2camp_uncal:0.2f})", fontsize=fs2,
                 ha='left', va='center', transform=ax.transAxes)
 
         ################################################################################
@@ -351,10 +348,10 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
             if i > 30:
                 break
             data = cphase_chisq_data[idx[i]]
-            tristr = r"%s-%s-%s" % (data[0], data[1], data[2])
-            nstr = r"%i" % data[3]
-            rchisqstr = r"%0.1f" % (float(data[4])/float(data[3]))
-            rrchisqstr = r"%0.3f" % (float(data[4])/float(n_cphase))
+            tristr = rf"{data[0]}-{data[1]}-{data[2]}"
+            nstr = rf"{int(data[3])}"
+            rchisqstr = rf"{float(data[4]) / float(data[3]):0.1f}"
+            rrchisqstr = rf"{float(data[4]) / float(n_cphase):0.3f}"
             if first:
                 chisqtab += r" " + tristr + " & " + nstr + " & " + rchisqstr + " & " + rrchisqstr
                 first = False
@@ -434,10 +431,10 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
             if i > 45:
                 break
             data = camp_chisq_data[idx[i]]
-            tristr = r"%s-%s-%s-%s" % (data[0], data[1], data[2], data[3])
-            nstr = r"%i" % data[4]
-            rchisqstr = r"%0.1f" % (data[5]/float(data[4]))
-            rrchisqstr = r"%0.3f" % (data[5]/float(n_camps))
+            tristr = rf"{data[0]}-{data[1]}-{data[2]}-{data[3]}"
+            nstr = rf"{int(data[4])}"
+            rchisqstr = rf"{data[5] / float(data[4]):0.1f}"
+            rrchisqstr = rf"{data[5] / float(n_camps):0.3f}"
             if i == 0:
                 chisqtab += r" " + tristr + " & " + nstr + " & " + rchisqstr + " & " + rrchisqstr
             else:
@@ -481,7 +478,7 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
         ax.set_ylim([0, 1.2*flux])
         yticks_maj = np.array([0, .2, .4, .6, .8, 1])*flux
         ax.set_yticks(yticks_maj)
-        ax.set_yticklabels(["%0.2f" % fl for fl in yticks_maj])
+        ax.set_yticklabels([f"{fl:0.2f}" for fl in yticks_maj])
         yticks_min = np.array([.1, .3, .5, .7, .9])*flux
         ax.set_yticks(yticks_min, minor=True)
         ax.set_yticklabels([], minor=True)
@@ -492,6 +489,7 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
             print("plotting gains")
             ax2 = plt.subplot(gs[0:2, 2:6])
             obs_tmp = obs_uncal.copy()
+            ct_out = None
             for i in range(1):
                 ct = selfcal(obs_tmp, im_or_mov,
                              method='amp', ttype=ttype,
@@ -520,7 +518,7 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
             for station in ct_out.tarr['site']:
                 try:
                     gain = np.median(np.abs(ct_out.data[station]['lscale']))
-                except:
+                except Exception:
                     continue
                 pdiff = np.abs(gain-1)*100
                 data = (station, gain, pdiff)
@@ -536,9 +534,9 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
                 if i > 45:
                     break
                 data = gain_data[idx[i]]
-                sitestr = r"%s" % (data[0])
-                gstr = r"%0.2f" % data[1]
-                pstr = r"%0.0f" % data[2]
+                sitestr = rf"{data[0]}"
+                gstr = rf"{data[1]:0.2f}"
+                pstr = rf"{data[2]:0.0f}"
                 if i == 0:
                     chisqtab += r" " + sitestr + " & " + gstr + " & " + pstr
                 else:
@@ -599,10 +597,10 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
             if i > 45:
                 break
             data = bl_chisq_data[idx[i]]
-            tristr = r"%s-%s" % (data[0], data[1])
-            nstr = r"%i" % data[2]
-            rchisqstr = r"%0.1f" % (data[3]/float(data[2]))
-            rrchisqstr = r"%0.3f" % (data[3]/float(n_bl))
+            tristr = rf"{data[0]}-{data[1]}"
+            nstr = rf"{int(data[2])}"
+            rchisqstr = rf"{data[3] / float(data[2]):0.1f}"
+            rrchisqstr = rf"{data[3] / float(n_bl):0.3f}"
             if i == 0:
                 chisqtab += r" " + tristr + " & " + nstr + " & " + rchisqstr + " & " + rrchisqstr
             else:
@@ -656,7 +654,7 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
                 ax.set_xlabel('')
 
                 if i == 3:
-                    print('saving pdf page %i' % page)
+                    print(f'saving pdf page {int(page)}')
                     page += 1
                     pdf.savefig(pad_inches=MARGINS, bbox_inches='tight')
                     plt.close()
@@ -666,7 +664,7 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
                     j = 0
                     switch = False
 
-            print('saving pdf page %i' % page)
+            print(f'saving pdf page {int(page)}')
             page += 1
             pdf.savefig(pad_inches=MARGINS, bbox_inches='tight')
             plt.close()
@@ -705,7 +703,7 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
                 ax.set_xlabel('')
 
                 if i == 3:
-                    print('saving pdf page %i' % page)
+                    print(f'saving pdf page {int(page)}')
                     page += 1
                     pdf.savefig(pad_inches=MARGINS, bbox_inches='tight')
                     plt.close()
@@ -714,7 +712,7 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
                     i = 0
                     j = 0
                     switch = False
-            print('saving pdf page %i' % page)
+            print(f'saving pdf page {int(page)}')
             page += 1
             pdf.savefig(pad_inches=MARGINS, bbox_inches='tight')
             plt.close()
@@ -754,7 +752,7 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
                 ax.set_xlabel('')
 
                 if i == 3:
-                    print('saving pdf page %i' % page)
+                    print(f'saving pdf page {int(page)}')
                     page += 1
                     pdf.savefig(pad_inches=MARGINS, bbox_inches='tight')
                     plt.close()
@@ -763,7 +761,7 @@ def imgsum(im_or_mov, obs, obs_uncal, outname, outdir='.', title='imgsum', comme
                     i = 0
                     j = 0
                     switch = False
-            print('saving pdf page %i' % page)
+            print(f'saving pdf page {int(page)}')
             page += 1
             pdf.savefig(pad_inches=MARGINS, bbox_inches='tight')
             plt.close()
@@ -854,12 +852,12 @@ def imgsum_pol(im, obs, obs_uncal, outname,
         im.ivec += 1.e-50*np.max(im.ivec)
 
     with PdfPages(outname) as pdf:
-        titlestr = 'Summary Sheet for %s on MJD %s' % (im.source, im.mjd)
+        titlestr = f'Summary Sheet for {im.source} on MJD {im.mjd}'
 
         # pdf metadata
         d = pdf.infodict()
         d['Title'] = title
-        d['Author'] = u'EHT Team 1'
+        d['Author'] = 'EHT Team 1'
         d['Subject'] = titlestr
         d['CreationDate'] = datetime.datetime.today()
         d['ModDate'] = datetime.datetime.today()
@@ -1001,10 +999,10 @@ def imgsum_pol(im, obs, obs_uncal, outname,
         chi2uvis_uncal = obs_uncal.chisq(im, dtype='vis', ttype='nfft',
                                          systematic_noise=sysnoise, pol='U')
 
-        print("chi^2 m: %0.2f %0.2f" % (chi2m, chi2m_uncal))
-        print("chi^2 pvis: %0.2f %0.2f" % (chi2pvis, chi2pvis_uncal))
-        print("chi^2 qvis: %0.2f %0.2f" % (chi2qvis, chi2qvis_uncal))
-        print("chi^2 uvis: %0.2f %0.2f" % (chi2uvis, chi2uvis_uncal))
+        print(f"chi^2 m: {chi2m:0.2f} {chi2m_uncal:0.2f}")
+        print(f"chi^2 pvis: {chi2pvis:0.2f} {chi2pvis_uncal:0.2f}")
+        print(f"chi^2 qvis: {chi2qvis:0.2f} {chi2qvis_uncal:0.2f}")
+        print(f"chi^2 uvis: {chi2uvis:0.2f} {chi2uvis_uncal:0.2f}")
 
         fs = int(1*fontsize)
         fs2 = int(.8*fontsize)
@@ -1019,15 +1017,15 @@ def imgsum_pol(im, obs, obs_uncal, outname,
         ax.text(.05, .1, "FLUX:", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
 
-        ax.text(.23, .9, "%s" % im.source, fontsize=fs,
+        ax.text(.23, .9, f"{im.source}", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.23, .7, "%i" % im.mjd, fontsize=fs,
+        ax.text(.23, .7, f"{int(im.mjd)}", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.23, .5, "%0.0f GHz" % (im.rf/1.e9), fontsize=fs,
+        ax.text(.23, .5, f"{im.rf / 1000000000.0:0.0f} GHz", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.23, .3, r"%0.1f $\mu$as" % (im.fovx()/ehc.RADPERUAS), fontsize=fs,
+        ax.text(.23, .3, rf"{im.fovx() / ehc.RADPERUAS:0.1f} $\mu$as", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.23, .1, "%0.2f Jy" % flux, fontsize=fs,
+        ax.text(.23, .1, f"{flux:0.2f} Jy", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
 
         ax.text(.5, .9, r"$\chi^2_{m}$", fontsize=fs,
@@ -1039,22 +1037,22 @@ def imgsum_pol(im, obs, obs_uncal, outname,
         ax.text(.5, .3, r"$\chi^2_{U}$", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
 
-        ax.text(.72, .9, "%0.2f" % chi2m, fontsize=fs,
+        ax.text(.72, .9, f"{chi2m:0.2f}", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.72, .7, "%0.2f" % chi2pvis, fontsize=fs,
+        ax.text(.72, .7, f"{chi2pvis:0.2f}", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.72, .5, "%0.2f" % chi2qvis, fontsize=fs,
+        ax.text(.72, .5, f"{chi2qvis:0.2f}", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.72, .3, "%0.2f" % chi2uvis, fontsize=fs,
+        ax.text(.72, .3, f"{chi2uvis:0.2f}", fontsize=fs,
                 ha='left', va='center', transform=ax.transAxes)
 
-        ax.text(.85, .9, "(%0.2f)" % chi2m_uncal, fontsize=fs2,
+        ax.text(.85, .9, f"({chi2m_uncal:0.2f})", fontsize=fs2,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.85, .7, "(%0.2f)" % chi2pvis_uncal, fontsize=fs2,
+        ax.text(.85, .7, f"({chi2pvis_uncal:0.2f})", fontsize=fs2,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.85, .5, "(%0.2f)" % chi2qvis_uncal, fontsize=fs2,
+        ax.text(.85, .5, f"({chi2qvis_uncal:0.2f})", fontsize=fs2,
                 ha='left', va='center', transform=ax.transAxes)
-        ax.text(.85, .3, "(%0.2f)" % chi2uvis_uncal, fontsize=fs2,
+        ax.text(.85, .3, f"({chi2uvis_uncal:0.2f})", fontsize=fs2,
                 ha='left', va='center', transform=ax.transAxes)
 
         ################################################################################
@@ -1185,11 +1183,11 @@ def imgsum_pol(im, obs, obs_uncal, outname,
             if i > 45:
                 break
             data = bl_chisq_data_m[idx_m[i]]
-            tristr = r"%s-%s" % (data[0], data[1])
-            nstr = r"%i" % data[2]
-            chisqstr = r"%0.1f" % data[3]
-            rchisqstr = r"%0.1f" % (data[3]/float(data[2]))
-            rrchisqstr = r"%0.3f" % (data[3]/float(n_bl))
+            tristr = rf"{data[0]}-{data[1]}"
+            nstr = rf"{int(data[2])}"
+            chisqstr = rf"{data[3]:0.1f}"
+            rchisqstr = rf"{data[3] / float(data[2]):0.1f}"
+            rrchisqstr = rf"{data[3] / float(n_bl):0.3f}"
             if i == 0:
                 chisqtab_m += r" " + tristr + " & " + nstr + " & " + rchisqstr + " & " + rrchisqstr
             else:
@@ -1198,10 +1196,10 @@ def imgsum_pol(im, obs, obs_uncal, outname,
             if i > 45:
                 break
             data = bl_chisq_data_pvis[idx_p[i]]
-            tristr = r"%s-%s" % (data[0], data[1])
-            nstr = r"%i" % data[2]
-            rchisqstr = r"%0.1f" % (data[3]/float(data[2]))
-            rrchisqstr = r"%0.3f" % (data[3]/float(n_bl))
+            tristr = rf"{data[0]}-{data[1]}"
+            nstr = rf"{int(data[2])}"
+            rchisqstr = rf"{data[3] / float(data[2]):0.1f}"
+            rrchisqstr = rf"{data[3] / float(n_bl):0.3f}"
             if i == 0:
                 chisqtab_p += r" " + tristr + " & " + nstr + " & " + rchisqstr + " & " + rrchisqstr
             else:
@@ -1210,10 +1208,10 @@ def imgsum_pol(im, obs, obs_uncal, outname,
             if i > 45:
                 break
             data = bl_chisq_data_qvis[idx_q[i]]
-            tristr = r"%s-%s" % (data[0], data[1])
-            nstr = r"%i" % data[2]
-            rchisqstr = r"%0.1f" % (data[3]/float(data[2]))
-            rrchisqstr = r"%0.3f" % (data[3]/float(n_bl))
+            tristr = rf"{data[0]}-{data[1]}"
+            nstr = rf"{int(data[2])}"
+            rchisqstr = rf"{data[3] / float(data[2]):0.1f}"
+            rrchisqstr = rf"{data[3] / float(n_bl):0.3f}"
             if i == 0:
                 chisqtab_q += r" " + tristr + " & " + nstr + " & " + rchisqstr + " & " + rrchisqstr
             else:
@@ -1222,10 +1220,10 @@ def imgsum_pol(im, obs, obs_uncal, outname,
             if i > 45:
                 break
             data = bl_chisq_data_qvis[idx_u[i]]
-            tristr = r"%s-%s" % (data[0], data[1])
-            nstr = r"%i" % data[2]
-            rchisqstr = r"%0.1f" % (data[3]/float(data[2]))
-            rrchisqstr = r"%0.3f" % (data[3]/float(n_bl))
+            tristr = rf"{data[0]}-{data[1]}"
+            nstr = rf"{int(data[2])}"
+            rchisqstr = rf"{data[3] / float(data[2]):0.1f}"
+            rrchisqstr = rf"{data[3] / float(n_bl):0.3f}"
             if i == 0:
                 chisqtab_u += r" " + tristr + " & " + nstr + " & " + rchisqstr + " & " + rrchisqstr
             else:
@@ -1309,7 +1307,7 @@ def imgsum_pol(im, obs, obs_uncal, outname,
                     continue
 
                 if i == 3:
-                    print('saving pdf page %i' % page)
+                    print(f'saving pdf page {int(page)}')
                     page += 1
                     pdf.savefig(pad_inches=MARGINS, bbox_inches='tight')
                     plt.close()
@@ -1319,7 +1317,7 @@ def imgsum_pol(im, obs, obs_uncal, outname,
                     j = 0
 
                 if nbl == len(uniquebl):
-                    print('saving pdf page %i' % page)
+                    print(f'saving pdf page {int(page)}')
                     page += 1
                     pdf.savefig(pad_inches=MARGINS, bbox_inches='tight')
                     plt.close()
@@ -1363,7 +1361,7 @@ def imgsum_pol(im, obs, obs_uncal, outname,
                     continue
 
                 if i == 3:
-                    print('saving pdf page %i' % page)
+                    print(f'saving pdf page {int(page)}')
                     page += 1
                     pdf.savefig(pad_inches=MARGINS, bbox_inches='tight')
                     plt.close()
@@ -1373,7 +1371,7 @@ def imgsum_pol(im, obs, obs_uncal, outname,
                     j = 0
 
                 if nbl == len(uniquebl):
-                    print('saving pdf page %i' % page)
+                    print(f'saving pdf page {int(page)}')
                     page += 1
                     pdf.savefig(pad_inches=MARGINS, bbox_inches='tight')
                     plt.close()
@@ -1417,7 +1415,7 @@ def imgsum_pol(im, obs, obs_uncal, outname,
                     continue
 
                 if i == 3:
-                    print('saving pdf page %i' % page)
+                    print(f'saving pdf page {int(page)}')
                     page += 1
                     pdf.savefig(pad_inches=MARGINS, bbox_inches='tight')
                     plt.close()
@@ -1427,7 +1425,7 @@ def imgsum_pol(im, obs, obs_uncal, outname,
                     j = 0
 
                 if nbl == len(uniquebl):
-                    print('saving pdf page %i' % page)
+                    print(f'saving pdf page {int(page)}')
                     page += 1
                     pdf.savefig(pad_inches=MARGINS, bbox_inches='tight')
                     plt.close()
@@ -1471,7 +1469,7 @@ def imgsum_pol(im, obs, obs_uncal, outname,
                     continue
 
                 if i == 3:
-                    print('saving pdf page %i' % page)
+                    print(f'saving pdf page {int(page)}')
                     page += 1
                     pdf.savefig(pad_inches=MARGINS, bbox_inches='tight')
                     plt.close()
@@ -1481,7 +1479,7 @@ def imgsum_pol(im, obs, obs_uncal, outname,
                     j = 0
 
                 if nbl == len(uniquebl):
-                    print('saving pdf page %i' % page)
+                    print(f'saving pdf page {int(page)}')
                     page += 1
                     pdf.savefig(pad_inches=MARGINS, bbox_inches='tight')
                     plt.close()
@@ -1543,7 +1541,7 @@ def _display_img(im, beamparams=None, scale='linear', gamma=0.5, cbar_lims=False
         if cbar_lims:
             plt.clim(cbar_lims[0], cbar_lims[1])
 
-    if not(beamparams is None):
+    if beamparams is not None:
         beamparams = [beamparams[0], beamparams[1], beamparams[2],
                       -.35*im.fovx(), -.35*im.fovy()]
         beamimage = im.copy()
@@ -1615,7 +1613,7 @@ def _display_img_pol(im, beamparams=None, scale='linear', gamma=0.5, cbar_lims=F
                     im2 = im.switch_polrep('stokes')
                 imvec = np.array(im2._imdict[pol]).reshape(-1)
             except KeyError:
-                raise Exception("Cannot make pol %s image in display()!" % pol)
+                raise Exception(f"Cannot make pol {pol} image in display()!")
 
     # flux unit is Tb
     imvec = imvec * factor
@@ -1698,7 +1696,7 @@ def _display_img_pol(im, beamparams=None, scale='linear', gamma=0.5, cbar_lims=F
         if cbar_lims:
             ax.set_clim(cbar_lims[0], cbar_lims[1])
 
-    if not(beamparams is None):
+    if beamparams is not None:
         beamparams = [beamparams[0], beamparams[1], beamparams[2],
                       -.35*im.fovx(), -.35*im.fovy()]
         beamimage = im.copy()

--- a/ehtim/statistics/dataframes.py
+++ b/ehtim/statistics/dataframes.py
@@ -1,5 +1,5 @@
 # DataFrames.py
-# variety of statistical functions useful for 
+# variety of statistical functions useful for
 #
 #    Copyright (C) 2018 Maciek Wielgus
 #
@@ -16,13 +16,8 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
-from builtins import str
-from builtins import map
-from builtins import range
 
-import numpy as np 
+import numpy as np
 
 try:
     import pandas as pd
@@ -31,8 +26,24 @@ except ImportError:
     print("Please install pandas to use statistics package!")
 
 import datetime as datetime
+
 from astropy.time import Time
-from ehtim.statistics.stats import *
+
+from ehtim.statistics.stats import (
+    DTAMP,
+    DTBIS,
+    DTCAMP,
+    DTCPHASE,
+    DTCPHASEDIAG,
+    DTLOGCAMPDIAG,
+    DTPOL_CIRC,
+    DTPOL_STOKES,
+    EP,
+    bootstrap,
+    circular_mean,
+    mean_incoh_avg,
+)
+
 
 def make_df(obs,polarization='unknown',band='unknown',round_s=0.1):
 
@@ -53,9 +64,11 @@ def make_df(obs,polarization='unknown',band='unknown',round_s=0.1):
     telescopes = [(x[0],x[1]) for x in telescopes]
     df['baseline'] = [x[0]+'-'+x[1] for x in telescopes]
     if obs.polrep=='stokes':
-        vis1='vis'; sig1='sigma'
+        vis1='vis'
+        sig1='sigma'
     elif obs.polrep=='circ':
-        vis1='rrvis'; sig1='rrsigma'
+        vis1='rrvis'
+        sig1='rrsigma'
         df['vis']=df[vis1]
         df['sigma']=df[sig1]
         df['rramp']=np.abs(df['rrvis'])
@@ -100,7 +113,7 @@ def make_amp(obs,debias=True,polarization='unknown',band='unknown',round_s=0.1):
     telescopes = [(x[0],x[1]) for x in telescopes]
     df['baseline'] = [x[0]+'-'+x[1] for x in telescopes]
     df['amp'] = list(map(np.abs,df['vis']))
-    if debias==True:
+    if debias:
         amp2 = np.maximum(np.asarray(df['amp'])**2-np.asarray(df['sigma'])**2,np.asarray(df['sigma'])**2)
         df['amp'] = np.sqrt(amp2)
     df['phase'] = list(map(lambda x: (180./np.pi)*np.angle(x),df['vis']))
@@ -126,16 +139,16 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
     Returns:
         vis_avg: coherently averaged visibilities
     """
-    if (dt<=0)&(scan_avg==False):
+    if (dt<=0)&(not scan_avg):
         return obs.data
     else:
         vis = make_df(obs)
-        if scan_avg==False:
+        if not scan_avg:
             #TODO
             #we don't have to work on datetime products at all
             #change it to only use 'time' in mjd
-            t0 = datetime.datetime(1960,1,1) 
-            vis['round_time'] = list(map(lambda x: np.floor((x- t0).total_seconds()/float(dt)),vis.datetime))  
+            t0 = datetime.datetime(1960,1,1)
+            vis['round_time'] = list(map(lambda x: np.floor((x- t0).total_seconds()/float(dt)),vis.datetime))
             grouping=['tau1','tau2','polarization','band','baseline','t1','t2','round_time']
         else:
             bins, labs = get_bins_labels(obs.scans)
@@ -151,20 +164,34 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
             err_type='predicted'
 
         if obs.polrep=='stokes':
-            vis1='vis'; vis2='qvis'; vis3='uvis'; vis4='vvis'
-            sig1='sigma'; sig2='qsigma'; sig3='usigma'; sig4='vsigma'
+            vis1='vis'
+            vis2='qvis'
+            vis3='uvis'
+            vis4='vvis'
+            sig1='sigma'
+            sig2='qsigma'
+            sig3='usigma'
+            sig4='vsigma'
         elif obs.polrep=='circ':
-            vis1='rrvis'; vis2='llvis'; vis3='rlvis'; vis4='lrvis'
-            sig1='rrsigma'; sig2='llsigma'; sig3='rlsigma'; sig4='lrsigma'
+            vis1='rrvis'
+            vis2='llvis'
+            vis3='rlvis'
+            vis4='lrvis'
+            sig1='rrsigma'
+            sig2='llsigma'
+            sig3='rlsigma'
+            sig4='lrsigma'
 
-        #AVERAGING-------------------------------    
+        #AVERAGING-------------------------------
         if err_type=='measured':
             vis['dummy'] = vis[vis1]
             vis['qdummy'] = vis[vis2]
             vis['udummy'] = vis[vis3]
             vis['vdummy'] = vis[vis4]
-            meanF = lambda x: np.nanmean(np.asarray(x))
-            meanerrF = lambda x: bootstrap(np.abs(x), np.mean, num_samples=num_samples,wrapping_variable=False)
+            def meanF(x):
+                return np.nanmean(np.asarray(x))
+            def meanerrF(x):
+                return bootstrap(np.abs(x), np.mean, num_samples=num_samples,wrapping_variable=False)
             aggregated[vis1] = meanF
             aggregated[vis2] = meanF
             aggregated[vis3] = meanF
@@ -173,18 +200,21 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
             aggregated['udummy'] = meanerrF
             aggregated['vdummy'] = meanerrF
             aggregated['qdummy'] = meanerrF
-       
+
         elif err_type=='predicted':
-            meanF = lambda x: np.nanmean(np.asarray(x))
+            def meanF(x):
+                return np.nanmean(np.asarray(x))
             #meanerrF = lambda x: bootstrap(np.abs(x), np.mean, num_samples=num_samples,wrapping_variable=False)
             def meanerrF(x):
                 x = np.asarray(x)
                 x = x[x==x]
-                
-                if len(x)>0: ret = np.sqrt(np.sum(x**2)/len(x)**2)
-                else: ret = np.nan +1j*np.nan
+
+                if len(x)>0:
+                    ret = np.sqrt(np.sum(x**2)/len(x)**2)
+                else:
+                    ret = np.nan +1j*np.nan
                 return ret
-              
+
             aggregated[vis1] = meanF
             aggregated[vis2] = meanF
             aggregated[vis3] = meanF
@@ -196,7 +226,7 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
 
         #ACTUAL AVERAGING
         vis_avg = vis.groupby(grouping).agg(aggregated).reset_index()
-        
+
         if err_type=='measured':
             vis_avg[sig1] = [0.5*(x[1][1]-x[1][0]) for x in list(vis_avg['dummy'])]
             vis_avg[sig2] = [0.5*(x[1][1]-x[1][0]) for x in list(vis_avg['qdummy'])]
@@ -207,7 +237,7 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
         vis_avg['phase'] = list(map(lambda x: (180./np.pi)*np.angle(x),vis_avg[vis1]))
         vis_avg['snr'] = vis_avg['amp']/vis_avg[sig1]
 
-        if scan_avg==False:
+        if not scan_avg:
             #round datetime and time to the begining of the bucket and add half of a bucket time
             half_bucket = dt/2.
             vis_avg['datetime'] =  list(map(lambda x: t0 + datetime.timedelta(seconds= int(dt*x) + half_bucket), vis_avg['round_time']))
@@ -216,7 +246,7 @@ def coh_avg_vis(obs,dt=0,scan_avg=False,return_type='rec',err_type='predicted',n
             #drop values that couldn't be matched to any scan
             vis_avg.drop(list(vis_avg[vis_avg.scan<0].index.values),inplace=True)
         if err_type=='measured':
-            vis_avg.drop(labels=['udummy','vdummy','qdummy','dummy'],axis='columns',inplace=True)      
+            vis_avg.drop(labels=['udummy','vdummy','qdummy','dummy'],axis='columns',inplace=True)
         if return_type=='rec':
             if obs.polrep=='stokes':
                 return df_to_rec(vis_avg,'vis')
@@ -239,11 +269,23 @@ def coh_moving_avg_vis(obs,dt=50,return_type='rec'):
     if dt <= 0:
         raise Exception('Time dt must be positive!')
     if obs.polrep=='stokes':
-        vis1='vis'; vis2='qvis'; vis3='uvis'; vis4='vvis'
-        sig1='sigma'; sig2='qsigma'; sig3='usigma'; sig4='vsigma'
+        vis1='vis'
+        vis2='qvis'
+        vis3='uvis'
+        vis4='vvis'
+        sig1='sigma'
+        sig2='qsigma'
+        sig3='usigma'
+        sig4='vsigma'
     elif obs.polrep=='circ':
-        vis1='rrvis'; vis2='llvis'; vis3='rlvis'; vis4='lrvis'
-        sig1='rrsigma'; sig2='llsigma'; sig3='rlsigma'; sig4='lrsigma'
+        vis1='rrvis'
+        vis2='llvis'
+        vis3='rlvis'
+        vis4='lrvis'
+        sig1='rrsigma'
+        sig2='llsigma'
+        sig3='rlsigma'
+        sig4='lrsigma'
 
     vis = make_df(obs)
     vis = vis.sort_values(['baseline','datetime']).reset_index().copy()
@@ -252,11 +294,13 @@ def coh_moving_avg_vis(obs,dt=50,return_type='rec'):
     vis['roll_vis'] = list(zip(vis['total_seconds'],vis[vis1],vis[vis2],vis[vis3],vis[vis4],vis['datetime']))
     vis['roll_sig'] = list(zip(vis['total_seconds'],vis[sig1],vis[sig2],vis[sig3],vis[sig4],vis['datetime']))
 
-    roll_vis_local = lambda x: roll_vis(x,dt=str(int(dt))+'s',min_periods=min_periods)
-    roll_sig_local = lambda x: roll_sig(x,dt=str(int(dt))+'s',min_periods=min_periods)
+    def roll_vis_local(x):
+        return roll_vis(x,dt=str(int(dt))+'s',min_periods=min_periods)
+    def roll_sig_local(x):
+        return roll_sig(x,dt=str(int(dt))+'s',min_periods=min_periods)
     vis_avg_roll_vis = vis[['baseline','roll_vis']].groupby('baseline').transform(roll_vis_local)['roll_vis'].copy()
     vis_avg_roll_sig = vis[['baseline','roll_sig']].groupby('baseline').transform(roll_sig_local)['roll_sig'].copy()
-    
+
     for cou,col in enumerate([vis1,vis2,vis3,vis4]):
         vis[col] = [x[2*cou] + 1j*x[2*cou+1] for x in vis_avg_roll_vis]
     for cou,col in enumerate([sig1,sig2,sig3,sig4]):
@@ -293,7 +337,7 @@ def roll_sig(ser,dt='1s',min_periods=1):
                    index=[x[0] for x in ser])
     avg0 = foo.rolling(dt, min_periods=min_periods).mean()
     sumSq = foo.rolling(dt, min_periods=min_periods).sum()
-    avg = pd.DataFrame({},index=[x[0] for x in ser]) 
+    avg = pd.DataFrame({},index=[x[0] for x in ser])
     avg['sig1'] = (avg0['sig1']**1.0)/(sumSq['sig1']**0.5)
     avg['sig2'] = (avg0['sig2']**1.0)/(sumSq['sig2']**0.5)
     avg['sig3'] = (avg0['sig3']**1.0)/(sumSq['sig3']**0.5)
@@ -315,17 +359,17 @@ def incoh_avg_vis(obs,dt=0,debias=True,scan_avg=False,return_type='rec',rec_type
     Returns:
         vis_avg: coherently averaged visibilities
     """
-    if (dt<=0)&(scan_avg==False):
+    if (dt<=0)&(not scan_avg):
         print('Either averaging time must be positive, or scan_avg option should be selected!')
         return obs.data
     else:
         vis = make_df(obs)
-        if scan_avg==False:
+        if not scan_avg:
             #TODO
             #we don't have to work on datetime products at all
             #change it to only use 'time' in mjd
-            t0 = datetime.datetime(1960,1,1) 
-            vis['round_time'] = list(map(lambda x: np.floor((x- t0).total_seconds()/float(dt)),vis.datetime))  
+            t0 = datetime.datetime(1960,1,1)
+            vis['round_time'] = list(map(lambda x: np.floor((x- t0).total_seconds()/float(dt)),vis.datetime))
             grouping=['tau1','tau2','polarization','band','baseline','t1','t2','round_time']
         else:
             bins, labs = get_bins_labels(obs.scans)
@@ -340,7 +384,7 @@ def incoh_avg_vis(obs,dt=0,debias=True,scan_avg=False,return_type='rec',rec_type
             print("Error type can only be 'predicted' or 'measured'! Assuming 'predicted'.")
             err_type='predicted'
 
-        #AVERAGING------------------------------- 
+        #AVERAGING-------------------------------
         vis['dummy'] = list(zip(np.abs(vis['vis']),vis['sigma']))
         vis['udummy'] = list(zip(np.abs(vis['uvis']),vis['usigma']))
         vis['vdummy'] = list(zip(np.abs(vis['vvis']),vis['vsigma']))
@@ -370,7 +414,7 @@ def incoh_avg_vis(obs,dt=0,debias=True,scan_avg=False,return_type='rec',rec_type
             vis_avg['usigma'] = [x[1] for x in list(vis_avg['udummy'])]
             vis_avg['qsigma'] = [x[1] for x in list(vis_avg['qdummy'])]
             vis_avg['vsigma'] = [x[1] for x in list(vis_avg['vdummy'])]
-        
+
         elif err_type=='measured':
             vis_avg['vis'] = [x[0] for x in list(vis_avg['dummy'])]
             vis_avg['uvis'] = [x[0] for x in list(vis_avg['udummy'])]
@@ -384,7 +428,7 @@ def incoh_avg_vis(obs,dt=0,debias=True,scan_avg=False,return_type='rec',rec_type
         vis_avg['amp'] = list(map(np.abs,vis_avg['vis']))
         vis_avg['phase'] = 0
         vis_avg['snr'] = vis_avg['amp']/vis_avg['sigma']
-        if scan_avg==False:
+        if not scan_avg:
             #round datetime and time to the begining of the bucket and add half of a bucket time
             half_bucket = dt/2.
             vis_avg['datetime'] =  list(map(lambda x: t0 + datetime.timedelta(seconds= int(dt*x) + half_bucket), vis_avg['round_time']))
@@ -392,8 +436,8 @@ def incoh_avg_vis(obs,dt=0,debias=True,scan_avg=False,return_type='rec',rec_type
         else:
             #drop values that couldn't be matched to any scan
             vis_avg.drop(list(vis_avg[vis_avg.scan<0].index.values),inplace=True)
-            
-        vis_avg.drop(labels=['udummy','vdummy','qdummy','dummy'],axis='columns',inplace=True)    
+
+        vis_avg.drop(labels=['udummy','vdummy','qdummy','dummy'],axis='columns',inplace=True)
         if return_type=='rec':
             return df_to_rec(vis_avg,rec_type)
         elif return_type=='df':
@@ -404,7 +448,7 @@ def make_cphase_df(obs,band='unknown',polarization='unknown',mode='all',count='m
 
     """generate DataFrame of closure phases
 
-    Args: 
+    Args:
         obs: ObsData object
         round_s: accuracy of datetime object in seconds
 
@@ -430,7 +474,7 @@ def make_cphase_diag_df(obs,vtype='vis',band='unknown',polarization='unknown',co
 
     """generate DataFrame of diagonalized closure phases
 
-    Args: 
+    Args:
         obs: ObsData object
         round_s: accuracy of datetime object in seconds
 
@@ -492,7 +536,7 @@ def make_camp_df(obs,ctype='logcamp',debias=False,band='unknown',polarization='u
 
     """generate DataFrame of closure amplitudes
 
-    Args: 
+    Args:
         obs: ObsData object
         round_s: accuracy of datetime object in seconds
 
@@ -519,7 +563,7 @@ def make_logcamp_diag_df(obs,debias=True,band='unknown',polarization='unknown',m
 
     """generate DataFrame of closure amplitudes
 
-    Args: 
+    Args:
         obs: ObsData object
         round_s: accuracy of datetime object in seconds
 
@@ -581,7 +625,7 @@ def make_bsp_df(obs,band='unknown',polarization='unknown',mode='all',count='min'
 
     """generate DataFrame of bispectra
 
-    Args: 
+    Args:
         obs: ObsData object
         round_s: accuracy of datetime object in seconds
 
@@ -619,14 +663,14 @@ def average_cphases(cdf,dt,return_type='rec',err_type='predicted',num_samples=10
 
     cdf2 = cdf.copy()
     t0 = datetime.datetime(1960,1,1)
-    cdf2['round_time'] = list(map(lambda x: np.round((x- t0).total_seconds()/float(dt)),cdf2.datetime))  
+    cdf2['round_time'] = list(map(lambda x: np.round((x- t0).total_seconds()/float(dt)),cdf2.datetime))
     grouping=['polarization','band','triangle','t1','t2','t3','round_time']
     #column just for counting the elements
     cdf2['number'] = 1
     aggregated = {'datetime': np.min, 'time': np.mean,
     'number': lambda x: len(x), 'u1':np.mean, 'u2': np.mean, 'u3':np.mean,'v1':np.mean, 'v2': np.mean, 'v3':np.mean}
 
-    #AVERAGING-------------------------------    
+    #AVERAGING-------------------------------
     if err_type=='measured':
         cdf2['dummy'] = cdf2['cphase']
         aggregated['dummy'] = lambda x: bootstrap(x, circular_mean, num_samples=num_samples,wrapping_variable=True)
@@ -646,14 +690,14 @@ def average_cphases(cdf,dt,return_type='rec',err_type='predicted',num_samples=10
         cdf2['sigmacp'] = [0.5*(x[1][1]-x[1][0]) for x in list(cdf2['dummy'])]
 
     # snrcut
-    # CHECK 
+    # CHECK
     if snrcut==0:
         snrcut=EP
     cdf2 = cdf2[cdf2['sigmacp'] < 180./np.pi/snrcut].copy()  # TODO CHECK
 
     #round datetime
     cdf2['datetime'] =  list(map(lambda x: t0 + datetime.timedelta(seconds= int(dt*x)), cdf2['round_time']))
-    
+
     #ANDREW TODO-- this can lead to big problems!!
     #drop values averaged from less than 3 datapoints
     #cdf2.drop(cdf2[cdf2.number < 3.].index, inplace=True)
@@ -678,14 +722,14 @@ def average_bispectra(cdf,dt,return_type='rec',num_samples=int(1e3), snrcut=0.):
 
     cdf2 = cdf.copy()
     t0 = datetime.datetime(1960,1,1)
-    cdf2['round_time'] = list(map(lambda x: np.round((x- t0).total_seconds()/float(dt)),cdf2.datetime))  
+    cdf2['round_time'] = list(map(lambda x: np.round((x- t0).total_seconds()/float(dt)),cdf2.datetime))
     grouping=['polarization','band','triangle','t1','t2','t3','round_time']
     #column just for counting the elements
     cdf2['number'] = 1
     aggregated = {'datetime': np.min, 'time': np.mean,
     'number': lambda x: len(x), 'u1':np.mean, 'u2': np.mean, 'u3':np.mean,'v1':np.mean, 'v2': np.mean, 'v3':np.mean}
 
-    #AVERAGING-------------------------------    
+    #AVERAGING-------------------------------
     aggregated['bispec'] = np.mean
     aggregated['sigmab'] = lambda x: np.sqrt(np.sum(x**2)/len(x)**2)
 
@@ -697,7 +741,7 @@ def average_bispectra(cdf,dt,return_type='rec',num_samples=int(1e3), snrcut=0.):
 
     #round datetime
     cdf2['datetime'] =  list(map(lambda x: t0 + datetime.timedelta(seconds= int(dt*x)), cdf2['round_time']))
-    
+
     #ANDREW TODO -- this can lead to big problems!!
     #drop values averaged from less than 3 datapoints
     #cdf2.drop(cdf2[cdf2.number < 3.].index, inplace=True)
@@ -723,14 +767,14 @@ def average_camp(cdf,dt,return_type='rec',err_type='predicted',num_samples=int(1
 
     cdf2 = cdf.copy()
     t0 = datetime.datetime(1960,1,1)
-    cdf2['round_time'] = list(map(lambda x: np.round((x- t0).total_seconds()/float(dt)),cdf2.datetime))  
+    cdf2['round_time'] = list(map(lambda x: np.round((x- t0).total_seconds()/float(dt)),cdf2.datetime))
     grouping=['polarization','band','quadrangle','t1','t2','t3','t4','round_time']
     #column just for counting the elements
     cdf2['number'] = 1
     aggregated = {'datetime': np.min, 'time': np.mean,
     'number': lambda x: len(x), 'u1':np.mean, 'u2': np.mean, 'u3':np.mean, 'u4': np.mean, 'v1':np.mean, 'v2': np.mean, 'v3':np.mean,'v4':np.mean}
 
-    #AVERAGING-------------------------------    
+    #AVERAGING-------------------------------
     if err_type=='measured':
         cdf2['dummy'] = cdf2['camp']
         aggregated['dummy'] = lambda x: bootstrap(x, np.mean, num_samples=num_samples,wrapping_variable=False)
@@ -751,7 +795,7 @@ def average_camp(cdf,dt,return_type='rec',err_type='predicted',num_samples=int(1
 
     #round datetime
     cdf2['datetime'] =  list(map(lambda x: t0 + datetime.timedelta(seconds= int(dt*x)), cdf2['round_time']))
-    
+
     #ANDREW TODO -- this can lead to big problems!!
     #drop values averaged from less than 3 datapoints
     #cdf2.drop(cdf2[cdf2.number < 3.].index, inplace=True)
@@ -820,7 +864,7 @@ def get_bins_labels(intervals,dt=0.00001):
     Args:
         intervals:
         dt (float): time margin to add to the scan limits
-    ''' 
+    '''
 
     def fix_midnight_overlap(x):
         if x[1] < x[0]:
@@ -830,8 +874,9 @@ def get_bins_labels(intervals,dt=0.00001):
     def is_overlapping(interval0,interval1):
         if ((interval1[0]<=interval0[0])&(interval1[1]>=interval0[0]))|((interval1[0]<=interval0[1])&(interval1[1]>=interval0[1])):
             return True
-        else: return False
-    
+        else:
+            return False
+
     def merge_overlapping_intervals(intervals):
         return (np.min([x[0] for x in intervals]),np.max([x[1] for x in intervals]))
 
@@ -840,21 +885,21 @@ def get_bins_labels(intervals,dt=0.00001):
         indic_overlap=[is_overlapping(x,intervals[element_ind]) for x in intervals]
         fooarr=np.asarray(intervals)
         return sorted([tuple(x) for x in fooarr[indic_not_overlap]]+[merge_overlapping_intervals(list(fooarr[indic_overlap]))])
-    
+
     intervals = sorted(list(set(zip(intervals[:,0],intervals[:,1]))))
     intervals = [fix_midnight_overlap(x) for x in intervals]
     cou=0
-    while cou < len(intervals): 
+    while cou < len(intervals):
         intervals = replace_overlapping_intervals(intervals,cou)
         cou+=1
-        
+
     binsT=[None]*(2*np.shape(intervals)[0])
     binsT[::2] = [x[0]-dt for x in intervals]
     binsT[1::2] = [x[1]+dt for x in intervals]
     labels=[None]*(2*np.shape(intervals)[0]-1)
     labels[::2] = [cou for cou in range(1,len(intervals)+1)]
     labels[1::2] = [-cou for cou in range(1,len(intervals))]
-    
+
     return binsT, labels
 
 def common_set(obs1, obs2, tolerance = 0,uniquely=False, by_what='uvdist'):
@@ -880,7 +925,7 @@ def common_set(obs1, obs2, tolerance = 0,uniquely=False, by_what='uvdist'):
 
     if by_what=='ut':
         if tolerance>0:
-            d_mjd = tolerance/24.0/60.0/60.0      
+            d_mjd = tolerance/24.0/60.0/60.0
             df1['roundtime']=np.round(df1.mjd/d_mjd)
             df2['roundtime']=np.round(df2.mjd/d_mjd)
         else:
@@ -888,12 +933,12 @@ def common_set(obs1, obs2, tolerance = 0,uniquely=False, by_what='uvdist'):
             df2['roundtime'] = df2['time']
         #matching data
         df1,df2 = match_multiple_frames([df1.copy(),df2.copy()],['ta','tb','roundtime'],uniquely=uniquely)
-    
+
     elif by_what=='gmst':
         df1 = add_gmst(df1)
         df2 = add_gmst(df2)
         if tolerance>0:
-            d_gmst = tolerance      
+            d_gmst = tolerance
             df1['roundgmst']=np.round(df1.gmst/d_gmst)
             df2['roundgmst']=np.round(df2.gmst/d_gmst)
         else:
@@ -909,7 +954,7 @@ def common_set(obs1, obs2, tolerance = 0,uniquely=False, by_what='uvdist'):
             df1['roundv'] = np.round(df1.v/d_lambda)
             df2['roundu'] = np.round(df2.u/d_lambda)
             df2['roundv'] = np.round(df2.v/d_lambda)
-        else: 
+        else:
             df1['roundu'] = df1['u']
             df1['roundv'] = df1['v']
             df2['roundu'] = df2['u']
@@ -952,14 +997,14 @@ def common_multiple_sets(obsL, tolerance = 0,uniquely=False, by_what='uvdist'):
 
     if by_what=='ut':
         if tolerance>0:
-            d_mjd = tolerance/24.0/60.0/60.0    
+            d_mjd = tolerance/24.0/60.0/60.0
             for df in dfL:  df['roundtime']=np.round(df.mjd/d_mjd)
         else:
             for df in dfL:  df['roundtime']=df['time']
         #matching data
         dfcout = match_multiple_frames(dfL,['ta','tb','roundtime'],uniquely=uniquely)
-    
-    elif by_what=='gmst': 
+
+    elif by_what=='gmst':
         dfL = [add_gmst(df) for df in dfL]
         if tolerance>0:
             d_gmst = tolerance
@@ -969,13 +1014,13 @@ def common_multiple_sets(obsL, tolerance = 0,uniquely=False, by_what='uvdist'):
         #matching data
         dfcut = match_multiple_frames([df1.copy(),df2.copy()],['ta','tb','roundgmst'],uniquely=uniquely)
 
-    
+
     elif by_what=='uvdist':
         if tolerance>0:
             d_lambda = tolerance
             for df in dfL: df['roundu'] = np.round(df.u/d_lambda)
             for df in dfL: df['roundv'] = np.round(df.v/d_lambda)
-        else: 
+        else:
             for df in dfL: df['roundu'] = df['u']
             for df in dfL: df['roundv'] = df['v']
         #matching data
@@ -1001,10 +1046,10 @@ def match_multiple_frames(frames, what_is_same, dt = 0,uniquely=True):
         for frame in frames:
             frame['round_time'] = list(map(lambda x: np.round((x- datetime.datetime(2017,4,4)).total_seconds()/dt),frame['datetime']))
         what_is_same += ['round_time']
-    
+
     frames_common = {}
     for frame in frames:
-        frame['all_ind'] = list(zip(*[frame[x] for x in what_is_same]))   
+        frame['all_ind'] = list(zip(*[frame[x] for x in what_is_same]))
         if frames_common != {}:
             frames_common = frames_common&set(frame['all_ind'])
         else:

--- a/ehtim/statistics/dataframes.py
+++ b/ehtim/statistics/dataframes.py
@@ -1040,5 +1040,5 @@ def add_gmst(df):
         times_unix, format='unix').sidereal_time('mean', 'greenwich').hour # vectorized
     df['gmst'] = 0. # initialize new column
     for (gmst, idx) in zip(times_gmst, indices):
-        df.ix[idx, 'gmst'] = gmst
+        df.loc[idx, 'gmst'] = gmst
     return df

--- a/ehtim/survey.py
+++ b/ehtim/survey.py
@@ -18,8 +18,13 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 import os
+
+try:
+    import pandas as pd
+except ImportError:
+    print("Warning: pandas not installed!")
+    print("Please install pandas to use the survey package!")
 
 import ehtim as eh
 import paramsurvey

--- a/ehtim/survey.py
+++ b/ehtim/survey.py
@@ -16,24 +16,28 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import csv
 import os
 
 import matplotlib.pyplot as plt
 import numpy as np
-
-try:
-    import pandas as pd
-except ImportError:
-    print("Warning: pandas not installed!")
-    print("Please install pandas to use the survey package!")
-
-
 import paramsurvey
 import paramsurvey.params
 
 import ehtim as eh
 
 #warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning)
+
+
+def _save_row_csv(path, row):
+    """Write a one-row CSV matching pandas DataFrame.to_csv output: a leading
+    unnamed integer-index column (value 0), then one column per key in order.
+    A NaN value is written as an empty field, as pandas does.
+    """
+    with open(path, 'w', newline='') as f:
+        writer = csv.writer(f, lineterminator='\n')
+        writer.writerow([''] + list(row.keys()))
+        writer.writerow([0] + ['' if v != v else v for v in row.values()])
 
 
 ##################################################################################################
@@ -451,8 +455,7 @@ class ParameterSet:
         stats_dict['chi2_lc_sys'] = [chi2_lc_sys]
         stats_dict['chi2_vis_sys'] = [chi2_vis_sys]
 
-        df = pd.DataFrame.from_dict(stats_dict)
-        df.to_csv(outstats)
+        _save_row_csv(outstats, {k: stats_dict[k][0] for k in stats_dict})
 
     def save_params(self):
         """
@@ -466,10 +469,8 @@ class ParameterSet:
         self.paramset['fov'] = self.fov
         self.paramset['zbl_tot'] = self.zbl_tot
 
-        df = pd.DataFrame.from_dict([self.paramset])
-
         outparams = os.path.join(self.outpath, f'{self.outfile}_params.csv')
-        df.to_csv(outparams)
+        _save_row_csv(outparams, self.paramset)
 
     def run(self):
 

--- a/ehtim/survey.py
+++ b/ehtim/survey.py
@@ -16,9 +16,10 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+
 import matplotlib.pyplot as plt
 import numpy as np
-import os
 
 try:
     import pandas as pd
@@ -26,11 +27,12 @@ except ImportError:
     print("Warning: pandas not installed!")
     print("Please install pandas to use the survey package!")
 
-import ehtim as eh
+
 import paramsurvey
 import paramsurvey.params
 
-import warnings
+import ehtim as eh
+
 #warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning)
 
 
@@ -81,7 +83,7 @@ class ParameterSet:
         os.makedirs(self.outpath, exist_ok=True)
         self.paramset = paramset
         self.params_fixed = params_fixed
-        self.outfile = '%s_%0.7i' % (self.outfile_base, self.i)
+        self.outfile = f'{self.outfile_base}_{int(self.i):0.7}'
 
         self.fov *= eh.RADPERUAS
         self.reverse_taper_uas *= eh.RADPERUAS
@@ -154,7 +156,8 @@ class ParameterSet:
 
         if self.zbl != self.zbl_tot:
             for j in range(len(self.obs.data)):
-                if (self.obs.data['u'][j] ** 2 + self.obs.data['v'][j] ** 2) ** 0.5 >= self.uv_zblcut: continue
+                if (self.obs.data['u'][j] ** 2 + self.obs.data['v'][j] ** 2) ** 0.5 >= self.uv_zblcut:
+                    continue
                 for field in ['vis', 'qvis', 'uvis', 'vvis', 'sigma', 'qsigma', 'usigma', 'vsigma']:
                     self.obs.data[field][j] *= self.zbl / self.zbl_tot
 
@@ -344,29 +347,29 @@ class ParameterSet:
             self.im_out = self.im_out.blur_circ(self.reverse_taper_uas)
 
         # Save the final image
-        outfits = os.path.join(self.outpath, '%s.fits' % (self.outfile))
+        outfits = os.path.join(self.outpath, f'{self.outfile}.fits')
         self.im_out.save_fits(outfits)
 
         # Save caltab
-        if hasattr(self, 'save_caltab') and self.save_caltab == True:
-            outcal = os.path.join(self.outpath, '%s/' % (self.outfile))
+        if hasattr(self, 'save_caltab') and self.save_caltab:
+            outcal = os.path.join(self.outpath, f'{self.outfile}/')
             eh.caltable.save_caltable(self.caltab, self.obs_sc_init, outcal)
 
         # Save self-calibrated uvfits
         if self.save_uvfits:
-            outuvfits = os.path.join(self.outpath, '%s.uvfits' % (self.outfile))
+            outuvfits = os.path.join(self.outpath, f'{self.outfile}.uvfits')
             self.obs_sc_addcmp.save_uvfits(outuvfits)
 
         # Save pdf of final image
         if self.save_pdf:
-            outpdf = os.path.join(self.outpath, '%s.pdf' % (self.outfile))
+            outpdf = os.path.join(self.outpath, f'{self.outfile}.pdf')
             self.im_out.display(cbar_unit=['Tb'], label_type='scale', export_pdf=outpdf)
 
         # Save pdf of image summary
         if self.save_imgsums:
             # Save an image summary sheet
             plt.close('all')
-            outimgsum = os.path.join(self.outpath, '%s_imgsum.pdf' % (self.outfile))
+            outimgsum = os.path.join(self.outpath, f'{self.outfile}_imgsum.pdf')
             eh.imgsum(self.im_addcmp, self.obs_sc_addcmp, self.obs_orig, outimgsum, cp_uv_min=self.uv_zblcut,
                       processes=-1)
 
@@ -386,7 +389,7 @@ class ParameterSet:
         stats_dict = {}
         stats_dict['i'] = [self.i]
 
-        outstats = os.path.join(self.outpath, '%s_stats.csv' % (self.outfile))
+        outstats = os.path.join(self.outpath, f'{self.outfile}_stats.csv')
 
         # if ground truth image available, compute nxcorr
         if self.ground_truth_img != 'None':
@@ -465,7 +468,7 @@ class ParameterSet:
 
         df = pd.DataFrame.from_dict([self.paramset])
 
-        outparams = os.path.join(self.outpath, '%s_params.csv' % (self.outfile))
+        outparams = os.path.join(self.outpath, f'{self.outfile}_params.csv')
         df.to_csv(outparams)
 
     def run(self):
@@ -481,7 +484,7 @@ class ParameterSet:
 
         # if a *_params.csv file exists, it means this parameter has already been run and can be skipped
         # useful in case survey with multiple parameter sets gets interrupted
-        outcsv = os.path.join(self.outpath, '%s_params.csv' % (self.outfile))
+        outcsv = os.path.join(self.outpath, f'{self.outfile}_params.csv')
 
         if not self.overwrite:
             if os.path.exists(outcsv):

--- a/ehtim/survey.py
+++ b/ehtim/survey.py
@@ -21,8 +21,13 @@ import os
 
 import matplotlib.pyplot as plt
 import numpy as np
-import paramsurvey
-import paramsurvey.params
+
+try:
+    import paramsurvey
+    import paramsurvey.params
+except ImportError:
+    print("Warning: paramsurvey not installed!")
+    print("Please install paramsurvey to use the survey package!")
 
 import ehtim as eh
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "ehtim"
 version = "1.3.0"
 description = "Imaging, analysis, and simulation software for radio interferometry"
 readme = "README.rst"
+requires-python = ">=3.11,<3.13"
 license = { text = "GPLv3" }
 keywords = ["imaging", "astronomy", "EHT", "polarimetry"]
 
@@ -20,21 +21,21 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 dependencies = [
-    "numpy>=1.24",
-    "scipy>=1.9.3",
-    "astropy>=5.0.4",
+    "numpy>=2.0",
+    "scipy>=1.13",
+    "astropy>=6.0",
     "matplotlib>=3.7.3",
     "finufft>=2.2",
     "skyfield",
-    "h5py",
-    "pandas",
+    "h5py>=3.0",
     "requests",
     "future",
-    "networkx",
+    "networkx>=3.0",
     "paramsurvey",
 ]
 
@@ -43,6 +44,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov",
     "ruff",
+    "pandas",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "requests",
     "future",
     "networkx>=3.0",
-    "paramsurvey",
 ]
 
 [project.optional-dependencies]
@@ -45,6 +44,7 @@ dev = [
     "pytest-cov",
     "ruff",
     "pandas",
+    "paramsurvey",
 ]
 
 [project.urls]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,45 @@
+"""Smoke tests for ehtim.model geometric models.
+
+Builds every mring variant (each stores complex beta-coefficient arrays) and
+checks the model-parameter dispatch, including the unrecognized-type branch.
+"""
+
+import numpy as np
+import pytest
+
+import ehtim as eh
+
+RADPERUAS = eh.RADPERUAS
+
+MRING_VARIANTS = [
+    ("add_mring", {}),
+    ("add_stretched_mring", {"stretch": 1.2, "stretch_PA": 0.3}),
+    ("add_thick_mring", {"alpha": 10 * RADPERUAS}),
+    ("add_thick_mring_floor", {"alpha": 10 * RADPERUAS, "ff": 0.1}),
+    ("add_thick_mring_Gfloor", {"alpha": 10 * RADPERUAS, "ff": 0.1, "FWHM": 40 * RADPERUAS}),
+    ("add_stretched_thick_mring", {"alpha": 10 * RADPERUAS, "stretch": 1.2, "stretch_PA": 0.3}),
+    ("add_stretched_thick_mring_floor",
+     {"alpha": 10 * RADPERUAS, "ff": 0.1, "stretch": 1.2, "stretch_PA": 0.3}),
+]
+
+
+@pytest.mark.parametrize("builder,kwargs", MRING_VARIANTS)
+def test_mring_variant_builds_and_images(builder, kwargs):
+    mod = eh.model.Model()
+    mod = getattr(mod, builder)(F0=1.5, d=40 * RADPERUAS,
+                                beta_list=[0.0, 0.2 + 0.1j], **kwargs)
+    im = mod.make_image(120 * RADPERUAS, 32)
+    assert np.all(np.isfinite(im.imvec))
+    assert im.total_flux() > 0
+
+
+def test_model_params_unknown_returns_empty():
+    # the dispatch fall-through branch (unrecognized model type)
+    assert eh.model.model_params("not_a_real_model") == []
+
+
+def test_model_params_mring_includes_beta_terms():
+    params = eh.model.model_params("mring", {"beta_list": [0.0, 0.1j]})
+    assert "F0" in params
+    assert "d" in params
+    assert any(p.startswith("beta1") for p in params)

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -1,0 +1,27 @@
+"""Smoke tests for ehtim.movie: image-list merge and HDF5 round-trip."""
+
+import numpy as np
+
+import ehtim as eh
+
+
+def _gauss_movie():
+    im = eh.image.make_empty(32, 200 * eh.RADPERUAS, 17.761, -29.0, rf=230e9)
+    im = im.add_gauss(1.0, (40 * eh.RADPERUAS, 40 * eh.RADPERUAS, 0, 0, 0))
+    return eh.movie.merge_im_list([im, im, im], framedur=60.0), im
+
+
+def test_merge_im_list_builds_movie():
+    mov, im = _gauss_movie()
+    assert mov.nframes == 3
+    assert mov.xdim == im.xdim
+    assert mov.ydim == im.ydim
+
+
+def test_movie_hdf5_roundtrip(tmp_path):
+    mov, _ = _gauss_movie()
+    fname = str(tmp_path / "mov.h5")
+    mov.save_hdf5(fname)
+    mov2 = eh.movie.load_hdf5(fname)
+    assert mov2.nframes == mov.nframes
+    np.testing.assert_allclose(mov2.frames[0], mov.frames[0], rtol=1e-6)

--- a/tests/test_rex.py
+++ b/tests/test_rex.py
@@ -78,6 +78,33 @@ def test_compute_ring_profile_recovers_ring_radius(ring_image):
     assert abs(pp.pkrad - R_RING_UAS) < 3.0
 
 
+def test_compute_ring_profile_rectangular():
+    """Ring extraction on a rectangular image (xdim != ydim).
+
+    The interpolator is built as RGI((ys, xs), imarr) with imarr of shape
+    (ydim, xdim); a swapped axis order would raise on the shape mismatch here
+    even though it is silent on square images.
+    """
+    xdim, ydim = 48, 64
+    psize = 200 * eh.RADPERUAS / max(xdim, ydim)
+    psize_uas = psize / eh.RADPERUAS
+    xs = np.arange(xdim) * psize_uas
+    ys = np.arange(ydim) * psize_uas
+    xc = 0.5 * (xdim - 1) * psize_uas
+    yc = 0.5 * (ydim - 1) * psize_uas
+    xx, yy = np.meshgrid(xs, ys)                 # (ydim, xdim)
+    rr = np.sqrt((xx - xc) ** 2 + (yy - yc) ** 2)
+    ring = np.exp(-0.5 * ((rr - R_RING_UAS) / RING_WIDTH_UAS) ** 2)
+    im = eh.image.Image(ring, psize, 17.761, -29.0,
+                        polrep="stokes", pol_prim="I", rf=230e9)
+
+    pp = rex.compute_ring_profile(im, xc, yc, rmax=40, interptype="cubic")
+    pp.calc_meanprof_and_stats()
+
+    assert np.all(np.isfinite(pp.meanprof))
+    assert abs(pp.pkrad - R_RING_UAS) < 3.0
+
+
 def test_compute_ring_profile_polarized_runs(ring_image):
     im, center = ring_image
     im = im.copy()

--- a/tests/test_rex.py
+++ b/tests/test_rex.py
@@ -1,0 +1,98 @@
+"""Tests for ehtim.features.rex ring-profile extraction.
+
+REX resamples the image with a grid interpolator built as
+``RegularGridInterpolator((ys, xs), imarr)`` and samples a physical point
+``(x, y)`` as ``rgi((y, x))`` (first axis is ``ys``, second is ``xs``). The
+axis-convention test pins that contract; the remaining tests exercise the
+interpolation through the public REX entry points.
+"""
+
+import numpy as np
+import pytest
+from scipy.interpolate import RegularGridInterpolator
+
+import ehtim as eh
+from ehtim.features import rex
+
+R_RING_UAS = 25.0      # radius of the synthetic test ring
+RING_WIDTH_UAS = 4.0
+NPIX = 64
+FOV_UAS = 120.0
+
+
+@pytest.fixture(scope="module")
+def ring_image():
+    """A centered Gaussian annulus of known radius, as an ehtim Image."""
+    im = eh.image.make_empty(NPIX, FOV_UAS * eh.RADPERUAS, 17.761, -29.0, rf=230e9)
+    psize_uas = im.psize / eh.RADPERUAS
+    coords = np.arange(NPIX) * psize_uas
+    # geometric center is fixed under REX's imarr row-flip, so the recovered
+    # center and peak radius are unaffected by that flip.
+    center = 0.5 * (NPIX - 1) * psize_uas
+    xx, yy = np.meshgrid(coords, coords)
+    rr = np.sqrt((xx - center) ** 2 + (yy - center) ** 2)
+    ring = np.exp(-0.5 * ((rr - R_RING_UAS) / RING_WIDTH_UAS) ** 2)
+    im.imvec = ring.ravel()
+    return im, center
+
+
+def test_rex_module_imports():
+    assert hasattr(rex, "compute_ring_profile")
+    assert hasattr(rex, "findCenter")
+
+
+def test_interp_axis_convention_rectangular():
+    """rgi((ys, xs), imarr) sampled as rgi((y, x)) recovers the right value.
+
+    Uses a rectangular grid (ydim != xdim) and a ramp that depends differently
+    on x and y, so an axis transpose would either raise on the shape mismatch
+    or return the wrong value.
+    """
+    ydim, xdim = 7, 11
+    psize_uas = 2.0
+    xs = np.arange(xdim) * psize_uas
+    ys = np.arange(ydim) * psize_uas
+    xx, yy = np.meshgrid(xs, ys)                 # shape (ydim, xdim)
+    imarr = 3.0 * xx + 100.0 * yy                # imarr[i, j] = 3*xs[j] + 100*ys[i]
+
+    rgi = RegularGridInterpolator(
+        (ys, xs), imarr, method="linear", bounds_error=False, fill_value=None)
+
+    # exact at grid nodes
+    assert np.isclose(rgi((ys[5], xs[8])), imarr[5, 8])
+
+    # interior point sampled as rgi((y, x))
+    xq = xs[3] + 0.5 * psize_uas
+    yq = ys[2] + 0.25 * psize_uas
+    assert np.isclose(rgi((yq, xq)), 3.0 * xq + 100.0 * yq)
+
+
+def test_compute_ring_profile_recovers_ring_radius(ring_image):
+    im, center = ring_image
+    pp = rex.compute_ring_profile(im, center, center, rmax=50, interptype="cubic")
+    pp.calc_meanprof_and_stats()
+
+    assert pp.meanprof.shape == (pp.nrs,)
+    assert np.all(np.isfinite(pp.meanprof))
+    # mean radial profile peaks at the ring radius
+    assert abs(pp.pkrad - R_RING_UAS) < 3.0
+
+
+def test_compute_ring_profile_polarized_runs(ring_image):
+    im, center = ring_image
+    im = im.copy()
+    im.add_qu(0.10 * im.imarr(), 0.05 * im.imarr())
+    pp = rex.compute_ring_profile(im, center, center, rmax=50, pol_profs=True)
+
+    assert pp.profilesQ.shape[0] == len(pp.thetas)
+    assert np.all(np.isfinite(pp.profilesQ))
+    assert np.all(np.isfinite(pp.profilesU))
+
+
+def test_findcenter_locates_ring_center(ring_image):
+    im, center = ring_image
+    res = rex.findCenter(im, rmin_search=15.0, rmax_search=60.0,
+                         nrays_search=25, nrs_search=50)
+    assert np.all(np.isfinite(res))
+    assert abs(res[0] - center) < 8.0
+    assert abs(res[1] - center) < 8.0


### PR DESCRIPTION
`import ehtim` currently fails on the latest scientific stack: SciPy 1.14 removed `scipy.ndimage.filters`, and NumPy 2 removed `np.float`, `np.complex_`, `np.string_` and deprecated `numpy.matlib`. This PR replaces the dead/deprecated APIs, makes pandas optional, raises the Python floor to 3.11 (required by the latest NumPy/SciPy/Astropy/pandas/NetworkX), and removes the remaining SyntaxWarning/DeprecationWarning emitted on import.

Validated in a clean environment with the current stable releases (numpy 2.4.6, scipy 1.17.1, astropy 7.2.0, matplotlib 3.10.9, h5py 3.16.0, networkx 3.6.1, finufft 2.5.1, pandas 3.0.3) on Python 3.12: `import ehtim` is warning-free and the full suite passes (1294 passed, 1 xfailed).

### Changes
- SciPy: `scipy.ndimage.filters`/`.interpolation` to top-level `scipy.ndimage`; REX migrated from the removed `interp2d` to `RegularGridInterpolator`.
- NumPy 2: `np.float` to `float`, `np.complex_` to `np.complex128`, `np.string_` to `np.bytes_`, `np.row_stack` to `np.vstack`, `numpy.matlib.repmat` to `np.tile`, and `np.sum(generator)` to `sum(...)` in the model sampling path.
- pandas is now optional: removed from core dependencies (moved to the `dev` extra) and the eager import in `survey.py` is guarded; also fixed the removed `.ix` accessor.
- Raw strings for LaTeX plot labels (silences the invalid-escape SyntaxWarnings).
- Cleared the pre-existing ruff debt in the touched files (whitespace, import order, compound-statement splits, printf to f-strings, dewildcarded `import *`) so the lint job is green. This surfaced a few latent bugs, now fixed: the numpy-2 `np.sum(generator)` error above (which broke all model imaging), undefined names in `rex.FindProfileSingle`, and an undefined name in the model-parameter dispatch.
- Packaging: `requires-python = ">=3.11,<3.13"`; floors raised (`numpy>=2.0`, `scipy>=1.13`, `astropy>=6.0`, `h5py>=3.0`, `networkx>=3.0`) with no upper caps; CI matrix moved from 3.10 to 3.11.

### Testing
- New `tests/test_rex.py`: the interpolation migration end to end (axis-convention contract, ring-radius recovery, polarized profiles, `findCenter`, rectangular image).
- New `tests/test_model.py` and `tests/test_movie.py`: smoke coverage for the previously-untested model and movie modules (every mring variant, the model dispatch, image-list merge, HDF5 round-trip); this is what caught the `np.sum` numpy-2 bug.
- Full suite green on Python 3.11 and 3.12.

### Out of scope
- The pre-existing `Array.add_satellite_tle` NameError (still xfail in test_array.py) is unrelated and left for a focused fix.
- 63 numerical RuntimeWarnings (divide-by-zero in chisq paths) and 2 UserWarnings are not Syntax/Deprecation and were left untouched.