### PR TITLE
Vectorize diagonalized closure gradients and tidy the imaging backend for JAX

### DIFF
--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -355,10 +355,8 @@ def pack_imarr(imarr, which_solve):
     if nsolve != len(which_solve):
         raise Exception("in pack_imarr, imarr has inconsistent shape with which_solve!")
 
-    vec = np.array([])
-    for kk in range(nsolve):
-        if which_solve[kk]!=0:
-            vec = np.hstack((vec,imarr[kk]))
+    blocks = [imarr[kk] for kk in range(nsolve) if which_solve[kk] != 0]
+    vec = np.concatenate(blocks) if blocks else np.array([])
 
     return vec
 

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -1167,7 +1167,7 @@ def chisq_cphase_diag_nfft(imvec, A, clphase_diag, sigma):
     sigma = np.concatenate(sigma) * ehc.DEGREE
 
     A3 = A[0]
-    tform_mats = A[1]
+    tform_blockdiag = A[1]
 
     # get nfft objects
     nfft_info1 = A3[0]
@@ -1197,7 +1197,7 @@ def chisq_cphase_diag_nfft(imvec, A, clphase_diag, sigma):
 
     clphase_samples = np.angle(samples1*samples2*samples3)
 
-    clphase_diag_samples = tform_mats.dot(clphase_samples)
+    clphase_diag_samples = tform_blockdiag.dot(clphase_samples)
 
     # compute chi^2
     chisq = (2.0/len(clphase_diag)) * \
@@ -1213,7 +1213,7 @@ def chisqgrad_cphase_diag_nfft(imvec, A, clphase_diag, sigma):
     sigma = np.concatenate(sigma) * ehc.DEGREE
 
     A3 = A[0]
-    tform_mats = A[1]
+    tform_blockdiag = A[1]
 
     # get nfft objects
     nfft_info1 = A3[0]
@@ -1244,9 +1244,9 @@ def chisqgrad_cphase_diag_nfft(imvec, A, clphase_diag, sigma):
     clphase_samples = np.angle(v1*v2*v3)
 
     # gradient vec for adjoint FT
-    clphase_diag_samples = tform_mats.dot(clphase_samples)
+    clphase_diag_samples = tform_blockdiag.dot(clphase_samples)
     weight = 2.0 * np.sin(clphase_diag - clphase_diag_samples) / (sigma**2)
-    pref = tform_mats.T.dot(weight)
+    pref = tform_blockdiag.T.dot(weight)
 
     pt1 = pref/v1.conj() * pulsefac1.conj()
     pt2 = pref/v2.conj() * pulsefac2.conj()
@@ -1504,7 +1504,7 @@ def chisq_logcamp_diag_nfft(imvec, A, log_clamp_diag, sigma):
     sigma = np.concatenate(sigma)
 
     A4 = A[0]
-    tform_mats = A[1]
+    tform_blockdiag = A[1]
 
     # get nfft objects
     nfft_info1 = A4[0]
@@ -1543,7 +1543,7 @@ def chisq_logcamp_diag_nfft(imvec, A, log_clamp_diag, sigma):
     log_clamp_samples = (np.log(np.abs(samples1)) + np.log(np.abs(samples2)) -
                          np.log(np.abs(samples3)) - np.log(np.abs(samples4)))
 
-    log_clamp_diag_samples = tform_mats.dot(log_clamp_samples)
+    log_clamp_diag_samples = tform_blockdiag.dot(log_clamp_samples)
 
     # compute chi^2
     chisq = np.sum(np.abs((log_clamp_diag - log_clamp_diag_samples)/sigma)**2) / \
@@ -1560,7 +1560,7 @@ def chisqgrad_logcamp_diag_nfft(imvec, A, log_clamp_diag, sigma):
     sigma = np.concatenate(sigma)
 
     A4 = A[0]
-    tform_mats = A[1]
+    tform_blockdiag = A[1]
 
     # get nfft objects
     nfft_info1 = A4[0]
@@ -1599,9 +1599,9 @@ def chisqgrad_logcamp_diag_nfft(imvec, A, log_clamp_diag, sigma):
     log_clamp_samples = np.log(np.abs((v1 * v2)/(v3 * v4)))
 
     # gradient vec for adjoint FT
-    log_clamp_diag_samples = tform_mats.dot(log_clamp_samples)
+    log_clamp_diag_samples = tform_blockdiag.dot(log_clamp_samples)
     weight = -2.0 * (log_clamp_diag - log_clamp_diag_samples) / (sigma**2)
-    pp = tform_mats.T.dot(weight)
+    pp = tform_blockdiag.T.dot(weight)
 
     pt1 = pp / v1.conj() * pulsefac1.conj()
     pt2 = pp / v2.conj() * pulsefac2.conj()

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -21,6 +21,7 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
+import scipy.sparse as sps
 
 import ehtim.const_def as ehc
 import ehtim.observing.obs_helpers as obsh
@@ -652,9 +653,8 @@ def chisqgrad_cphase_diag_fft(imvec, A, clphase_diag, sigma):
         clphase_diag_measured = clphase_diag[count:count+len(tform_mat)]
         clphase_diag_sigma = sigma[count:count+len(tform_mat)]
 
-        for j in range(len(clphase_diag_measured)):
-            pref[count:count+len(tform_mat)] += 2.0 * tform_mat[j, :] * np.sin(
-                clphase_diag_measured[j] - clphase_diag_samples[j])/(clphase_diag_sigma[j]**2)
+        weight = 2.0 * np.sin(clphase_diag_measured - clphase_diag_samples) / (clphase_diag_sigma**2)
+        pref[count:count+len(tform_mat)] += np.dot(weight, tform_mat)
 
         count += len(tform_mat)
 
@@ -818,10 +818,8 @@ def chisqgrad_logcamp_diag_fft(imvec, A, log_clamp_diag, sigma):
         log_clamp_diag_measured = log_clamp_diag[count:count+len(tform_mat)]
         log_clamp_diag_sigma = sigma[count:count+len(tform_mat)]
 
-        for j in range(len(log_clamp_diag_measured)):
-            pref[count:count+len(tform_mat)] += -2.0 * tform_mat[j, :] * \
-                (log_clamp_diag_measured[j] - log_clamp_diag_samples[j]) / \
-                (log_clamp_diag_sigma[j]**2)
+        weight = -2.0 * (log_clamp_diag_measured - log_clamp_diag_samples) / (log_clamp_diag_sigma**2)
+        pref[count:count+len(tform_mat)] += np.dot(weight, tform_mat)
 
         count += len(tform_mat)
 
@@ -1199,14 +1197,7 @@ def chisq_cphase_diag_nfft(imvec, A, clphase_diag, sigma):
 
     clphase_samples = np.angle(samples1*samples2*samples3)
 
-    count = 0
-    clphase_diag_samples = []
-    for tform_mat in tform_mats:
-        clphase_samples_here = clphase_samples[count:count+len(tform_mat)]
-        clphase_diag_samples.append(np.dot(tform_mat, clphase_samples_here))
-        count += len(tform_mat)
-
-    clphase_diag_samples = np.concatenate(clphase_diag_samples)
+    clphase_diag_samples = tform_mats.dot(clphase_samples)
 
     # compute chi^2
     chisq = (2.0/len(clphase_diag)) * \
@@ -1253,19 +1244,9 @@ def chisqgrad_cphase_diag_nfft(imvec, A, clphase_diag, sigma):
     clphase_samples = np.angle(v1*v2*v3)
 
     # gradient vec for adjoint FT
-    count = 0
-    pref = np.zeros_like(clphase_samples)
-    for tform_mat in tform_mats:
-
-        clphase_diag_samples = np.dot(tform_mat, clphase_samples[count:count+len(tform_mat)])
-        clphase_diag_measured = clphase_diag[count:count+len(tform_mat)]
-        clphase_diag_sigma = sigma[count:count+len(tform_mat)]
-
-        for j in range(len(clphase_diag_measured)):
-            pref[count:count+len(tform_mat)] += 2.0 * tform_mat[j, :] * np.sin(
-                clphase_diag_measured[j] - clphase_diag_samples[j])/(clphase_diag_sigma[j]**2)
-
-        count += len(tform_mat)
+    clphase_diag_samples = tform_mats.dot(clphase_samples)
+    weight = 2.0 * np.sin(clphase_diag - clphase_diag_samples) / (sigma**2)
+    pref = tform_mats.T.dot(weight)
 
     pt1 = pref/v1.conj() * pulsefac1.conj()
     pt2 = pref/v2.conj() * pulsefac2.conj()
@@ -1562,14 +1543,7 @@ def chisq_logcamp_diag_nfft(imvec, A, log_clamp_diag, sigma):
     log_clamp_samples = (np.log(np.abs(samples1)) + np.log(np.abs(samples2)) -
                          np.log(np.abs(samples3)) - np.log(np.abs(samples4)))
 
-    count = 0
-    log_clamp_diag_samples = []
-    for tform_mat in tform_mats:
-        log_clamp_samples_here = log_clamp_samples[count:count+len(tform_mat)]
-        log_clamp_diag_samples.append(np.dot(tform_mat, log_clamp_samples_here))
-        count += len(tform_mat)
-
-    log_clamp_diag_samples = np.concatenate(log_clamp_diag_samples)
+    log_clamp_diag_samples = tform_mats.dot(log_clamp_samples)
 
     # compute chi^2
     chisq = np.sum(np.abs((log_clamp_diag - log_clamp_diag_samples)/sigma)**2) / \
@@ -1625,20 +1599,9 @@ def chisqgrad_logcamp_diag_nfft(imvec, A, log_clamp_diag, sigma):
     log_clamp_samples = np.log(np.abs((v1 * v2)/(v3 * v4)))
 
     # gradient vec for adjoint FT
-    count = 0
-    pp = np.zeros_like(log_clamp_samples)
-    for tform_mat in tform_mats:
-
-        log_clamp_diag_samples = np.dot(tform_mat, log_clamp_samples[count:count+len(tform_mat)])
-        log_clamp_diag_measured = log_clamp_diag[count:count+len(tform_mat)]
-        log_clamp_diag_sigma = sigma[count:count+len(tform_mat)]
-
-        for j in range(len(log_clamp_diag_measured)):
-            pp[count:count+len(tform_mat)] += -2.0 * tform_mat[j, :] * \
-                (log_clamp_diag_measured[j] - log_clamp_diag_samples[j]) / \
-                (log_clamp_diag_sigma[j]**2)
-
-        count += len(tform_mat)
+    log_clamp_diag_samples = tform_mats.dot(log_clamp_samples)
+    weight = -2.0 * (log_clamp_diag - log_clamp_diag_samples) / (sigma**2)
+    pp = tform_mats.T.dot(weight)
 
     pt1 = pp / v1.conj() * pulsefac1.conj()
     pt2 = pp / v2.conj() * pulsefac2.conj()
@@ -3273,9 +3236,9 @@ def chisqdata_cphase_diag_nfft(Obsdata, Prior, pol='I', **kwargs):
     A3 = obsh.NFFTInfo(Prior.xdim, Prior.ydim, Prior.psize, Prior.pulse, npad, p_rad, uv3, eps=nfft_eps)
     A = [A1, A2, A3]
 
-    # Per-timestamp transform matrices have varying shapes; NumPy >= 1.24
-    # requires explicit dtype=object for inhomogeneous arrays.
-    Amatrices = (A, np.array(tform_mats, dtype=object))
+    # Stack the per-time-block decorrelating transforms into one block-diagonal
+    # operator so the diag chisq/grad apply them as a single matmul, not a loop.
+    Amatrices = (A, sps.block_diag(tform_mats, format='csr'))
 
     return (np.array(clphase_diag, dtype=object), np.array(sigma_diag, dtype=object), Amatrices)
 
@@ -3452,9 +3415,9 @@ def chisqdata_logcamp_diag_nfft(Obsdata, Prior, pol='I', **kwargs):
     A4 = obsh.NFFTInfo(Prior.xdim, Prior.ydim, Prior.psize, Prior.pulse, npad, p_rad, uv4, eps=nfft_eps)
     A = [A1, A2, A3, A4]
 
-    # Per-timestamp transform matrices have varying shapes; NumPy >= 1.24
-    # requires explicit dtype=object for inhomogeneous arrays.
-    Amatrices = (A, np.array(tform_mats, dtype=object))
+    # Stack the per-time-block decorrelating transforms into one block-diagonal
+    # operator so the diag chisq/grad apply them as a single matmul, not a loop.
+    Amatrices = (A, sps.block_diag(tform_mats, format='csr'))
 
     return (np.array(clamp_diag, dtype=object), np.array(sigma_diag, dtype=object), Amatrices)
 

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -244,8 +244,6 @@ def mcv_grad(imarr, gradarr):
     """
     vfrac = imarr[3]
     mfrac_max = 1 - np.abs(vfrac)
-    if np.any(mfrac_max > 1):
-        raise Exception("mfrac_max>1 in mcv_grad!")
 
     mprime = imarr[1]
     mfrac = mfrac_max * (0.5 + np.arctan(mprime / TANWIDTH_M) / np.pi)
@@ -319,8 +317,6 @@ def vcv_grad(imarr, gradarr):
     """
     mfrac = imarr[1]
     vfrac_max = 1 - np.abs(mfrac)
-    if np.any(vfrac_max > 1):
-        raise Exception("vfrac_max>1 in vcv_grad!")
 
     vprime = imarr[3]
     vfrac = 2 * vfrac_max * np.arctan(vprime / TANWIDTH_V) / np.pi

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -17,6 +17,11 @@ DATATERMS = ["vis", "bs", "amp", "cphase", "camp", "logcamp"]
 REGULARIZERS = ["simple", "gs", "l1w", "tv", "tv2"]
 TTYPES = ["direct"]  # expand to ["direct", "fast", "nfft"] to test other transforms
 
+# Diagonalized closure gradients, checked on the supported transforms.
+# ('fast'/plain-FFT is omitted; that mode is slated for deprecation.)
+DATATERMS_DIAG = ["cphase_diag", "logcamp_diag"]
+TTYPES_DIAG = ["direct", "nfft"]
+
 # Tolerances (calibrated on 32x48 synthetic Gaussian with relative step size)
 CHISQ_GRAD_MEDIAN_TOL = 0.001
 CHISQ_GRAD_MAX_TOL = 0.01
@@ -99,6 +104,53 @@ class TestChisqGradientFiniteDiff:
         _, max_frac = _chisq_gradient_check(grad_setup, dtype, ttype)
         assert max_frac < CHISQ_GRAD_MAX_TOL, (
             f"{dtype} ({ttype}) max fractional gradient diff = {max_frac:.6f}"
+        )
+
+
+class TestChisqGradientFiniteDiffDiag:
+    """Diagonalized-closure gradients match finite differences.
+
+    Pins the vectorized per-time-block matvec in chisqgrad_{cphase,logcamp}_diag
+    against numeric finite differences, at the same tolerance as the standard
+    closures.
+    """
+
+    @pytest.mark.parametrize("dtype", DATATERMS_DIAG)
+    @pytest.mark.parametrize("ttype", TTYPES_DIAG)
+    def test_median_frac_diff(self, grad_setup, dtype, ttype):
+        median_frac, _ = _chisq_gradient_check(grad_setup, dtype, ttype)
+        assert median_frac < CHISQ_GRAD_MEDIAN_TOL, (
+            f"{dtype} ({ttype}) median fractional gradient diff = {median_frac:.6f}"
+        )
+
+    @pytest.mark.parametrize("dtype", DATATERMS_DIAG)
+    @pytest.mark.parametrize("ttype", TTYPES_DIAG)
+    def test_max_frac_diff(self, grad_setup, dtype, ttype):
+        _, max_frac = _chisq_gradient_check(grad_setup, dtype, ttype)
+        assert max_frac < CHISQ_GRAD_MAX_TOL, (
+            f"{dtype} ({ttype}) max fractional gradient diff = {max_frac:.6f}"
+        )
+
+
+def test_diag_chisq_nfft_matches_direct(grad_setup):
+    """Block-diagonal nfft diag chisq agrees with the direct-DFT diag chisq.
+
+    The nfft diagonalized-closure terms apply the per-block decorrelating
+    transforms as one block-diagonal matmul; the direct terms loop. Both share
+    the same transforms and measured closures and differ only by Fourier
+    accuracy, so their chi^2 must agree closely. Guards the block-diagonal
+    restructure against a self-consistent-but-wrong error (which finite
+    differences alone would not catch).
+    """
+    obs, prior, mask = grad_setup["obs"], grad_setup["prior"], grad_setup["mask"]
+    iv = grad_setup["test_imvec"]
+    for dtype in DATATERMS_DIAG:
+        cdir = chisqdata(obs, prior, mask, dtype, ttype="direct")
+        cnf = chisqdata(obs, prior, mask, dtype, ttype="nfft")
+        chi_dir = chisq(iv, cdir[2], cdir[0], cdir[1], dtype, ttype="direct", mask=mask)
+        chi_nf = chisq(iv, cnf[2], cnf[0], cnf[1], dtype, ttype="nfft", mask=mask)
+        assert abs(chi_dir - chi_nf) <= 1e-2 * abs(chi_dir), (
+            f"{dtype}: direct={chi_dir:.6g} vs nfft={chi_nf:.6g}"
         )
 
 


### PR DESCRIPTION
Prep for the JAX backend port: removes NumPy patterns that are both poor NumPy and JAX friction. No behavior change.

Diagonalized closure terms (cphase_diag, logcamp_diag):
- The inner per-closure Python loop in the gradients is an exact matvec (weight @ tform_mat); replaced.
- For the nfft (production) path, the outer per-time-block loop is also collapsed: the per-block decorrelating transforms are stacked once into a block-diagonal sparse operator in chisqdata, so chisq/grad apply them as a single `T @ samples` / `T.T @ weight`. The block-diagonal layout is vmap/jit-ready for the JAX port.
- direct diag (interleaves the per-block DFT matrices) and plain-FFT `fast` (slated for deprecation) are left as-is.

Other tidy-ups:
- Removed a dead range-check from mcv_grad/vcv_grad: `mfrac_max = 1 - |vfrac| > 1` is unreachable, so the raise never fired; it was only a data-dependent branch in the gradient path.
- pack_imarr: hstack-in-loop replaced by a single concatenate.

Tests: new finite-difference tests pin the diagonalized closure gradients (previously untested) on direct + nfft, plus a cross-check tying the block-diagonal nfft chisq to the direct path. FD diffs are byte-identical before/after the inner-loop change; the block-diagonal form is exact by construction.

Testing: full suite (1286 passed, 1 xfailed); memray within noise (~481 MB peak RSS).
