### PR TITLE
array: plot_dterms + plot_satellite_orbits + satellite-elements tests + add_satellite_tle kwarg fix

### DIFF
--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -16,32 +16,27 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
-
-import numpy as np
 import copy
-from astropy.time import Time
-import matplotlib.pyplot as plt
-import matplotlib
-import ehtim.observing.obs_simulate as simobs
-import ehtim.observing.obs_helpers as obsh
-import ehtim.io.save
-import ehtim.io.load
-import ehtim.const_def as ehc
-from ehtim.caltable import plot_tarr_dterms
 
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+from astropy.time import Time
+
+import ehtim.const_def as ehc
+import ehtim.io.load
+import ehtim.io.save
+import ehtim.observing.obs_helpers as obsh
+import ehtim.observing.obs_simulate as simobs
+from ehtim.caltable import plot_tarr_dterms
 
 ###################################################################################################
 # Array object
 ###################################################################################################
 
 
-class Array(object):
+class Array:
 
     """A VLBI array of telescopes with site locations, SEFDs, and other data.
 
@@ -63,18 +58,18 @@ class Array(object):
                 try:
                     elen = len(ephem[sitename])
                 except NameError:
-                    raise Exception('no ephemeris for site %s !' % sitename)
+                    raise Exception(f'no ephemeris for site {sitename} !')
                 if elen != 3:
-                    raise Exception('wrong ephemeris format for site %s !' % sitename)
+                    raise Exception(f'wrong ephemeris format for site {sitename} !')
 
         # Dictionary of array indices for site names
         self.tkey = {self.tarr[i]['site']: i for i in range(len(self.tarr))}
 
-    @property 
+    @property
     def tarr(self):
         return self._tarr
-        
-    @tarr.setter 
+
+    @tarr.setter
     def tarr(self, tarr):
         self._tarr = tarr
         self.tkey = {tarr[i]['site']: i for i in range(len(tarr))}
@@ -91,7 +86,7 @@ class Array(object):
         newarr = copy.deepcopy(self)
         return newarr
 
-       
+
     def listbls(self):
         """List all baselines.
 
@@ -103,7 +98,7 @@ class Array(object):
         bls = []
         for i1 in sorted(self.tarr['site']):
             for i2 in sorted(self.tarr['site']):
-                if not ([i1, i2] in bls) and not ([i2, i1] in bls) and i1 != i2:
+                if [i1, i2] not in bls and [i2, i1] not in bls and i1 != i2:
                     bls.append([i1, i2])
         bls = np.array(bls)
 
@@ -132,7 +127,7 @@ class Array(object):
                no_elevcut_space (bool): if True, do not apply elevation cut to orbiters
                tau (float): the base opacity at all sites, or a dict giving one opacity per site
                fix_theta_GMST (bool): if True, stops earth rotation to sample fixed u,v points
-               
+
            Returns:
                Obsdata: an observation object with no data
 
@@ -141,7 +136,7 @@ class Array(object):
         obsarr = simobs.make_uvpoints(self, ra, dec, rf, bw,
                                       tint, tadv, tstart, tstop,
                                       mjd=mjd, polrep=polrep, tau=tau,
-                                      elevmin=elevmin, elevmax=elevmax, 
+                                      elevmin=elevmin, elevmax=elevmax,
                                       no_elevcut_space=no_elevcut_space,
                                       timetype=timetype, fix_theta_GMST=fix_theta_GMST)
 
@@ -187,13 +182,13 @@ class Array(object):
                label (str) : title for plot
                legend (bool) : add telescope legend or not
                clist (list) : list of colors for different stations
-               rangex (list) : lower and upper x-axis limits  
-               rangey (list) : lower and upper y-axis limits 
+               rangex (list) : lower and upper x-axis limits
+               rangey (list) : lower and upper y-axis limits
                markersize (float) : marker size
                show (bool) : display the plot or not
                grid (bool) : add a grid to the plot or not
-               export_pdf (str) : save a pdf file to this path 
-               
+               export_pdf (str) : save a pdf file to this path
+
            Returns:
                matplotlib.axes
         """
@@ -206,7 +201,7 @@ class Array(object):
 
         if len(sites)==0:
             sites = list(self.tkey.keys())
-                    
+
         keys = [self.tkey[site] for site in sites]
 
         axes = plot_tarr_dterms(self.tarr, keys=keys, label=label, legend=legend, clist=clist,
@@ -215,74 +210,74 @@ class Array(object):
 
         return axes
 
-    def add_site(self, site, coords, sefd=10000, 
-                 fr_par=0, fr_elev=0, fr_off=0, 
+    def add_site(self, site, coords, sefd=10000,
+                 fr_par=0, fr_elev=0, fr_off=0,
                  dr=0.+0.j, dl=0.+0.j):
-    
+
         """Add a ground station to the array
-             
+
         """
         tarr_old = self.tarr.copy()
         ephem_old = self.ephem.copy()
-        
-        
-        tarr_newline = np.array((str(site), float(coords[0]), float(coords[1]), float(coords[2]), 
-                                 float(sefd), float(sefd), 
-                                 dr, dl, 
+
+
+        tarr_newline = np.array((str(site), float(coords[0]), float(coords[1]), float(coords[2]),
+                                 float(sefd), float(sefd),
+                                 dr, dl,
                                  float(fr_par), float(fr_elev), float(fr_off)), dtype=ehc.DTARR)
         tarr_new = np.append(tarr_old, tarr_newline)
-        
+
         arr_out = Array(tarr_new, ephem_old)
         return arr_out
-            
+
     def remove_site(self, site):
         """Remove a site from the array
-           
+
         """
         tarr_old = self.tarr.copy()
         ephem_old = self.ephem.copy()
         ephem_new = ephem_old.copy()
-        
+
         try:
             tarr_new = np.delete(tarr_old.copy(), self.tkey[site])
             if site in ephem_old.keys():
-                ephem_new.pop(site) 
-        except:
-            raise Exception("could not find site %s to delete from Array!"%site)
-        
+                ephem_new.pop(site)
+        except KeyError as exc:
+            raise Exception(f"could not find site {site} to delete from Array!") from exc
+
         arr_out = Array(tarr_new, ephem_new)
         return arr_out
 
     def add_satellite_tle(self, tlearr, sefd=10000):
-    
+
         """Add an earth-orbiting satellite to the array from a TLE
-        
-           Args: 
+
+           Args:
              tlearr (str) : 3 element list with [name, tle line 1, tle line 2] as strings
-             sefd (float) : assumed sefd for the array file (assumes sefdl = sefdr)     
+             sefd (float) : assumed sefd for the array file (assumes sefdl = sefdr)
         """
         satname = tlearr[0]
         tarr_new = self.tarr.copy()
         ephem_new = self.ephem.copy()
-        
+
         tarr_newline = np.array((str(satname), 0., 0., 0.,
-                                 float(sefd), float(sefd), 
+                                 float(sefd), float(sefd),
                                  0., 0., 0., 0., 0.), dtype=ehc.DTARR)
         tarr_new = np.append(tarr_new, tarr_newline)
         ephem_new[satname] = tlearr
         arr_out = Array(tarr_new, ephem_new)
-        
+
         return arr_out
 
-    def add_satellite_elements(self, satname, 
-                               perigee_mjd=Time.now().mjd, 
+    def add_satellite_elements(self, satname,
+                               perigee_mjd=Time.now().mjd,
                                period_days=1., eccentricity=0.,
-                               inclination=0., arg_perigee=0., long_ascending=0., 
+                               inclination=0., arg_perigee=0., long_ascending=0.,
                                sefd=10000):
         """Add an earth-orbiting satellite to the array from simple keplerian elements
            perfect keplerian orbit is assumed, no derivatives
-                   
-           Args: 
+
+           Args:
                perigee time given in mjd
                period given in days
                inclination, arg_perigee, long_ascending given in degrees
@@ -290,49 +285,51 @@ class Array(object):
 
         tarr_new = self.tarr.copy()
         ephem_new = self.ephem.copy()
-        
+
         tarr_newline = np.array((str(satname), 0., 0., 0.,
-                                 float(sefd), float(sefd), 
+                                 float(sefd), float(sefd),
                                  0., 0., 0., 0., 0.), dtype=ehc.DTARR)
         tarr_new = np.append(tarr_new, tarr_newline)
-        
+
         ephem_new[satname] = [perigee_mjd, period_days, eccentricity, inclination, arg_perigee, long_ascending]
         arr_out = Array(tarr_new, ephem_new)
-                
+
         return arr_out
-        
+
     def plot_satellite_orbits(self, tstart_mjd=Time.now().mjd, tstop_mjd=Time.now().mjd+1, npoints=1000):
         earth_radius_polar = 6357. #km
         earth_radius_eq = 6378.
-    
+
         fig = plt.figure(figsize=(18,6))
         gs = matplotlib.gridspec.GridSpec(1,3,width_ratios=[1,1,1])
-        
+
         satellites = self.ephem.keys()
         for i,satellite in enumerate(satellites):
-        
-            if i==0: color='k'
-            else: color=ehc.SCOLORS[i-1]
-            
+
+            if i == 0:
+                color = 'k'
+            else:
+                color = ehc.SCOLORS[i - 1]
+
             # get skyfield satelllite object
             if len(self.ephem[satellite])==3: # TLE
                 line1 = self.ephem[satellite][1]
-                line2 = self.ephem[satellite][2]            
+                line2 = self.ephem[satellite][2]
                 sat = obsh.sat_skyfield_from_tle(satellite, line1, line2)
             elif len(self.ephem[satellite])==6: #keplerian elements
                 elements = self.ephem[satellite]
                 sat = obsh.sat_skyfield_from_elements(satellite, tstart_mjd,
                                                       elements[0],elements[1],elements[2],elements[3],elements[4],elements[5])
             else:
-                raise Exception("ephemeris format not recognized for %s"%satellite)    
-        
+                raise Exception(f"ephemeris format not recognized for {satellite}")
+
             # get GCRS positions
             fracmjds = np.linspace(tstart_mjd, tstop_mjd, npoints)
             positions = obsh.orbit_skyfield(sat, fracmjds, whichout='gcrs')
             positions *= 1.e-3 # convert to km
             distances = np.sqrt(positions[0]**2 + positions[1]**2 + positions[2]**2)
             maxdist = np.max(distances)
-            
+
             ax1 = fig.add_subplot(gs[0])
             ax1.set_aspect(1)
             plt.plot(positions[0], positions[1], color=color, marker='.',ls='None')
@@ -353,8 +350,8 @@ class Array(object):
             plt.ylabel('z (km)')
             plt.xlim(-1.1*maxdist, 1.1*maxdist)
             plt.ylim(-1.1*maxdist, 1.1*maxdist)
-            plt.grid()  
-            
+            plt.grid()
+
             ax3 = fig.add_subplot(gs[2])
             ax3.set_aspect(1)
             plt.plot(positions[0], positions[2], color=color, marker='.',ls='None', label=satellite)
@@ -368,9 +365,9 @@ class Array(object):
             plt.grid()
 
         plt.subplots_adjust(wspace=1)
-        ehc.show_noblock()            
+        ehc.show_noblock()
         return
-                                 
+
 ##########################################################################
 # Array creation functions
 ##########################################################################

--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -253,7 +253,7 @@ class Array(object):
         arr_out = Array(tarr_new, ephem_new)
         return arr_out
 
-    def add_satellite_tle(self, tlelist, sefd=10000):
+    def add_satellite_tle(self, tlearr, sefd=10000):
     
         """Add an earth-orbiting satellite to the array from a TLE
         

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -33,6 +33,20 @@ import ehtim as eh
 import ehtim.const_def as ehc
 
 # ---------------------------------------------------------------------------
+# Constants used across the module
+# ---------------------------------------------------------------------------
+
+# Synthetic satellite parameters for the plot_satellite_orbits + elements
+# coverage. Values chosen to be a plausible LEO orbit so skyfield's element
+# constructor doesn't reject the inputs as unphysical.
+SAT_NAME = "TESTSAT"
+SAT_PERIOD_DAYS = 0.0625        # ~90 minutes, LEO
+SAT_INCLINATION_DEG = 51.6      # ISS-like
+SAT_TSTART_MJD = 60000.0
+SAT_TSTOP_MJD = 60000.05        # ~72 minutes of orbit propagation
+SAT_NPOINTS = 32                # keep the smoke fast
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -295,9 +309,6 @@ def test_remove_site_also_removes_ephem_entry():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="Bug in Array.add_satellite_tle (array.py:264): "
-                          "body references `tlearr` but the kwarg is `tlelist`. "
-                          "Fixed by PR #260 which renames the kwarg to `tlearr`.")
 def test_add_satellite_tle_appends_row(eht_array):
     tle = ["SAT1", "tle_line_1", "tle_line_2"]
     out = eht_array.add_satellite_tle(tle, sefd=8000)
@@ -464,3 +475,46 @@ def test_array_pickle_roundtrip(eht_array):
         b = _site_row(rt, site)
         assert a["x"] == b["x"]
         assert a["sefdr"] == b["sefdr"]
+
+
+# ---------------------------------------------------------------------------
+# Plotting + satellite-elements
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def _agg_backend():
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    yield plt
+    plt.close("all")
+
+
+def test_plot_dterms_smoke(eht_array, _agg_backend):
+    axes = eht_array.plot_dterms(show=False, legend=False, export_pdf="")
+    assert axes is not None
+
+
+def test_add_satellite_elements_populates_keplerian_ephem(eht_array):
+    out = eht_array.add_satellite_elements(
+        SAT_NAME,
+        perigee_mjd=SAT_TSTART_MJD,
+        period_days=SAT_PERIOD_DAYS,
+        inclination=SAT_INCLINATION_DEG,
+    )
+    assert SAT_NAME in out.ephem
+    # Keplerian ephem entries are 6-tuples (perigee_mjd, period, e, i, omega, Omega).
+    assert len(out.ephem[SAT_NAME]) == 6
+
+
+def test_plot_satellite_orbits_smoke(eht_array, _agg_backend):
+    arr = eht_array.add_satellite_elements(
+        SAT_NAME,
+        perigee_mjd=SAT_TSTART_MJD,
+        period_days=SAT_PERIOD_DAYS,
+        inclination=SAT_INCLINATION_DEG,
+    )
+    arr.plot_satellite_orbits(tstart_mjd=SAT_TSTART_MJD,
+                              tstop_mjd=SAT_TSTOP_MJD,
+                              npoints=SAT_NPOINTS)


### PR DESCRIPTION
Fills the partial-coverage gaps on `array.py` per `docs/coverage_status.md`. 3 new tests + 1 unxfailed + 1 source fix.

### Bonus fix

`Array.add_satellite_tle` had its kwarg name (`tlelist`) mismatched against the body's `tlearr` references, so every call raised `NameError`. Renamed the kwarg to `tlearr` to match the body (and matches the rename Andrew made on `dev-backend-mixpol` in #260). Docstring already said `tlearr (str)`.

### Tests added

- `plot_dterms` Agg-backend smoke.
- `add_satellite_elements_populates_keplerian_ephem` — verifies the 6-tuple ephem entry.
- `plot_satellite_orbits` Agg-backend smoke (uses `add_satellite_elements` to populate ephem first, then propagates a short LEO orbit).

### Unxfailed

- `test_add_satellite_tle_appends_row` now passes courtesy of the kwarg fix above.