### PR TITLE
Pre-release prep: bump to 1.4.0 + README update + self_cal ComplexWarning fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ The package contains several primary classes for loading, simulating, and manipu
 Installation
 ------------
 
-The latest development version (`1.4 <https://github.com/achael/eht-imaging/releases/tag/v1.4>`_) _. Requires Python 3.11 or 3.12. Simply install pip and run
+The latest development version (`1.4 <https://github.com/achael/eht-imaging/releases/tag/v1.4>`_) requires Python 3.11 or 3.12. Simply install pip and run
 
 .. code-block:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ The package contains several primary classes for loading, simulating, and manipu
 Installation
 ------------
 
-The latest stable version (`1.3 <https://github.com/achael/eht-imaging/releases/tag/v1.3>`_) is available on `PyPi <https://pypi.org/project/ehtim/>`_. Simply install pip and run
+The latest stable version (`1.4 <https://github.com/achael/eht-imaging/releases/tag/v1.4>`_) is available on `PyPi <https://pypi.org/project/ehtim/>`_. Requires Python 3.11 or 3.12. Simply install pip and run
 
 .. code-block:: bash
 
@@ -22,29 +22,21 @@ Incremental updates are developed on the `dev branch <https://github.com/achael/
 
     pip install .
 
-Installing with pip will update most of the required libraries automatically (`numpy <http://www.numpy.org/>`_, `scipy <http://www.scipy.org/>`_, `matplotlib <http://www.matplotlib.org/>`_, `astropy <http://www.astropy.org/>`_, `ephem <http://pypi.python.org/pypi/pyephem/>`_, `future <http://pypi.python.org/pypi/future>`_, `h5py <http://www.h5py.org/>`_, and `pandas <http://www.pandas.pydata.org/>`_).
+Installing with pip will install the required libraries automatically (`numpy <http://www.numpy.org/>`_, `scipy <http://www.scipy.org/>`_, `matplotlib <http://www.matplotlib.org/>`_, `astropy <http://www.astropy.org/>`_, `finufft <https://github.com/flatironinstitute/finufft>`_, `skyfield <https://rhodesmill.org/skyfield/>`_, `h5py <http://www.h5py.org/>`_, `networkx <https://networkx.github.io/>`_, `requests <http://docs.python-requests.org/en/master/>`_, and `future <http://pypi.python.org/pypi/future>`_).
 
 
-NFFT Installation
------------------
-**If you want to use fast fourier transforms, you will also need to separately install** `NFFT <https://github.com/NFFT/nfft>`_ **and its** `pyNFFT wrapper <https://github.com/ghisvail/pyNFFT/>`__.
+Optional Dependencies
+---------------------
+Certain functions require packages not in the default install:
 
-**Note that, unfortunately, pyNFFT is only supported for python versions <=3.11  and numpy versions <=1.26.4**
+- `pandas <http://www.pandas.pydata.org/>`_ for the legacy ``ehtim.statistics.dataframes`` utilities and the flag-file CSV reader / scan-id binning helpers in ``Obsdata``
+- `paramsurvey <https://github.com/wumpus/paramsurvey>`_ for the parameter-survey utilities in ``ehtim.survey``
 
-A new eht-imaging version 2.0 replacing pynfft with the actively maintained `finufft <https://github.com/flatironinstitute/finufft>`__ library is in active development.
-
-The simplest way is to use `conda <https://anaconda.org/conda-forge/pynfft/>`__ to install both NFFT and pyNFFT:
-
+Install individually as needed:
 
 .. code-block:: bash
 
-    conda install -c conda-forge pynfft
-
-Alternatively, first install NFFT manually following the instructions on the `readme <https://github.com/NFFT/nfft>`__, making sure to use the ``--enable-openmp`` flag in compilation. Then install `pynfft <https://github.com/ghisvail/pyNFFT/>`__, with pip, following the readme instructions to link the installation to where you installed NFFT. Finally, reinstall ehtim.
-
-**For M1 Macs and later (MacOS >= v12.0)**, install the updated Mac version of `pynfft <https://github.com/rohandahale/pyNFFT.git>`__ and follow the instructions on the `readme  <https://github.com/rohandahale/pyNFFT.git>`__ to manually install `fftw <http://www.fftw.org>`_, `nfft <https://github.com/NFFT/nfft>`__ and then `pynfft <https://github.com/rohandahale/pyNFFT.git>`__.
-
-**Certain eht-imaging functions require other external packages that are not automatically installed.** In addition to pynfft, these include  `networkx <https://networkx.github.io/>`_ (for image comparison functions), `requests <http://docs.python-requests.org/en/master/>`_ (for dynamical imaging), and `scikit-image <https://scikit-image.org/>`_ (for a few image analysis functions). However, the vast majority of the code will work without these dependencies.
+    pip install pandas paramsurvey
 
 Documentation and Tutorials
 ---------------------------

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ The package contains several primary classes for loading, simulating, and manipu
 Installation
 ------------
 
-The latest stable version (`1.4 <https://github.com/achael/eht-imaging/releases/tag/v1.4>`_) is available on `PyPi <https://pypi.org/project/ehtim/>`_. Requires Python 3.11 or 3.12. Simply install pip and run
+The latest development version (`1.4 <https://github.com/achael/eht-imaging/releases/tag/v1.4>`_) _. Requires Python 3.11 or 3.12. Simply install pip and run
 
 .. code-block:: bash
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ The package contains several primary classes for loading, simulating, and manipu
 Installation
 ------------
 
-The latest stable version (`1.2.11 <https://github.com/achael/eht-imaging/releases/tag/v1.2.11>`_) is available on `PyPi <https://pypi.org/project/ehtim/>`_. Simply install pip and run
+The latest stable version (`1.4 <https://github.com/achael/eht-imaging/releases/tag/v1.4>`_) is available on `PyPi <https://pypi.org/project/ehtim/>`_. Requires Python 3.11 or 3.12. Simply install pip and run
 
 .. code-block:: bash
 
@@ -33,27 +33,21 @@ Incremental updates are developed on the `dev branch <https://github.com/achael/
 
     pip install .
 
-Installing with pip will update most of the required libraries automatically (`numpy <http://www.numpy.org/>`_, `scipy <http://www.scipy.org/>`_, `matplotlib <http://www.matplotlib.org/>`_, `astropy <http://www.astropy.org/>`_, `ephem <http://pypi.python.org/pypi/pyephem/>`_, `future <http://pypi.python.org/pypi/future>`_, `h5py <http://www.h5py.org/>`_, and `pandas <http://www.pandas.pydata.org/>`_).
+Installing with pip will install the required libraries automatically (`numpy <http://www.numpy.org/>`_, `scipy <http://www.scipy.org/>`_, `matplotlib <http://www.matplotlib.org/>`_, `astropy <http://www.astropy.org/>`_, `finufft <https://github.com/flatironinstitute/finufft>`_, `skyfield <https://rhodesmill.org/skyfield/>`_, `h5py <http://www.h5py.org/>`_, `networkx <https://networkx.github.io/>`_, `requests <http://docs.python-requests.org/en/master/>`_, and `future <http://pypi.python.org/pypi/future>`_).
 
 
-NFFT Installation
-------------
-**If you want to use fast fourier transforms, you will also need to separately install** `NFFT <https://github.com/NFFT/nfft>`_ **and its** `pyNFFT wrapper <https://github.com/ghisvail/pyNFFT/>`__. 
+Optional Dependencies
+---------------------
+Certain functions require packages not in the default install:
 
-The simplest way is to use `conda <https://anaconda.org/conda-forge/pynfft/>`__ to install both NFFT and pyNFFT:
+- `pandas <http://www.pandas.pydata.org/>`_ for the legacy ``ehtim.statistics.dataframes`` utilities and the flag-file CSV reader / scan-id binning helpers in ``Obsdata``
+- `paramsurvey <https://github.com/wumpus/paramsurvey>`_ for the parameter-survey utilities in ``ehtim.survey``
 
+Install individually as needed:
 
 .. code-block:: bash
 
-    conda install -c conda-forge pynfft
-
-Alternatively, first install NFFT manually following the instructions on the `readme <https://github.com/NFFT/nfft>`__, making sure to use the ``--enable-openmp`` flag in compilation. Then install `pynfft <https://github.com/ghisvail/pyNFFT/>`__, with pip, following the readme instructions to link the installation to where you installed NFFT. Finally, reinstall ehtim.
-
-**Note that, unfortunately, pyNFFT is only supported for python versions 3.11 or lower.** eht-imaging version 2.0 using the `finufft <https://github.com/flatironinstitute/finufft>`__ library is in active development.
-
-**For M1/M2/M3/M4/M5 Macs (MacOS >= v12.0)**, install the updated Mac version of `pynfft <https://github.com/rohandahale/pyNFFT.git>`__ and follow the instructions on the `readme  <https://github.com/rohandahale/pyNFFT.git>`__ to manually install `fftw <http://www.fftw.org>`_, `nfft <https://github.com/NFFT/nfft>`__ and then `pynfft <https://github.com/rohandahale/pyNFFT.git>`__.
-
-**Certain eht-imaging functions require other external packages that are not automatically installed.** In addition to pynfft, these include  `networkx <https://networkx.github.io/>`_ (for image comparison functions), `requests <http://docs.python-requests.org/en/master/>`_ (for dynamical imaging), and `scikit-image <https://scikit-image.org/>`_ (for a few image analysis functions). However, the vast majority of the code will work without these dependencies.
+    pip install pandas paramsurvey
 
 Documentation and Tutorials
 ---------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ The package contains several primary classes for loading, simulating, and manipu
 Installation
 ------------
 
-The latest stable version (`1.4 <https://github.com/achael/eht-imaging/releases/tag/v1.4>`_) is available on `PyPi <https://pypi.org/project/ehtim/>`_. Requires Python 3.11 or 3.12. Simply install pip and run
+The latest development version (`1.4 <https://github.com/achael/eht-imaging/releases/tag/v1.4>`_) requires Python 3.11 or 3.12. Simply install pip and run
 
 .. code-block:: bash
 

--- a/ehtim/calibrating/self_cal.py
+++ b/ehtim/calibrating/self_cal.py
@@ -554,8 +554,8 @@ def errfunc_grad_full(gpar, vis, v_scan, sigma_inv, gain_tol, sites, g1_keys, g2
         g1idx = np.argwhere(np.array(g1_keys)==i)
         g2idx = np.argwhere(np.array(g2_keys)==i)
 
-        dchisq_dgr[i] = np.sum(dchisq_dg1r[g1idx]) + np.sum(dchisq_dg2r[g2idx])
-        dchisq_dgi[i] = np.sum(dchisq_dg1i[g1idx]) + np.sum(dchisq_dg2i[g2idx])
+        dchisq_dgr[i] = (np.sum(dchisq_dg1r[g1idx]) + np.sum(dchisq_dg2r[g2idx])).real
+        dchisq_dgi[i] = (np.sum(dchisq_dg1i[g1idx]) + np.sum(dchisq_dg2i[g2idx])).real
 
     ###################################
     # prior term chi^2 derivitive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ehtim"
-version = "1.3.0"
+version = "1.4.0"
 description = "Imaging, analysis, and simulation software for radio interferometry"
 readme = "README.rst"
 requires-python = ">=3.11,<3.13"
@@ -49,7 +49,7 @@ dev = [
 
 [project.urls]
 Homepage = "https://github.com/achael/eht-imaging"
-Download = "https://github.com/achael/eht-imaging/archive/v1.2.11.tar.gz"
+Download = "https://github.com/achael/eht-imaging/archive/v1.4.0.tar.gz"
 
 # --- setuptools-specific config ---
 


### PR DESCRIPTION
Release prep for the `dev-backend --> dev`, plus a small follow-up agreed on PR #276.

1. **Bump version 1.3.0 → 1.4.0.** : No breaking removals on dev-backend yet, so a minor bump is enough.

2. **README + docs/source/index.rst cleanup.** The pyNFFT installation section is obsolete since PR #253 swapped pyNFFT for FiNUFFT in May 2026, and the auto-installed dep list still listed `ephem` and `pandas` (gone after #271 and #252). Reconciled with `pyproject.toml`. New `Optional Dependencies` section documents `pandas` and `paramsurvey` install paths. Dead `scikit-image` mention removed (not imported anywhere in the codebase).

3. **self_cal `ComplexWarning` fix.** Follow-up on the side note from PR #276: `dchisq_dgr[i] = np.sum(complex_quantity)` at `self_cal.py:557-558` silently discarded the imaginary part. The FD parity in PR #276 confirmed the imaginary parts are numerically zero, so the warning was benign — but explicit `.real` at the source is cleaner than relying on the cast. Comment at line 583 (`# any imaginary parts??? should all be real`) acknowledged the uncertainty.