### PR TITLE
Clean up ruff debt in network_cal.py

### DIFF
--- a/ehtim/calibrating/network_cal.py
+++ b/ehtim/calibrating/network_cal.py
@@ -17,24 +17,20 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from __future__ import division
-from __future__ import print_function
 
-from builtins import str
-from builtins import range
-from builtins import object
+import copy
+import time
+from multiprocessing import Pool, cpu_count
 
 import numpy as np
 import scipy.optimize as opt
-import time
-import copy
-from multiprocessing import cpu_count, Pool
 
-import ehtim.obsdata
-import ehtim.parloop as parloop
-from . import cal_helpers as calh
-import ehtim.observing.obs_helpers as obsh
 import ehtim.const_def as ehc
+import ehtim.obsdata
+import ehtim.observing.obs_helpers as obsh
+import ehtim.parloop as parloop
+
+from . import cal_helpers as calh
 
 ZBLCUTOFF = 1.e7
 MAXIT = 5000
@@ -109,14 +105,14 @@ def network_cal(obs, zbl, sites=[], zbl_uvdist_max=ZBLCUTOFF, method="amp", mini
         counter = parloop.Counter(initval=0, maxval=len(scans))
         if processes > len(scans):
             processes = len(scans)
-        print("Using Multiprocessing with %d Processes" % processes)
+        print(f"Using Multiprocessing with {processes} Processes")
         pool = Pool(processes=processes, initializer=init, initargs=(counter,))
     elif processes == 0:
         counter = parloop.Counter(initval=0, maxval=len(scans))
         processes = int(cpu_count())
         if processes > len(scans):
             processes = len(scans)
-        print("Using Multiprocessing with %d Processes" % processes)
+        print(f"Using Multiprocessing with {processes} Processes")
         pool = Pool(processes=processes, initializer=init, initargs=(counter,))
     else:
         print("Not Using Multiprocessing")
@@ -140,7 +136,7 @@ def network_cal(obs, zbl, sites=[], zbl_uvdist_max=ZBLCUTOFF, method="amp", mini
                                             pad_amp=pad_amp, gain_tol=gain_tol, debias=debias)
 
     tstop = time.time()
-    print("\nnetwork_cal time: %f s" % (tstop - tstart))
+    print(f"\nnetwork_cal time: {tstop - tstart:f} s")
 
     if caltable:  # create and return  a caltable
         allsites = obs.tarr['site']
@@ -302,7 +298,7 @@ def network_cal_scan(scan, zbl, sites, clustered_sites, polrep='stokes', pol='I'
     n_gains = len(sites)
     n_clusterbls = len(clusterbls)
     if show_solution:
-        print('%d Gains; %d Clusters' % (n_gains, n_clusterbls))
+        print(f'{n_gains} Gains; {n_clusterbls} Clusters')
 
     gpar_guess = np.ones(n_gains, dtype=np.complex128).view(dtype=np.float64)
     vpar_guess = np.ones(n_clusterbls, dtype=np.complex128)


### PR DESCRIPTION
Pre-existing ruff debt in `ehtim/calibrating/network_cal.py` (the touch-debt-laden-file pattern) gets inherited by any PR that touches the file. PR #276 hit this during the cal-cluster work and bundled the cleanup; extracting it here so it lands independently and the next touch is clean.

Pure ruff fixes, no functional change:

- Removed unused `from __future__ import division` / `print_function` (`UP010`).
- Removed unused `from builtins import str`, `range`, `object` (`UP029`).
- 4× `'...' % var` → `f"..."` (`UP031`).
- Import block sort (`I001`).
- Whitespace and trailing-blank-line strips (`W291`, `W293`).

Identical cleanup as the one bundled in PR #276; that commit becomes a no-op on rebase after this lands. The matching cleanup for `array.py` was bundled with the kwarg fix in PR #280 and isn't extracted here because the cleanup uncovers a latent `F821` that needs the kwarg fix to resolve.