### PR TITLE
Deprecate ttype='fast' with a DeprecationWarning

### DIFF
--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -33,6 +33,7 @@ import ehtim.const_def as ehc
 import ehtim.image
 import ehtim.imaging.imager_utils as imutils
 import ehtim.imaging.pol_imager_utils as polutils
+import ehtim.observing.obs_helpers as obsh
 from ehtim.const_def import (
     FFT_INTERP_DEFAULT,
     FFT_PAD_DEFAULT,
@@ -194,6 +195,8 @@ class Imager:
 
         # FFT / Fourier-grid parameters (consumed by the backend via self._fft_params())
         ttype = kwargs.get('ttype', 'nfft')
+        if ttype == 'fast':
+            obsh.warn_fast_ttype_deprecated()
         self._fft_gridder_prad = kwargs.get('fft_gridder_prad', GRIDDER_P_RAD_DEFAULT)
         self._fft_conv_func = kwargs.get('fft_conv_func', GRIDDER_CONV_FUNC_DEFAULT)
         self._fft_pad_factor = kwargs.get('fft_pad_factor', FFT_PAD_DEFAULT)

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -196,7 +196,7 @@ class Imager:
         # FFT / Fourier-grid parameters (consumed by the backend via self._fft_params())
         ttype = kwargs.get('ttype', 'nfft')
         if ttype == 'fast':
-            obsh.warn_fast_ttype_deprecated()
+            obsh.warn_fast_ttype_deprecated_imaging()
         self._fft_gridder_prad = kwargs.get('fft_gridder_prad', GRIDDER_P_RAD_DEFAULT)
         self._fft_conv_func = kwargs.get('fft_conv_func', GRIDDER_CONV_FUNC_DEFAULT)
         self._fft_pad_factor = kwargs.get('fft_pad_factor', FFT_PAD_DEFAULT)

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -47,18 +47,28 @@ warnings.filterwarnings("ignore", message="divide by zero encountered in double_
 def warn_fast_ttype_deprecated():
     """Emit a DeprecationWarning for the ``ttype='fast'`` (plain FFT) path.
 
-    The plain-FFT transform is deprecated: its imaging gradients are
-    inaccurate because the forward sampler (cubic-spline interpolation of the
-    FFT grid) and the adjoint gridder (Gaussian convolution) are not transpose
-    operators, so the FFT gradient does not match the FFT chi-squared. Use
-    ``ttype='nfft'`` (accurate, recommended) or ``ttype='direct'`` (small
-    problems) instead.
+    Used at forward-sampling sites where the path is deprecated but otherwise
+    correct. For imaging callers, use :func:`warn_fast_ttype_deprecated_imaging`,
+    which additionally notes that the FFT imaging gradients are inaccurate.
     """
     warnings.warn(
         "ttype='fast' (plain FFT) is deprecated and will be removed in a "
-        "future release. Its imaging gradients are inaccurate (the FFT sampler "
-        "and gridder are not adjoint operators). Use ttype='nfft' (recommended) "
-        "or ttype='direct' instead.",
+        "future release. Use ttype='nfft' (recommended) or ttype='direct' "
+        "instead.",
+        DeprecationWarning, stacklevel=2,
+    )
+
+
+def warn_fast_ttype_deprecated_imaging():
+    """Emit a DeprecationWarning for ``ttype='fast'`` from imaging callers.
+
+    Same as :func:`warn_fast_ttype_deprecated` but adds the imaging-specific
+    note that FFT gradients are inaccurate.
+    """
+    warnings.warn(
+        "ttype='fast' (plain FFT) is deprecated and will be removed in a "
+        "future release; its imaging gradients are inaccurate. Use "
+        "ttype='nfft' (recommended) or ttype='direct' instead.",
         DeprecationWarning, stacklevel=2,
     )
 

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -44,6 +44,25 @@ warnings.filterwarnings("ignore", message="divide by zero encountered in double_
 ##################################################################################################
 
 
+def warn_fast_ttype_deprecated():
+    """Emit a DeprecationWarning for the ``ttype='fast'`` (plain FFT) path.
+
+    The plain-FFT transform is deprecated: its imaging gradients are
+    inaccurate because the forward sampler (cubic-spline interpolation of the
+    FFT grid) and the adjoint gridder (Gaussian convolution) are not transpose
+    operators, so the FFT gradient does not match the FFT chi-squared. Use
+    ``ttype='nfft'`` (accurate, recommended) or ``ttype='direct'`` (small
+    problems) instead.
+    """
+    warnings.warn(
+        "ttype='fast' (plain FFT) is deprecated and will be removed in a "
+        "future release. Its imaging gradients are inaccurate (the FFT sampler "
+        "and gridder are not adjoint operators). Use ttype='nfft' (recommended) "
+        "or ttype='direct' instead.",
+        DeprecationWarning, stacklevel=2,
+    )
+
+
 def compute_uv_coordinates(array, site1, site2, time, mjd, ra, dec, rf, timetype='UTC',
                            elevmin=ehc.ELEV_LOW,  elevmax=ehc.ELEV_HIGH, no_elevcut_space=False,
                            fix_theta_GMST=False, earthshadow_space=True):

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -227,6 +227,7 @@ def sample_vis(im_org, uv, sgrscat=False, polrep_obs='stokes',
 
     # Get visibilities from straightforward FFT
     if ttype == "fast":
+        obsh.warn_fast_ttype_deprecated()
 
         # Padded image size
         npad = fft_pad_factor * np.max((im.xdim, im.ydim))

--- a/tests/test_imager_e2e.py
+++ b/tests/test_imager_e2e.py
@@ -195,11 +195,11 @@ class TestEndToEndReconstruction:
 
 
 def test_imager_fast_ttype_warns_deprecated(gauss_im, observe):
-    """Constructing an Imager with ttype='fast' emits a DeprecationWarning
-    pointing to nfft (the FFT imaging gradients are inaccurate)."""
+    """Constructing an Imager with ttype='fast' emits the imaging-context
+    DeprecationWarning noting that gradients are inaccurate."""
     obs = observe(gauss_im, ttype="nfft")
     prior = _independent_prior(gauss_im.total_flux())
-    with pytest.warns(DeprecationWarning, match=r"ttype='fast'"):
+    with pytest.warns(DeprecationWarning, match=r"gradients are inaccurate"):
         eh.imager.Imager(
             obs, prior, prior_im=prior, flux=gauss_im.total_flux(),
             **_imager_kwargs_stokes_i("fast"),

--- a/tests/test_imager_e2e.py
+++ b/tests/test_imager_e2e.py
@@ -192,3 +192,15 @@ class TestEndToEndReconstruction:
         p_truth = np.sum(np.sqrt(gauss_im_pol.qvec**2 + gauss_im_pol.uvec**2)) * gauss_im_pol.psize**2
         assert p_total == pytest.approx(p_truth, rel=0.5), (
             f"total polarized flux {p_total:.3e} off from truth {p_truth:.3e}")
+
+
+def test_imager_fast_ttype_warns_deprecated(gauss_im, observe):
+    """Constructing an Imager with ttype='fast' emits a DeprecationWarning
+    pointing to nfft (the FFT imaging gradients are inaccurate)."""
+    obs = observe(gauss_im, ttype="nfft")
+    prior = _independent_prior(gauss_im.total_flux())
+    with pytest.warns(DeprecationWarning, match=r"ttype='fast'"):
+        eh.imager.Imager(
+            obs, prior, prior_im=prior, flux=gauss_im.total_flux(),
+            **_imager_kwargs_stokes_i("fast"),
+        )

--- a/tests/test_obs_simulate.py
+++ b/tests/test_obs_simulate.py
@@ -881,13 +881,21 @@ class TestAddNoiseLegacy:
 
 
 def test_observe_fast_ttype_warns_deprecated(gauss_im, observe):
-    """Forward sampling with ttype='fast' emits a DeprecationWarning pointing
-    to nfft (the FFT sampler/gridder are not adjoint operators)."""
-    with pytest.warns(DeprecationWarning, match=r"ttype='fast'"):
+    """Forward sampling with ttype='fast' emits the sampling-context
+    DeprecationWarning (no gradient note — those values are correct)."""
+    with pytest.warns(DeprecationWarning, match=r"ttype='fast'") as w:
         observe(gauss_im, ttype="fast")
+    assert "gradient" not in str(w.list[0].message)
 
 
 def test_warn_fast_ttype_deprecated_helper():
-    """The shared helper emits a DeprecationWarning."""
-    with pytest.warns(DeprecationWarning, match=r"ttype='fast'"):
+    """The sampling helper does not mention gradients."""
+    with pytest.warns(DeprecationWarning, match=r"ttype='fast'") as w:
         obsh.warn_fast_ttype_deprecated()
+    assert "gradient" not in str(w.list[0].message)
+
+
+def test_warn_fast_ttype_deprecated_imaging_helper():
+    """The imaging helper additionally notes that gradients are inaccurate."""
+    with pytest.warns(DeprecationWarning, match=r"gradients are inaccurate"):
+        obsh.warn_fast_ttype_deprecated_imaging()

--- a/tests/test_obs_simulate.py
+++ b/tests/test_obs_simulate.py
@@ -878,3 +878,16 @@ class TestAddNoiseLegacy:
         residual = out["vis"] - obs.data["vis"]
         ratio = np.std(residual.real) / np.mean(out["sigma"])
         assert 0.5 < ratio < 2.0
+
+
+def test_observe_fast_ttype_warns_deprecated(gauss_im, observe):
+    """Forward sampling with ttype='fast' emits a DeprecationWarning pointing
+    to nfft (the FFT sampler/gridder are not adjoint operators)."""
+    with pytest.warns(DeprecationWarning, match=r"ttype='fast'"):
+        observe(gauss_im, ttype="fast")
+
+
+def test_warn_fast_ttype_deprecated_helper():
+    """The shared helper emits a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match=r"ttype='fast'"):
+        obsh.warn_fast_ttype_deprecated()


### PR DESCRIPTION
`ttype='fast'` (plain FFT) imaging gradients are inaccurate. Tthe forward sampler (cubic-spline interpolation of the FFT grid) and the adjoint gridder (Gaussian convolution) are not transpose operators, so `chisqgrad_*_fft` is the gradient of a different forward model than `chisq_*_fft` evaluates (found via FD + dot-product adjoint tests while adding the #272 diag-gradient tests; `direct` and `nfft` are exact). Rather than rework the FFT path we're moving off, this deprecates it.

Adds `obs_helpers.warn_fast_ttype_deprecated()`, fired once at the two user entry points where `fast` is selected: `Imager.__init__` (imaging) and `sample_vis` (all forward sampling, incl. `Image.observe` / `Movie`). Points users to `nfft` / `direct`. The code path is kept and still runs.