### PR TITLE
Obsdata polrep widening for LIN and MIXED basis

### DIFF
--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -87,7 +87,7 @@ class TarrView:
 
     Note: this guard catches whole-column access (tarr['sefdr']). It does
     not catch row-form access (tarr[i]['sefdr']) — the row is a numpy
-    void object owned by numpy. Phase 2+ code should prefer
+    void object owned by numpy. New code should prefer
     Array.sefd_for_feed / Array.dterm_for_feed for per-station lookups.
     """
 
@@ -393,7 +393,7 @@ class Array:
                              all-RL feeds; 'lin' requires all-XY feeds; 'mixed'
                              requires at least two distinct feed types. 'lin'
                              and 'mixed' are not yet wired through the
-                             simulation backend (Phase 5).
+                             simulation backend.
                elevmin (float): station minimum elevation in degrees
                elevmax (float): station maximum elevation in degrees
                no_elevcut_space (bool): if True, do not apply elevation cut to orbiters
@@ -425,8 +425,7 @@ class Array:
         if polrep in ('lin', 'mixed'):
             raise NotImplementedError(
                 f"Array.obsdata(polrep={polrep!r}) is not yet supported by "
-                f"the simulation backend (see Phase 5 of "
-                f"obsdata_mixedpol_plan_v2.md)")
+                f"the simulation backend")
 
         obsarr = simobs.make_uvpoints(self, ra, dec, rf, bw,
                                       tint, tadv, tstart, tstop,

--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -35,23 +35,15 @@ from ehtim.caltable import plot_tarr_dterms
 # Array object
 ###################################################################################################
 
-# Valid two-character feed_type strings for a single station (lowercase).
-# Mixed-basis stations (e.g. Effelsberg R+X) are explicitly enumerated.
-VALID_FEED_TYPES = frozenset({
-    'rl', 'lr', 'xy', 'yx',
-    'rx', 'ry', 'lx', 'ly',
-    'xr', 'xl', 'yr', 'yl',
-})
-
 # Default symmetric SEFD when none is supplied (legacy convention).
 _DEFAULT_SEFD = 10000.0
 
 
 def _validate_feed_type(feed_type):
     """Raise ValueError if feed_type is not a recognised 2-char feed string."""
-    if not isinstance(feed_type, str) or feed_type.lower() not in VALID_FEED_TYPES:
+    if not isinstance(feed_type, str) or feed_type.lower() not in ehc.VALID_FEED_TYPES:
         raise ValueError(
-            f"feed_type must be one of {sorted(VALID_FEED_TYPES)}; "
+            f"feed_type must be one of {sorted(ehc.VALID_FEED_TYPES)}; "
             f"got {feed_type!r}")
 
 

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -262,6 +262,11 @@ POLDICT_CIRC = {'vis1': 'rrvis', 'vis2': 'llvis', 'vis3': 'rlvis', 'vis4': 'lrvi
                 'sigma1': 'rrsigma', 'sigma2': 'llsigma', 'sigma3': 'rlsigma', 'sigma4': 'lrsigma'}
 POLDICT_LIN = {'vis1': 'xxvis', 'vis2': 'yyvis', 'vis3': 'xyvis', 'vis4': 'yxvis',
                'sigma1': 'xxsigma', 'sigma2': 'yysigma', 'sigma3': 'xysigma', 'sigma4': 'yxsigma'}
+POLDICT_MIXED = {'vis1': 'p1p1vis', 'vis2': 'p2p2vis', 'vis3': 'p1p2vis', 'vis4': 'p2p1vis',
+                 'sigma1': 'p1p1sigma', 'sigma2': 'p2p2sigma',
+                 'sigma3': 'p1p2sigma', 'sigma4': 'p2p1sigma'}
+polrep_to_poldict = {'stokes': POLDICT_STOKES, 'circ': POLDICT_CIRC,
+                     'lin': POLDICT_LIN, 'mixed': POLDICT_MIXED}
 vis_poldict = {'I': 'vis', 'Q': 'qvis', 'U': 'uvis', 'V': 'vvis',
                'RR': 'rrvis', 'LL': 'llvis', 'RL': 'rlvis', 'LR': 'lrvis',
                'XX': 'xxvis', 'YY': 'yyvis', 'XY': 'xyvis', 'YX': 'yxvis'}
@@ -292,19 +297,37 @@ FIELDS = ['time', 'time_utc', 'time_gmst',
           'llvis', 'llamp', 'llphase', 'llsnr', 'llsigma', 'llsigma_phase',
           'rlvis', 'rlamp', 'rlphase', 'rlsnr', 'rlsigma', 'rlsigma_phase',
           'lrvis', 'lramp', 'lrphase', 'lrsnr', 'lrsigma', 'lrsigma_phase',
-          'rrllvis', 'rrllamp', 'rrllphase', 'rrllsnr', 'rrllsigma', 'rrllsigma_phase']
+          'rrllvis', 'rrllamp', 'rrllphase', 'rrllsnr', 'rrllsigma', 'rrllsigma_phase',
+          'xxvis', 'xxamp', 'xxphase', 'xxsnr', 'xxsigma', 'xxsigma_phase',
+          'yyvis', 'yyamp', 'yyphase', 'yysnr', 'yysigma', 'yysigma_phase',
+          'xyvis', 'xyamp', 'xyphase', 'xysnr', 'xysigma', 'xysigma_phase',
+          'yxvis', 'yxamp', 'yxphase', 'yxsnr', 'yxsigma', 'yxsigma_phase',
+          'p1p1vis', 'p1p1amp', 'p1p1phase', 'p1p1snr', 'p1p1sigma', 'p1p1sigma_phase',
+          'p2p2vis', 'p2p2amp', 'p2p2phase', 'p2p2snr', 'p2p2sigma', 'p2p2sigma_phase',
+          'p1p2vis', 'p1p2amp', 'p1p2phase', 'p1p2snr', 'p1p2sigma', 'p1p2sigma_phase',
+          'p2p1vis', 'p2p1amp', 'p2p1phase', 'p2p1snr', 'p2p1sigma', 'p2p1sigma_phase']
 
 FIELDS_AMPS = ["amp", "qamp", "uamp", "vamp",
-               "pamp", "mamp", "rramp", "llamp", "rlamp", "lramp", "rrllamp"]
+               "pamp", "mamp", "rramp", "llamp", "rlamp", "lramp", "rrllamp",
+               "xxamp", "yyamp", "xyamp", "yxamp",
+               "p1p1amp", "p2p2amp", "p1p2amp", "p2p1amp"]
 FIELDS_SIGS = ["sigma", "qsigma", "usigma", "vsigma",
-               "psigma", "msigma", "rrsigma", "llsigma", "rlsigma", "lrsigma", "rrllsigma"]
+               "psigma", "msigma", "rrsigma", "llsigma", "rlsigma", "lrsigma", "rrllsigma",
+               "xxsigma", "yysigma", "xysigma", "yxsigma",
+               "p1p1sigma", "p2p2sigma", "p1p2sigma", "p2p1sigma"]
 FIELDS_PHASE = ["phase", "qphase", "uphase", "vphase", "pphase", "mphase",
-                "rrphase", "llphase", "rlphase", "lrphase", "rrllphase"]
+                "rrphase", "llphase", "rlphase", "lrphase", "rrllphase",
+                "xxphase", "yyphase", "xyphase", "yxphase",
+                "p1p1phase", "p2p2phase", "p1p2phase", "p2p1phase"]
 FIELDS_SIGPHASE = ["sigma_phase", "qsigma_phase", "usigma_phase", "vsigma_phase",
                    "psigma_phase", "msigma_phase", "rrsigma_phase", "llsigma_phase",
-                   "rlsigma_phase", "lrsigma_phase", "rrllsigma_phase"]
+                   "rlsigma_phase", "lrsigma_phase", "rrllsigma_phase",
+                   "xxsigma_phase", "yysigma_phase", "xysigma_phase", "yxsigma_phase",
+                   "p1p1sigma_phase", "p2p2sigma_phase", "p1p2sigma_phase", "p2p1sigma_phase"]
 FIELDS_SNRS = ["snr", "qsnr", "usnr", "vsnr", "psnr", "msnr",
-               "rrsnr", "llsnr", "rlsnr", "lrsnr", "rrllsnr"]
+               "rrsnr", "llsnr", "rlsnr", "lrsnr", "rrllsnr",
+               "xxsnr", "yysnr", "xysnr", "yxsnr",
+               "p1p1snr", "p2p2snr", "p1p2snr", "p2p1snr"]
 
 # Plotting
 MARKERSIZE = 3

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -79,6 +79,13 @@ FFT_INTERP_DEFAULT = 3
 # dynamic range; relax to 1e-6 for fast low-SNR work.
 NFFT_EPS_DEFAULT = 1e-9
 
+# Valid two-character feed_type strings for a single station (lowercase).
+VALID_FEED_TYPES = frozenset({
+    'rl', 'lr', 'xy', 'yx',
+    'rx', 'ry', 'lx', 'ly',
+    'xr', 'xl', 'yr', 'yl',
+})
+
 # Observation recarray datatypes
 # DTARR uses generic names primary because it is a single shared dtype across
 # all stations; legacy names are title aliases. Per-Obsdata/Caltable dtypes
@@ -122,7 +129,7 @@ DTPOL_MIXED = [('time', 'f8'), ('tint', 'f8'),
                ('p1p2vis', 'c16'), ('p2p1vis', 'c16'),
                ('p1p1sigma', 'f8'), ('p2p2sigma', 'f8'),
                ('p1p2sigma', 'f8'), ('p2p1sigma', 'f8'),
-               ('polbasis', 'U2')]
+               ('polbasis', 'U4')]
 
 DTAMP = [('time', 'f8'), ('tint', 'f8'),
          ('t1', 'U32'), ('t2', 'U32'),

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -132,20 +132,22 @@ class Obsdata:
         # Silently upgrade legacy DTPOL_CIRC (no title aliases) to the
         # current dtype; zero-copy view-cast when applicable.
         datatable = ehc.upgrade_dtpol_circ(datatable)
-        if datatable.dtype not in [ehc.DTPOL_STOKES, ehc.DTPOL_CIRC]:
-            raise Exception("Data table dtype should be DTPOL_STOKES or DTPOL_CIRC")
 
         # Polarization Representation
-        if polrep == 'stokes':
-            self.polrep = 'stokes'
-            self.poldict = ehc.POLDICT_STOKES
-            self.poltype = ehc.DTPOL_STOKES
-        elif polrep == 'circ':
-            self.polrep = 'circ'
-            self.poldict = ehc.POLDICT_CIRC
-            self.poltype = ehc.DTPOL_CIRC
-        else:
-            raise Exception("only 'stokes' and 'circ' are supported polreps!")
+        if polrep not in ehc.polrep_to_poldict:
+            raise Exception(
+                f"polrep must be one of {sorted(ehc.polrep_to_poldict.keys())}; "
+                f"got {polrep!r}"
+            )
+        self.polrep = polrep
+        self.poldict = ehc.polrep_to_poldict[polrep]
+        self.poltype = ehc.feed_dtype_for_polrep(polrep)
+
+        # Validate the datatable dtype matches the declared polrep.
+        if datatable.dtype != np.dtype(self.poltype):
+            raise Exception(
+                f"datatable dtype {datatable.dtype} does not match polrep={polrep!r}"
+            )
 
         # Set the various observation parameters
         self.source = str(source)
@@ -170,6 +172,22 @@ class Obsdata:
         # Telescope array: default ordering is by sefd
         self.tarr = ehc.upgrade_tarr(tarr)
         self.tkey = {self.tarr[i]['site']: i for i in range(len(self.tarr))}
+
+        # Validate tarr feed_type agrees with polrep for homogeneous polreps.
+        # 'mixed' validation is handled separately (requires >= 2 feed types
+        # and per-row polbasis population).
+        feed_types = {str(ft) for ft in self.tarr['feed_type']}
+        if self.polrep == 'circ' and feed_types != {'rl'}:
+            raise ValueError(
+                f"polrep='circ' requires all stations to have feed_type='rl'; "
+                f"tarr has feed_types={sorted(feed_types)}"
+            )
+        if self.polrep == 'lin' and feed_types != {'xy'}:
+            raise ValueError(
+                f"polrep='lin' requires all stations to have feed_type='xy'; "
+                f"tarr has feed_types={sorted(feed_types)}"
+            )
+
         if np.any(self.tarr['sefdr'] != 0) or np.any(self.tarr['sefdl'] != 0):
             self.reorder_tarr_sefd(reorder_baselines=False)
 

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -1314,6 +1314,11 @@ class Obsdata:
            Returns:
                 (Obsdata): Obsdata object containing averaged data
         """
+        if self.polrep in ('lin', 'mixed'):
+            raise NotImplementedError(
+                f"avg_coherent is not yet supported on polrep={self.polrep!r}; "
+                "the averaging code is currently CIRC/STOKES-only."
+            )
 
         if (scan_avg) and (getattr(self.scans, "shape", None) is None or len(self.scans) == 0):
             print('No scan data, ignoring scan_avg!')
@@ -1347,6 +1352,11 @@ class Obsdata:
            Returns:
                 (Obsdata): Obsdata object containing averaged data
         """
+        if self.polrep in ('lin', 'mixed'):
+            raise NotImplementedError(
+                f"avg_incoherent is not yet supported on polrep={self.polrep!r}; "
+                "the averaging code is currently CIRC/STOKES-only."
+            )
 
         print('Incoherently averaging data, putting phases to zero!')
         amp_rec = ehdf.incoh_avg_vis(self, dt=inttime, debias=debias, scan_avg=scan_avg,

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -173,10 +173,19 @@ class Obsdata:
         self.tarr = ehc.upgrade_tarr(tarr)
         self.tkey = {self.tarr[i]['site']: i for i in range(len(self.tarr))}
 
-        # Validate tarr feed_type agrees with polrep for homogeneous polreps.
-        # 'mixed' validation is handled separately (requires >= 2 feed types
-        # and per-row polbasis population).
+        # Validate tarr feed_type values and agreement with polrep.
         feed_types = {str(ft) for ft in self.tarr['feed_type']}
+        if '??' in feed_types:
+            raise ValueError(
+                "tarr contains unset feed_type='??'; all stations must "
+                "declare a feed_type before constructing an Obsdata"
+            )
+        unknown = feed_types - ehc.VALID_FEED_TYPES
+        if unknown:
+            raise ValueError(
+                f"tarr contains unknown feed_type(s): {sorted(unknown)}; "
+                f"valid values are {sorted(ehc.VALID_FEED_TYPES)}"
+            )
         if self.polrep == 'circ' and feed_types != {'rl'}:
             raise ValueError(
                 f"polrep='circ' requires all stations to have feed_type='rl'; "
@@ -187,6 +196,28 @@ class Obsdata:
                 f"polrep='lin' requires all stations to have feed_type='xy'; "
                 f"tarr has feed_types={sorted(feed_types)}"
             )
+        if self.polrep == 'mixed':
+            if len(feed_types) < 2:
+                raise ValueError(
+                    f"polrep='mixed' requires at least two distinct feed types; "
+                    f"tarr has feed_types={sorted(feed_types)}"
+                )
+            sites_in_tarr = set(self.tarr['site'])
+            data_sites = set(self.data['t1']).union(self.data['t2'])
+            missing = data_sites - sites_in_tarr
+            if missing:
+                raise ValueError(
+                    f"polrep='mixed' data references stations not in tarr: "
+                    f"{sorted(missing)}"
+                )
+            # Populate polbasis: full feed_type of each station, concatenated.
+            # E.g. ('rl','rl') -> 'rlrl'; ('rl','xy') -> 'rlxy'.
+            t1_idx = np.fromiter((self.tkey[t] for t in self.data['t1']),
+                                 dtype=int, count=len(self.data))
+            t2_idx = np.fromiter((self.tkey[t] for t in self.data['t2']),
+                                 dtype=int, count=len(self.data))
+            ft_arr = self.tarr['feed_type']
+            self.data['polbasis'] = np.char.add(ft_arr[t1_idx], ft_arr[t2_idx])
 
         if np.any(self.tarr['sefdr'] != 0) or np.any(self.tarr['sefdl'] != 0):
             self.reorder_tarr_sefd(reorder_baselines=False)

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -451,6 +451,23 @@ class Obsdata:
             yxs_orig = dat['yxsigma'].copy()
             dat['xysigma'][ordermask] = yxs_orig[ordermask]
             dat['yxsigma'][ordermask] = xys_orig[ordermask]
+        elif self.polrep == 'mixed':
+            # Same conjugate/swap algebra as circ/lin, in generic-slot names.
+            dat['p1p1vis'][ordermask] = np.conj(dat['p1p1vis'][ordermask])
+            dat['p2p2vis'][ordermask] = np.conj(dat['p2p2vis'][ordermask])
+            p12_orig = dat['p1p2vis'].copy()
+            p21_orig = dat['p2p1vis'].copy()
+            dat['p1p2vis'][ordermask] = np.conj(p21_orig[ordermask])
+            dat['p2p1vis'][ordermask] = np.conj(p12_orig[ordermask])
+            p12s_orig = dat['p1p2sigma'].copy()
+            p21s_orig = dat['p2p1sigma'].copy()
+            dat['p1p2sigma'][ordermask] = p21s_orig[ordermask]
+            dat['p2p1sigma'][ordermask] = p12s_orig[ordermask]
+            # polbasis encodes t1_feed+t2_feed; swap the two halves on
+            # reordered rows so the encoding stays consistent with (t1,t2).
+            pb_swapped = np.array([s[2:] + s[:2] for s in dat['polbasis']],
+                                  dtype='U4')
+            dat['polbasis'][ordermask] = pb_swapped[ordermask]
         else:
             raise Exception(f"reorder_baselines: unsupported polrep={self.polrep!r}")
 

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -173,7 +173,11 @@ class Obsdata:
         self.tarr = ehc.upgrade_tarr(tarr)
         self.tkey = {self.tarr[i]['site']: i for i in range(len(self.tarr))}
 
-        # Validate tarr feed_type values and agreement with polrep.
+        # Validate tarr feed_type values. polrep declares the data-layout
+        # basis (DTPOL_*); tarr.feed_type describes the physical array. The
+        # two need not match -- switch_polrep transforms data across bases
+        # without touching tarr -- but we warn on the mismatch to flag the
+        # discrepancy.
         feed_types = {str(ft) for ft in self.tarr['feed_type']}
         if '??' in feed_types:
             raise ValueError(
@@ -187,14 +191,18 @@ class Obsdata:
                 f"valid values are {sorted(ehc.VALID_FEED_TYPES)}"
             )
         if self.polrep == 'circ' and feed_types != {'rl'}:
-            raise ValueError(
-                f"polrep='circ' requires all stations to have feed_type='rl'; "
-                f"tarr has feed_types={sorted(feed_types)}"
+            warnings.warn(
+                f"polrep='circ' Obsdata constructed on a tarr with "
+                f"feed_types={sorted(feed_types)}; the data is in the circular "
+                f"basis but the physical array is not all-circular.",
+                stacklevel=2,
             )
         if self.polrep == 'lin' and feed_types != {'xy'}:
-            raise ValueError(
-                f"polrep='lin' requires all stations to have feed_type='xy'; "
-                f"tarr has feed_types={sorted(feed_types)}"
+            warnings.warn(
+                f"polrep='lin' Obsdata constructed on a tarr with "
+                f"feed_types={sorted(feed_types)}; the data is in the linear "
+                f"basis but the physical array is not all-linear.",
+                stacklevel=2,
             )
         if self.polrep == 'mixed':
             if len(feed_types) < 2:
@@ -451,8 +459,22 @@ class Obsdata:
                 _warn_singlepol(int(np.sum(Vmask)),
                                 f"copied Stokes I into {prefix}vis where vvis was missing")
 
+        elif (self.polrep, polrep_out) in (('circ', 'lin'), ('lin', 'circ')):
+            # No direct kernel between linear and circular feed bases; route
+            # through Stokes. Both legs share the same allow_singlepol /
+            # singlepol_hand kwargs (singlepol_hand only fires on the
+            # stokes -> target leg, which validates it for the target basis).
+            return self.switch_polrep(
+                'stokes',
+                allow_singlepol=allow_singlepol,
+                singlepol_hand=singlepol_hand,
+            ).switch_polrep(
+                polrep_out,
+                allow_singlepol=allow_singlepol,
+                singlepol_hand=singlepol_hand,
+            )
+
         else:
-            # circ <-> lin: implemented in a follow-up via two-step composition.
             raise NotImplementedError(
                 f"switch_polrep({self.polrep!r} -> {polrep_out!r}) is not yet implemented"
             )

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -318,11 +318,13 @@ class Obsdata:
         """Return a new observation with the polarization representation changed
 
            Args:
-               polrep_out (str):  the polrep of the output data
-               allow_singlepol (bool): If True, treat single-polarization data as Stokes I
-                                       when converting from 'circ' polrep to 'stokes'
-               singlepol_hand (str): 'R' or 'L'; determines which parallel-hand is assumed
-                                       when converting 'stokes' to 'circ' if only I is present
+               polrep_out (str):  the polrep of the output data ('stokes', 'circ', 'lin')
+               allow_singlepol (bool): If True, fill missing parallel-hand rows with the
+                                       surviving one (or with Stokes I) when converting.
+                                       Emits a warning whenever any substitution occurs.
+               singlepol_hand (str): For 'stokes' -> 'circ', 'R' or 'L'; for 'stokes' ->
+                                     'lin', 'X' or 'Y'. Case-insensitive. Selects which
+                                     parallel-hand receives Stokes I when only I is present.
 
            Returns:
                (Obsdata): new Obsdata object with potentially different polrep
@@ -336,7 +338,16 @@ class Obsdata:
             )
         if polrep_out == self.polrep:
             return self.copy()
-        elif polrep_out == 'stokes':  # circ -> stokes
+
+        def _warn_singlepol(n, msg):
+            if n > 0:
+                warnings.warn(
+                    f"switch_polrep: allow_singlepol substituted {n} row(s) "
+                    f"({msg}); cross-hand visibilities are not modified",
+                    stacklevel=3,
+                )
+
+        if polrep_out == 'stokes' and self.polrep == 'circ':  # circ -> stokes
             data = np.empty(len(self.data), dtype=ehc.DTPOL_STOKES)
             rrmask = np.isnan(self.data['rrvis'])
             llmask = np.isnan(self.data['llvis'])
@@ -353,15 +364,38 @@ class Obsdata:
                 self.data['rlsigma'], self.data['lrsigma'])
 
             if allow_singlepol:
-                # In cases where only one polarization is present
-                # use it as an estimator for Stokes I
                 data['vis'][rrmask] = self.data['llvis'][rrmask]
                 data['sigma'][rrmask] = self.data['llsigma'][rrmask]
-
                 data['vis'][llmask] = self.data['rrvis'][llmask]
                 data['sigma'][llmask] = self.data['rrsigma'][llmask]
+                _warn_singlepol(int(np.sum(rrmask | llmask)),
+                                "filled missing rrvis/llvis with surviving parallel-hand")
 
-        elif polrep_out == 'circ':  # stokes -> circ
+        elif polrep_out == 'stokes' and self.polrep == 'lin':  # lin -> stokes
+            data = np.empty(len(self.data), dtype=ehc.DTPOL_STOKES)
+            xxmask = np.isnan(self.data['xxvis'])
+            yymask = np.isnan(self.data['yyvis'])
+
+            for f in ['time', 'tint', 't1', 't2', 'tau1', 'tau2', 'u', 'v']:
+                data[f] = self.data[f]
+            (data['vis'], data['qvis'],
+             data['uvis'], data['vvis']) = pol_conventions.lin_to_stokes(
+                self.data['xxvis'], self.data['yyvis'],
+                self.data['xyvis'], self.data['yxvis'])
+            (data['sigma'], data['qsigma'],
+             data['usigma'], data['vsigma']) = pol_conventions.lin_to_stokes_sigma(
+                self.data['xxsigma'], self.data['yysigma'],
+                self.data['xysigma'], self.data['yxsigma'])
+
+            if allow_singlepol:
+                data['vis'][xxmask] = self.data['yyvis'][xxmask]
+                data['sigma'][xxmask] = self.data['yysigma'][xxmask]
+                data['vis'][yymask] = self.data['xxvis'][yymask]
+                data['sigma'][yymask] = self.data['xxsigma'][yymask]
+                _warn_singlepol(int(np.sum(xxmask | yymask)),
+                                "filled missing xxvis/yyvis with surviving parallel-hand")
+
+        elif polrep_out == 'circ' and self.polrep == 'stokes':  # stokes -> circ
             data = np.empty(len(self.data), dtype=ehc.DTPOL_CIRC)
             Vmask = np.isnan(self.data['vvis'])
 
@@ -377,13 +411,51 @@ class Obsdata:
                 self.data['usigma'], self.data['vsigma'])
 
             if allow_singlepol:
-                # In cases where only Stokes I is present, copy it to a specified parallel-hand
-                prefix = singlepol_hand.lower() + singlepol_hand.lower()  # rr or ll
-                if prefix not in ['rr', 'll']:
-                    raise Exception('singlepol_hand must be R or L')
-
+                hand = singlepol_hand.upper() if isinstance(singlepol_hand, str) else None
+                if hand not in ('R', 'L'):
+                    raise Exception(
+                        f"singlepol_hand must be 'R' or 'L' when converting to circ; "
+                        f"got {singlepol_hand!r}"
+                    )
+                prefix = hand.lower() * 2  # 'rr' or 'll'
                 data[prefix + 'vis'][Vmask] = self.data['vis'][Vmask]
                 data[prefix + 'sigma'][Vmask] = self.data['sigma'][Vmask]
+                _warn_singlepol(int(np.sum(Vmask)),
+                                f"copied Stokes I into {prefix}vis where vvis was missing")
+
+        elif polrep_out == 'lin' and self.polrep == 'stokes':  # stokes -> lin
+            data = np.empty(len(self.data), dtype=ehc.DTPOL_LIN)
+            Vmask = np.isnan(self.data['vvis'])
+
+            for f in ['time', 'tint', 't1', 't2', 'tau1', 'tau2', 'u', 'v']:
+                data[f] = self.data[f]
+            (data['xxvis'], data['yyvis'],
+             data['xyvis'], data['yxvis']) = pol_conventions.stokes_to_lin(
+                self.data['vis'], self.data['qvis'],
+                self.data['uvis'], self.data['vvis'])
+            (data['xxsigma'], data['yysigma'],
+             data['xysigma'], data['yxsigma']) = pol_conventions.stokes_to_lin_sigma(
+                self.data['sigma'], self.data['qsigma'],
+                self.data['usigma'], self.data['vsigma'])
+
+            if allow_singlepol:
+                hand = singlepol_hand.upper() if isinstance(singlepol_hand, str) else None
+                if hand not in ('X', 'Y'):
+                    raise Exception(
+                        f"singlepol_hand must be 'X' or 'Y' when converting to lin; "
+                        f"got {singlepol_hand!r}"
+                    )
+                prefix = hand.lower() * 2  # 'xx' or 'yy'
+                data[prefix + 'vis'][Vmask] = self.data['vis'][Vmask]
+                data[prefix + 'sigma'][Vmask] = self.data['sigma'][Vmask]
+                _warn_singlepol(int(np.sum(Vmask)),
+                                f"copied Stokes I into {prefix}vis where vvis was missing")
+
+        else:
+            # circ <-> lin: implemented in a follow-up via two-step composition.
+            raise NotImplementedError(
+                f"switch_polrep({self.polrep!r} -> {polrep_out!r}) is not yet implemented"
+            )
 
         arglist, argdict = self.obsdata_args()
         arglist[DATPOS] = data

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -328,8 +328,12 @@ class Obsdata:
                (Obsdata): new Obsdata object with potentially different polrep
         """
 
-        if polrep_out not in ['stokes', 'circ']:
-            raise Exception("polrep_out must be either 'stokes' or 'circ'")
+        if polrep_out not in ('stokes', 'circ', 'lin'):
+            raise Exception("polrep_out must be 'stokes', 'circ', or 'lin'")
+        if self.polrep == 'mixed':
+            raise NotImplementedError(
+                "conversion from polrep='mixed' is not yet implemented"
+            )
         if polrep_out == self.polrep:
             return self.copy()
         elif polrep_out == 'stokes':  # circ -> stokes

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -1557,6 +1557,12 @@ class Obsdata:
            Returns:
                (Image): an Image object with dirty image.
         """
+        if self.polrep == 'mixed':
+            raise NotImplementedError(
+                "dirtyimage is not supported on polrep='mixed' observations: "
+                "per-baseline feed-basis interpretation varies and Image has no "
+                "'mixed' polrep. Call obs.switch_polrep('stokes') first."
+            )
 
         pdim = fov / npix
         u = self.unpack('u')['u']

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -440,8 +440,19 @@ class Obsdata:
             lrs_orig = dat['lrsigma'].copy()
             dat['rlsigma'][ordermask] = lrs_orig[ordermask]
             dat['lrsigma'][ordermask] = rls_orig[ordermask]
+        elif self.polrep == 'lin':
+            dat['xxvis'][ordermask] = np.conj(dat['xxvis'][ordermask])
+            dat['yyvis'][ordermask] = np.conj(dat['yyvis'][ordermask])
+            xy_orig = dat['xyvis'].copy()
+            yx_orig = dat['yxvis'].copy()
+            dat['xyvis'][ordermask] = np.conj(yx_orig[ordermask])
+            dat['yxvis'][ordermask] = np.conj(xy_orig[ordermask])
+            xys_orig = dat['xysigma'].copy()
+            yxs_orig = dat['yxsigma'].copy()
+            dat['xysigma'][ordermask] = yxs_orig[ordermask]
+            dat['yxsigma'][ordermask] = xys_orig[ordermask]
         else:
-            raise Exception("polrep must be either 'stokes' or 'circ'")
+            raise Exception(f"reorder_baselines: unsupported polrep={self.polrep!r}")
 
         # Group rows by canonical (time, t1, t2). np.unique with axis=0 collapses
         # repeated rows in `keys` and returns:

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -389,147 +389,111 @@ class Obsdata:
         return newobs
 
     def reorder_baselines(self, trial_speedups=False):
-        """Reorder baselines to match uvfits convention, based on the telescope array ordering
+        """Reorder baselines to canonical order (tkey[t1] < tkey[t2]) and handle duplicates.
+
+        Within each timestep, any row whose baseline is in reversed order is swapped
+        so it appears as (t1, t2) with tkey[t1] < tkey[t2], conjugating the
+        visibilities and negating (u, v) as needed.
+
+        After the swap, rows that collide on (time, t1, t2) are classified:
+          - **Conjugate pair**: one row was originally (A, B), the other (B, A) at
+            the same time. The two rows represent the same measurement; one is
+            silently dropped.
+          - **True duplicate or multi-channel data**: anything else. A
+            ``UserWarning`` is emitted and only the first row is kept. The
+            single-frequency Obsdata schema cannot represent per-channel data,
+            so loaders that flatten multi-channel files lose information here.
+
+        Args:
+            trial_speedups (bool): kept for API compatibility; the implementation
+                is now always vectorized and this flag has no effect.
         """
-        if trial_speedups:
-            self.reorder_baselines_trial_speedups()
-
-        else: # original code
-
-            # Time partition the datatable
-            datatable = self.data.copy()
-            datalist = []
-            for key, group in it.groupby(datatable, lambda x: x['time']):
-                #print(key*60*60,len(list(group)))
-                datalist.append(np.array([obs for obs in group]))
-
-            # loop through all data
-            obsdata = []
-            for tlist in datalist:
-                blpairs = []
-                for dat in tlist:
-                    # Remove conjugate baselines
-                    if (set((dat['t1'], dat['t2']))) not in blpairs:
-
-                        # Reverse the baseline in the right order for uvfits:
-                        if(self.tkey[dat['t2']] < self.tkey[dat['t1']]):
-
-                            (dat['t1'], dat['t2']) = (dat['t2'], dat['t1'])
-                            (dat['tau1'], dat['tau2']) = (dat['tau2'], dat['tau1'])
-                            dat['u'] = -dat['u']
-                            dat['v'] = -dat['v']
-
-                            if self.polrep == 'stokes':
-                                dat['vis'] = np.conj(dat['vis'])
-                                dat['qvis'] = np.conj(dat['qvis'])
-                                dat['uvis'] = np.conj(dat['uvis'])
-                                dat['vvis'] = np.conj(dat['vvis'])
-                            elif self.polrep == 'circ':
-                                dat['rrvis'] = np.conj(dat['rrvis'])
-                                dat['llvis'] = np.conj(dat['llvis'])
-                                # must switch l & r !!
-                                rl = dat['rlvis'].copy()
-                                lr = dat['lrvis'].copy()
-                                dat['rlvis'] = np.conj(lr)
-                                dat['lrvis'] = np.conj(rl)
-
-                                # You also have to switch the errors for the coherency!
-                                rlerr = dat['rlsigma'].copy()
-                                lrerr = dat['lrsigma'].copy()
-                                dat["rlsigma"] = lrerr
-                                dat["lrsigma"] = rlerr
-
-                            else:
-                                raise Exception("polrep must be either 'stokes' or 'circ'")
-
-                        # Append the data point
-                        blpairs.append(set((dat['t1'], dat['t2'])))
-                        obsdata.append(dat)
-
-            obsdata = np.array(obsdata, dtype=self.poltype)
-
-            # Timesort data
-            obsdata = obsdata[np.argsort(obsdata, order=['time', 't1'])]
-
-            # Save the data
-            self.data = obsdata
-
-        return
-
-    def reorder_baselines_trial_speedups(self):
-        """Reorder baselines to match uvfits convention, based on the telescope array ordering
-        """
-
         dat = self.data.copy()
 
-        ############ Ensure correct baseline order
-        # TODO can these be faster?
-        t1nums = np.fromiter([self.tkey[t] for t in dat['t1']],int)
-        t2nums = np.fromiter([self.tkey[t] for t in dat['t2']],int)
-
-        # which entries are in the wrong telescope order?
+        t1nums = np.fromiter((self.tkey[t] for t in dat['t1']), int, count=len(dat))
+        t2nums = np.fromiter((self.tkey[t] for t in dat['t2']), int, count=len(dat))
         ordermask = t2nums < t1nums
 
-        # flip the order of these entries
-        t1 = dat['t1'].copy()
-        t2 = dat['t2'].copy()
-        tau1 = dat['tau1'].copy()
-        tau2 = dat['tau2'].copy()
-
-        dat['t1'][ordermask] = t2[ordermask]
-        dat['t2'][ordermask] = t1[ordermask]
-        dat['tau1'][ordermask] = tau2[ordermask]
-        dat['tau2'][ordermask] = tau1[ordermask]
+        # Swap reversed rows: site labels, opacities, (u,v), and the visibilities.
+        t1_orig = dat['t1'].copy()
+        t2_orig = dat['t2'].copy()
+        tau1_orig = dat['tau1'].copy()
+        tau2_orig = dat['tau2'].copy()
+        dat['t1'][ordermask] = t2_orig[ordermask]
+        dat['t2'][ordermask] = t1_orig[ordermask]
+        dat['tau1'][ordermask] = tau2_orig[ordermask]
+        dat['tau2'][ordermask] = tau1_orig[ordermask]
         dat['u'][ordermask] *= -1
         dat['v'][ordermask] *= -1
 
-        if self.polrep=='stokes':
-            dat['vis'][ordermask]  = np.conj(dat['vis'][ordermask])
-            dat['qvis'][ordermask] = np.conj(dat['qvis'][ordermask])
-            dat['uvis'][ordermask] = np.conj(dat['uvis'][ordermask])
-            dat['vvis'][ordermask] = np.conj(dat['vvis'][ordermask])
-
+        if self.polrep == 'stokes':
+            for f in ('vis', 'qvis', 'uvis', 'vvis'):
+                dat[f][ordermask] = np.conj(dat[f][ordermask])
         elif self.polrep == 'circ':
             dat['rrvis'][ordermask] = np.conj(dat['rrvis'][ordermask])
             dat['llvis'][ordermask] = np.conj(dat['llvis'][ordermask])
-            rl = dat['rlvis'].copy()
-            lr = dat['lrvis'].copy()
-            dat['rlvis'][ordermask] = np.conj(lr[ordermask])
-            dat['lrvis'][ordermask] = np.conj(rl[ordermask])
-
-            # Also need to switch error matrix
-            rle = dat['rlsigma'].copy()
-            lre = dat['lrsigma'].copy()
-            dat['rlsigma'][ordermask] = lre[ordermask]
-            dat['lrsigma'][ordermask] = rle[ordermask]
-
+            rl_orig = dat['rlvis'].copy()
+            lr_orig = dat['lrvis'].copy()
+            dat['rlvis'][ordermask] = np.conj(lr_orig[ordermask])
+            dat['lrvis'][ordermask] = np.conj(rl_orig[ordermask])
+            rls_orig = dat['rlsigma'].copy()
+            lrs_orig = dat['lrsigma'].copy()
+            dat['rlsigma'][ordermask] = lrs_orig[ordermask]
+            dat['lrsigma'][ordermask] = rls_orig[ordermask]
         else:
             raise Exception("polrep must be either 'stokes' or 'circ'")
 
-        # Remove duplicate or conjugate entries at any timestep
-        # Since telescope order has been sorted conjugates should appear as duplicates
-        timeblcombos = np.vstack((dat['time'],t1nums,t2nums)).T
-        uniqdat, uniqdatinv = np.unique(timeblcombos,axis=0, return_inverse=True)
+        # Group rows by canonical (time, t1, t2). np.unique with axis=0 collapses
+        # repeated rows in `keys` and returns:
+        #   first_idx[g] -> index in `keys` of the first occurrence of group g
+        #   inverse[i]   -> the group id that row i belongs to
+        #   counts[g]    -> number of rows belonging to group g
+        canon_t1 = np.minimum(t1nums, t2nums)
+        canon_t2 = np.maximum(t1nums, t2nums)
+        keys = np.stack(
+            (dat['time'], canon_t1.astype(float), canon_t2.astype(float)), axis=1,
+        )
+        _, first_idx, inverse, counts = np.unique(
+            keys, axis=0, return_index=True, return_inverse=True, return_counts=True,
+        )
 
-        if len(uniqdat) != len(dat):
-            print("WARNING: removing duplicate/conjuagte points in reorder_baselines!")
-            deletemask = np.ones(len(dat)).astype(bool)
+        if np.any(counts > 1):
+            # Start by keeping only the first occurrence of each group.
+            keep = np.zeros(len(dat), dtype=bool)
+            keep[first_idx] = True
 
-            for j in range(len(uniqdat)):
-                idxs = np.argwhere(uniqdatinv==j)[:,0]
-                for idx in idxs[1:]: # delete all but first occurance
-                    deletemask[idx] = False
+            # True conjugate pair: exactly two rows, opposite original
+            # orderings (one had ordermask=True, one False), with matching
+            # (u, v) after the swap negates (u, v) on the reversed row. Drop
+            # one silently. Any other collision -- including same-side
+            # duplicates with matching uv (data inconsistency), or more than
+            # two rows, or mismatched (u, v) (multi-channel data flattened
+            # into a single-frequency schema) -- is real data loss; warn.
+            n_true_dupes_dropped = 0
+            for g in np.where(counts > 1)[0]:
+                members = np.where(inverse == g)[0]
+                uv = np.stack((dat['u'][members], dat['v'][members]), axis=1)
+                is_conj_pair = (
+                    len(members) == 2
+                    and ordermask[members].sum() == 1
+                    and np.allclose(uv[0], uv[1])
+                )
+                if is_conj_pair:
+                    pass
+                else:
+                    n_true_dupes_dropped += len(members) - 1
 
-            # remove duplicates
-            dat_unique = dat[deletemask]
+            if n_true_dupes_dropped > 0:
+                warnings.warn(
+                    f"reorder_baselines: dropped {n_true_dupes_dropped} duplicate "
+                    "row(s) at matching (time, t1, t2) that aren't a conjugate pair "
+                    "(e.g. flattened multi-channel or duplicate data) "
+                    "Inspect your loader.",
+                    stacklevel=2,
+                )
+            dat = dat[keep]
 
-        # sort data
-        dat = dat[np.argsort(dat, order=['time', 't1'])]
-
-        # save the data
-        self.data = dat
-
-        return
+        self.data = dat[np.argsort(dat, order=['time', 't1'])]
 
     def reorder_tarr_sefd(self, reorder_baselines=True):
         """Reorder the telescope array by SEFD minimal to maximum.

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -355,7 +355,7 @@ def test_switch_polrep_raises_if_output_pol_missing(gauss_im):
 
 
 # ---------------------------------------------------------------------------
-# Section 5b: lin polrep (Phase 3)
+# Section 5b: lin polrep 
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -355,7 +355,7 @@ def test_switch_polrep_raises_if_output_pol_missing(gauss_im):
 
 
 # ---------------------------------------------------------------------------
-# Section 5b: lin polrep 
+# Section 5b: lin polrep
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,6 +2,8 @@
 
 import os
 
+import numpy as np
+
 import ehtim as eh
 from ehtim.io import load
 
@@ -15,6 +17,17 @@ def test_load_obs_uvfits():
     """Test that load_obs_uvfits can read a UVFITS file and return an Obsdata."""
     obs = load.load_obs_uvfits(os.path.join(DATA_DIR, "sample.uvfits"))
     assert isinstance(obs, eh.obsdata.Obsdata)
+
+
+def test_load_obs_uvfits_trial_speedups_matches_default():
+    """The trial_speedups paths in load_obs_uvfits (vectorized site lookup,
+    alternate datatable assembly) must produce data and tarr identical to the
+    default paths."""
+    path = os.path.join(DATA_DIR, "sample.uvfits")
+    obs_default = load.load_obs_uvfits(path, trial_speedups=False)
+    obs_trial = load.load_obs_uvfits(path, trial_speedups=True)
+    np.testing.assert_array_equal(obs_default.data, obs_trial.data)
+    np.testing.assert_array_equal(obs_default.tarr, obs_trial.tarr)
 
 
 def test_load_array_txt():

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -1,8 +1,5 @@
 """Tests for the mixed-polarization data infrastructure.
 
-Tests are grouped by the phase of obsdata_mixedpol_plan_v2.md they cover.
-Subsequent phases (2, 2.5, 3, ...) should append their tests to this file
-under matching headers.
 """
 import os
 import pickle
@@ -17,7 +14,7 @@ import ehtim.const_def as ehc
 import ehtim.obsdata as eo
 import ehtim.warnings as ehw
 
-# Legacy (pre-Phase-1) dtypes — used to verify upgrade plumbing.
+# Legacy dtypes — used to verify upgrade plumbing.
 _LEGACY_DTARR = [('site', 'U32'), ('x', 'f8'), ('y', 'f8'), ('z', 'f8'),
                  ('sefdr', 'f8'), ('sefdl', 'f8'), ('dr', 'c16'), ('dl', 'c16'),
                  ('fr_par', 'f8'), ('fr_elev', 'f8'), ('fr_off', 'f8')]
@@ -53,10 +50,9 @@ def _legacy_circ_datatable():
 
 
 # ============================================================================
-# Phase 1 — Schema additions and warnings module
+# Schema additions and warnings module
 # ============================================================================
 #
-# Plan reference: obsdata_mixedpol_plan_v2.md, "Phase 1".
 # Scope:
 #   - ehtim/warnings.py module + warning classes
 #   - DTARR migration to 12 fields with feed_type
@@ -72,14 +68,14 @@ def _legacy_circ_datatable():
 
 # ----- Warnings module -----------------------------------------------------
 
-def test_phase1_warning_classes_are_user_warning_subclasses():
+def test_warning_classes_are_user_warning_subclasses():
     assert issubclass(ehw.MixedPolConventionWarning, UserWarning)
     assert issubclass(ehw.MixedPolClosureSkipWarning, UserWarning)
 
 
 # ----- DTARR ---------------------------------------------------------------
 
-def test_phase1_dtarr_alias_equivalence():
+def test_dtarr_alias_equivalence():
     a = np.zeros(2, dtype=ehc.DTARR)
     a['sefd_p1'] = [1000., 2000.]
     assert np.array_equal(a['sefdr'], a['sefd_p1'])
@@ -87,7 +83,7 @@ def test_phase1_dtarr_alias_equivalence():
     assert np.array_equal(a['dr'], a['d_p1'])
 
 
-def test_phase1_dtarr_primary_names_are_generic():
+def test_dtarr_primary_names_are_generic():
     names = np.dtype(ehc.DTARR).names
     assert 'sefd_p1' in names and 'sefd_p2' in names
     assert 'd_p1' in names and 'd_p2' in names
@@ -97,7 +93,7 @@ def test_phase1_dtarr_primary_names_are_generic():
     assert 'sefdl' not in names
 
 
-def test_phase1_dtarr_default_feed_type_is_empty_until_filled():
+def test_dtarr_default_feed_type_is_empty_until_filled():
     a = np.zeros(1, dtype=ehc.DTARR)
     # np.zeros gives an empty unicode string; ehtim's constructors fill 'rl'.
     assert a['feed_type'][0] == ''
@@ -105,7 +101,7 @@ def test_phase1_dtarr_default_feed_type_is_empty_until_filled():
 
 # ----- DTPOL_CIRC ----------------------------------------------------------
 
-def test_phase1_dtpol_circ_alias_equivalence():
+def test_dtpol_circ_alias_equivalence():
     d = np.zeros(2, dtype=ehc.DTPOL_CIRC)
     d['rrvis'] = [1 + 0j, 2 + 0j]
     assert np.array_equal(d['p1p1vis'], d['rrvis'])
@@ -115,13 +111,13 @@ def test_phase1_dtpol_circ_alias_equivalence():
     assert np.array_equal(d['p1p1sigma'], d['rrsigma'])
 
 
-def test_phase1_dtpol_circ_primary_names_are_physical():
+def test_dtpol_circ_primary_names_are_physical():
     names = np.dtype(ehc.DTPOL_CIRC).names
     assert 'rrvis' in names and 'lrvis' in names
     assert 'p1p1vis' not in names  # generic is a title alias, not primary
 
 
-def test_phase1_dtpol_circ_wrong_feed_access_raises():
+def test_dtpol_circ_wrong_feed_access_raises():
     d = np.zeros(1, dtype=ehc.DTPOL_CIRC)
     with pytest.raises((ValueError, KeyError)):
         d['xxvis']
@@ -129,7 +125,7 @@ def test_phase1_dtpol_circ_wrong_feed_access_raises():
 
 # ----- DTPOL_LIN -----------------------------------------------------------
 
-def test_phase1_dtpol_lin_alias_equivalence():
+def test_dtpol_lin_alias_equivalence():
     d = np.zeros(2, dtype=ehc.DTPOL_LIN)
     d['xxvis'] = [1 + 0j, 2 + 0j]
     assert np.array_equal(d['p1p1vis'], d['xxvis'])
@@ -137,7 +133,7 @@ def test_phase1_dtpol_lin_alias_equivalence():
     assert np.array_equal(d['p2p1vis'], d['yxvis'])
 
 
-def test_phase1_dtpol_lin_wrong_feed_access_raises():
+def test_dtpol_lin_wrong_feed_access_raises():
     d = np.zeros(1, dtype=ehc.DTPOL_LIN)
     with pytest.raises((ValueError, KeyError)):
         d['rrvis']
@@ -145,7 +141,7 @@ def test_phase1_dtpol_lin_wrong_feed_access_raises():
 
 # ----- DTPOL_MIXED ---------------------------------------------------------
 
-def test_phase1_dtpol_mixed_has_only_generic_names_and_polbasis():
+def test_dtpol_mixed_has_only_generic_names_and_polbasis():
     names = np.dtype(ehc.DTPOL_MIXED).names
     assert 'p1p1vis' in names and 'p2p2vis' in names
     assert 'p1p2vis' in names and 'p2p1vis' in names
@@ -156,7 +152,7 @@ def test_phase1_dtpol_mixed_has_only_generic_names_and_polbasis():
 
 # ----- DTCAL ---------------------------------------------------------------
 
-def test_phase1_dtcal_circ_alias_equivalence():
+def test_dtcal_circ_alias_equivalence():
     c = np.zeros(2, dtype=ehc.DTCAL_CIRC)
     c['rscale'] = [1 + 0j, 2 + 0j]
     assert np.array_equal(c['p1scale'], c['rscale'])
@@ -164,19 +160,19 @@ def test_phase1_dtcal_circ_alias_equivalence():
     assert np.array_equal(c['d_p1'], c['dr'])
 
 
-def test_phase1_dtcal_lin_alias_equivalence():
+def test_dtcal_lin_alias_equivalence():
     c = np.zeros(2, dtype=ehc.DTCAL_LIN)
     c['xscale'] = [1 + 0j, 2 + 0j]
     assert np.array_equal(c['p1scale'], c['xscale'])
 
 
-def test_phase1_dtcal_legacy_alias_is_dtcal_circ():
+def test_dtcal_legacy_alias_is_dtcal_circ():
     assert ehc.DTCAL is ehc.DTCAL_CIRC
 
 
 # ----- Polrep / feed dispatch helpers --------------------------------------
 
-def test_phase1_feed_dtype_for_polrep():
+def test_feed_dtype_for_polrep():
     assert ehc.feed_dtype_for_polrep('stokes') is ehc.DTPOL_STOKES
     assert ehc.feed_dtype_for_polrep('circ') is ehc.DTPOL_CIRC
     assert ehc.feed_dtype_for_polrep('lin') is ehc.DTPOL_LIN
@@ -185,7 +181,7 @@ def test_phase1_feed_dtype_for_polrep():
         ehc.feed_dtype_for_polrep('bogus')
 
 
-def test_phase1_feed_poldict_circular_pair():
+def test_feed_poldict_circular_pair():
     d = ehc.feed_poldict('rl', 'rl')
     assert d['vis1'] == 'rrvis'
     assert d['vis2'] == 'llvis'
@@ -193,7 +189,7 @@ def test_phase1_feed_poldict_circular_pair():
     assert d['vis4'] == 'lrvis'
 
 
-def test_phase1_feed_poldict_linear_pair():
+def test_feed_poldict_linear_pair():
     d = ehc.feed_poldict('xy', 'xy')
     assert d['vis1'] == 'xxvis'
     assert d['vis2'] == 'yyvis'
@@ -201,7 +197,7 @@ def test_phase1_feed_poldict_linear_pair():
     assert d['vis4'] == 'yxvis'
 
 
-def test_phase1_feed_poldict_mixed_pair():
+def test_feed_poldict_mixed_pair():
     d = ehc.feed_poldict('rl', 'xy')
     assert d['vis1'] == 'rxvis'
     assert d['vis2'] == 'lyvis'
@@ -209,7 +205,7 @@ def test_phase1_feed_poldict_mixed_pair():
     assert d['vis4'] == 'lxvis'
 
 
-def test_phase1_feed_poldict_unknown_raises():
+def test_feed_poldict_unknown_raises():
     with pytest.raises(ValueError):
         ehc.feed_poldict('rl', '??')
     with pytest.raises(ValueError):
@@ -218,7 +214,7 @@ def test_phase1_feed_poldict_unknown_raises():
 
 # ----- Schema upgrade helpers ---------------------------------------------
 
-def test_phase1_upgrade_tarr_from_legacy():
+def test_upgrade_tarr_from_legacy():
     ot = np.zeros(2, dtype=_LEGACY_DTARR)
     ot['site'] = ['A', 'B']
     ot['sefdr'] = [1000., 2000.]
@@ -233,13 +229,13 @@ def test_phase1_upgrade_tarr_from_legacy():
     assert np.array_equal(nt['d_p1'], ot['dr'])
 
 
-def test_phase1_upgrade_tarr_idempotent():
+def test_upgrade_tarr_idempotent():
     a = np.zeros(1, dtype=ehc.DTARR)
     a['feed_type'] = 'rl'
     assert ehc.upgrade_tarr(a) is a
 
 
-def test_phase1_upgrade_dtpol_circ_zero_copy_view():
+def test_upgrade_dtpol_circ_zero_copy_view():
     od = np.zeros(3, dtype=_LEGACY_DTPOL_CIRC)
     od['rrvis'] = [1 + 0j, 2 + 0j, 3 + 0j]
     nd = ehc.upgrade_dtpol_circ(od)
@@ -250,13 +246,13 @@ def test_phase1_upgrade_dtpol_circ_zero_copy_view():
     assert np.array_equal(nd['p1p1vis'], od['rrvis'])
 
 
-def test_phase1_upgrade_dtpol_circ_idempotent():
+def test_upgrade_dtpol_circ_idempotent():
     d = np.zeros(1, dtype=ehc.DTPOL_CIRC)
     out = ehc.upgrade_dtpol_circ(d)
     assert out.dtype == d.dtype
 
 
-def test_phase1_upgrade_dtcal_circ_from_legacy_adds_dterm_fields():
+def test_upgrade_dtcal_circ_from_legacy_adds_dterm_fields():
     oc = np.zeros(2, dtype=_LEGACY_DTCAL)
     oc['rscale'] = [1 + 0j, 2 + 0j]
     nc = ehc.upgrade_dtcal_circ(oc)
@@ -269,20 +265,20 @@ def test_phase1_upgrade_dtcal_circ_from_legacy_adds_dterm_fields():
 
 # ----- End-to-end: Array / Obsdata / Caltable upgrade through __init__ ----
 
-def test_phase1_array_upgrades_legacy_tarr():
+def test_array_upgrades_legacy_tarr():
     arr = ea.Array(_legacy_tarr())
     assert 'feed_type' in arr.tarr.dtype.names
     assert np.all(arr.tarr['feed_type'] == 'rl')
 
 
-def test_phase1_array_pickle_roundtrip_from_new():
+def test_array_pickle_roundtrip_from_new():
     arr = ea.Array(_legacy_tarr())
     arr2 = pickle.loads(pickle.dumps(arr))
     assert np.all(arr2.tarr['feed_type'] == 'rl')
     assert np.array_equal(arr2.tarr['sefd_p1'], arr.tarr['sefd_p1'])
 
 
-def test_phase1_array_setstate_upgrades_legacy_pickle():
+def test_array_setstate_upgrades_legacy_pickle():
     # Simulate a pickle made before the schema migration:
     legacy_state = {'_tarr': _legacy_tarr(), 'ephem': {},
                     'tkey': {'A': 0, 'B': 1}}
@@ -292,7 +288,7 @@ def test_phase1_array_setstate_upgrades_legacy_pickle():
     assert np.all(arr.tarr['feed_type'] == 'rl')
 
 
-def test_phase1_obsdata_upgrades_legacy_datatable_and_tarr():
+def test_obsdata_upgrades_legacy_datatable_and_tarr():
     obs = eo.Obsdata(ra=0., dec=0., rf=230e9, bw=1e9,
                      datatable=_legacy_circ_datatable(),
                      tarr=_legacy_tarr(), polrep='circ')
@@ -303,7 +299,7 @@ def test_phase1_obsdata_upgrades_legacy_datatable_and_tarr():
     assert np.array_equal(obs.data['p1p1vis'], obs.data['rrvis'])
 
 
-def test_phase1_obsdata_pickle_roundtrip_legacy_recarrays():
+def test_obsdata_pickle_roundtrip_legacy_recarrays():
     obs = eo.Obsdata(ra=0., dec=0., rf=230e9, bw=1e9,
                      datatable=_legacy_circ_datatable(),
                      tarr=_legacy_tarr(), polrep='circ')
@@ -312,7 +308,7 @@ def test_phase1_obsdata_pickle_roundtrip_legacy_recarrays():
     assert np.array_equal(obs2.data['p1p1vis'], obs.data['rrvis'])
 
 
-def test_phase1_caltable_upgrades_legacy_dtcal():
+def test_caltable_upgrades_legacy_dtcal():
     oc = np.zeros(2, dtype=_LEGACY_DTCAL)
     oc['rscale'] = [1 + 0j, 1.1 + 0j]
     caltab = ec.Caltable(ra=0., dec=0., rf=230e9, bw=1e9,
@@ -324,7 +320,7 @@ def test_phase1_caltable_upgrades_legacy_dtcal():
         assert np.all(caltab.data[site]['dr'] == 0)
 
 
-def test_phase1_caltable_pickle_roundtrip_legacy_dtcal():
+def test_caltable_pickle_roundtrip_legacy_dtcal():
     oc = np.zeros(2, dtype=_LEGACY_DTCAL)
     oc['rscale'] = [1 + 0j, 1.1 + 0j]
     caltab = ec.Caltable(ra=0., dec=0., rf=230e9, bw=1e9,
@@ -336,10 +332,9 @@ def test_phase1_caltable_pickle_roundtrip_legacy_dtcal():
 
 
 # ============================================================================
-# Phase 2 — Array class migration
+# Array class migration
 # ============================================================================
 #
-# Plan reference: obsdata_mixedpol_plan_v2.md, "Phase 2".
 # Scope:
 #   - Array query methods: is_homogeneous_feeds, feed_types,
 #     sefd_for_feed, dterm_for_feed
@@ -375,74 +370,74 @@ def _xy_tarr():
 
 # ----- Array query methods --------------------------------------------------
 
-def test_phase2_is_homogeneous_feeds_legacy_array_true():
+def test_is_homogeneous_feeds_legacy_array_true():
     arr = ea.Array(_legacy_tarr())
     assert arr.is_homogeneous_feeds() is True
 
 
-def test_phase2_is_homogeneous_feeds_xy_array_true():
+def test_is_homogeneous_feeds_xy_array_true():
     arr = ea.Array(_xy_tarr())
     assert arr.is_homogeneous_feeds() is True
 
 
-def test_phase2_is_homogeneous_feeds_mixed_array_false():
+def test_is_homogeneous_feeds_mixed_array_false():
     arr = ea.Array(_mixed_tarr())
     assert arr.is_homogeneous_feeds() is False
 
 
-def test_phase2_feed_types_legacy_array():
+def test_feed_types_legacy_array():
     arr = ea.Array(_legacy_tarr())
     assert arr.feed_types() == {'rl'}
 
 
-def test_phase2_feed_types_mixed_array():
+def test_feed_types_mixed_array():
     arr = ea.Array(_mixed_tarr())
     assert arr.feed_types() == {'rl', 'xy'}
 
 
-def test_phase2_sefd_for_feed_rl_station_returns_p1_p2():
+def test_sefd_for_feed_rl_station_returns_p1_p2():
     arr = ea.Array(_mixed_tarr())
     assert arr.sefd_for_feed('APEX', 'R') == 4000.
     assert arr.sefd_for_feed('APEX', 'L') == 4100.
 
 
-def test_phase2_sefd_for_feed_xy_station_returns_p1_p2():
+def test_sefd_for_feed_xy_station_returns_p1_p2():
     arr = ea.Array(_mixed_tarr())
     assert arr.sefd_for_feed('ALMA', 'X') == 100.
     assert arr.sefd_for_feed('ALMA', 'Y') == 110.
 
 
-def test_phase2_sefd_for_feed_case_insensitive():
+def test_sefd_for_feed_case_insensitive():
     arr = ea.Array(_mixed_tarr())
     assert arr.sefd_for_feed('ALMA', 'x') == arr.sefd_for_feed('ALMA', 'X')
 
 
-def test_phase2_sefd_for_feed_wrong_feed_raises():
+def test_sefd_for_feed_wrong_feed_raises():
     arr = ea.Array(_mixed_tarr())
     # ALMA is 'xy'; asking for R should raise.
     with pytest.raises(ValueError, match="feed 'R' not in feed_type 'xy'"):
         arr.sefd_for_feed('ALMA', 'R')
 
 
-def test_phase2_sefd_for_feed_unknown_site_raises():
+def test_sefd_for_feed_unknown_site_raises():
     arr = ea.Array(_mixed_tarr())
     with pytest.raises(KeyError, match="site 'NOSITE' not in array"):
         arr.sefd_for_feed('NOSITE', 'R')
 
 
-def test_phase2_dterm_for_feed_rl_station_dispatch():
+def test_dterm_for_feed_rl_station_dispatch():
     arr = ea.Array(_mixed_tarr())
     assert arr.dterm_for_feed('APEX', 'R') == 0.03 + 0.04j
     assert arr.dterm_for_feed('APEX', 'L') == 0.07 + 0.08j
 
 
-def test_phase2_dterm_for_feed_xy_station_dispatch():
+def test_dterm_for_feed_xy_station_dispatch():
     arr = ea.Array(_mixed_tarr())
     assert arr.dterm_for_feed('ALMA', 'X') == 0.01 + 0.02j
     assert arr.dterm_for_feed('ALMA', 'Y') == 0.05 + 0.06j
 
 
-def test_phase2_dterm_for_feed_wrong_feed_raises():
+def test_dterm_for_feed_wrong_feed_raises():
     arr = ea.Array(_mixed_tarr())
     with pytest.raises(ValueError, match="not in feed_type"):
         arr.dterm_for_feed('APEX', 'X')
@@ -454,7 +449,7 @@ def _empty_array():
     return ea.Array(np.zeros(0, dtype=ehc.DTARR))
 
 
-def test_phase2_add_site_default_kwargs_bit_identical_to_legacy():
+def test_add_site_default_kwargs_bit_identical_to_legacy():
     arr = _empty_array().add_site('A', (1.0, 2.0, 3.0))
     row = arr.tarr[arr.tkey['A']]
     assert row['sefd_p1'] == 10000.0
@@ -464,7 +459,7 @@ def test_phase2_add_site_default_kwargs_bit_identical_to_legacy():
     assert str(row['feed_type']) == 'rl'
 
 
-def test_phase2_add_site_legacy_sefd_and_dr_dl_still_work():
+def test_add_site_legacy_sefd_and_dr_dl_still_work():
     arr = _empty_array().add_site('A', (1., 2., 3.),
                                   sefd=5000, dr=0.1 + 0.2j, dl=0.3 + 0.4j)
     row = arr.tarr[arr.tkey['A']]
@@ -475,7 +470,7 @@ def test_phase2_add_site_legacy_sefd_and_dr_dl_still_work():
     assert str(row['feed_type']) == 'rl'
 
 
-def test_phase2_add_site_with_feed_type_xy_and_generic_sefds():
+def test_add_site_with_feed_type_xy_and_generic_sefds():
     arr = _empty_array().add_site('A', (1., 2., 3.),
                                   feed_type='xy',
                                   sefd_p1=100., sefd_p2=110.,
@@ -488,50 +483,50 @@ def test_phase2_add_site_with_feed_type_xy_and_generic_sefds():
     assert row['d_p2'] == 0.02 + 0j
 
 
-def test_phase2_add_site_dr_with_non_rl_feed_raises():
+def test_add_site_dr_with_non_rl_feed_raises():
     with pytest.raises(ValueError, match="dr/dl kwargs are only valid"):
         _empty_array().add_site('A', (0., 0., 0.),
                                 feed_type='xy', dr=0.1 + 0j)
 
 
-def test_phase2_add_site_dl_with_non_rl_feed_raises():
+def test_add_site_dl_with_non_rl_feed_raises():
     with pytest.raises(ValueError, match="dr/dl kwargs are only valid"):
         _empty_array().add_site('A', (0., 0., 0.),
                                 feed_type='xy', dl=0.1 + 0j)
 
 
-def test_phase2_add_site_dr_and_d_p1_both_raises():
+def test_add_site_dr_and_d_p1_both_raises():
     with pytest.raises(ValueError, match="dr.*d_p1"):
         _empty_array().add_site('A', (0., 0., 0.),
                                 dr=0.1 + 0j, d_p1=0.2 + 0j)
 
 
-def test_phase2_add_site_dl_and_d_p2_both_raises():
+def test_add_site_dl_and_d_p2_both_raises():
     with pytest.raises(ValueError, match="dl.*d_p2"):
         _empty_array().add_site('A', (0., 0., 0.),
                                 dl=0.1 + 0j, d_p2=0.2 + 0j)
 
 
-def test_phase2_add_site_sefd_and_sefd_p1_both_raises():
+def test_add_site_sefd_and_sefd_p1_both_raises():
     with pytest.raises(ValueError, match="sefd.*sefd_p1"):
         _empty_array().add_site('A', (0., 0., 0.),
                                 sefd=5000, sefd_p1=100., sefd_p2=110.)
 
 
-def test_phase2_add_site_sefd_p1_without_p2_raises():
+def test_add_site_sefd_p1_without_p2_raises():
     with pytest.raises(ValueError, match="sefd_p1 and sefd_p2"):
         _empty_array().add_site('A', (0., 0., 0.),
                                 feed_type='xy', sefd_p1=100.)
 
 
-def test_phase2_add_site_invalid_feed_type_raises():
+def test_add_site_invalid_feed_type_raises():
     with pytest.raises(ValueError, match="feed_type must be one of"):
         _empty_array().add_site('A', (0., 0., 0.), feed_type='zz')
 
 
 # ----- add_satellite_* signature extension ----------------------------------
 
-def test_phase2_add_satellite_tle_default_feed_type_rl():
+def test_add_satellite_tle_default_feed_type_rl():
     tle = ['SAT1', 'line1', 'line2']
     arr = _empty_array().add_satellite_tle(tle, sefd=10000)
     row = arr.tarr[arr.tkey['SAT1']]
@@ -540,7 +535,7 @@ def test_phase2_add_satellite_tle_default_feed_type_rl():
     assert row['sefd_p2'] == 10000.0
 
 
-def test_phase2_add_satellite_tle_with_feed_type_xy():
+def test_add_satellite_tle_with_feed_type_xy():
     tle = ['SAT1', 'line1', 'line2']
     arr = _empty_array().add_satellite_tle(tle, feed_type='xy',
                                             sefd_p1=500., sefd_p2=600.)
@@ -550,14 +545,14 @@ def test_phase2_add_satellite_tle_with_feed_type_xy():
     assert row['sefd_p2'] == 600.0
 
 
-def test_phase2_add_satellite_elements_default_feed_type_rl():
+def test_add_satellite_elements_default_feed_type_rl():
     arr = _empty_array().add_satellite_elements('SAT2', sefd=2000)
     row = arr.tarr[arr.tkey['SAT2']]
     assert str(row['feed_type']) == 'rl'
     assert row['sefd_p1'] == 2000.0
 
 
-def test_phase2_add_satellite_elements_with_feed_type_xy_and_dterms():
+def test_add_satellite_elements_with_feed_type_xy_and_dterms():
     arr = _empty_array().add_satellite_elements('SAT2', feed_type='xy',
                                                  sefd_p1=300., sefd_p2=400.,
                                                  d_p1=0.05 + 0.01j,
@@ -570,7 +565,7 @@ def test_phase2_add_satellite_elements_with_feed_type_xy_and_dterms():
     assert row['d_p2'] == 0.06 + 0.02j
 
 
-def test_phase2_add_satellite_tle_invalid_feed_type_raises():
+def test_add_satellite_tle_invalid_feed_type_raises():
     tle = ['SAT1', 'line1', 'line2']
     with pytest.raises(ValueError, match="feed_type must be one of"):
         _empty_array().add_satellite_tle(tle, feed_type='qq')
@@ -578,63 +573,63 @@ def test_phase2_add_satellite_tle_invalid_feed_type_raises():
 
 # ----- TarrView wrapper -----------------------------------------------------
 
-def test_phase2_tarrview_is_returned_by_tarr_property():
+def test_tarrview_is_returned_by_tarr_property():
     arr = ea.Array(_legacy_tarr())
     assert isinstance(arr.tarr, ea.TarrView)
 
 
-def test_phase2_tarrview_sefdr_on_homogeneous_rl_works():
+def test_tarrview_sefdr_on_homogeneous_rl_works():
     arr = ea.Array(_legacy_tarr())
     # Legacy title-alias access still works on an all-RL array.
     np.testing.assert_array_equal(arr.tarr['sefdr'], [1000., 2000.])
     np.testing.assert_array_equal(arr.tarr['sefdl'], [1100., 2100.])
 
 
-def test_phase2_tarrview_sefdr_on_xy_array_raises():
+def test_tarrview_sefdr_on_xy_array_raises():
     arr = ea.Array(_xy_tarr())
     with pytest.raises(KeyError, match=r"tarr\['sefdr'\].*xy"):
         _ = arr.tarr['sefdr']
 
 
-def test_phase2_tarrview_sefdl_on_xy_array_raises():
+def test_tarrview_sefdl_on_xy_array_raises():
     arr = ea.Array(_xy_tarr())
     with pytest.raises(KeyError, match=r"tarr\['sefdl'\].*xy"):
         _ = arr.tarr['sefdl']
 
 
-def test_phase2_tarrview_sefdr_on_mixed_array_raises():
+def test_tarrview_sefdr_on_mixed_array_raises():
     arr = ea.Array(_mixed_tarr())
     with pytest.raises(KeyError, match=r"tarr\['sefdr'\].*"):
         _ = arr.tarr['sefdr']
 
 
-def test_phase2_tarrview_dr_on_mixed_array_raises():
+def test_tarrview_dr_on_mixed_array_raises():
     arr = ea.Array(_mixed_tarr())
     with pytest.raises(KeyError, match="dterm_for_feed"):
         _ = arr.tarr['dr']
 
 
-def test_phase2_tarrview_generic_names_always_work():
+def test_tarrview_generic_names_always_work():
     # Generic per-feed names are never guarded.
     arr = ea.Array(_mixed_tarr())
     np.testing.assert_array_equal(arr.tarr['sefd_p1'], [100., 4000.])
     np.testing.assert_array_equal(arr.tarr['sefd_p2'], [110., 4100.])
 
 
-def test_phase2_tarrview_dtype_attribute_forwarded():
+def test_tarrview_dtype_attribute_forwarded():
     arr = ea.Array(_legacy_tarr())
     assert 'feed_type' in arr.tarr.dtype.names
     assert arr.tarr.dtype == ehc.DTARR
 
 
-def test_phase2_tarrview_len_iter_forwarded():
+def test_tarrview_len_iter_forwarded():
     arr = ea.Array(_legacy_tarr())
     assert len(arr.tarr) == 2
     sites = [str(row['site']) for row in arr.tarr]
     assert sites == ['A', 'B']
 
 
-def test_phase2_tarrview_row_index_returns_void():
+def test_tarrview_row_index_returns_void():
     arr = ea.Array(_legacy_tarr())
     row = arr.tarr[0]
     # Single-row index returns a numpy void; field access on it bypasses
@@ -642,7 +637,7 @@ def test_phase2_tarrview_row_index_returns_void():
     assert str(row['site']) == 'A'
 
 
-def test_phase2_tarrview_boolean_mask_returns_wrapped_view():
+def test_tarrview_boolean_mask_returns_wrapped_view():
     arr = ea.Array(_mixed_tarr())
     mask = np.array([True, False])
     sub = arr.tarr[mask]
@@ -651,7 +646,7 @@ def test_phase2_tarrview_boolean_mask_returns_wrapped_view():
     assert str(sub[0]['site']) == 'ALMA'
 
 
-def test_phase2_tarrview_boolean_mask_preserves_guard():
+def test_tarrview_boolean_mask_preserves_guard():
     # Slicing a mixed array down to one xy station: legacy 'sefdr'
     # still raises on the subview (feed_types still non-RL).
     arr = ea.Array(_mixed_tarr())
@@ -660,27 +655,27 @@ def test_phase2_tarrview_boolean_mask_preserves_guard():
         _ = sub['sefdr']
 
 
-def test_phase2_tarrview_equality_recarray_lhs():
+def test_tarrview_equality_recarray_lhs():
     arr = ea.Array(_legacy_tarr())
     raw = arr.tarr._tarr.copy()
     cmp = raw == arr.tarr
     assert np.all(cmp)
 
 
-def test_phase2_tarrview_equality_recarray_rhs():
+def test_tarrview_equality_recarray_rhs():
     arr = ea.Array(_legacy_tarr())
     raw = arr.tarr._tarr.copy()
     cmp = arr.tarr == raw
     assert np.all(cmp)
 
 
-def test_phase2_tarrview_equality_both_views():
+def test_tarrview_equality_both_views():
     arr1 = ea.Array(_legacy_tarr())
     arr2 = ea.Array(_legacy_tarr())
     assert np.all(arr1.tarr == arr2.tarr)
 
 
-def test_phase2_tarrview_pickle_roundtrip():
+def test_tarrview_pickle_roundtrip():
     arr = ea.Array(_legacy_tarr())
     view = arr.tarr
     view2 = pickle.loads(pickle.dumps(view))
@@ -688,13 +683,13 @@ def test_phase2_tarrview_pickle_roundtrip():
     assert np.all(view == view2)
 
 
-def test_phase2_tarrview_unhashable():
+def test_tarrview_unhashable():
     arr = ea.Array(_legacy_tarr())
     with pytest.raises(TypeError):
         hash(arr.tarr)
 
 
-def test_phase2_tarrview_numpy_interop_via_array_protocol():
+def test_tarrview_numpy_interop_via_array_protocol():
     arr = ea.Array(_legacy_tarr())
     # np.asarray should produce a recarray view (no copy required by spec).
     asarr = np.asarray(arr.tarr)
@@ -702,7 +697,7 @@ def test_phase2_tarrview_numpy_interop_via_array_protocol():
     assert asarr.dtype.names == arr.tarr.dtype.names
 
 
-def test_phase2_tarrview_setter_unwraps_view():
+def test_tarrview_setter_unwraps_view():
     # Assigning a TarrView via the property setter unwraps it so _tarr
     # remains a plain ndarray (the storage truth).
     arr = ea.Array(_legacy_tarr())
@@ -713,7 +708,7 @@ def test_phase2_tarrview_setter_unwraps_view():
     assert arr._tarr.dtype.names is not None  # structured dtype preserved
 
 
-def test_phase2_tarrview_array_pickle_roundtrip_preserves_ndarray_storage():
+def test_tarrview_array_pickle_roundtrip_preserves_ndarray_storage():
     # The Array itself round-trips through pickle: storage stays as an
     # ndarray (not a TarrView), so the on-disk format is unchanged.
     arr = ea.Array(_legacy_tarr())
@@ -757,62 +752,62 @@ def _obs_kwargs():
                 tint=60.0, tadv=600.0, tstart=0.0, tstop=24.0)
 
 
-def test_phase2_obsdata_polrep_invalid_raises():
+def test_obsdata_polrep_invalid_raises():
     arr = ea.Array(_eht_like_rl_array())
     with pytest.raises(ValueError, match="polrep must be one of"):
         arr.obsdata(polrep='bogus', **_obs_kwargs())
 
 
-def test_phase2_obsdata_polrep_stokes_on_rl_array_succeeds():
+def test_obsdata_polrep_stokes_on_rl_array_succeeds():
     arr = ea.Array(_eht_like_rl_array())
     obs = arr.obsdata(polrep='stokes', **_obs_kwargs())
     assert obs.polrep == 'stokes'
 
 
-def test_phase2_obsdata_polrep_circ_on_rl_array_succeeds():
+def test_obsdata_polrep_circ_on_rl_array_succeeds():
     arr = ea.Array(_eht_like_rl_array())
     obs = arr.obsdata(polrep='circ', **_obs_kwargs())
     assert obs.polrep == 'circ'
 
 
-def test_phase2_obsdata_polrep_circ_on_xy_array_raises():
+def test_obsdata_polrep_circ_on_xy_array_raises():
     arr = ea.Array(_eht_like_xy_array())
     with pytest.raises(ValueError,
                        match="polrep='circ' requires all stations.*'rl'"):
         arr.obsdata(polrep='circ', **_obs_kwargs())
 
 
-def test_phase2_obsdata_polrep_circ_on_mixed_array_raises():
+def test_obsdata_polrep_circ_on_mixed_array_raises():
     arr = ea.Array(_eht_like_mixed_array())
     with pytest.raises(ValueError, match="polrep='circ'"):
         arr.obsdata(polrep='circ', **_obs_kwargs())
 
 
-def test_phase2_obsdata_polrep_lin_on_rl_array_raises():
+def test_obsdata_polrep_lin_on_rl_array_raises():
     arr = ea.Array(_eht_like_rl_array())
     with pytest.raises(ValueError,
                        match="polrep='lin' requires all stations.*'xy'"):
         arr.obsdata(polrep='lin', **_obs_kwargs())
 
 
-def test_phase2_obsdata_polrep_lin_on_xy_array_raises_not_implemented():
+def test_obsdata_polrep_lin_on_xy_array_raises_not_implemented():
     # Validation passes (all xy) but simulation backend doesn't support
     # 'lin' yet — should raise NotImplementedError pointing to Phase 5.
     arr = ea.Array(_eht_like_xy_array())
-    with pytest.raises(NotImplementedError, match="Phase 5"):
+    with pytest.raises(NotImplementedError, match="is not yet supported"):
         arr.obsdata(polrep='lin', **_obs_kwargs())
 
 
-def test_phase2_obsdata_polrep_mixed_on_homogeneous_array_raises():
+def test_obsdata_polrep_mixed_on_homogeneous_array_raises():
     arr = ea.Array(_eht_like_rl_array())
     with pytest.raises(ValueError,
                        match="polrep='mixed' requires at least two"):
         arr.obsdata(polrep='mixed', **_obs_kwargs())
 
 
-def test_phase2_obsdata_polrep_mixed_on_mixed_array_raises_not_implemented():
+def test_obsdata_polrep_mixed_on_mixed_array_raises_not_implemented():
     arr = ea.Array(_eht_like_mixed_array())
-    with pytest.raises(NotImplementedError, match="Phase 5"):
+    with pytest.raises(NotImplementedError, match="is not yet supported"):
         arr.obsdata(polrep='mixed', **_obs_kwargs())
 
 
@@ -858,7 +853,7 @@ def _assert_tarr_round_trip(arr_before, arr_after, atol_sefd=1e-2,
     np.testing.assert_allclose(a['fr_off'], b['fr_off'], atol=atol_fr)
 
 
-def test_phase2_save_array_txt_emits_v2_header(tmp_path):
+def test_save_array_txt_emits_v2_header(tmp_path):
     arr = ea.Array(_full_tarr(['rl', 'rl']))
     fname = str(tmp_path / 'a.txt')
     arr.save_txt(fname)
@@ -867,7 +862,7 @@ def test_phase2_save_array_txt_emits_v2_header(tmp_path):
     assert first == '# ehtim array format v2'
 
 
-def test_phase2_save_load_array_txt_roundtrip_rl(tmp_path):
+def test_save_load_array_txt_roundtrip_rl(tmp_path):
     arr = ea.Array(_full_tarr(['rl', 'rl']))
     fname = str(tmp_path / 'a.txt')
     arr.save_txt(fname)
@@ -876,7 +871,7 @@ def test_phase2_save_load_array_txt_roundtrip_rl(tmp_path):
     assert set(arr2.feed_types()) == {'rl'}
 
 
-def test_phase2_save_load_array_txt_roundtrip_xy(tmp_path):
+def test_save_load_array_txt_roundtrip_xy(tmp_path):
     arr = ea.Array(_full_tarr(['xy', 'xy', 'xy']))
     fname = str(tmp_path / 'a.txt')
     arr.save_txt(fname)
@@ -885,7 +880,7 @@ def test_phase2_save_load_array_txt_roundtrip_xy(tmp_path):
     assert set(arr2.feed_types()) == {'xy'}
 
 
-def test_phase2_save_load_array_txt_roundtrip_mixed(tmp_path):
+def test_save_load_array_txt_roundtrip_mixed(tmp_path):
     arr = ea.Array(_full_tarr(['rl', 'xy', 'lx']))
     fname = str(tmp_path / 'a.txt')
     arr.save_txt(fname)
@@ -902,10 +897,10 @@ _LEGACY_ARRAY_FILES = sorted([
 
 
 @pytest.mark.parametrize('fname', _LEGACY_ARRAY_FILES)
-def test_phase2_load_array_txt_legacy_bit_identical(fname):
+def test_load_array_txt_legacy_bit_identical(fname):
     """For every existing arrays/*.txt file, the loaded tarr's numeric
     columns match a fresh np.loadtxt read of the same file byte-for-byte
-    (Phase 1 added a feed_type column; nothing else may differ).
+    (mixpol added a feed_type column; nothing else may differ).
     """
     path = os.path.join(ARRAYS_DIR, fname)
     # SITES.txt is a non-array reference file (site name → code table).
@@ -967,7 +962,7 @@ def test_phase2_load_array_txt_legacy_bit_identical(fname):
 
 # ----- save_obs_txt / load_obs_txt embedded-tarr round-trip -----------------
 
-def test_phase2_save_load_obs_txt_embedded_tarr_with_feed_type(tmp_path):
+def test_save_load_obs_txt_embedded_tarr_with_feed_type(tmp_path):
     """The obs.txt embedded tarr block now emits feed_type; round-trip
     must preserve it for non-trivial values."""
     tarr = _full_tarr(['rl', 'xy', 'lx'])
@@ -990,13 +985,13 @@ def test_phase2_save_load_obs_txt_embedded_tarr_with_feed_type(tmp_path):
 
 
 # ============================================================================
-# Phase 4a — Obsdata polrep enum + dtype dispatch
+# Obsdata polrep enum + dtype dispatch
 # ============================================================================
 
 
 # ----- Helpers --------------------------------------------------------------
 
-def _phase4a_tarr(feed_types, sites=None):
+def _tarr(feed_types, sites=None):
     """Minimal valid tarr with the given feed_type list (one per station)."""
     n = len(feed_types)
     if sites is None:
@@ -1007,7 +1002,7 @@ def _phase4a_tarr(feed_types, sites=None):
     return t
 
 
-def _phase4a_lin_data(t1s, t2s, times=None):
+def _lin_data(t1s, t2s, times=None):
     """DTPOL_LIN datatable with non-trivial visibility values."""
     n = len(t1s)
     d = np.zeros(n, dtype=ehc.DTPOL_LIN)
@@ -1027,7 +1022,7 @@ def _phase4a_lin_data(t1s, t2s, times=None):
     return d
 
 
-def _phase4a_mixed_data(t1s, t2s, times=None):
+def _mixed_data(t1s, t2s, times=None):
     """DTPOL_MIXED datatable; polbasis is left empty (populated in __init__)."""
     n = len(t1s)
     d = np.zeros(n, dtype=ehc.DTPOL_MIXED)
@@ -1047,26 +1042,26 @@ def _phase4a_mixed_data(t1s, t2s, times=None):
     return d
 
 
-def _phase4a_lin_obs(t1s=('S0',), t2s=('S1',)):
+def _lin_obs(t1s=('S0',), t2s=('S1',)):
     return eo.Obsdata(0., 0., 230e9, 1e9,
-                      _phase4a_lin_data(list(t1s), list(t2s)),
-                      _phase4a_tarr(['xy', 'xy']),
+                      _lin_data(list(t1s), list(t2s)),
+                      _tarr(['xy', 'xy']),
                       polrep='lin')
 
 
-def _phase4a_mixed_obs():
+def _mixed_obs():
     """3-station mixed array: S0/S1 are 'rl', S2 is 'xy'. 3 baselines."""
     return eo.Obsdata(0., 0., 230e9, 1e9,
-                      _phase4a_mixed_data(['S0', 'S0', 'S1'],
+                      _mixed_data(['S0', 'S0', 'S1'],
                                           ['S1', 'S2', 'S2']),
-                      _phase4a_tarr(['rl', 'rl', 'xy']),
+                      _tarr(['rl', 'rl', 'xy']),
                       polrep='mixed')
 
 
 # ----- Construction & validation --------------------------------------------
 
-def test_phase4a_init_lin_from_synthetic_table():
-    obs = _phase4a_lin_obs()
+def test_init_lin_from_synthetic_table():
+    obs = _lin_obs()
     assert obs.polrep == 'lin'
     assert obs.poltype is ehc.DTPOL_LIN
     assert obs.poldict is ehc.POLDICT_LIN
@@ -1074,8 +1069,8 @@ def test_phase4a_init_lin_from_synthetic_table():
     np.testing.assert_array_equal(obs.data['p2p1vis'], obs.data['yxvis'])
 
 
-def test_phase4a_init_mixed_from_synthetic_table():
-    obs = _phase4a_mixed_obs()
+def test_init_mixed_from_synthetic_table():
+    obs = _mixed_obs()
     assert obs.polrep == 'mixed'
     assert obs.poltype is ehc.DTPOL_MIXED
     assert obs.poldict is ehc.POLDICT_MIXED
@@ -1084,75 +1079,75 @@ def test_phase4a_init_mixed_from_synthetic_table():
     assert set(obs.data['polbasis']) == {'rlrl', 'rlxy'}
 
 
-def test_phase4a_init_circ_warns_on_non_rl_tarr():
+def test_init_circ_warns_on_non_rl_tarr():
     d = np.zeros(1, dtype=ehc.DTPOL_CIRC)
     d['t1'] = 'S0'
     d['t2'] = 'S1'
-    tarr = _phase4a_tarr(['rl', 'xy'])
+    tarr = _tarr(['rl', 'xy'])
     with pytest.warns(UserWarning, match="polrep='circ' Obsdata constructed on a tarr"):
         eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='circ')
 
 
-def test_phase4a_init_lin_warns_on_non_xy_tarr():
-    d = _phase4a_lin_data(['S0'], ['S1'])
-    tarr = _phase4a_tarr(['rl', 'rl'])
+def test_init_lin_warns_on_non_xy_tarr():
+    d = _lin_data(['S0'], ['S1'])
+    tarr = _tarr(['rl', 'rl'])
     with pytest.warns(UserWarning, match="polrep='lin' Obsdata constructed on a tarr"):
         eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='lin')
 
 
-def test_phase4a_init_mixed_rejects_homogeneous_tarr():
-    d = _phase4a_mixed_data(['S0'], ['S1'])
-    tarr = _phase4a_tarr(['rl', 'rl'])
+def test_init_mixed_rejects_homogeneous_tarr():
+    d = _mixed_data(['S0'], ['S1'])
+    tarr = _tarr(['rl', 'rl'])
     with pytest.raises(ValueError, match="polrep='mixed' requires at least two distinct feed types"):
         eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='mixed')
 
 
-def test_phase4a_init_rejects_unset_feed_type_qq():
+def test_init_rejects_unset_feed_type_qq():
     d = np.zeros(1, dtype=ehc.DTPOL_STOKES)
     d['t1'] = 'S0'
     d['t2'] = 'S1'
-    tarr = _phase4a_tarr(['??', '??'])
+    tarr = _tarr(['??', '??'])
     with pytest.raises(ValueError, match="unset feed_type='\\?\\?'"):
         eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='stokes')
 
 
-def test_phase4a_init_rejects_unknown_feed_type():
+def test_init_rejects_unknown_feed_type():
     d = np.zeros(1, dtype=ehc.DTPOL_STOKES)
     d['t1'] = 'S0'
     d['t2'] = 'S1'
-    tarr = _phase4a_tarr(['rl', 'zz'])
+    tarr = _tarr(['rl', 'zz'])
     with pytest.raises(ValueError, match="unknown feed_type"):
         eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='stokes')
 
 
-def test_phase4a_init_mixed_rejects_missing_station():
-    d = _phase4a_mixed_data(['SX'], ['S1'])
-    tarr = _phase4a_tarr(['rl', 'xy'])
+def test_init_mixed_rejects_missing_station():
+    d = _mixed_data(['SX'], ['S1'])
+    tarr = _tarr(['rl', 'xy'])
     with pytest.raises(ValueError, match="data references stations not in tarr"):
         eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='mixed')
 
 
-def test_phase4a_dtype_polrep_mismatch_raises():
+def test_dtype_polrep_mismatch_raises():
     d = np.zeros(1, dtype=ehc.DTPOL_STOKES)
     d['t1'] = 'S0'
     d['t2'] = 'S1'
-    tarr = _phase4a_tarr(['xy', 'xy'])
+    tarr = _tarr(['xy', 'xy'])
     with pytest.raises(Exception, match="does not match polrep='lin'"):
         eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='lin')
 
 
 # ----- Round-trip & query methods -------------------------------------------
 
-def test_phase4a_copy_roundtrip_lin():
-    obs = _phase4a_lin_obs()
+def test_copy_roundtrip_lin():
+    obs = _lin_obs()
     other = obs.copy()
     assert other.polrep == 'lin'
     assert other.poltype == ehc.DTPOL_LIN
     np.testing.assert_array_equal(other.data['xxvis'], obs.data['xxvis'])
 
 
-def test_phase4a_copy_roundtrip_mixed():
-    obs = _phase4a_mixed_obs()
+def test_copy_roundtrip_mixed():
+    obs = _mixed_obs()
     other = obs.copy()
     assert other.polrep == 'mixed'
     assert other.poltype == ehc.DTPOL_MIXED
@@ -1160,11 +1155,11 @@ def test_phase4a_copy_roundtrip_mixed():
     np.testing.assert_array_equal(other.data['p1p1vis'], obs.data['p1p1vis'])
 
 
-def test_phase4a_tlist_bllist_lin():
+def test_tlist_bllist_lin():
     obs = eo.Obsdata(0., 0., 230e9, 1e9,
-                     _phase4a_lin_data(['S0', 'S0'], ['S1', 'S1'],
+                     _lin_data(['S0', 'S0'], ['S1', 'S1'],
                                        times=[0.0, 1.0]),
-                     _phase4a_tarr(['xy', 'xy']),
+                     _tarr(['xy', 'xy']),
                      polrep='lin')
     tl = obs.tlist()
     bl = obs.bllist()
@@ -1172,32 +1167,32 @@ def test_phase4a_tlist_bllist_lin():
     assert len(bl) == 1
 
 
-def test_phase4a_tlist_bllist_mixed():
-    obs = _phase4a_mixed_obs()
+def test_tlist_bllist_mixed():
+    obs = _mixed_obs()
     tl = obs.tlist()
     bl = obs.bllist()
     assert len(tl) == 1
     assert len(bl) == 3
 
 
-def test_phase4a_flag_uvdist_lin():
-    obs = _phase4a_lin_obs()
+def test_flag_uvdist_lin():
+    obs = _lin_obs()
     kept = obs.flag_uvdist(uv_min=0., uv_max=1e20)
     assert len(kept.data) == len(obs.data)
 
 
-def test_phase4a_flag_sites_mixed():
-    obs = _phase4a_mixed_obs()
+def test_flag_sites_mixed():
+    obs = _mixed_obs()
     kept = obs.flag_sites(['S2'])
     assert 'S2' not in set(kept.data['t1']) | set(kept.data['t2'])
 
 
 # ----- reorder_baselines ----------------------------------------------------
 
-def test_phase4a_reorder_baselines_lin_swap():
+def test_reorder_baselines_lin_swap():
     # t1=S1, t2=S0 is reversed; reorder swaps and applies LIN conj/cross-swap.
-    d = _phase4a_lin_data(['S1'], ['S0'])
-    obs = eo.Obsdata(0., 0., 230e9, 1e9, d, _phase4a_tarr(['xy', 'xy']),
+    d = _lin_data(['S1'], ['S0'])
+    obs = eo.Obsdata(0., 0., 230e9, 1e9, d, _tarr(['xy', 'xy']),
                      polrep='lin')
     row = obs.data[0]
     assert row['t1'] == 'S0'
@@ -1212,11 +1207,11 @@ def test_phase4a_reorder_baselines_lin_swap():
     assert row['yxsigma'] == 0.3
 
 
-def test_phase4a_reorder_baselines_mixed_swap_and_polbasis_flip():
+def test_reorder_baselines_mixed_swap_and_polbasis_flip():
     # t1=S1 (xy), t2=S0 (rl); reorder swaps and flips polbasis 'xyrl' -> 'rlxy'.
-    d = _phase4a_mixed_data(['S1'], ['S0'])
+    d = _mixed_data(['S1'], ['S0'])
     obs = eo.Obsdata(0., 0., 230e9, 1e9, d,
-                     _phase4a_tarr(['rl', 'xy']),
+                     _tarr(['rl', 'xy']),
                      polrep='mixed')
     row = obs.data[0]
     assert row['t1'] == 'S0'
@@ -1233,34 +1228,34 @@ def test_phase4a_reorder_baselines_mixed_swap_and_polbasis_flip():
 
 # ----- avg_coherent / avg_incoherent guards ---------------------------------
 
-def test_phase4a_avg_coherent_lin_raises():
-    obs = _phase4a_lin_obs()
+def test_avg_coherent_lin_raises():
+    obs = _lin_obs()
     with pytest.raises(NotImplementedError, match="not yet supported on polrep='lin'"):
         obs.avg_coherent(60.0)
 
 
-def test_phase4a_avg_coherent_mixed_raises():
-    obs = _phase4a_mixed_obs()
+def test_avg_coherent_mixed_raises():
+    obs = _mixed_obs()
     with pytest.raises(NotImplementedError, match="not yet supported on polrep='mixed'"):
         obs.avg_coherent(60.0)
 
 
-def test_phase4a_avg_incoherent_lin_raises():
-    obs = _phase4a_lin_obs()
+def test_avg_incoherent_lin_raises():
+    obs = _lin_obs()
     with pytest.raises(NotImplementedError, match="not yet supported on polrep='lin'"):
         obs.avg_incoherent(60.0)
 
 
-def test_phase4a_avg_incoherent_mixed_raises():
-    obs = _phase4a_mixed_obs()
+def test_avg_incoherent_mixed_raises():
+    obs = _mixed_obs()
     with pytest.raises(NotImplementedError, match="not yet supported on polrep='mixed'"):
         obs.avg_incoherent(60.0)
 
 
 # ----- dirtyimage -----------------------------------------------------------
 
-def test_phase4a_dirtyimage_mixed_raises():
-    obs = _phase4a_mixed_obs()
+def test_dirtyimage_mixed_raises():
+    obs = _mixed_obs()
     with pytest.raises(NotImplementedError, match="dirtyimage is not supported on polrep='mixed'"):
         obs.dirtyimage(npix=8, fov=1e-6)
 
@@ -1271,15 +1266,15 @@ def test_phase4a_dirtyimage_mixed_raises():
 
 
 # ============================================================================
-# Phase 4b — Obsdata.switch_polrep extensions
+#  Obsdata.switch_polrep extensions
 # ============================================================================
 
 
 # ----- Helpers --------------------------------------------------------------
 
-def _phase4b_stokes_obs(tarr_feeds=('rl', 'rl'), with_nan_v=False):
+def _stokes_obs(tarr_feeds=('rl', 'rl'), with_nan_v=False):
     """Stokes Obsdata on a 2-station tarr with the given feed_types."""
-    tarr = _phase4a_tarr(list(tarr_feeds))
+    tarr = _tarr(list(tarr_feeds))
     d = np.zeros(2, dtype=ehc.DTPOL_STOKES)
     d['time'] = [0.0, 0.5]
     d['t1'] = ['S0', 'S0']
@@ -1297,14 +1292,14 @@ def _phase4b_stokes_obs(tarr_feeds=('rl', 'rl'), with_nan_v=False):
     return eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='stokes')
 
 
-def _phase4b_circ_obs():
+def _circ_obs():
     """A non-trivial circ Obsdata on an rl tarr."""
-    return _phase4b_stokes_obs().switch_polrep('circ')
+    return _stokes_obs().switch_polrep('circ')
 
 
-def _phase4b_lin_obs(with_nan_xx=False):
+def _lin_obs(with_nan_xx=False):
     """A non-trivial lin Obsdata on an xy tarr (built from stokes)."""
-    obs_s = _phase4b_stokes_obs(tarr_feeds=('xy', 'xy'))
+    obs_s = _stokes_obs(tarr_feeds=('xy', 'xy'))
     obs_l = obs_s.switch_polrep('lin', singlepol_hand='X')
     if with_nan_xx:
         obs_l.data['xxvis'] = np.nan
@@ -1313,16 +1308,16 @@ def _phase4b_lin_obs(with_nan_xx=False):
 
 # ----- Direct lin <-> stokes round-trips ------------------------------------
 
-def test_phase4b_switch_polrep_lin_stokes_lin_roundtrip():
-    obs = _phase4b_lin_obs()
+def test_switch_polrep_lin_stokes_lin_roundtrip():
+    obs = _lin_obs()
     rt = obs.switch_polrep('stokes').switch_polrep('lin', singlepol_hand='X')
     for f in ('xxvis', 'yyvis', 'xyvis', 'yxvis'):
         np.testing.assert_allclose(rt.data[f], obs.data[f], atol=1e-12)
 
 
-def test_phase4b_switch_polrep_cross_convention_check():
+def test_switch_polrep_cross_convention_check():
     """Build matched circ + lin obs from the same Stokes; both -> stokes match."""
-    obs_s = _phase4b_stokes_obs()
+    obs_s = _stokes_obs()
     obs_c = obs_s.switch_polrep('circ')
     obs_l = obs_s.switch_polrep('lin', singlepol_hand='X')
     s_from_c = obs_c.switch_polrep('stokes')
@@ -1333,24 +1328,24 @@ def test_phase4b_switch_polrep_cross_convention_check():
 
 # ----- circ <-> lin composition ---------------------------------------------
 
-def test_phase4b_switch_polrep_circ_to_lin_equals_explicit():
-    obs_c = _phase4b_circ_obs()
+def test_switch_polrep_circ_to_lin_equals_explicit():
+    obs_c = _circ_obs()
     composed = obs_c.switch_polrep('lin', singlepol_hand='X')
     explicit = obs_c.switch_polrep('stokes').switch_polrep('lin', singlepol_hand='X')
     for f in ('xxvis', 'yyvis', 'xyvis', 'yxvis'):
         np.testing.assert_allclose(composed.data[f], explicit.data[f], atol=1e-12)
 
 
-def test_phase4b_switch_polrep_lin_to_circ_equals_explicit():
-    obs_l = _phase4b_lin_obs()
+def test_switch_polrep_lin_to_circ_equals_explicit():
+    obs_l = _lin_obs()
     composed = obs_l.switch_polrep('circ', singlepol_hand='R')
     explicit = obs_l.switch_polrep('stokes').switch_polrep('circ', singlepol_hand='R')
     for f in ('rrvis', 'llvis', 'rlvis', 'lrvis'):
         np.testing.assert_allclose(composed.data[f], explicit.data[f], atol=1e-12)
 
 
-def test_phase4b_switch_polrep_circ_lin_circ_roundtrip():
-    obs_c = _phase4b_circ_obs()
+def test_switch_polrep_circ_lin_circ_roundtrip():
+    obs_c = _circ_obs()
     rt = obs_c.switch_polrep('lin', singlepol_hand='X').switch_polrep('circ', singlepol_hand='R')
     for f in ('rrvis', 'llvis', 'rlvis', 'lrvis'):
         np.testing.assert_allclose(rt.data[f], obs_c.data[f], atol=1e-12)
@@ -1358,14 +1353,14 @@ def test_phase4b_switch_polrep_circ_lin_circ_roundtrip():
 
 # ----- Mixed source / invalid output ----------------------------------------
 
-def test_phase4b_switch_polrep_mixed_source_raises():
-    obs_m = _phase4a_mixed_obs()
+def test_switch_polrep_mixed_source_raises():
+    obs_m = _mixed_obs()
     with pytest.raises(NotImplementedError, match="polrep='mixed' is not yet implemented"):
         obs_m.switch_polrep('stokes')
 
 
-def test_phase4b_switch_polrep_invalid_output_raises():
-    obs_c = _phase4b_circ_obs()
+def test_switch_polrep_invalid_output_raises():
+    obs_c = _circ_obs()
     with pytest.raises(Exception, match="polrep_out must be"):
         obs_c.switch_polrep('mixed')
     with pytest.raises(Exception, match="polrep_out must be"):
@@ -1374,8 +1369,8 @@ def test_phase4b_switch_polrep_invalid_output_raises():
 
 # ----- allow_singlepol on lin -> stokes -------------------------------------
 
-def test_phase4b_switch_polrep_allow_singlepol_lin_to_stokes_fills_xx_with_yy():
-    obs = _phase4b_lin_obs(with_nan_xx=True)
+def test_switch_polrep_allow_singlepol_lin_to_stokes_fills_xx_with_yy():
+    obs = _lin_obs(with_nan_xx=True)
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
         out = obs.switch_polrep('stokes', allow_singlepol=True)
@@ -1383,8 +1378,8 @@ def test_phase4b_switch_polrep_allow_singlepol_lin_to_stokes_fills_xx_with_yy():
     np.testing.assert_allclose(out.data['vis'], obs.data['yyvis'], atol=1e-12)
 
 
-def test_phase4b_switch_polrep_allow_singlepol_false_leaves_nan():
-    obs = _phase4b_lin_obs(with_nan_xx=True)
+def test_switch_polrep_allow_singlepol_false_leaves_nan():
+    obs = _lin_obs(with_nan_xx=True)
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
         out = obs.switch_polrep('stokes', allow_singlepol=False)
@@ -1393,22 +1388,22 @@ def test_phase4b_switch_polrep_allow_singlepol_false_leaves_nan():
 
 # ----- singlepol warning behaviour ------------------------------------------
 
-def test_phase4b_switch_polrep_singlepol_warns_on_substitution():
-    obs = _phase4b_stokes_obs(with_nan_v=True)
+def test_switch_polrep_singlepol_warns_on_substitution():
+    obs = _stokes_obs(with_nan_v=True)
     with pytest.warns(UserWarning, match="allow_singlepol substituted"):
         obs.switch_polrep('circ', singlepol_hand='R')
 
 
-def test_phase4b_switch_polrep_singlepol_no_warn_when_disabled():
-    obs = _phase4b_stokes_obs(with_nan_v=True)
+def test_switch_polrep_singlepol_no_warn_when_disabled():
+    obs = _stokes_obs(with_nan_v=True)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         obs.switch_polrep('circ', allow_singlepol=False, singlepol_hand='R')
         assert not any('allow_singlepol substituted' in str(wi.message) for wi in w)
 
 
-def test_phase4b_switch_polrep_singlepol_no_warn_when_no_substitution():
-    obs = _phase4b_stokes_obs(with_nan_v=False)
+def test_switch_polrep_singlepol_no_warn_when_no_substitution():
+    obs = _stokes_obs(with_nan_v=False)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         obs.switch_polrep('circ', allow_singlepol=True, singlepol_hand='R')
@@ -1417,20 +1412,20 @@ def test_phase4b_switch_polrep_singlepol_no_warn_when_no_substitution():
 
 # ----- singlepol_hand validation --------------------------------------------
 
-def test_phase4b_switch_polrep_singlepol_hand_X_invalid_for_circ():
-    obs = _phase4b_stokes_obs(with_nan_v=True)
+def test_switch_polrep_singlepol_hand_X_invalid_for_circ():
+    obs = _stokes_obs(with_nan_v=True)
     with pytest.raises(Exception, match="singlepol_hand must be 'R' or 'L'"):
         obs.switch_polrep('circ', singlepol_hand='X')
 
 
-def test_phase4b_switch_polrep_singlepol_hand_R_invalid_for_lin():
-    obs = _phase4b_stokes_obs(with_nan_v=True)
+def test_switch_polrep_singlepol_hand_R_invalid_for_lin():
+    obs = _stokes_obs(with_nan_v=True)
     with pytest.raises(Exception, match="singlepol_hand must be 'X' or 'Y'"):
         obs.switch_polrep('lin', singlepol_hand='R')
 
 
-def test_phase4b_switch_polrep_singlepol_hand_case_insensitive():
-    obs = _phase4b_stokes_obs(with_nan_v=True)
+def test_switch_polrep_singlepol_hand_case_insensitive():
+    obs = _stokes_obs(with_nan_v=True)
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
         out_r = obs.switch_polrep('circ', singlepol_hand='r')
@@ -1440,9 +1435,9 @@ def test_phase4b_switch_polrep_singlepol_hand_case_insensitive():
     assert not np.all(np.isnan(out_x.data['xxvis']))
 
 
-def test_phase4b_switch_polrep_singlepol_hand_unused_when_disabled():
+def test_switch_polrep_singlepol_hand_unused_when_disabled():
     """When allow_singlepol=False, singlepol_hand is not validated."""
-    obs = _phase4b_stokes_obs(with_nan_v=True)
+    obs = _stokes_obs(with_nan_v=True)
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
         # 'X' would be invalid for circ if validated; with allow_singlepol=False
@@ -1452,8 +1447,8 @@ def test_phase4b_switch_polrep_singlepol_hand_unused_when_disabled():
 
 # ----- tarr preservation ----------------------------------------------------
 
-def test_phase4b_switch_polrep_tarr_unchanged():
-    obs_c = _phase4b_circ_obs()
+def test_switch_polrep_tarr_unchanged():
+    obs_c = _circ_obs()
     obs_l = obs_c.switch_polrep('lin', singlepol_hand='X')
     # tarr.feed_type is physical-array description; switch_polrep does not
     # touch it.

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -6,6 +6,7 @@ under matching headers.
 """
 import os
 import pickle
+import warnings
 
 import numpy as np
 import pytest
@@ -1267,3 +1268,193 @@ def test_phase4a_dirtyimage_mixed_raises():
 # LIN dirtyimage smoke coverage is deferred: unpack_dat does not yet handle
 # LIN sigma/Stokes-derived fields, so dirtyimage falls over before it can
 # build the image. Will be exercised once unpack_dat gains the LIN branch.
+
+
+# ============================================================================
+# Phase 4b — Obsdata.switch_polrep extensions
+# ============================================================================
+
+
+# ----- Helpers --------------------------------------------------------------
+
+def _phase4b_stokes_obs(tarr_feeds=('rl', 'rl'), with_nan_v=False):
+    """Stokes Obsdata on a 2-station tarr with the given feed_types."""
+    tarr = _phase4a_tarr(list(tarr_feeds))
+    d = np.zeros(2, dtype=ehc.DTPOL_STOKES)
+    d['time'] = [0.0, 0.5]
+    d['t1'] = ['S0', 'S0']
+    d['t2'] = ['S1', 'S1']
+    d['u'] = [1e6, 2e6]
+    d['v'] = [1e5, 2e5]
+    d['vis'] = [1.0 + 0j, 1.2 + 0j]
+    d['qvis'] = [0.3 + 0.1j, 0.4 + 0.1j]
+    d['uvis'] = [0.2 - 0.1j, 0.25 - 0.1j]
+    d['vvis'] = [0.05 + 0j, 0.06 + 0j] if not with_nan_v else [np.nan, np.nan]
+    d['sigma'] = 0.01
+    d['qsigma'] = 0.01
+    d['usigma'] = 0.01
+    d['vsigma'] = 0.01
+    return eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='stokes')
+
+
+def _phase4b_circ_obs():
+    """A non-trivial circ Obsdata on an rl tarr."""
+    return _phase4b_stokes_obs().switch_polrep('circ')
+
+
+def _phase4b_lin_obs(with_nan_xx=False):
+    """A non-trivial lin Obsdata on an xy tarr (built from stokes)."""
+    obs_s = _phase4b_stokes_obs(tarr_feeds=('xy', 'xy'))
+    obs_l = obs_s.switch_polrep('lin', singlepol_hand='X')
+    if with_nan_xx:
+        obs_l.data['xxvis'] = np.nan
+    return obs_l
+
+
+# ----- Direct lin <-> stokes round-trips ------------------------------------
+
+def test_phase4b_switch_polrep_lin_stokes_lin_roundtrip():
+    obs = _phase4b_lin_obs()
+    rt = obs.switch_polrep('stokes').switch_polrep('lin', singlepol_hand='X')
+    for f in ('xxvis', 'yyvis', 'xyvis', 'yxvis'):
+        np.testing.assert_allclose(rt.data[f], obs.data[f], atol=1e-12)
+
+
+def test_phase4b_switch_polrep_cross_convention_check():
+    """Build matched circ + lin obs from the same Stokes; both -> stokes match."""
+    obs_s = _phase4b_stokes_obs()
+    obs_c = obs_s.switch_polrep('circ')
+    obs_l = obs_s.switch_polrep('lin', singlepol_hand='X')
+    s_from_c = obs_c.switch_polrep('stokes')
+    s_from_l = obs_l.switch_polrep('stokes')
+    for f in ('vis', 'qvis', 'uvis', 'vvis'):
+        np.testing.assert_allclose(s_from_c.data[f], s_from_l.data[f], atol=1e-12)
+
+
+# ----- circ <-> lin composition ---------------------------------------------
+
+def test_phase4b_switch_polrep_circ_to_lin_equals_explicit():
+    obs_c = _phase4b_circ_obs()
+    composed = obs_c.switch_polrep('lin', singlepol_hand='X')
+    explicit = obs_c.switch_polrep('stokes').switch_polrep('lin', singlepol_hand='X')
+    for f in ('xxvis', 'yyvis', 'xyvis', 'yxvis'):
+        np.testing.assert_allclose(composed.data[f], explicit.data[f], atol=1e-12)
+
+
+def test_phase4b_switch_polrep_lin_to_circ_equals_explicit():
+    obs_l = _phase4b_lin_obs()
+    composed = obs_l.switch_polrep('circ', singlepol_hand='R')
+    explicit = obs_l.switch_polrep('stokes').switch_polrep('circ', singlepol_hand='R')
+    for f in ('rrvis', 'llvis', 'rlvis', 'lrvis'):
+        np.testing.assert_allclose(composed.data[f], explicit.data[f], atol=1e-12)
+
+
+def test_phase4b_switch_polrep_circ_lin_circ_roundtrip():
+    obs_c = _phase4b_circ_obs()
+    rt = obs_c.switch_polrep('lin', singlepol_hand='X').switch_polrep('circ', singlepol_hand='R')
+    for f in ('rrvis', 'llvis', 'rlvis', 'lrvis'):
+        np.testing.assert_allclose(rt.data[f], obs_c.data[f], atol=1e-12)
+
+
+# ----- Mixed source / invalid output ----------------------------------------
+
+def test_phase4b_switch_polrep_mixed_source_raises():
+    obs_m = _phase4a_mixed_obs()
+    with pytest.raises(NotImplementedError, match="polrep='mixed' is not yet implemented"):
+        obs_m.switch_polrep('stokes')
+
+
+def test_phase4b_switch_polrep_invalid_output_raises():
+    obs_c = _phase4b_circ_obs()
+    with pytest.raises(Exception, match="polrep_out must be"):
+        obs_c.switch_polrep('mixed')
+    with pytest.raises(Exception, match="polrep_out must be"):
+        obs_c.switch_polrep('bogus')
+
+
+# ----- allow_singlepol on lin -> stokes -------------------------------------
+
+def test_phase4b_switch_polrep_allow_singlepol_lin_to_stokes_fills_xx_with_yy():
+    obs = _phase4b_lin_obs(with_nan_xx=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        out = obs.switch_polrep('stokes', allow_singlepol=True)
+    # vis should equal yyvis where xxvis was NaN (the surviving parallel-hand)
+    np.testing.assert_allclose(out.data['vis'], obs.data['yyvis'], atol=1e-12)
+
+
+def test_phase4b_switch_polrep_allow_singlepol_false_leaves_nan():
+    obs = _phase4b_lin_obs(with_nan_xx=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        out = obs.switch_polrep('stokes', allow_singlepol=False)
+    assert np.all(np.isnan(out.data['vis']))
+
+
+# ----- singlepol warning behaviour ------------------------------------------
+
+def test_phase4b_switch_polrep_singlepol_warns_on_substitution():
+    obs = _phase4b_stokes_obs(with_nan_v=True)
+    with pytest.warns(UserWarning, match="allow_singlepol substituted"):
+        obs.switch_polrep('circ', singlepol_hand='R')
+
+
+def test_phase4b_switch_polrep_singlepol_no_warn_when_disabled():
+    obs = _phase4b_stokes_obs(with_nan_v=True)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        obs.switch_polrep('circ', allow_singlepol=False, singlepol_hand='R')
+        assert not any('allow_singlepol substituted' in str(wi.message) for wi in w)
+
+
+def test_phase4b_switch_polrep_singlepol_no_warn_when_no_substitution():
+    obs = _phase4b_stokes_obs(with_nan_v=False)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        obs.switch_polrep('circ', allow_singlepol=True, singlepol_hand='R')
+        assert not any('allow_singlepol substituted' in str(wi.message) for wi in w)
+
+
+# ----- singlepol_hand validation --------------------------------------------
+
+def test_phase4b_switch_polrep_singlepol_hand_X_invalid_for_circ():
+    obs = _phase4b_stokes_obs(with_nan_v=True)
+    with pytest.raises(Exception, match="singlepol_hand must be 'R' or 'L'"):
+        obs.switch_polrep('circ', singlepol_hand='X')
+
+
+def test_phase4b_switch_polrep_singlepol_hand_R_invalid_for_lin():
+    obs = _phase4b_stokes_obs(with_nan_v=True)
+    with pytest.raises(Exception, match="singlepol_hand must be 'X' or 'Y'"):
+        obs.switch_polrep('lin', singlepol_hand='R')
+
+
+def test_phase4b_switch_polrep_singlepol_hand_case_insensitive():
+    obs = _phase4b_stokes_obs(with_nan_v=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        out_r = obs.switch_polrep('circ', singlepol_hand='r')
+        out_x = obs.switch_polrep('lin', singlepol_hand='x')
+    # lowercase accepted -- xxvis (lin) / rrvis (circ) should hold the Stokes I fill
+    assert not np.all(np.isnan(out_r.data['rrvis']))
+    assert not np.all(np.isnan(out_x.data['xxvis']))
+
+
+def test_phase4b_switch_polrep_singlepol_hand_unused_when_disabled():
+    """When allow_singlepol=False, singlepol_hand is not validated."""
+    obs = _phase4b_stokes_obs(with_nan_v=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        # 'X' would be invalid for circ if validated; with allow_singlepol=False
+        # it's never used and never validated.
+        obs.switch_polrep('circ', allow_singlepol=False, singlepol_hand='X')
+
+
+# ----- tarr preservation ----------------------------------------------------
+
+def test_phase4b_switch_polrep_tarr_unchanged():
+    obs_c = _phase4b_circ_obs()
+    obs_l = obs_c.switch_polrep('lin', singlepol_hand='X')
+    # tarr.feed_type is physical-array description; switch_polrep does not
+    # touch it.
+    np.testing.assert_array_equal(obs_l.tarr['feed_type'], obs_c.tarr['feed_type'])

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -986,3 +986,284 @@ def test_phase2_save_load_obs_txt_embedded_tarr_with_feed_type(tmp_path):
     np.testing.assert_array_equal(obs2.tarr['site'], obs.tarr['site'])
     np.testing.assert_allclose(obs2.tarr['sefd_p1'], obs.tarr['sefd_p1'], atol=1e-2)
     np.testing.assert_allclose(obs2.tarr['sefd_p2'], obs.tarr['sefd_p2'], atol=1e-2)
+
+
+# ============================================================================
+# Phase 4a — Obsdata polrep enum + dtype dispatch
+# ============================================================================
+
+
+# ----- Helpers --------------------------------------------------------------
+
+def _phase4a_tarr(feed_types, sites=None):
+    """Minimal valid tarr with the given feed_type list (one per station)."""
+    n = len(feed_types)
+    if sites is None:
+        sites = [f'S{i}' for i in range(n)]
+    t = np.zeros(n, dtype=ehc.DTARR)
+    t['site'] = sites
+    t['feed_type'] = feed_types
+    return t
+
+
+def _phase4a_lin_data(t1s, t2s, times=None):
+    """DTPOL_LIN datatable with non-trivial visibility values."""
+    n = len(t1s)
+    d = np.zeros(n, dtype=ehc.DTPOL_LIN)
+    d['time'] = times if times is not None else np.zeros(n)
+    d['t1'] = t1s
+    d['t2'] = t2s
+    d['u'] = 1e6 * (np.arange(n) + 1)
+    d['v'] = 1e5 * (np.arange(n) + 1)
+    d['xxvis'] = (1 + 2j) * (np.arange(n) + 1)
+    d['yyvis'] = (3 + 4j) * (np.arange(n) + 1)
+    d['xyvis'] = (5 + 6j) * (np.arange(n) + 1)
+    d['yxvis'] = (7 + 8j) * (np.arange(n) + 1)
+    d['xxsigma'] = 0.1 * (np.arange(n) + 1)
+    d['yysigma'] = 0.2 * (np.arange(n) + 1)
+    d['xysigma'] = 0.3 * (np.arange(n) + 1)
+    d['yxsigma'] = 0.4 * (np.arange(n) + 1)
+    return d
+
+
+def _phase4a_mixed_data(t1s, t2s, times=None):
+    """DTPOL_MIXED datatable; polbasis is left empty (populated in __init__)."""
+    n = len(t1s)
+    d = np.zeros(n, dtype=ehc.DTPOL_MIXED)
+    d['time'] = times if times is not None else np.zeros(n)
+    d['t1'] = t1s
+    d['t2'] = t2s
+    d['u'] = 1e6 * (np.arange(n) + 1)
+    d['v'] = 1e5 * (np.arange(n) + 1)
+    d['p1p1vis'] = (1 + 2j) * (np.arange(n) + 1)
+    d['p2p2vis'] = (3 + 4j) * (np.arange(n) + 1)
+    d['p1p2vis'] = (5 + 6j) * (np.arange(n) + 1)
+    d['p2p1vis'] = (7 + 8j) * (np.arange(n) + 1)
+    d['p1p1sigma'] = 0.1 * (np.arange(n) + 1)
+    d['p2p2sigma'] = 0.2 * (np.arange(n) + 1)
+    d['p1p2sigma'] = 0.3 * (np.arange(n) + 1)
+    d['p2p1sigma'] = 0.4 * (np.arange(n) + 1)
+    return d
+
+
+def _phase4a_lin_obs(t1s=('S0',), t2s=('S1',)):
+    return eo.Obsdata(0., 0., 230e9, 1e9,
+                      _phase4a_lin_data(list(t1s), list(t2s)),
+                      _phase4a_tarr(['xy', 'xy']),
+                      polrep='lin')
+
+
+def _phase4a_mixed_obs():
+    """3-station mixed array: S0/S1 are 'rl', S2 is 'xy'. 3 baselines."""
+    return eo.Obsdata(0., 0., 230e9, 1e9,
+                      _phase4a_mixed_data(['S0', 'S0', 'S1'],
+                                          ['S1', 'S2', 'S2']),
+                      _phase4a_tarr(['rl', 'rl', 'xy']),
+                      polrep='mixed')
+
+
+# ----- Construction & validation --------------------------------------------
+
+def test_phase4a_init_lin_from_synthetic_table():
+    obs = _phase4a_lin_obs()
+    assert obs.polrep == 'lin'
+    assert obs.poltype is ehc.DTPOL_LIN
+    assert obs.poldict is ehc.POLDICT_LIN
+    np.testing.assert_array_equal(obs.data['p1p1vis'], obs.data['xxvis'])
+    np.testing.assert_array_equal(obs.data['p2p1vis'], obs.data['yxvis'])
+
+
+def test_phase4a_init_mixed_from_synthetic_table():
+    obs = _phase4a_mixed_obs()
+    assert obs.polrep == 'mixed'
+    assert obs.poltype is ehc.DTPOL_MIXED
+    assert obs.poldict is ehc.POLDICT_MIXED
+    # polbasis is the lossless 4-char t1+t2 feed_type concat:
+    # (S0,S1) -> rlrl, (S0,S2) -> rlxy, (S1,S2) -> rlxy
+    assert set(obs.data['polbasis']) == {'rlrl', 'rlxy'}
+
+
+def test_phase4a_init_circ_rejects_xy_tarr():
+    d = np.zeros(1, dtype=ehc.DTPOL_CIRC)
+    d['t1'] = 'S0'
+    d['t2'] = 'S1'
+    tarr = _phase4a_tarr(['rl', 'xy'])
+    with pytest.raises(ValueError, match="polrep='circ' requires all stations to have feed_type='rl'"):
+        eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='circ')
+
+
+def test_phase4a_init_lin_rejects_rl_tarr():
+    d = _phase4a_lin_data(['S0'], ['S1'])
+    tarr = _phase4a_tarr(['rl', 'rl'])
+    with pytest.raises(ValueError, match="polrep='lin' requires all stations to have feed_type='xy'"):
+        eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='lin')
+
+
+def test_phase4a_init_mixed_rejects_homogeneous_tarr():
+    d = _phase4a_mixed_data(['S0'], ['S1'])
+    tarr = _phase4a_tarr(['rl', 'rl'])
+    with pytest.raises(ValueError, match="polrep='mixed' requires at least two distinct feed types"):
+        eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='mixed')
+
+
+def test_phase4a_init_rejects_unset_feed_type_qq():
+    d = np.zeros(1, dtype=ehc.DTPOL_STOKES)
+    d['t1'] = 'S0'
+    d['t2'] = 'S1'
+    tarr = _phase4a_tarr(['??', '??'])
+    with pytest.raises(ValueError, match="unset feed_type='\\?\\?'"):
+        eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='stokes')
+
+
+def test_phase4a_init_rejects_unknown_feed_type():
+    d = np.zeros(1, dtype=ehc.DTPOL_STOKES)
+    d['t1'] = 'S0'
+    d['t2'] = 'S1'
+    tarr = _phase4a_tarr(['rl', 'zz'])
+    with pytest.raises(ValueError, match="unknown feed_type"):
+        eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='stokes')
+
+
+def test_phase4a_init_mixed_rejects_missing_station():
+    d = _phase4a_mixed_data(['SX'], ['S1'])
+    tarr = _phase4a_tarr(['rl', 'xy'])
+    with pytest.raises(ValueError, match="data references stations not in tarr"):
+        eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='mixed')
+
+
+def test_phase4a_dtype_polrep_mismatch_raises():
+    d = np.zeros(1, dtype=ehc.DTPOL_STOKES)
+    d['t1'] = 'S0'
+    d['t2'] = 'S1'
+    tarr = _phase4a_tarr(['xy', 'xy'])
+    with pytest.raises(Exception, match="does not match polrep='lin'"):
+        eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='lin')
+
+
+# ----- Round-trip & query methods -------------------------------------------
+
+def test_phase4a_copy_roundtrip_lin():
+    obs = _phase4a_lin_obs()
+    other = obs.copy()
+    assert other.polrep == 'lin'
+    assert other.poltype == ehc.DTPOL_LIN
+    np.testing.assert_array_equal(other.data['xxvis'], obs.data['xxvis'])
+
+
+def test_phase4a_copy_roundtrip_mixed():
+    obs = _phase4a_mixed_obs()
+    other = obs.copy()
+    assert other.polrep == 'mixed'
+    assert other.poltype == ehc.DTPOL_MIXED
+    np.testing.assert_array_equal(other.data['polbasis'], obs.data['polbasis'])
+    np.testing.assert_array_equal(other.data['p1p1vis'], obs.data['p1p1vis'])
+
+
+def test_phase4a_tlist_bllist_lin():
+    obs = eo.Obsdata(0., 0., 230e9, 1e9,
+                     _phase4a_lin_data(['S0', 'S0'], ['S1', 'S1'],
+                                       times=[0.0, 1.0]),
+                     _phase4a_tarr(['xy', 'xy']),
+                     polrep='lin')
+    tl = obs.tlist()
+    bl = obs.bllist()
+    assert len(tl) == 2
+    assert len(bl) == 1
+
+
+def test_phase4a_tlist_bllist_mixed():
+    obs = _phase4a_mixed_obs()
+    tl = obs.tlist()
+    bl = obs.bllist()
+    assert len(tl) == 1
+    assert len(bl) == 3
+
+
+def test_phase4a_flag_uvdist_lin():
+    obs = _phase4a_lin_obs()
+    kept = obs.flag_uvdist(uv_min=0., uv_max=1e20)
+    assert len(kept.data) == len(obs.data)
+
+
+def test_phase4a_flag_sites_mixed():
+    obs = _phase4a_mixed_obs()
+    kept = obs.flag_sites(['S2'])
+    assert 'S2' not in set(kept.data['t1']) | set(kept.data['t2'])
+
+
+# ----- reorder_baselines ----------------------------------------------------
+
+def test_phase4a_reorder_baselines_lin_swap():
+    # t1=S1, t2=S0 is reversed; reorder swaps and applies LIN conj/cross-swap.
+    d = _phase4a_lin_data(['S1'], ['S0'])
+    obs = eo.Obsdata(0., 0., 230e9, 1e9, d, _phase4a_tarr(['xy', 'xy']),
+                     polrep='lin')
+    row = obs.data[0]
+    assert row['t1'] == 'S0'
+    assert row['t2'] == 'S1'
+    assert row['u'] == -1e6
+    assert row['xxvis'] == np.conj(1 + 2j)
+    assert row['yyvis'] == np.conj(3 + 4j)
+    # cross: new xyvis = conj(old yxvis); new yxvis = conj(old xyvis)
+    assert row['xyvis'] == np.conj(7 + 8j)
+    assert row['yxvis'] == np.conj(5 + 6j)
+    assert row['xysigma'] == 0.4
+    assert row['yxsigma'] == 0.3
+
+
+def test_phase4a_reorder_baselines_mixed_swap_and_polbasis_flip():
+    # t1=S1 (xy), t2=S0 (rl); reorder swaps and flips polbasis 'xyrl' -> 'rlxy'.
+    d = _phase4a_mixed_data(['S1'], ['S0'])
+    obs = eo.Obsdata(0., 0., 230e9, 1e9, d,
+                     _phase4a_tarr(['rl', 'xy']),
+                     polrep='mixed')
+    row = obs.data[0]
+    assert row['t1'] == 'S0'
+    assert row['t2'] == 'S1'
+    assert row['u'] == -1e6
+    assert row['polbasis'] == 'rlxy'
+    assert row['p1p1vis'] == np.conj(1 + 2j)
+    assert row['p2p2vis'] == np.conj(3 + 4j)
+    assert row['p1p2vis'] == np.conj(7 + 8j)
+    assert row['p2p1vis'] == np.conj(5 + 6j)
+    assert row['p1p2sigma'] == 0.4
+    assert row['p2p1sigma'] == 0.3
+
+
+# ----- avg_coherent / avg_incoherent guards ---------------------------------
+
+def test_phase4a_avg_coherent_lin_raises():
+    obs = _phase4a_lin_obs()
+    with pytest.raises(NotImplementedError, match="not yet supported on polrep='lin'"):
+        obs.avg_coherent(60.0)
+
+
+def test_phase4a_avg_coherent_mixed_raises():
+    obs = _phase4a_mixed_obs()
+    with pytest.raises(NotImplementedError, match="not yet supported on polrep='mixed'"):
+        obs.avg_coherent(60.0)
+
+
+def test_phase4a_avg_incoherent_lin_raises():
+    obs = _phase4a_lin_obs()
+    with pytest.raises(NotImplementedError, match="not yet supported on polrep='lin'"):
+        obs.avg_incoherent(60.0)
+
+
+def test_phase4a_avg_incoherent_mixed_raises():
+    obs = _phase4a_mixed_obs()
+    with pytest.raises(NotImplementedError, match="not yet supported on polrep='mixed'"):
+        obs.avg_incoherent(60.0)
+
+
+# ----- dirtyimage -----------------------------------------------------------
+
+def test_phase4a_dirtyimage_mixed_raises():
+    obs = _phase4a_mixed_obs()
+    with pytest.raises(NotImplementedError, match="dirtyimage is not supported on polrep='mixed'"):
+        obs.dirtyimage(npix=8, fov=1e-6)
+
+
+# LIN dirtyimage smoke coverage is deferred: unpack_dat does not yet handle
+# LIN sigma/Stokes-derived fields, so dirtyimage falls over before it can
+# build the image. Will be exercised once unpack_dat gains the LIN branch.

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -1083,19 +1083,19 @@ def test_phase4a_init_mixed_from_synthetic_table():
     assert set(obs.data['polbasis']) == {'rlrl', 'rlxy'}
 
 
-def test_phase4a_init_circ_rejects_xy_tarr():
+def test_phase4a_init_circ_warns_on_non_rl_tarr():
     d = np.zeros(1, dtype=ehc.DTPOL_CIRC)
     d['t1'] = 'S0'
     d['t2'] = 'S1'
     tarr = _phase4a_tarr(['rl', 'xy'])
-    with pytest.raises(ValueError, match="polrep='circ' requires all stations to have feed_type='rl'"):
+    with pytest.warns(UserWarning, match="polrep='circ' Obsdata constructed on a tarr"):
         eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='circ')
 
 
-def test_phase4a_init_lin_rejects_rl_tarr():
+def test_phase4a_init_lin_warns_on_non_xy_tarr():
     d = _phase4a_lin_data(['S0'], ['S1'])
     tarr = _phase4a_tarr(['rl', 'rl'])
-    with pytest.raises(ValueError, match="polrep='lin' requires all stations to have feed_type='xy'"):
+    with pytest.warns(UserWarning, match="polrep='lin' Obsdata constructed on a tarr"):
         eo.Obsdata(0., 0., 230e9, 1e9, d, tarr, polrep='lin')
 
 

--- a/tests/test_obsdata.py
+++ b/tests/test_obsdata.py
@@ -33,8 +33,8 @@ def test_init_rejects_empty_table(obs_direct):
 
 def test_init_rejects_bad_polrep(obs_direct):
     arglist, argdict = obs_direct.obsdata_args()
-    argdict["polrep"] = "lin"
-    with pytest.raises(Exception, match="only 'stokes' and 'circ'"):
+    argdict["polrep"] = "bogus"
+    with pytest.raises(Exception, match="polrep must be one of"):
         eh.obsdata.Obsdata(*arglist, **argdict)
 
 
@@ -42,7 +42,7 @@ def test_init_rejects_bad_dtype(obs_direct):
     arglist, argdict = obs_direct.obsdata_args()
     wrong = np.zeros(len(obs_direct.data), dtype=[("time", "f8"), ("u", "f8"), ("v", "f8")])
     arglist[4] = wrong
-    with pytest.raises(Exception, match="DTPOL_STOKES or DTPOL_CIRC"):
+    with pytest.raises(Exception, match="does not match polrep"):
         eh.obsdata.Obsdata(*arglist, **argdict)
 
 

--- a/tests/test_obsdata.py
+++ b/tests/test_obsdata.py
@@ -236,16 +236,68 @@ def test_reorder_baselines_time_sorted(obs_direct):
 
 
 def test_trial_speedups_matches_default(obs_direct):
-    obs_default = obs_direct.copy()
+    # The trial_speedups flag in reorder_baselines is now a no-op; both
+    # invocations must produce byte-identical output, including when the
+    # input contains conjugate pairs and true duplicates.
+    extra = obs_direct.data[0].copy()
+    extra["t1"], extra["t2"] = obs_direct.data[0]["t2"], obs_direct.data[0]["t1"]
+    extra["u"], extra["v"] = -obs_direct.data[0]["u"], -obs_direct.data[0]["v"]
+    extra["vis"] = np.conj(obs_direct.data[0]["vis"])
+    seeded = obs_direct.copy()
+    seeded.data = np.concatenate([obs_direct.data, np.array([extra], dtype=obs_direct.data.dtype)])
+
+    obs_default = seeded.copy()
     obs_default.reorder_baselines(trial_speedups=False)
-    obs_trial = obs_direct.copy()
+    obs_trial = seeded.copy()
     obs_trial.reorder_baselines(trial_speedups=True)
-    np.testing.assert_array_equal(
-        obs_default.data["time"], obs_trial.data["time"]
+    np.testing.assert_array_equal(obs_default.data, obs_trial.data)
+
+
+def _seed_extra_row(obs, **overrides):
+    """Return a copy of `obs` with one extra row tacked on, fields overridden."""
+    row = obs.data[0].copy()
+    for k, v in overrides.items():
+        row[k] = v
+    new = obs.copy()
+    new.data = np.concatenate([obs.data, np.array([row], dtype=obs.data.dtype)])
+    return new
+
+
+def test_reorder_baselines_conjugate_pair_silent_merge(obs_direct):
+    # (A,B) and (B,A) at the same time with conjugate u,v are the same
+    # measurement; reorder_baselines must drop one without warning.
+    r0 = obs_direct.data[0]
+    seeded = _seed_extra_row(
+        obs_direct, t1=r0["t2"], t2=r0["t1"], u=-r0["u"], v=-r0["v"],
+        vis=np.conj(r0["vis"]),
     )
-    np.testing.assert_array_equal(obs_default.data["t1"], obs_trial.data["t1"])
-    np.testing.assert_array_equal(obs_default.data["t2"], obs_trial.data["t2"])
-    np.testing.assert_array_equal(obs_default.data["vis"], obs_trial.data["vis"])
+    n_before = len(seeded.data)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        seeded.reorder_baselines()
+    assert len(seeded.data) == n_before - 1
+
+
+def test_reorder_baselines_true_duplicate_warns(obs_direct):
+    # Same canonical (time, t1, t2) and same (u, v) but different vis ->
+    # not a conjugate pair, the user supplied inconsistent data. Warn.
+    seeded = _seed_extra_row(obs_direct, vis=obs_direct.data[0]["vis"] + 100.0)
+    n_before = len(seeded.data)
+    with pytest.warns(UserWarning, match="reorder_baselines: dropped 1"):
+        seeded.reorder_baselines()
+    assert len(seeded.data) == n_before - 1
+
+
+def test_reorder_baselines_multichannel_like_warns(obs_direct):
+    # Five extra rows with the same canonical baseline but distinct (u, v) --
+    # mimics multi-channel data flattened into a single-frequency Obsdata.
+    rows = [obs_direct.data[0].copy() for _ in range(5)]
+    for k, r in enumerate(rows):
+        r["u"] = obs_direct.data[0]["u"] * (1.0 + 0.01 * (k + 1))
+    seeded = obs_direct.copy()
+    seeded.data = np.concatenate([obs_direct.data, np.array(rows, dtype=obs_direct.data.dtype)])
+    with pytest.warns(UserWarning, match="reorder_baselines: dropped 5"):
+        seeded.reorder_baselines()
 
 
 def test_reorder_tarr_sefd_monotonic(obs_direct):

--- a/tests/test_obsdata.py
+++ b/tests/test_obsdata.py
@@ -195,7 +195,7 @@ def test_switch_polrep_noop_returns_copy(obs_direct):
 
 def test_switch_polrep_invalid_raises(obs_direct):
     with pytest.raises(Exception, match="polrep_out"):
-        obs_direct.switch_polrep("lin")
+        obs_direct.switch_polrep("bogus")
 
 
 def test_switch_polrep_singlepol_hand_invalid(obs_direct):


### PR DESCRIPTION
Implements Obsdata polrep enum + dtype dispatch and switch_polrep extensions 

Tracking issue: #212 

- `Obsdata.__init__` now accepts `polrep='lin'` and `polrep='mixed'`. The dispatch goes through `ehc.polrep_to_poldict` and `feed_dtype_for_polrep`. Datatable dtype is cross-checked against the declared polrep.
- For MIXED, `data['polbasis']` is populated as the lossless 4-char concatenation of `tarr['feed_type']` for the (t1, t2) pair (e.g. `'rlrl'`,  `'rlxy'`). The polbasis dtype widens from U2 to U4 in DTPOL_MIXED.
- `VALID_FEED_TYPES` moves from `array.py` to `const_def.py` so both Array and Obsdata validate against the same source. tarr `feed_type='??'` and unknown codes are rejected at construction.
- The strict `polrep` ↔ `tarr.feed_type` agreement (e.g. circ requires all-rl) is **relaxed to a UserWarning**. polrep declares the data-layout basis; tarr.feed_type describes the physical array. The two need not match,  this is what makes `circ` <--> `lin` round-trips work without mutating tarr.
- `reorder_baselines` gets LIN and MIXED branches. MIXED also flips the two halves of `polbasis` on reordered rows.
- `dirtyimage` raises informatively on MIXED. `avg_coherent` / `avg_incoherent` raise on LIN/MIXED pending the averaging follow-up.
- `switch_polrep` accepts `'lin'` as a target. lin<-->stokes direct, circ<-->lin via a two-step composition through stokes. `allow_singlepol` emits a warning on substitution (now for all four directions, with a note that cross-hand visibilities are not modified). `singlepol_hand` accepts `'X'`/`'Y'` for lin targets (case-insensitive).
- Cherry-picks #267 (reorder_baselines duplicate-handling rewrite) onto this branch so the upstream sync is conflict-free.

## Out of scope

- `unpack` / `unpack_dat` LIN/MIXED dispatch
- `data_conj` LIN/MIXED slot dispatch
- Closure quantities (`bispectra`, `c_phases`, ...) 
- uvfits IO for LIN/MIXED