### PR TITLE
diagnostics: add sumdown_lin + sumdown_img tests

### DIFF
--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -39,3 +39,55 @@ class TestOnedimize:
         imgs = [gauss2(0.0, 0.0, 0.1, 0.1)]
         oneds, ref = ds.onedimize(imgs, n=32)
         assert np.all(ref[:-1] >= ref[1:])
+
+
+# Sizes for the sumdown tests. The 1D length is non-trivial (not a multiple
+# of N) so the piecewise-linear cumulative bin boundaries are exercised; the
+# image padding path likewise needs nx, ny not multiples of N.
+SUMDOWN_LINE_LEN = 100
+SUMDOWN_IMG_SHAPE = (45, 37)
+SUMDOWN_N = 16
+SUMDOWN_TOTAL_RTOL = 1e-10
+
+
+class TestSumdownLin:
+    """Test the sumdown_lin() 1D segment summer."""
+
+    def test_output_shape(self):
+        out = ds.sumdown_lin(np.zeros(SUMDOWN_LINE_LEN), n=SUMDOWN_N)
+        assert out.shape == (SUMDOWN_N,)
+
+    def test_preserves_total(self):
+        rng = np.random.default_rng(0)
+        y = rng.standard_normal(SUMDOWN_LINE_LEN)
+        out = ds.sumdown_lin(y, n=SUMDOWN_N)
+        np.testing.assert_allclose(out.sum(), y.sum(), rtol=SUMDOWN_TOTAL_RTOL)
+
+    def test_uniform_input_gives_uniform_output(self):
+        y = np.ones(SUMDOWN_LINE_LEN)
+        out = ds.sumdown_lin(y, n=SUMDOWN_N)
+        expected = SUMDOWN_LINE_LEN / SUMDOWN_N
+        np.testing.assert_allclose(out, expected, rtol=1e-10)
+
+
+class TestSumdownImg:
+    """Test the sumdown_img() 2D block summer."""
+
+    def test_output_shape(self):
+        out = ds.sumdown_img(np.zeros(SUMDOWN_IMG_SHAPE), n=SUMDOWN_N)
+        assert out.shape == (SUMDOWN_N, SUMDOWN_N)
+
+    def test_preserves_total(self):
+        rng = np.random.default_rng(1)
+        img = rng.standard_normal(SUMDOWN_IMG_SHAPE)
+        out = ds.sumdown_img(img, n=SUMDOWN_N)
+        # Padding fills with zeros, so the total is exactly conserved.
+        np.testing.assert_allclose(out.sum(), img.sum(), rtol=SUMDOWN_TOTAL_RTOL)
+
+    def test_uniform_image_gives_uniform_output(self):
+        img = np.ones(SUMDOWN_IMG_SHAPE)
+        out = ds.sumdown_img(img, n=SUMDOWN_N)
+        # Inner cells are full mx*my cells of 1; edge cells contain padding
+        # zeros. Total still equals nx*ny.
+        np.testing.assert_allclose(out.sum(),
+                                   SUMDOWN_IMG_SHAPE[0] * SUMDOWN_IMG_SHAPE[1])

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -4,6 +4,14 @@ import numpy as np
 
 import ehtim.diagnostics as ds
 
+# Sizes for the sumdown tests. The 1D length is non-trivial (not a multiple
+# of N) so the piecewise-linear cumulative bin boundaries are exercised; the
+# image padding path likewise needs nx, ny not multiples of N.
+SUMDOWN_LINE_LEN = 100
+SUMDOWN_IMG_SHAPE = (45, 37)
+SUMDOWN_N = 16
+SUMDOWN_TOTAL_RTOL = 1e-10
+
 
 def gauss(x0, sx):
     n = 128
@@ -39,15 +47,6 @@ class TestOnedimize:
         imgs = [gauss2(0.0, 0.0, 0.1, 0.1)]
         oneds, ref = ds.onedimize(imgs, n=32)
         assert np.all(ref[:-1] >= ref[1:])
-
-
-# Sizes for the sumdown tests. The 1D length is non-trivial (not a multiple
-# of N) so the piecewise-linear cumulative bin boundaries are exercised; the
-# image padding path likewise needs nx, ny not multiples of N.
-SUMDOWN_LINE_LEN = 100
-SUMDOWN_IMG_SHAPE = (45, 37)
-SUMDOWN_N = 16
-SUMDOWN_TOTAL_RTOL = 1e-10
 
 
 class TestSumdownLin:


### PR DESCRIPTION
Closes the small `diagnostics.py` gap per `docs/coverage_status.md`. 6 new tests across `sumdown_lin` (1D segment summer) and `sumdown_img` (2D block summer), covering output shape, total conservation, and uniform-input correctness.