### PR TITLE
MixPol: data_conj, closures, and unpack widening for lin/mixed

### DIFF
--- a/ehtim/io/load.py
+++ b/ehtim/io/load.py
@@ -1093,7 +1093,27 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
     dr = np.zeros(len(tnames)) + 1j * np.zeros(len(tnames))
     dl = np.zeros(len(tnames)) + 1j * np.zeros(len(tnames))
 
-    # TODO (Phase 3c/6 mixed-pol): read POLTYA/POLTYB from the AIPS AN table
+    # Detect antenna feed types and raise if the observation is mixed-polarization
+    # (full POLTYA/POLTYB -> feed_type parsing is not yet implemented). Both feed
+    # columns are checked, so a hybrid station (e.g. POLTYA='R', POLTYB='X') is
+    # caught rather than silently loaded as circular.
+    feeds = set()
+    for col in ('POLTYA', 'POLTYB'):
+        try:
+            poltys = hdulist['AIPS AN'].data[col]
+        except KeyError:
+            continue
+        for p in poltys:
+            s = (p.decode() if isinstance(p, bytes) else str(p)).strip().upper()
+            if s:
+                feeds.add(s)
+    if not feeds <= {'R', 'L'}:
+        raise NotImplementedError(
+            "mixed-pol / linear-feed uvfits load is not yet supported; "
+            f"detected feed types {sorted(feeds)} in POLTYA/POLTYB. "
+            "See obsdata_mixedpol_plan.md.")
+
+    # TODO (Phase 7 mixed-pol): read POLTYA/POLTYB from the AIPS AN table
     # to populate per-station feed_type. Until then, assume circular feeds.
     tarr = [np.array((
             str(tnames[i]), xyz[i][0], xyz[i][1], xyz[i][2],

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -1007,122 +1007,15 @@ class Obsdata:
                 tdata = self.tarr[keys]
                 out = sites
                 ty = 'U32'
-            elif self.polrep == 'mixed':
-                # MIXED has no single column formula (slot meaning varies per row
-                # with feed_type), so dispatch per row via polbasis: row-aligned
-                # NaN-fill, Stokes-derived recovered with coherency_to_stokes.
-                out, sig, ty = obsh.unpack_vis_mixed(data, field)
-            elif field in ['vis', 'amp', 'phase', 'snr', 'sigma', 'sigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.vis_component(data, 'vis', self.polrep)
-            elif field in ['qvis', 'qamp', 'qphase', 'qsnr', 'qsigma', 'qsigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.vis_component(data, 'qvis', self.polrep)
-            elif field in ['uvis', 'uamp', 'uphase', 'usnr', 'usigma', 'usigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.vis_component(data, 'uvis', self.polrep)
-            elif field in ['vvis', 'vamp', 'vphase', 'vsnr', 'vsigma', 'vsigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.vis_component(data, 'vvis', self.polrep)
-            elif field in ['pvis', 'pamp', 'pphase', 'psnr', 'psigma', 'psigma_phase']:
-                ty = 'c16'
-                if self.polrep in ('stokes', 'circ'):
-                    out, sig = obsh.vis_component(data, 'rlvis', self.polrep)  # P = RL
-                elif self.polrep == 'lin':
-                    q, qsig = obsh.vis_component(data, 'qvis', 'lin')
-                    u, usig = obsh.vis_component(data, 'uvis', 'lin')
-                    out = q + 1j * u
-                    sig = np.sqrt(qsig**2 + usig**2)
-            elif field in ['m', 'mamp', 'mphase', 'msnr', 'msigma', 'msigma_phase']:
-                ty = 'c16'
-                if self.polrep == 'stokes':
-                    out = (data['qvis'] + 1j * data['uvis']) / data['vis']
-                    sig = obsh.merr(data['sigma'], data['qsigma'], data['usigma'], data['vis'], out)
-                elif self.polrep == 'circ':
-                    out = 2 * data['rlvis'] / (data['rrvis'] + data['llvis'])
-                    sig = obsh.merr2(data['rlsigma'], data['rrsigma'], data['llsigma'],
-                                     0.5 * (data['rrvis'] + data['llvis']), out)
-                elif self.polrep == 'lin':
-                    ivis, isig = obsh.vis_component(data, 'vis', 'lin')
-                    q, qsig = obsh.vis_component(data, 'qvis', 'lin')
-                    u, usig = obsh.vis_component(data, 'uvis', 'lin')
-                    out = (q + 1j * u) / ivis
-                    sig = obsh.merr(isig, qsig, usig, ivis, out)
-            elif field in ['evis', 'eamp', 'ephase', 'esnr', 'esigma', 'esigma_phase']:
-                ty = 'c16'
-                ang = np.arctan2(data['u'], data['v'])  # TODO: correct convention EofN?
-                q, qsig = obsh.vis_component(data, 'qvis', self.polrep)
-                u, usig = obsh.vis_component(data, 'uvis', self.polrep)
-                out = (np.cos(2 * ang) * q + np.sin(2 * ang) * u)
-                sig = np.sqrt(0.5 * ((np.cos(2 * ang) * qsig)**2 + (np.sin(2 * ang) * usig)**2))
-            elif field in ['bvis', 'bamp', 'bphase', 'bsnr', 'bsigma', 'bsigma_phase']:
-                ty = 'c16'
-                ang = np.arctan2(data['u'], data['v'])  # TODO: correct convention EofN?
-                q, qsig = obsh.vis_component(data, 'qvis', self.polrep)
-                u, usig = obsh.vis_component(data, 'uvis', self.polrep)
-                out = (-np.sin(2 * ang) * q + np.cos(2 * ang) * u)
-                sig = np.sqrt(0.5 * ((np.sin(2 * ang) * qsig)**2 + (np.cos(2 * ang) * usig)**2))
-            elif field in ['rrvis', 'rramp', 'rrphase', 'rrsnr', 'rrsigma', 'rrsigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.vis_component(data, 'rrvis', self.polrep)
-            elif field in ['llvis', 'llamp', 'llphase', 'llsnr', 'llsigma', 'llsigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.vis_component(data, 'llvis', self.polrep)
-            elif field in ['rlvis', 'rlamp', 'rlphase', 'rlsnr', 'rlsigma', 'rlsigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.vis_component(data, 'rlvis', self.polrep)
-            elif field in ['lrvis', 'lramp', 'lrphase', 'lrsnr', 'lrsigma', 'lrsigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.vis_component(data, 'lrvis', self.polrep)
-            elif field in ['rrllvis', 'rrllamp', 'rrllphase', 'rrllsnr',
-                           'rrllsigma', 'rrllsigma_phase']:
-                ty = 'c16'
-                if self.polrep == 'stokes':
-                    out = (data['vis'] + data['vvis']) / (data['vis'] - data['vvis'])
-                    sig = (2.0**0.5 * (np.abs(data['vis'])**2 + np.abs(data['vvis'])**2)**0.5
-                           / np.abs(data['vis'] - data['vvis'])**2
-                           * (data['sigma']**2 + data['vsigma']**2)**0.5)
-                elif self.polrep == 'circ':
-                    out = data['rrvis'] / data['llvis']
-                    sig = np.sqrt(np.abs(data['rrsigma'] / data['llvis'])**2
-                                  + np.abs(data['llsigma'] * data['rrvis'] / data['llvis'])**2)
-                else:
-                    raise Exception(f"unpack: field {field!r} not supported for "
-                                    f"polrep {self.polrep!r}")
-
-            elif field in ['xxvis', 'xxamp', 'xxphase', 'xxsnr', 'xxsigma', 'xxsigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.vis_component(data, 'xxvis', self.polrep)
-            elif field in ['yyvis', 'yyamp', 'yyphase', 'yysnr', 'yysigma', 'yysigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.vis_component(data, 'yyvis', self.polrep)
-            elif field in ['xyvis', 'xyamp', 'xyphase', 'xysnr', 'xysigma', 'xysigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.vis_component(data, 'xyvis', self.polrep)
-            elif field in ['yxvis', 'yxamp', 'yxphase', 'yxsnr', 'yxsigma', 'yxsigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.vis_component(data, 'yxvis', self.polrep)
-
-            elif field in ['p1p1vis', 'p1p1amp', 'p1p1phase', 'p1p1snr',
-                           'p1p1sigma', 'p1p1sigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.unpack_generic_slot(data, 'p1p1', self.polrep)
-            elif field in ['p2p2vis', 'p2p2amp', 'p2p2phase', 'p2p2snr',
-                           'p2p2sigma', 'p2p2sigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.unpack_generic_slot(data, 'p2p2', self.polrep)
-            elif field in ['p1p2vis', 'p1p2amp', 'p1p2phase', 'p1p2snr',
-                           'p1p2sigma', 'p1p2sigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.unpack_generic_slot(data, 'p1p2', self.polrep)
-            elif field in ['p2p1vis', 'p2p1amp', 'p2p1phase', 'p2p1snr',
-                           'p2p1sigma', 'p2p1sigma_phase']:
-                ty = 'c16'
-                out, sig = obsh.unpack_generic_slot(data, 'p2p1', self.polrep)
-
             else:
-                raise Exception(f"{field} is not a valid field \n" +
-                                "valid field values are: " + ' '.join(ehc.FIELDS))
+                # vis-family fields (or invalid -> the helpers raise). MIXED needs
+                # per-row dispatch (unpack_vis_mixed); stokes/circ/lin use
+                # unpack_vis_standard. Both return the base complex value + sigma;
+                # the suffix stage below turns it into amp/phase/snr/etc.
+                if self.polrep == 'mixed':
+                    out, sig, ty = obsh.unpack_vis_mixed(data, field)
+                else:
+                    out, sig, ty = obsh.unpack_vis_standard(data, field, self.polrep)
 
             if field in ["time_utc"] and self.timetype == 'GMST':
                 out = obsh.gmst_to_utc(out, self.mjd)

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -1008,16 +1008,10 @@ class Obsdata:
                 out = sites
                 ty = 'U32'
             else:
+                # all visibility logic for all polreps in obsh.unpack_vis
                 out, sig, ty = obsh.unpack_vis(data, field, self.polrep)
-                # vis-family fields (or invalid -> the helpers raise). MIXED needs
-                # per-row dispatch (unpack_vis_mixed); stokes/circ/lin use
-                # unpack_vis_standard. Both return the base complex value + sigma;
-                # the suffix stage below turns it into amp/phase/snr/etc.
-                #if self.polrep == 'mixed':
-                #    out, sig, ty = obsh.unpack_vis_standard(data, field, self.polrep)
-                #else:
-                #    out, sig, ty = obsh.unpack_vis_standard(data, field, self.polrep)
 
+            # time transforms
             if field in ["time_utc"] and self.timetype == 'GMST':
                 out = obsh.gmst_to_utc(out, self.mjd)
             if field in ["time_gmst"] and self.timetype == 'UTC':

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -670,7 +670,15 @@ class Obsdata:
                (numpy.recarray): a copy of the Obsdata.data table including all conjugate baselines.
         """
 
+        if self.polrep not in ('stokes', 'circ', 'lin', 'mixed'):
+            raise Exception("polrep must be 'stokes', 'circ', 'lin', or 'mixed'")
+
         data = np.empty(2 * len(self.data), dtype=self.poltype)
+
+        # Generic polarization slot names for this polrep
+        vis1, vis2 = self.poldict['vis1'], self.poldict['vis2']
+        vis3, vis4 = self.poldict['vis3'], self.poldict['vis4']
+        sig3, sig4 = self.poldict['sigma3'], self.poldict['sigma4']
 
         # Add the conjugate baseline data
         for f in self.data.dtype.names:
@@ -684,26 +692,35 @@ class Obsdata:
             elif f in ['u', 'v']:
                 data[f] = np.hstack((self.data[f], -self.data[f]))
 
-            elif f in [self.poldict['vis1'], self.poldict['vis2'],
-                       self.poldict['vis3'], self.poldict['vis4']]:
-                if self.polrep == 'stokes':
-                    data[f] = np.hstack((self.data[f], np.conj(self.data[f])))
-                elif self.polrep == 'circ':
-                    if f in ['rrvis', 'llvis']:
-                        data[f] = np.hstack((self.data[f], np.conj(self.data[f])))
-                    elif f == 'rlvis':
-                        data[f] = np.hstack((self.data['rlvis'], np.conj(self.data['lrvis'])))
-                    elif f == 'lrvis':
-                        data[f] = np.hstack((self.data['lrvis'], np.conj(self.data['rlvis'])))
+            elif f == 'polbasis':
+                # The conjugate baseline swaps the two stations, so the two
+                # halves of the per-row feed-type code swap (e.g. 'rlxy' -> 'xyrl').
+                pb = self.data['polbasis']
+                pb_swapped = np.array([s[2:] + s[:2] for s in pb], dtype=pb.dtype)
+                data[f] = np.hstack((pb, pb_swapped))
 
-                    # ALSO SWITCH THE ERRORS!
+            elif f in (vis1, vis2, vis3, vis4):
+                if self.polrep == 'stokes':
+                    # Stokes visibilities are Hermitian: conjugate all four.
+                    data[f] = np.hstack((self.data[f], np.conj(self.data[f])))
                 else:
-                    raise Exception("polrep must be either 'stokes' or 'circ'")
-            # The conjugate baselines need the transpose error terms.
-            elif f == "rlsigma":
-                data[f] = np.hstack((self.data["rlsigma"], self.data["lrsigma"]))
-            elif f == "lrsigma":
-                data[f] = np.hstack((self.data["lrsigma"], self.data["rlsigma"]))
+                    # Coherency matrix transforms as V_ji = V_ij^dagger under
+                    # baseline reversal: diagonal slots conjugate, cross-hand
+                    # slots conjugate and swap. Expressed in generic slot names,
+                    # this holds for circ, lin, and every mixed-feed row.
+                    if f in (vis1, vis2):
+                        data[f] = np.hstack((self.data[f], np.conj(self.data[f])))
+                    elif f == vis3:
+                        data[f] = np.hstack((self.data[vis3], np.conj(self.data[vis4])))
+                    elif f == vis4:
+                        data[f] = np.hstack((self.data[vis4], np.conj(self.data[vis3])))
+
+            # The conjugate baselines need the transposed cross-hand error terms
+            # (the diagonal sigmas are unchanged). Stokes has no cross-hand swap.
+            elif self.polrep != 'stokes' and f == sig3:
+                data[f] = np.hstack((self.data[sig3], self.data[sig4]))
+            elif self.polrep != 'stokes' and f == sig4:
+                data[f] = np.hstack((self.data[sig4], self.data[sig3]))
 
             else:
                 data[f] = np.hstack((self.data[f], self.data[f]))

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -1008,9 +1008,10 @@ class Obsdata:
                 out = sites
                 ty = 'U32'
             elif self.polrep == 'mixed':
-                # MIXED unpack (row-aligned NaN-fill) lands in the next commit.
-                raise NotImplementedError(
-                    "unpack on polrep='mixed' is not yet implemented")
+                # MIXED has no single column formula (slot meaning varies per row
+                # with feed_type), so dispatch per row via polbasis: row-aligned
+                # NaN-fill, Stokes-derived recovered with coherency_to_stokes.
+                out, sig, ty = obsh.unpack_vis_mixed(data, field)
             elif field in ['vis', 'amp', 'phase', 'snr', 'sigma', 'sigma_phase']:
                 ty = 'c16'
                 out, sig = obsh.vis_component(data, 'vis', self.polrep)
@@ -1105,19 +1106,19 @@ class Obsdata:
             elif field in ['p1p1vis', 'p1p1amp', 'p1p1phase', 'p1p1snr',
                            'p1p1sigma', 'p1p1sigma_phase']:
                 ty = 'c16'
-                out, sig = self._unpack_generic_slot(data, 'p1p1')
+                out, sig = obsh.unpack_generic_slot(data, 'p1p1', self.polrep)
             elif field in ['p2p2vis', 'p2p2amp', 'p2p2phase', 'p2p2snr',
                            'p2p2sigma', 'p2p2sigma_phase']:
                 ty = 'c16'
-                out, sig = self._unpack_generic_slot(data, 'p2p2')
+                out, sig = obsh.unpack_generic_slot(data, 'p2p2', self.polrep)
             elif field in ['p1p2vis', 'p1p2amp', 'p1p2phase', 'p1p2snr',
                            'p1p2sigma', 'p1p2sigma_phase']:
                 ty = 'c16'
-                out, sig = self._unpack_generic_slot(data, 'p1p2')
+                out, sig = obsh.unpack_generic_slot(data, 'p1p2', self.polrep)
             elif field in ['p2p1vis', 'p2p1amp', 'p2p1phase', 'p2p1snr',
                            'p2p1sigma', 'p2p1sigma_phase']:
                 ty = 'c16'
-                out, sig = self._unpack_generic_slot(data, 'p2p1')
+                out, sig = obsh.unpack_generic_slot(data, 'p2p1', self.polrep)
 
             else:
                 raise Exception(f"{field} is not a valid field \n" +
@@ -1203,16 +1204,6 @@ class Obsdata:
                 allout = out
 
         return allout
-
-    def _unpack_generic_slot(self, data, slot):
-        """Return (vis, sigma) for a generic feed slot ('p1p1'/'p2p2'/'p1p2'/
-           'p2p1'), read directly via the DTPOL title alias. Defined for circ
-           and lin (where the slot aliases the physical correlation); stokes
-           has no feed slots. (mixed is handled before this is reached.)"""
-        if self.polrep == 'stokes':
-            raise Exception(f"unpack: generic slot {slot}vis has no meaning "
-                            "for polrep 'stokes'")
-        return data[slot + 'vis'], data[slot + 'sigma']
 
     def sourcevec(self):
         """Return the source position vector in geocentric coordinates at 0h GMST.

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -1008,14 +1008,15 @@ class Obsdata:
                 out = sites
                 ty = 'U32'
             else:
+                out, sig, ty = obsh.unpack_vis(data, field, self.polrep)
                 # vis-family fields (or invalid -> the helpers raise). MIXED needs
                 # per-row dispatch (unpack_vis_mixed); stokes/circ/lin use
                 # unpack_vis_standard. Both return the base complex value + sigma;
                 # the suffix stage below turns it into amp/phase/snr/etc.
-                if self.polrep == 'mixed':
-                    out, sig, ty = obsh.unpack_vis_mixed(data, field)
-                else:
-                    out, sig, ty = obsh.unpack_vis_standard(data, field, self.polrep)
+                #if self.polrep == 'mixed':
+                #    out, sig, ty = obsh.unpack_vis_standard(data, field, self.polrep)
+                #else:
+                #    out, sig, ty = obsh.unpack_vis_standard(data, field, self.polrep)
 
             if field in ["time_utc"] and self.timetype == 'GMST':
                 out = obsh.gmst_to_utc(out, self.mjd)

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -1007,46 +1007,31 @@ class Obsdata:
                 tdata = self.tarr[keys]
                 out = sites
                 ty = 'U32'
+            elif self.polrep == 'mixed':
+                # MIXED unpack (row-aligned NaN-fill) lands in the next commit.
+                raise NotImplementedError(
+                    "unpack on polrep='mixed' is not yet implemented")
             elif field in ['vis', 'amp', 'phase', 'snr', 'sigma', 'sigma_phase']:
                 ty = 'c16'
-                if self.polrep == 'stokes':
-                    out = data['vis']
-                    sig = data['sigma']
-                elif self.polrep == 'circ':
-                    out = 0.5 * (data['rrvis'] + data['llvis'])
-                    sig = 0.5 * np.sqrt(data['rrsigma']**2 + data['llsigma']**2)
+                out, sig = obsh.vis_component(data, 'vis', self.polrep)
             elif field in ['qvis', 'qamp', 'qphase', 'qsnr', 'qsigma', 'qsigma_phase']:
                 ty = 'c16'
-                if self.polrep == 'stokes':
-                    out = data['qvis']
-                    sig = data['qsigma']
-                elif self.polrep == 'circ':
-                    out = 0.5 * (data['lrvis'] + data['rlvis'])
-                    sig = 0.5 * np.sqrt(data['lrsigma']**2 + data['rlsigma']**2)
+                out, sig = obsh.vis_component(data, 'qvis', self.polrep)
             elif field in ['uvis', 'uamp', 'uphase', 'usnr', 'usigma', 'usigma_phase']:
                 ty = 'c16'
-                if self.polrep == 'stokes':
-                    out = data['uvis']
-                    sig = data['usigma']
-                elif self.polrep == 'circ':
-                    out = 0.5j * (data['lrvis'] - data['rlvis'])
-                    sig = 0.5 * np.sqrt(data['lrsigma']**2 + data['rlsigma']**2)
+                out, sig = obsh.vis_component(data, 'uvis', self.polrep)
             elif field in ['vvis', 'vamp', 'vphase', 'vsnr', 'vsigma', 'vsigma_phase']:
                 ty = 'c16'
-                if self.polrep == 'stokes':
-                    out = data['vvis']
-                    sig = data['vsigma']
-                elif self.polrep == 'circ':
-                    out = 0.5 * (data['rrvis'] - data['llvis'])
-                    sig = 0.5 * np.sqrt(data['rrsigma']**2 + data['llsigma']**2)
+                out, sig = obsh.vis_component(data, 'vvis', self.polrep)
             elif field in ['pvis', 'pamp', 'pphase', 'psnr', 'psigma', 'psigma_phase']:
                 ty = 'c16'
-                if self.polrep == 'stokes':
-                    out = data['qvis'] + 1j * data['uvis']
-                    sig = np.sqrt(data['qsigma']**2 + data['usigma']**2)
-                elif self.polrep == 'circ':
-                    out = data['rlvis']
-                    sig = data['rlsigma']
+                if self.polrep in ('stokes', 'circ'):
+                    out, sig = obsh.vis_component(data, 'rlvis', self.polrep)  # P = RL
+                elif self.polrep == 'lin':
+                    q, qsig = obsh.vis_component(data, 'qvis', 'lin')
+                    u, usig = obsh.vis_component(data, 'uvis', 'lin')
+                    out = q + 1j * u
+                    sig = np.sqrt(qsig**2 + usig**2)
             elif field in ['m', 'mamp', 'mphase', 'msnr', 'msigma', 'msigma_phase']:
                 ty = 'c16'
                 if self.polrep == 'stokes':
@@ -1056,68 +1041,38 @@ class Obsdata:
                     out = 2 * data['rlvis'] / (data['rrvis'] + data['llvis'])
                     sig = obsh.merr2(data['rlsigma'], data['rrsigma'], data['llsigma'],
                                      0.5 * (data['rrvis'] + data['llvis']), out)
+                elif self.polrep == 'lin':
+                    ivis, isig = obsh.vis_component(data, 'vis', 'lin')
+                    q, qsig = obsh.vis_component(data, 'qvis', 'lin')
+                    u, usig = obsh.vis_component(data, 'uvis', 'lin')
+                    out = (q + 1j * u) / ivis
+                    sig = obsh.merr(isig, qsig, usig, ivis, out)
             elif field in ['evis', 'eamp', 'ephase', 'esnr', 'esigma', 'esigma_phase']:
                 ty = 'c16'
                 ang = np.arctan2(data['u'], data['v'])  # TODO: correct convention EofN?
-                if self.polrep == 'stokes':
-                    q = data['qvis']
-                    u = data['uvis']
-                    qsig = data['qsigma']
-                    usig = data['usigma']
-                elif self.polrep == 'circ':
-                    q = 0.5 * (data['lrvis'] + data['rlvis'])
-                    u = 0.5j * (data['lrvis'] - data['rlvis'])
-                    qsig = 0.5 * np.sqrt(data['lrsigma']**2 + data['rlsigma']**2)
-                    usig = qsig
+                q, qsig = obsh.vis_component(data, 'qvis', self.polrep)
+                u, usig = obsh.vis_component(data, 'uvis', self.polrep)
                 out = (np.cos(2 * ang) * q + np.sin(2 * ang) * u)
                 sig = np.sqrt(0.5 * ((np.cos(2 * ang) * qsig)**2 + (np.sin(2 * ang) * usig)**2))
             elif field in ['bvis', 'bamp', 'bphase', 'bsnr', 'bsigma', 'bsigma_phase']:
                 ty = 'c16'
                 ang = np.arctan2(data['u'], data['v'])  # TODO: correct convention EofN?
-                if self.polrep == 'stokes':
-                    q = data['qvis']
-                    u = data['uvis']
-                    qsig = data['qsigma']
-                    usig = data['usigma']
-                elif self.polrep == 'circ':
-                    q = 0.5 * (data['lrvis'] + data['rlvis'])
-                    u = 0.5j * (data['lrvis'] - data['rlvis'])
-                    qsig = 0.5 * np.sqrt(data['lrsigma']**2 + data['rlsigma']**2)
-                    usig = qsig
+                q, qsig = obsh.vis_component(data, 'qvis', self.polrep)
+                u, usig = obsh.vis_component(data, 'uvis', self.polrep)
                 out = (-np.sin(2 * ang) * q + np.cos(2 * ang) * u)
                 sig = np.sqrt(0.5 * ((np.sin(2 * ang) * qsig)**2 + (np.cos(2 * ang) * usig)**2))
             elif field in ['rrvis', 'rramp', 'rrphase', 'rrsnr', 'rrsigma', 'rrsigma_phase']:
                 ty = 'c16'
-                if self.polrep == 'stokes':
-                    out = data['vis'] + data['vvis']
-                    sig = np.sqrt(data['sigma']**2 + data['vsigma']**2)
-                elif self.polrep == 'circ':
-                    out = data['rrvis']
-                    sig = data['rrsigma']
+                out, sig = obsh.vis_component(data, 'rrvis', self.polrep)
             elif field in ['llvis', 'llamp', 'llphase', 'llsnr', 'llsigma', 'llsigma_phase']:
                 ty = 'c16'
-                if self.polrep == 'stokes':
-                    out = data['vis'] - data['vvis']
-                    sig = np.sqrt(data['sigma']**2 + data['vsigma']**2)
-                elif self.polrep == 'circ':
-                    out = data['llvis']
-                    sig = data['llsigma']
+                out, sig = obsh.vis_component(data, 'llvis', self.polrep)
             elif field in ['rlvis', 'rlamp', 'rlphase', 'rlsnr', 'rlsigma', 'rlsigma_phase']:
                 ty = 'c16'
-                if self.polrep == 'stokes':
-                    out = data['qvis'] + 1j * data['uvis']
-                    sig = np.sqrt(data['qsigma']**2 + data['usigma']**2)
-                elif self.polrep == 'circ':
-                    out = data['rlvis']
-                    sig = data['rlsigma']
+                out, sig = obsh.vis_component(data, 'rlvis', self.polrep)
             elif field in ['lrvis', 'lramp', 'lrphase', 'lrsnr', 'lrsigma', 'lrsigma_phase']:
                 ty = 'c16'
-                if self.polrep == 'stokes':
-                    out = data['qvis'] - 1j * data['uvis']
-                    sig = np.sqrt(data['qsigma']**2 + data['usigma']**2)
-                elif self.polrep == 'circ':
-                    out = data['lrvis']
-                    sig = data['lrsigma']
+                out, sig = obsh.vis_component(data, 'lrvis', self.polrep)
             elif field in ['rrllvis', 'rrllamp', 'rrllphase', 'rrllsnr',
                            'rrllsigma', 'rrllsigma_phase']:
                 ty = 'c16'
@@ -1130,6 +1085,39 @@ class Obsdata:
                     out = data['rrvis'] / data['llvis']
                     sig = np.sqrt(np.abs(data['rrsigma'] / data['llvis'])**2
                                   + np.abs(data['llsigma'] * data['rrvis'] / data['llvis'])**2)
+                else:
+                    raise Exception(f"unpack: field {field!r} not supported for "
+                                    f"polrep {self.polrep!r}")
+
+            elif field in ['xxvis', 'xxamp', 'xxphase', 'xxsnr', 'xxsigma', 'xxsigma_phase']:
+                ty = 'c16'
+                out, sig = obsh.vis_component(data, 'xxvis', self.polrep)
+            elif field in ['yyvis', 'yyamp', 'yyphase', 'yysnr', 'yysigma', 'yysigma_phase']:
+                ty = 'c16'
+                out, sig = obsh.vis_component(data, 'yyvis', self.polrep)
+            elif field in ['xyvis', 'xyamp', 'xyphase', 'xysnr', 'xysigma', 'xysigma_phase']:
+                ty = 'c16'
+                out, sig = obsh.vis_component(data, 'xyvis', self.polrep)
+            elif field in ['yxvis', 'yxamp', 'yxphase', 'yxsnr', 'yxsigma', 'yxsigma_phase']:
+                ty = 'c16'
+                out, sig = obsh.vis_component(data, 'yxvis', self.polrep)
+
+            elif field in ['p1p1vis', 'p1p1amp', 'p1p1phase', 'p1p1snr',
+                           'p1p1sigma', 'p1p1sigma_phase']:
+                ty = 'c16'
+                out, sig = self._unpack_generic_slot(data, 'p1p1')
+            elif field in ['p2p2vis', 'p2p2amp', 'p2p2phase', 'p2p2snr',
+                           'p2p2sigma', 'p2p2sigma_phase']:
+                ty = 'c16'
+                out, sig = self._unpack_generic_slot(data, 'p2p2')
+            elif field in ['p1p2vis', 'p1p2amp', 'p1p2phase', 'p1p2snr',
+                           'p1p2sigma', 'p1p2sigma_phase']:
+                ty = 'c16'
+                out, sig = self._unpack_generic_slot(data, 'p1p2')
+            elif field in ['p2p1vis', 'p2p1amp', 'p2p1phase', 'p2p1snr',
+                           'p2p1sigma', 'p2p1sigma_phase']:
+                ty = 'c16'
+                out, sig = self._unpack_generic_slot(data, 'p2p1')
 
             else:
                 raise Exception(f"{field} is not a valid field \n" +
@@ -1170,28 +1158,39 @@ class Obsdata:
 
             # Get arg/amps/snr
             if field in ["amp", "qamp", "uamp", "vamp", "pamp", "mamp", "bamp", "eamp",
-                         "rramp", "llamp", "rlamp", "lramp", "rrllamp"]:
+                         "rramp", "llamp", "rlamp", "lramp", "rrllamp",
+                         "xxamp", "yyamp", "xyamp", "yxamp",
+                         "p1p1amp", "p2p2amp", "p1p2amp", "p2p1amp"]:
                 out = np.abs(out)
                 if debias:
                     out = obsh.amp_debias(out, sig)
                 ty = 'f8'
             elif field in ["sigma", "qsigma", "usigma", "vsigma",
                            "psigma", "msigma", "bsigma", "esigma",
-                           "rrsigma", "llsigma", "rlsigma", "lrsigma", "rrllsigma"]:
+                           "rrsigma", "llsigma", "rlsigma", "lrsigma", "rrllsigma",
+                           "xxsigma", "yysigma", "xysigma", "yxsigma",
+                           "p1p1sigma", "p2p2sigma", "p1p2sigma", "p2p1sigma"]:
                 out = np.abs(sig)
                 ty = 'f8'
             elif field in ["phase", "qphase", "uphase", "vphase", "pphase", "bphase", "ephase",
-                           "mphase", "rrphase", "llphase", "lrphase", "rlphase", "rrllphase"]:
+                           "mphase", "rrphase", "llphase", "lrphase", "rlphase", "rrllphase",
+                           "xxphase", "yyphase", "xyphase", "yxphase",
+                           "p1p1phase", "p2p2phase", "p1p2phase", "p2p1phase"]:
                 out = np.angle(out) / angle
                 ty = 'f8'
             elif field in ["sigma_phase", "qsigma_phase", "usigma_phase", "vsigma_phase",
                            "psigma_phase", "msigma_phase", "bsigma_phase", "esigma_phase",
                            "rrsigma_phase", "llsigma_phase", "rlsigma_phase", "lrsigma_phase",
-                           "rrllsigma_phase"]:
+                           "rrllsigma_phase",
+                           "xxsigma_phase", "yysigma_phase", "xysigma_phase", "yxsigma_phase",
+                           "p1p1sigma_phase", "p2p2sigma_phase", "p1p2sigma_phase",
+                           "p2p1sigma_phase"]:
                 out = np.abs(sig) / np.abs(out) / angle
                 ty = 'f8'
             elif field in ["snr", "qsnr", "usnr", "vsnr", "psnr", "bsnr", "esnr",
-                           "msnr", "rrsnr", "llsnr", "rlsnr", "lrsnr", "rrllsnr"]:
+                           "msnr", "rrsnr", "llsnr", "rlsnr", "lrsnr", "rrllsnr",
+                           "xxsnr", "yysnr", "xysnr", "yxsnr",
+                           "p1p1snr", "p2p2snr", "p1p2snr", "p2p1snr"]:
                 out = np.abs(out) / np.abs(sig)
                 ty = 'f8'
 
@@ -1204,6 +1203,16 @@ class Obsdata:
                 allout = out
 
         return allout
+
+    def _unpack_generic_slot(self, data, slot):
+        """Return (vis, sigma) for a generic feed slot ('p1p1'/'p2p2'/'p1p2'/
+           'p2p1'), read directly via the DTPOL title alias. Defined for circ
+           and lin (where the slot aliases the physical correlation); stokes
+           has no feed slots. (mixed is handled before this is reached.)"""
+        if self.polrep == 'stokes':
+            raise Exception(f"unpack: generic slot {slot}vis has no meaning "
+                            "for polrep 'stokes'")
+        return data[slot + 'vis'], data[slot + 'sigma']
 
     def sourcevec(self):
         """Return the source position vector in geocentric coordinates at 0h GMST.

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -671,9 +671,6 @@ class Obsdata:
                (numpy.recarray): a copy of the Obsdata.data table including all conjugate baselines.
         """
 
-        if self.polrep not in ('stokes', 'circ', 'lin', 'mixed'):
-            raise Exception("polrep must be 'stokes', 'circ', 'lin', or 'mixed'")
-
         data = np.empty(2 * len(self.data), dtype=self.poltype)
 
         # Generic polarization slot names for this polrep

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -44,6 +44,7 @@ import ehtim.io.save
 import ehtim.observing.obs_helpers as obsh
 import ehtim.observing.pol_conventions as pol_conventions
 import ehtim.statistics.dataframes as ehdf
+import ehtim.warnings as ehw
 
 warnings.filterwarnings("ignore",
                         message="Casting complex values to real discards the imaginary part")
@@ -2610,6 +2611,11 @@ class Obsdata:
                   timetype=False, uv_min=False, snrcut=0.):
         """Return a recarray of the equal time bispectra.
 
+           For a mixed-feed observation (polrep='mixed'), closures form only
+           across baselines whose two stations share one feed basis ('rlrl' for
+           circular vtypes, 'xyxy' for linear); cross-basis and hybrid or
+           reordered-feed baselines are skipped (MixedPolClosureSkipWarning).
+
            Args:
                vtype (str): The visibilty type from which to assemble bispectra
                             ('vis', 'qvis', 'uvis','vvis','rrvis','lrvis','rlvis','llvis')
@@ -2631,11 +2637,17 @@ class Obsdata:
             raise Exception("possible options for mode are 'time' and 'all'")
         if count not in ('max', 'min', 'min-cut0bl'):
             raise Exception("possible options for count are 'max', 'min', or 'min-cut0bl'")
-        if vtype not in ('vis', 'qvis', 'uvis', 'vvis', 'rrvis', 'lrvis', 'rlvis', 'llvis'):
-            raise Exception("possible options for vtype are" +
-                            " 'vis', 'qvis', 'uvis','vvis','rrvis','lrvis','rlvis','llvis'")
+        if vtype not in obsh.valid_closure_vtypes(self.polrep):
+            raise Exception(f"for polrep={self.polrep!r}, possible options for "
+                            f"vtype are {obsh.valid_closure_vtypes(self.polrep)}")
         if timetype not in ['GMST', 'UTC', 'gmst', 'utc']:
             raise Exception("timetype should be 'GMST' or 'UTC'!")
+
+        # On a mixed-feed observation, only triangles whose three baselines all
+        # share this feed basis can form a closure (raises for Stokes/generic).
+        required_polbasis = None
+        if self.polrep == 'mixed':
+            required_polbasis = obsh.closure_skip_polbasis(vtype)
 
         # Flag zero baselines
         obsdata = self.copy()
@@ -2649,6 +2661,7 @@ class Obsdata:
         tlist = obsdata.tlist(conj=True)
         out = []
         bis = []
+        n_tri_skipped = 0
         tt = 1
         for tdata in tlist:
 
@@ -2723,6 +2736,14 @@ class Obsdata:
                 except KeyError:
                     continue
 
+                # Mixed-feed: skip triangles that don't share one feed basis
+                if required_polbasis is not None and not (
+                        l1['polbasis'] == required_polbasis and
+                        l2['polbasis'] == required_polbasis and
+                        l3['polbasis'] == required_polbasis):
+                    n_tri_skipped += 1
+                    continue
+
                 (bi, bisig) = obsh.make_bispectrum(l1, l2, l3, vtype, polrep=self.polrep)
 
                 # Cut out low snr points
@@ -2742,6 +2763,10 @@ class Obsdata:
                 out.append(np.array(bis))
                 bis = []
 
+        if n_tri_skipped:
+            warnings.warn(obsh.closure_skip_message(n_tri_skipped, count, 'triangles'),
+                          ehw.MixedPolClosureSkipWarning)
+
         if mode == 'all':
             out = np.array(bis)
 
@@ -2750,6 +2775,11 @@ class Obsdata:
     def c_phases(self, vtype='vis', mode='all', count='min', ang_unit='deg',
                  timetype=False, uv_min=False, snrcut=0.):
         """Return a recarray of the equal time closure phases.
+
+           For a mixed-feed observation (polrep='mixed'), closures form only
+           across baselines whose two stations share one feed basis ('rlrl' for
+           circular vtypes, 'xyxy' for linear); cross-basis and hybrid or
+           reordered-feed baselines are skipped (MixedPolClosureSkipWarning).
 
            Args:
                vtype (str): The visibilty type from which to assemble closure phases
@@ -2773,9 +2803,9 @@ class Obsdata:
             raise Exception("possible options for mode are 'time' and 'all'")
         if count not in ('max', 'min', 'min-cut0bl'):
             raise Exception("possible options for count are 'max', 'min', or 'min-cut0bl'")
-        if vtype not in ('vis', 'qvis', 'uvis', 'vvis', 'rrvis', 'lrvis', 'rlvis', 'llvis'):
-            raise Exception("possible options for vtype are" +
-                            " 'vis', 'qvis', 'uvis','vvis','rrvis','lrvis','rlvis','llvis'")
+        if vtype not in obsh.valid_closure_vtypes(self.polrep):
+            raise Exception(f"for polrep={self.polrep!r}, possible options for "
+                            f"vtype are {obsh.valid_closure_vtypes(self.polrep)}")
         if timetype not in ['GMST', 'UTC', 'gmst', 'utc']:
             raise Exception("timetype should be 'GMST' or 'UTC'!")
 
@@ -2816,6 +2846,11 @@ class Obsdata:
                       timetype=False, uv_min=False, snrcut=0.):
         """Return a recarray of the equal time diagonalized closure phases.
 
+           For a mixed-feed observation (polrep='mixed'), closures form only
+           across baselines whose two stations share one feed basis ('rlrl' for
+           circular vtypes, 'xyxy' for linear); cross-basis and hybrid or
+           reordered-feed baselines are skipped (MixedPolClosureSkipWarning).
+
            Args:
                vtype (str): The visibilty type ('vis','qvis','uvis','vvis','pvis')
                             from which to assemble closure phases
@@ -2836,10 +2871,9 @@ class Obsdata:
         if count not in ('min', 'min-cut0bl'):
             raise Exception(
                 "possible options for count are 'min' or 'min-cut0bl' for diagonal closure phases")
-        if vtype not in ('vis', 'qvis', 'uvis', 'vvis', 'rrvis', 'lrvis', 'rlvis', 'llvis'):
-            raise Exception(
-                "possible options for vtype are 'vis', 'qvis', " +
-                "'uvis','vvis','rrvis','lrvis','rlvis','llvis'")
+        if vtype not in obsh.valid_closure_vtypes(self.polrep):
+            raise Exception(f"for polrep={self.polrep!r}, possible options for "
+                            f"vtype are {obsh.valid_closure_vtypes(self.polrep)}")
         if timetype not in ['GMST', 'UTC', 'gmst', 'utc']:
             raise Exception("timetype should be 'GMST' or 'UTC'!")
 
@@ -2847,26 +2881,6 @@ class Obsdata:
             angle = ehc.DEGREE
         else:
             angle = 1.0
-
-        # determine the appropriate sigmatype
-        if vtype in ["vis", "qvis", "uvis", "vvis"]:
-            if vtype == 'vis':
-                sigmatype = 'sigma'
-            if vtype == 'qvis':
-                sigmatype = 'qsigma'
-            if vtype == 'uvis':
-                sigmatype = 'usigma'
-            if vtype == 'vvis':
-                sigmatype = 'vsigma'
-        if vtype in ["rrvis", "llvis", "rlvis", "lrvis"]:
-            if vtype == 'rrvis':
-                sigmatype = 'rrsigma'
-            if vtype == 'llvis':
-                sigmatype = 'llsigma'
-            if vtype == 'rlvis':
-                sigmatype = 'rlsigma'
-            if vtype == 'lrvis':
-                sigmatype = 'lrsigma'
 
         # get the time-sorted visibility data including conjugate baselines
         viss = np.concatenate(self.tlist(conj=True))
@@ -2928,8 +2942,9 @@ class Obsdata:
                 ind3 = ((viss_here['t1'] == cp['t3']) & (viss_here['t2'] == cp['t1']))
                 design_mat[ic, ind3] = 1.0
 
-            # construct the covariance matrix
-            visphase_err = viss_here[sigmatype] / np.abs(viss_here[vtype])
+            # construct the covariance matrix (per-baseline visibility, sigma pair)
+            vis_here, sig_here = obsh.vis_component(viss_here, vtype, self.polrep)
+            visphase_err = sig_here / np.abs(vis_here)
             sigma_mat = np.diag(visphase_err**2.0)
             covar_mat = np.matmul(np.matmul(design_mat, sigma_mat), np.transpose(design_mat))
 
@@ -2969,6 +2984,11 @@ class Obsdata:
 
         """Return complex bispectrum  over time on a triangle (1-2-3).
 
+           For a mixed-feed observation (polrep='mixed'), a closure is returned
+           only if all stations share one feed basis ('rl' for circular vtypes,
+           'xy' for linear); otherwise an empty array is returned with a
+           MixedPolClosureSkipWarning.
+
            Args:
                site1 (str): station 1 name
                site2 (str): station 2 name
@@ -2995,6 +3015,15 @@ class Obsdata:
 
         tri = (site1, site2, site3)
         outdata = []
+
+        # Mixed-feed: a closure exists only if all stations share one feed basis
+        if self.polrep == 'mixed':
+            req = obsh.closure_skip_polbasis(vtype)[:2]
+            feeds = {self.tarr[self.tkey[s]]['feed_type'] for s in tri}
+            if feeds != {req}:
+                warnings.warn("requested triangle mixes polarization bases; "
+                              "no closure formed.", ehw.MixedPolClosureSkipWarning)
+                return np.array(outdata)
 
         # get selected bispectra from the maximal set
         # TODO: verify consistency/performance of from_vis, and delete this method
@@ -3140,6 +3169,11 @@ class Obsdata:
                    cphases=[]):
         """Return closure phase  over time on a triangle (1-2-3).
 
+           For a mixed-feed observation (polrep='mixed'), a closure is returned
+           only if all stations share one feed basis ('rl' for circular vtypes,
+           'xy' for linear); otherwise an empty array is returned with a
+           MixedPolClosureSkipWarning.
+
            Args:
                site1 (str): station 1 name
                site2 (str): station 2 name
@@ -3168,6 +3202,15 @@ class Obsdata:
 
         tri = (site1, site2, site3)
         outdata = []
+
+        # Mixed-feed: a closure exists only if all stations share one feed basis
+        if self.polrep == 'mixed':
+            req = obsh.closure_skip_polbasis(vtype)[:2]
+            feeds = {self.tarr[self.tkey[s]]['feed_type'] for s in tri}
+            if feeds != {req}:
+                warnings.warn("requested triangle mixes polarization bases; "
+                              "no closure formed.", ehw.MixedPolClosureSkipWarning)
+                return np.array(outdata)
 
         # get selected closure phases from the maximal set
         # TODO: verify consistency/performance of from_vis, and delete this method
@@ -3317,6 +3360,11 @@ class Obsdata:
                      timetype=False, snrcut=0.):
         """Return a recarray of the equal time closure amplitudes.
 
+           For a mixed-feed observation (polrep='mixed'), closures form only
+           across baselines whose two stations share one feed basis ('rlrl' for
+           circular vtypes, 'xyxy' for linear); cross-basis and hybrid or
+           reordered-feed baselines are skipped (MixedPolClosureSkipWarning).
+
            Args:
                vtype (str): The visibilty type from which to assemble closure amplitudes
                             ('vis','qvis','uvis','vvis','pvis')
@@ -3340,18 +3388,25 @@ class Obsdata:
             raise Exception("possible options for mode are 'time' and 'all'")
         if count not in ('max', 'min'):
             raise Exception("possible options for count are 'max' and 'min'")
-        if vtype not in ('vis', 'qvis', 'uvis', 'vvis', 'rrvis', 'lrvis', 'rlvis', 'llvis'):
-            raise Exception("possible options for vtype are " +
-                            "'vis', 'qvis', 'uvis','vvis','rrvis','lrvis','rlvis','llvis'")
+        if vtype not in obsh.valid_closure_vtypes(self.polrep):
+            raise Exception(f"for polrep={self.polrep!r}, possible options for "
+                            f"vtype are {obsh.valid_closure_vtypes(self.polrep)}")
         if ctype not in ['camp', 'logcamp']:
             raise Exception("closure amplitude type must be 'camp' or 'logcamp'!")
         if timetype not in ['GMST', 'UTC', 'gmst', 'utc']:
             raise Exception("timetype should be 'GMST' or 'UTC'!")
 
+        # On a mixed-feed observation, only quadrangles whose four baselines all
+        # share this feed basis can form a closure (raises for Stokes/generic).
+        required_polbasis = None
+        if self.polrep == 'mixed':
+            required_polbasis = obsh.closure_skip_polbasis(vtype)
+
         # Get data sorted by time
         tlist = self.tlist(conj=True)
         out = []
         cas = []
+        n_quad_skipped = 0
         tt = 1
         for tdata in tlist:
 
@@ -3407,6 +3462,15 @@ class Obsdata:
                 except KeyError:
                     continue
 
+                # Mixed-feed: skip quadrangles that don't share one feed basis
+                if required_polbasis is not None and not (
+                        blue1['polbasis'] == required_polbasis and
+                        blue2['polbasis'] == required_polbasis and
+                        red1['polbasis'] == required_polbasis and
+                        red2['polbasis'] == required_polbasis):
+                    n_quad_skipped += 1
+                    continue
+
                 # Compute the closure amplitude and the error
                 (camp, camperr) = obsh.make_closure_amplitude(blue1, blue2, red1, red2, vtype,
                                                               polrep=self.polrep,
@@ -3431,6 +3495,10 @@ class Obsdata:
                 out.append(np.array(cas))
                 cas = []
 
+        if n_quad_skipped:
+            warnings.warn(obsh.closure_skip_message(n_quad_skipped, count, 'quadrangles'),
+                          ehw.MixedPolClosureSkipWarning)
+
         if mode == 'all':
             out = np.array(cas)
 
@@ -3439,6 +3507,11 @@ class Obsdata:
     def c_log_amplitudes_diag(self, vtype='vis', mode='all', count='min',
                               debias=True, timetype=False, snrcut=0.):
         """Return a recarray of the equal time diagonalized log closure amplitudes.
+
+           For a mixed-feed observation (polrep='mixed'), closures form only
+           across baselines whose two stations share one feed basis ('rlrl' for
+           circular vtypes, 'xyxy' for linear); cross-basis and hybrid or
+           reordered-feed baselines are skipped (MixedPolClosureSkipWarning).
 
            Args:
                vtype (str): The visibilty type ('vis','qvis','uvis','vvis','pvis')
@@ -3464,32 +3537,11 @@ class Obsdata:
             raise Exception("possible options for mode are 'time' and 'all'")
         if count not in ('min'):
             raise Exception("count can only be 'min' for diagonal log closure amplitudes")
-        if vtype not in ('vis', 'qvis', 'uvis', 'vvis', 'rrvis', 'lrvis', 'rlvis', 'llvis'):
-            raise Exception(
-                "possible options for vtype are 'vis', 'qvis', 'uvis', " +
-                "'vvis','rrvis','lrvis','rlvis','llvis'")
+        if vtype not in obsh.valid_closure_vtypes(self.polrep):
+            raise Exception(f"for polrep={self.polrep!r}, possible options for "
+                            f"vtype are {obsh.valid_closure_vtypes(self.polrep)}")
         if timetype not in ['GMST', 'UTC', 'gmst', 'utc']:
             raise Exception("timetype should be 'GMST' or 'UTC'!")
-
-        # determine the appropriate sigmatype
-        if vtype in ["vis", "qvis", "uvis", "vvis"]:
-            if vtype == 'vis':
-                sigmatype = 'sigma'
-            if vtype == 'qvis':
-                sigmatype = 'qsigma'
-            if vtype == 'uvis':
-                sigmatype = 'usigma'
-            if vtype == 'vvis':
-                sigmatype = 'vsigma'
-        if vtype in ["rrvis", "llvis", "rlvis", "lrvis"]:
-            if vtype == 'rrvis':
-                sigmatype = 'rrsigma'
-            if vtype == 'llvis':
-                sigmatype = 'llsigma'
-            if vtype == 'rlvis':
-                sigmatype = 'rlsigma'
-            if vtype == 'lrvis':
-                sigmatype = 'lrsigma'
 
         # get the time-sorted visibility data including conjugate baselines
         viss = np.concatenate(self.tlist(conj=True))
@@ -3557,7 +3609,8 @@ class Obsdata:
                 design_mat[il, ind4] = -1.0
 
             # construct the covariance matrix
-            logvisamp_err = viss_here[sigmatype] / np.abs(viss_here[vtype])
+            vis_here, sig_here = obsh.vis_component(viss_here, vtype, self.polrep)
+            logvisamp_err = sig_here / np.abs(vis_here)
             sigma_mat = np.diag(logvisamp_err**2.0)
             covar_mat = np.matmul(np.matmul(design_mat, sigma_mat), np.transpose(design_mat))
 
@@ -3595,6 +3648,11 @@ class Obsdata:
                   camps=[]):
         """Return closure phase over time on a quadrange (1-2)(3-4)/(1-4)(2-3).
 
+           For a mixed-feed observation (polrep='mixed'), a closure is returned
+           only if all stations share one feed basis ('rl' for circular vtypes,
+           'xy' for linear); otherwise an empty array is returned with a
+           MixedPolClosureSkipWarning.
+
            Args:
                site1 (str): station 1 name
                site2 (str): station 2 name
@@ -3626,6 +3684,15 @@ class Obsdata:
 
         quad = (site1, site2, site3, site4)
         outdata = []
+
+        # Mixed-feed: a closure exists only if all stations share one feed basis
+        if self.polrep == 'mixed':
+            req = obsh.closure_skip_polbasis(vtype)[:2]
+            feeds = {self.tarr[self.tkey[s]]['feed_type'] for s in quad}
+            if feeds != {req}:
+                warnings.warn("requested quadrangle mixes polarization bases; "
+                              "no closure formed.", ehw.MixedPolClosureSkipWarning)
+                return np.array(outdata)
 
         # get selected closure amplitudes from the maximal set
         # TODO: verify consistency/performance of from_vis, and delete this method

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -2777,6 +2777,10 @@ class Obsdata:
         cps = self.c_phases(vtype=vtype, mode='all', count=count, ang_unit=ang_unit,
                             timetype=timetype, uv_min=uv_min, snrcut=snrcut)
 
+        # no surviving closures (e.g. all triangles skipped on a mixed-feed obs)
+        if len(cps) == 0:
+            return []
+
         # get the unique timestamps for the closure phases
         T_cps = np.unique(cps['time'])
 
@@ -2829,6 +2833,13 @@ class Obsdata:
                 # matrix entry for third leg of triangle
                 ind3 = ((viss_here['t1'] == cp['t3']) & (viss_here['t2'] == cp['t1']))
                 design_mat[ic, ind3] = 1.0
+
+            # restrict to baselines actually used by the surviving closures; unused
+            # columns carry NaN visibilities on mixed-feed baselines and 0*NaN would
+            # poison the covariance of the surviving triangle
+            used = np.any(design_mat != 0.0, axis=0)
+            design_mat = design_mat[:, used]
+            viss_here = viss_here[used]
 
             # construct the covariance matrix (per-baseline visibility, sigma pair)
             vis_here, sig_here = obsh.vis_component(viss_here, vtype, self.polrep)
@@ -3438,6 +3449,10 @@ class Obsdata:
         lcas = self.c_amplitudes(vtype=vtype, mode=mode, count=count,
                                  ctype='logcamp', debias=debias, timetype=timetype, snrcut=snrcut)
 
+        # no surviving closures (e.g. all quadrangles skipped on a mixed-feed obs)
+        if len(lcas) == 0:
+            return []
+
         # get the unique timestamps for the log closure amplitudes
         T_lcas = np.unique(lcas['time'])
 
@@ -3495,6 +3510,13 @@ class Obsdata:
                 # matrix entry for fourth leg of quadrangle
                 ind4 = ((viss_here['t1'] == lca['t2']) & (viss_here['t2'] == lca['t3']))
                 design_mat[il, ind4] = -1.0
+
+            # restrict to baselines actually used by the surviving closures; unused
+            # columns carry NaN visibilities on mixed-feed baselines and 0*NaN would
+            # poison the covariance of the surviving quadrangle
+            used = np.any(design_mat != 0.0, axis=0)
+            design_mat = design_mat[:, used]
+            viss_here = viss_here[used]
 
             # construct the covariance matrix
             vis_here, sig_here = obsh.vis_component(viss_here, vtype, self.polrep)

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -409,6 +409,122 @@ def unpack_vis_mixed(data, field):
     raise Exception(f"{field} is not a valid field for polrep 'mixed'")
 
 
+def unpack_vis_standard(data, field, polrep):
+    """Return (out, sig, ty) for a vis-family field on a stokes/circ/lin
+       datatable. Direct correlations route through vis_component (so all basis
+       transforms come from pol_conventions); the derived fields (pvis/m/evis/
+       bvis/rrllvis) keep their per-basis algebra. Raises for unsupported fields
+       and (field, polrep) combinations."""
+    if field in ['vis', 'amp', 'phase', 'snr', 'sigma', 'sigma_phase']:
+        out, sig = vis_component(data, 'vis', polrep)
+        return out, sig, 'c16'
+    if field in ['qvis', 'qamp', 'qphase', 'qsnr', 'qsigma', 'qsigma_phase']:
+        out, sig = vis_component(data, 'qvis', polrep)
+        return out, sig, 'c16'
+    if field in ['uvis', 'uamp', 'uphase', 'usnr', 'usigma', 'usigma_phase']:
+        out, sig = vis_component(data, 'uvis', polrep)
+        return out, sig, 'c16'
+    if field in ['vvis', 'vamp', 'vphase', 'vsnr', 'vsigma', 'vsigma_phase']:
+        out, sig = vis_component(data, 'vvis', polrep)
+        return out, sig, 'c16'
+    if field in ['pvis', 'pamp', 'pphase', 'psnr', 'psigma', 'psigma_phase']:
+        if polrep in ('stokes', 'circ'):
+            out, sig = vis_component(data, 'rlvis', polrep)  # P = RL
+        elif polrep == 'lin':
+            q, qsig = vis_component(data, 'qvis', 'lin')
+            u, usig = vis_component(data, 'uvis', 'lin')
+            out = q + 1j * u
+            sig = np.sqrt(qsig**2 + usig**2)
+        return out, sig, 'c16'
+    if field in ['m', 'mamp', 'mphase', 'msnr', 'msigma', 'msigma_phase']:
+        if polrep == 'stokes':
+            out = (data['qvis'] + 1j * data['uvis']) / data['vis']
+            sig = merr(data['sigma'], data['qsigma'], data['usigma'], data['vis'], out)
+        elif polrep == 'circ':
+            out = 2 * data['rlvis'] / (data['rrvis'] + data['llvis'])
+            sig = merr2(data['rlsigma'], data['rrsigma'], data['llsigma'],
+                        0.5 * (data['rrvis'] + data['llvis']), out)
+        elif polrep == 'lin':
+            ivis, isig = vis_component(data, 'vis', 'lin')
+            q, qsig = vis_component(data, 'qvis', 'lin')
+            u, usig = vis_component(data, 'uvis', 'lin')
+            out = (q + 1j * u) / ivis
+            sig = merr(isig, qsig, usig, ivis, out)
+        return out, sig, 'c16'
+    if field in ['evis', 'eamp', 'ephase', 'esnr', 'esigma', 'esigma_phase']:
+        ang = np.arctan2(data['u'], data['v'])  # TODO: correct convention EofN?
+        q, qsig = vis_component(data, 'qvis', polrep)
+        u, usig = vis_component(data, 'uvis', polrep)
+        out = (np.cos(2 * ang) * q + np.sin(2 * ang) * u)
+        sig = np.sqrt(0.5 * ((np.cos(2 * ang) * qsig)**2 + (np.sin(2 * ang) * usig)**2))
+        return out, sig, 'c16'
+    if field in ['bvis', 'bamp', 'bphase', 'bsnr', 'bsigma', 'bsigma_phase']:
+        ang = np.arctan2(data['u'], data['v'])  # TODO: correct convention EofN?
+        q, qsig = vis_component(data, 'qvis', polrep)
+        u, usig = vis_component(data, 'uvis', polrep)
+        out = (-np.sin(2 * ang) * q + np.cos(2 * ang) * u)
+        sig = np.sqrt(0.5 * ((np.sin(2 * ang) * qsig)**2 + (np.cos(2 * ang) * usig)**2))
+        return out, sig, 'c16'
+    if field in ['rrvis', 'rramp', 'rrphase', 'rrsnr', 'rrsigma', 'rrsigma_phase']:
+        out, sig = vis_component(data, 'rrvis', polrep)
+        return out, sig, 'c16'
+    if field in ['llvis', 'llamp', 'llphase', 'llsnr', 'llsigma', 'llsigma_phase']:
+        out, sig = vis_component(data, 'llvis', polrep)
+        return out, sig, 'c16'
+    if field in ['rlvis', 'rlamp', 'rlphase', 'rlsnr', 'rlsigma', 'rlsigma_phase']:
+        out, sig = vis_component(data, 'rlvis', polrep)
+        return out, sig, 'c16'
+    if field in ['lrvis', 'lramp', 'lrphase', 'lrsnr', 'lrsigma', 'lrsigma_phase']:
+        out, sig = vis_component(data, 'lrvis', polrep)
+        return out, sig, 'c16'
+    if field in ['xxvis', 'xxamp', 'xxphase', 'xxsnr', 'xxsigma', 'xxsigma_phase']:
+        out, sig = vis_component(data, 'xxvis', polrep)
+        return out, sig, 'c16'
+    if field in ['yyvis', 'yyamp', 'yyphase', 'yysnr', 'yysigma', 'yysigma_phase']:
+        out, sig = vis_component(data, 'yyvis', polrep)
+        return out, sig, 'c16'
+    if field in ['xyvis', 'xyamp', 'xyphase', 'xysnr', 'xysigma', 'xysigma_phase']:
+        out, sig = vis_component(data, 'xyvis', polrep)
+        return out, sig, 'c16'
+    if field in ['yxvis', 'yxamp', 'yxphase', 'yxsnr', 'yxsigma', 'yxsigma_phase']:
+        out, sig = vis_component(data, 'yxvis', polrep)
+        return out, sig, 'c16'
+    if field in ['rrllvis', 'rrllamp', 'rrllphase', 'rrllsnr',
+                 'rrllsigma', 'rrllsigma_phase']:
+        if polrep == 'stokes':
+            out = (data['vis'] + data['vvis']) / (data['vis'] - data['vvis'])
+            sig = (2.0**0.5 * (np.abs(data['vis'])**2 + np.abs(data['vvis'])**2)**0.5
+                   / np.abs(data['vis'] - data['vvis'])**2
+                   * (data['sigma']**2 + data['vsigma']**2)**0.5)
+        elif polrep == 'circ':
+            out = data['rrvis'] / data['llvis']
+            sig = np.sqrt(np.abs(data['rrsigma'] / data['llvis'])**2
+                          + np.abs(data['llsigma'] * data['rrvis'] / data['llvis'])**2)
+        else:
+            raise Exception(f"unpack: field {field!r} not supported for "
+                            f"polrep {polrep!r}")
+        return out, sig, 'c16'
+    if field in ['p1p1vis', 'p1p1amp', 'p1p1phase', 'p1p1snr',
+                 'p1p1sigma', 'p1p1sigma_phase']:
+        out, sig = unpack_generic_slot(data, 'p1p1', polrep)
+        return out, sig, 'c16'
+    if field in ['p2p2vis', 'p2p2amp', 'p2p2phase', 'p2p2snr',
+                 'p2p2sigma', 'p2p2sigma_phase']:
+        out, sig = unpack_generic_slot(data, 'p2p2', polrep)
+        return out, sig, 'c16'
+    if field in ['p1p2vis', 'p1p2amp', 'p1p2phase', 'p1p2snr',
+                 'p1p2sigma', 'p1p2sigma_phase']:
+        out, sig = unpack_generic_slot(data, 'p1p2', polrep)
+        return out, sig, 'c16'
+    if field in ['p2p1vis', 'p2p1amp', 'p2p1phase', 'p2p1snr',
+                 'p2p1sigma', 'p2p1sigma_phase']:
+        out, sig = unpack_generic_slot(data, 'p2p1', polrep)
+        return out, sig, 'c16'
+
+    raise Exception(f"{field} is not a valid field \n" +
+                    "valid field values are: " + ' '.join(ehc.FIELDS))
+
+
 ##################################################################################################
 # Closure Quantity Construction
 ##################################################################################################

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -36,6 +36,7 @@ import scipy.ndimage as nd
 import scipy.spatial.distance
 
 import ehtim.const_def as ehc
+import ehtim.observing.pol_conventions as pc
 
 warnings.filterwarnings("ignore", message="divide by zero encountered in double_scalars")
 
@@ -218,132 +219,137 @@ def compute_uv_coordinates(array, site1, site2, time, mjd, ra, dec, rf, timetype
     return (time, u, v)
 
 
+##################################################################################################
+# Closure Quantity Construction
+##################################################################################################
+
+_STOKES_VTYPES = ('vis', 'qvis', 'uvis', 'vvis')
+_CIRC_VTYPES = ('rrvis', 'llvis', 'rlvis', 'lrvis')
+_LIN_VTYPES = ('xxvis', 'yyvis', 'xyvis', 'yxvis')
+_GENERIC_VTYPES = ('p1p1vis', 'p2p2vis', 'p1p2vis', 'p2p1vis')
+
+# Maps a single-correlation feed-basis vtype to the generic DTPOL_MIXED slot
+# that holds it on a homogeneous baseline of the matching feed basis.
+_MIXED_SLOT = {'rrvis': 'p1p1vis', 'xxvis': 'p1p1vis',
+               'llvis': 'p2p2vis', 'yyvis': 'p2p2vis',
+               'rlvis': 'p1p2vis', 'xyvis': 'p1p2vis',
+               'lrvis': 'p2p1vis', 'yxvis': 'p2p1vis',
+               'pvis': 'p1p2vis'}
+
+
+def valid_closure_vtypes(polrep):
+    """Visibility types from which closure quantities can be formed for a polrep.
+
+       Stokes is the complete basis: it can synthesize both circular and linear
+       correlations. Each feed basis can give its own correlations plus Stokes,
+       but not the other feed basis directly (that would need the two-step
+       circ<->stokes<->lin composition, which is out of scope for the kernels).
+    """
+    if polrep == 'stokes':
+        return _STOKES_VTYPES + _CIRC_VTYPES + _LIN_VTYPES
+    if polrep == 'circ':
+        return _CIRC_VTYPES + _STOKES_VTYPES
+    if polrep == 'lin':
+        return _LIN_VTYPES + _STOKES_VTYPES
+    if polrep == 'mixed':
+        # Permissive: feed-basis names pass here so the per-triangle filter
+        # (closure_skip_polbasis) can reject Stokes/generic vtypes in the body.
+        return _STOKES_VTYPES + _CIRC_VTYPES + _LIN_VTYPES + _GENERIC_VTYPES
+    raise Exception(f"unsupported polrep {polrep!r} for closure quantities")
+
+
+def closure_skip_polbasis(vtype):
+    """For a mixed-feed observation, the homogeneous per-baseline polbasis that a
+       closure of this vtype requires. Raises for vtypes with no single-baseline
+       feed-basis meaning (Stokes or generic p1p1vis-style)."""
+    if vtype in _CIRC_VTYPES or vtype == 'pvis':
+        return 'rlrl'
+    if vtype in _LIN_VTYPES:
+        return 'xyxy'
+    raise Exception(
+        f"closure quantity vtype={vtype!r} is not physical on a mixed-feed "
+        "observation: only single-correlation feed-basis vtypes "
+        "(rrvis/llvis/rlvis/lrvis or xxvis/yyvis/xyvis/yxvis) can be formed per "
+        "triangle. Stokes and generic p1p1vis-style closures need a homogeneous "
+        "feed basis; use switch_polrep('stokes') after calibration instead.")
+
+
+def closure_skip_message(n_skipped, count, kind='triangles'):
+    """Message for MixedPolClosureSkipWarning when feed-mixing baselines are
+       dropped. For minimal sets, note that the (site-based) minimal set is not
+       baseline-aware, so some recoverable closures may be lost."""
+    msg = (f"{n_skipped} {kind} skipped: closures require baselines between "
+           "stations with the same polarization basis.")
+    if count in ('min', 'min-cut0bl'):
+        msg += " Minimal set is site-based, not baseline-aware; use count='max' to keep all."
+    return msg
+
+
+def vis_component(l, vtype, polrep):
+    """Return (visibility, sigma) for a single correlation `vtype` from one
+       datatable `l`. Native correlations are read directly; correlations in a
+       different basis are synthesized through ehtim.observing.pol_conventions
+       so the basis-transform conventions live in exactly one place.
+    """
+    if vtype == 'pvis':  # polarized visibility == RL == Q + iU
+        vtype = 'rlvis'
+
+    if polrep == 'mixed':
+        slot = _MIXED_SLOT.get(vtype)
+        if slot is None:
+            raise Exception("mixed-feed closures support only single-correlation "
+                            f"feed-basis vtypes; got {vtype!r}")
+        return l[slot], l[slot[:-3] + 'sigma']
+
+    if polrep == 'stokes':
+        if vtype in _STOKES_VTYPES:
+            return l[vtype], l[vtype[:-3] + 'sigma']
+        i, q, u, v = l['vis'], l['qvis'], l['uvis'], l['vvis']
+        si, sq, su, sv = l['sigma'], l['qsigma'], l['usigma'], l['vsigma']
+        if vtype in _CIRC_VTYPES:
+            vals = dict(zip(_CIRC_VTYPES, pc.stokes_to_circ(i, q, u, v)))
+            sigs = dict(zip(_CIRC_VTYPES, pc.stokes_to_circ_sigma(si, sq, su, sv)))
+            return vals[vtype], sigs[vtype]
+        if vtype in _LIN_VTYPES:
+            vals = dict(zip(_LIN_VTYPES, pc.stokes_to_lin(i, q, u, v)))
+            sigs = dict(zip(_LIN_VTYPES, pc.stokes_to_lin_sigma(si, sq, su, sv)))
+            return vals[vtype], sigs[vtype]
+
+    elif polrep == 'circ':
+        if vtype in _CIRC_VTYPES:
+            return l[vtype], l[vtype[:-3] + 'sigma']
+        if vtype in _STOKES_VTYPES:
+            rr, ll, rl, lr = l['rrvis'], l['llvis'], l['rlvis'], l['lrvis']
+            srr, sll, srl, slr = l['rrsigma'], l['llsigma'], l['rlsigma'], l['lrsigma']
+            vals = dict(zip(_STOKES_VTYPES, pc.circ_to_stokes(rr, ll, rl, lr)))
+            sigs = dict(zip(_STOKES_VTYPES, pc.circ_to_stokes_sigma(srr, sll, srl, slr)))
+            return vals[vtype], sigs[vtype]
+
+    elif polrep == 'lin':
+        if vtype in _LIN_VTYPES:
+            return l[vtype], l[vtype[:-3] + 'sigma']
+        if vtype in _STOKES_VTYPES:
+            xx, yy, xy, yx = l['xxvis'], l['yyvis'], l['xyvis'], l['yxvis']
+            sxx, syy, sxy, syx = l['xxsigma'], l['yysigma'], l['xysigma'], l['yxsigma']
+            vals = dict(zip(_STOKES_VTYPES, pc.lin_to_stokes(xx, yy, xy, yx)))
+            sigs = dict(zip(_STOKES_VTYPES, pc.lin_to_stokes_sigma(sxx, syy, sxy, syx)))
+            return vals[vtype], sigs[vtype]
+
+    raise Exception(f"vtype {vtype!r} not supported for polrep {polrep!r}")
+
+
 def make_bispectrum(l1, l2, l3, vistype, polrep='stokes'):
     """Make a list of bispectra and errors
        l1,l2,l3 are full datatables of visibility entries
        vtype is visibility types
     """
 
-    if vistype == 'pvis':
-        vtype = 'rlvis'
-    else:
-        vtype = vistype
+    # Per-correlation values and sigmas (synthesis routed via pol_conventions)
+    p1, s1 = vis_component(l1, vistype, polrep)
+    p2, s2 = vis_component(l2, vistype, polrep)
+    p3, s3 = vis_component(l3, vistype, polrep)
 
-    # Choose the appropriate polarization and compute the bs and err
-    if polrep == 'stokes':
-        if vtype in ["vis", "qvis", "uvis", "vvis"]:
-            if vtype == 'vis':
-                sigmatype = 'sigma'
-            elif vtype == 'qvis':
-                sigmatype = 'qsigma'
-            elif vtype == 'uvis':
-                sigmatype = 'usigma'
-            elif vtype == 'vvis':
-                sigmatype = 'vsigma'
-
-            p1 = l1[vtype]
-            p2 = l2[vtype]
-            p3 = l3[vtype]
-
-            var1 = l1[sigmatype]**2
-            var2 = l2[sigmatype]**2
-            var3 = l3[sigmatype]**2
-
-        elif vtype == "rrvis":
-            p1 = l1['vis'] + l1['vvis']
-            p2 = l2['vis'] + l2['vvis']
-            p3 = l3['vis'] + l3['vvis']
-
-            var1 = l1['sigma']**2 + l1['vsigma']**2
-            var2 = l2['sigma']**2 + l2['vsigma']**2
-            var3 = l3['sigma']**2 + l3['vsigma']**2
-
-        elif vtype == "llvis":
-            p1 = l1['vis'] - l1['vvis']
-            p2 = l2['vis'] - l2['vvis']
-            p3 = l3['vis'] - l3['vvis']
-
-            var1 = l1['sigma']**2 + l1['vsigma']**2
-            var2 = l2['sigma']**2 + l2['vsigma']**2
-            var3 = l3['sigma']**2 + l3['vsigma']**2
-
-        elif vtype == "lrvis":
-            p1 = l1['qvis'] - 1j*l1['uvis']
-            p2 = l2['qvis'] - 1j*l2['uvis']
-            p3 = l3['qvis'] - 1j*l3['uvis']
-
-            var1 = l1['qsigma']**2 + l1['usigma']**2
-            var2 = l2['qsigma']**2 + l2['usigma']**2
-            var3 = l3['qsigma']**2 + l3['usigma']**2
-
-        elif vtype == "rlvis":
-            p1 = l1['qvis'] + 1j*l1['uvis']
-            p2 = l2['qvis'] + 1j*l2['uvis']
-            p3 = l3['qvis'] + 1j*l3['uvis']
-
-            var1 = l1['qsigma']**2 + l1['usigma']**2
-            var2 = l2['qsigma']**2 + l2['usigma']**2
-            var3 = l3['qsigma']**2 + l3['usigma']**2
-
-    elif polrep == 'circ':
-        if vtype in ["rrvis", "llvis", "rlvis", "lrvis"]:
-
-
-
-            if vtype == 'rrvis':
-                sigmatype = 'rrsigma'
-            elif vtype == 'llvis':
-                sigmatype = 'llsigma'
-            elif vtype == 'rlvis':
-                sigmatype = 'rlsigma'
-            elif vtype == 'lrvis':
-                sigmatype = 'lrsigma'
-
-            p1 = l1[vtype]
-            p2 = l2[vtype]
-            p3 = l3[vtype]
-
-            var1 = l1[sigmatype]**2
-            var2 = l2[sigmatype]**2
-            var3 = l3[sigmatype]**2
-
-        elif vtype == "vis":
-            p1 = 0.5*(l1['rrvis'] + l1['llvis'])
-            p2 = 0.5*(l2['rrvis'] + l2['llvis'])
-            p3 = 0.5*(l3['rrvis'] + l3['llvis'])
-
-            var1 = 0.25*(l1['rrsigma']**2 + l1['llsigma']**2)
-            var2 = 0.25*(l2['rrsigma']**2 + l2['llsigma']**2)
-            var3 = 0.25*(l3['rrsigma']**2 + l3['llsigma']**2)
-
-        elif vtype == "vvis":
-            p1 = 0.5*(l1['rrvis'] - l1['llvis'])
-            p2 = 0.5*(l2['rrvis'] - l2['llvis'])
-            p3 = 0.5*(l3['rrvis'] - l3['llvis'])
-
-            var1 = 0.25*(l1['rrsigma']**2 + l1['llsigma']**2)
-            var2 = 0.25*(l2['rrsigma']**2 + l2['llsigma']**2)
-            var3 = 0.25*(l3['rrsigma']**2 + l3['llsigma']**2)
-
-        elif vtype == "qvis":
-            p1 = 0.5*(l1['lrvis'] + l1['rlvis'])
-            p2 = 0.5*(l2['lrvis'] + l2['rlvis'])
-            p3 = 0.5*(l3['lrvis'] + l3['rlvis'])
-
-            var1 = 0.25*(l1['lrsigma']**2 + l1['rlsigma']**2)
-            var2 = 0.25*(l2['lrsigma']**2 + l2['rlsigma']**2)
-            var3 = 0.25*(l3['lrsigma']**2 + l3['rlsigma']**2)
-
-        elif vtype == "uvis":
-            p1 = 0.5j*(l1['lrvis'] - l1['rlvis'])
-            p2 = 0.5j*(l2['lrvis'] - l2['rlvis'])
-            p3 = 0.5j*(l3['lrvis'] - l3['rlvis'])
-
-            var1 = 0.25*(l1['lrsigma']**2 + l1['rlsigma']**2)
-            var2 = 0.25*(l2['lrsigma']**2 + l2['rlsigma']**2)
-            var3 = 0.25*(l3['lrsigma']**2 + l3['rlsigma']**2)
-    else:
-        raise Exception("only 'stokes' and 'circ' are supported polreps!")
+    var1, var2, var3 = s1**2, s2**2, s3**2
 
     # Make the bispectrum and its uncertainty
     bi = p1*p2*p3
@@ -365,176 +371,50 @@ def make_closure_amplitude(blue1, blue2, red1, red2, vtype,
     if ctype not in ['camp', 'logcamp']:
         raise Exception("closure amplitude type must be 'camp' or 'logcamp'!")
 
-    if polrep == 'stokes':
-
-        if vtype in ["vis", "qvis", "uvis", "vvis"]:
-            if vtype == 'vis':
-                sigmatype = 'sigma'
-            if vtype == 'qvis':
-                sigmatype = 'qsigma'
-            if vtype == 'uvis':
-                sigmatype = 'usigma'
-            if vtype == 'vvis':
-                sigmatype = 'vsigma'
-
-            sig1 = blue1[sigmatype]
-            sig2 = blue2[sigmatype]
-            sig3 = red1[sigmatype]
-            sig4 = red2[sigmatype]
-
-            p1 = np.abs(blue1[vtype])
-            p2 = np.abs(blue2[vtype])
-            p3 = np.abs(red1[vtype])
-            p4 = np.abs(red2[vtype])
-
-        elif vtype == "rrvis":
-            sig1 = np.sqrt(blue1['sigma']**2 + blue1['vsigma']**2)
-            sig2 = np.sqrt(blue2['sigma']**2 + blue2['vsigma']**2)
-            sig3 = np.sqrt(red1['sigma']**2 + red1['vsigma']**2)
-            sig4 = np.sqrt(red2['sigma']**2 + red2['vsigma']**2)
-
-            p1 = np.abs(blue1['vis'] + blue1['vvis'])
-            p2 = np.abs(blue2['vis'] + blue2['vvis'])
-            p3 = np.abs(red1['vis'] + red1['vvis'])
-            p4 = np.abs(red2['vis'] + red2['vvis'])
-
-        elif vtype == "llvis":
-            sig1 = np.sqrt(blue1['sigma']**2 + blue1['vsigma']**2)
-            sig2 = np.sqrt(blue2['sigma']**2 + blue2['vsigma']**2)
-            sig3 = np.sqrt(red1['sigma']**2 + red1['vsigma']**2)
-            sig4 = np.sqrt(red2['sigma']**2 + red2['vsigma']**2)
-
-            p1 = np.abs(blue1['vis'] - blue1['vvis'])
-            p2 = np.abs(blue2['vis'] - blue2['vvis'])
-            p3 = np.abs(red1['vis'] - red1['vvis'])
-            p4 = np.abs(red2['vis'] - red2['vvis'])
-
-        elif vtype == "lrvis":
-            sig1 = np.sqrt(blue1['qsigma']**2 + blue1['usigma']**2)
-            sig2 = np.sqrt(blue2['qsigma']**2 + blue2['usigma']**2)
-            sig3 = np.sqrt(red1['qsigma']**2 + red1['usigma']**2)
-            sig4 = np.sqrt(red2['qsigma']**2 + red2['usigma']**2)
-
-            p1 = np.abs(blue1['qvis'] - 1j*blue1['uvis'])
-            p2 = np.abs(blue2['qvis'] - 1j*blue2['uvis'])
-            p3 = np.abs(red1['qvis'] - 1j*red1['uvis'])
-            p4 = np.abs(red2['qvis'] - 1j*red2['uvis'])
-
-        elif vtype in ["pvis", "rlvis"]:
-            sig1 = np.sqrt(blue1['qsigma']**2 + blue1['usigma']**2)
-            sig2 = np.sqrt(blue2['qsigma']**2 + blue2['usigma']**2)
-            sig3 = np.sqrt(red1['qsigma']**2 + red1['usigma']**2)
-            sig4 = np.sqrt(red2['qsigma']**2 + red2['usigma']**2)
-
-            p1 = np.abs(blue1['qvis'] + 1j*blue1['uvis'])
-            p2 = np.abs(blue2['qvis'] + 1j*blue2['uvis'])
-            p3 = np.abs(red1['qvis'] + 1j*red1['uvis'])
-            p4 = np.abs(red2['qvis'] + 1j*red2['uvis'])
-
-    elif polrep == 'circ':
-        if vtype in ["rrvis", "llvis", "rlvis", "lrvis", 'pvis']:
-            if vtype == 'pvis':
-                vtype = 'rlvis'  # p = rl
-
-            if vtype == 'rrvis':
-                sigmatype = 'rrsigma'
-            if vtype == 'llvis':
-                sigmatype = 'llsigma'
-            if vtype == 'rlvis':
-                sigmatype = 'rlsigma'
-            if vtype == 'lrvis':
-                sigmatype = 'lrsigma'
-
-            sig1 = blue1[sigmatype]
-            sig2 = blue2[sigmatype]
-            sig3 = red1[sigmatype]
-            sig4 = red2[sigmatype]
-
-            p1 = np.abs(blue1[vtype])
-            p2 = np.abs(blue2[vtype])
-            p3 = np.abs(red1[vtype])
-            p4 = np.abs(red2[vtype])
-
-        elif vtype == "vis":
-            sig1 = 0.5*np.sqrt(blue1['rrsigma']**2 + blue1['llsigma']**2)
-            sig2 = 0.5*np.sqrt(blue2['rrsigma']**2 + blue2['llsigma']**2)
-            sig3 = 0.5*np.sqrt(red1['rrsigma']**2 + red1['llsigma']**2)
-            sig4 = 0.5*np.sqrt(red2['rrsigma']**2 + red2['llsigma']**2)
-
-            p1 = 0.5*np.abs(blue1['rrvis'] + blue1['llvis'])
-            p2 = 0.5*np.abs(blue2['rrvis'] + blue2['llvis'])
-            p3 = 0.5*np.abs(red1['rrvis'] + red1['llvis'])
-            p4 = 0.5*np.abs(red2['rrvis'] + red2['llvis'])
-
-        elif vtype == "vvis":
-            sig1 = 0.5*np.sqrt(blue1['rrsigma']**2 + blue1['llsigma']**2)
-            sig2 = 0.5*np.sqrt(blue2['rrsigma']**2 + blue2['llsigma']**2)
-            sig3 = 0.5*np.sqrt(red1['rrsigma']**2 + red1['llsigma']**2)
-            sig4 = 0.5*np.sqrt(red2['rrsigma']**2 + red2['llsigma']**2)
-
-            p1 = 0.5*np.abs(blue1['rrvis'] - blue1['llvis'])
-            p2 = 0.5*np.abs(blue2['rrvis'] - blue2['llvis'])
-            p3 = 0.5*np.abs(red1['rrvis'] - red1['llvis'])
-            p4 = 0.5*np.abs(red2['rrvis'] - red2['llvis'])
-
-        elif vtype == "qvis":
-            sig1 = 0.5*np.sqrt(blue1['lrsigma']**2 + blue1['rlsigma']**2)
-            sig2 = 0.5*np.sqrt(blue2['lrsigma']**2 + blue2['rlsigma']**2)
-            sig3 = 0.5*np.sqrt(red1['lrsigma']**2 + red1['rlsigma']**2)
-            sig4 = 0.5*np.sqrt(red2['lrsigma']**2 + red2['rlsigma']**2)
-
-            p1 = 0.5*np.abs(blue1['lrvis'] + blue1['rlvis'])
-            p2 = 0.5*np.abs(blue2['lrvis'] + blue2['rlvis'])
-            p3 = 0.5*np.abs(red1['lrvis'] + red1['rlvis'])
-            p4 = 0.5*np.abs(red2['lrvis'] + red2['rlvis'])
-
-        elif vtype == "uvis":
-            sig1 = 0.5*np.sqrt(blue1['lrsigma']**2 + blue1['rlsigma']**2)
-            sig2 = 0.5*np.sqrt(blue2['lrsigma']**2 + blue2['rlsigma']**2)
-            sig3 = 0.5*np.sqrt(red1['lrsigma']**2 + red1['rlsigma']**2)
-            sig4 = 0.5*np.sqrt(red2['lrsigma']**2 + red2['rlsigma']**2)
-
-            p1 = 0.5*np.abs(blue1['lrvis'] - blue1['rlvis'])
-            p2 = 0.5*np.abs(blue2['lrvis'] - blue2['rlvis'])
-            p3 = 0.5*np.abs(red1['lrvis'] - red1['rlvis'])
-            p4 = 0.5*np.abs(red2['lrvis'] - red2['rlvis'])
-    else:
-        raise Exception("only 'stokes' and 'circ' are supported polreps!")
+    # Per-correlation values and sigmas (synthesis routed via pol_conventions).
+    # blue1/blue2 are numerator baselines; red1/red2 are denominator baselines.
+    cblue1, sigblue1 = vis_component(blue1, vtype, polrep)
+    cblue2, sigblue2 = vis_component(blue2, vtype, polrep)
+    cred1, sigred1 = vis_component(red1, vtype, polrep)
+    cred2, sigred2 = vis_component(red2, vtype, polrep)
 
     # Debias the amplitude
     if debias:
-        p1 = amp_debias(p1, sig1, force_nonzero=True)
-        p2 = amp_debias(p2, sig2, force_nonzero=True)
-        p3 = amp_debias(p3, sig3, force_nonzero=True)
-        p4 = amp_debias(p4, sig4, force_nonzero=True)
+        pblue1 = amp_debias(np.abs(cblue1), sigblue1, force_nonzero=True)
+        pblue2 = amp_debias(np.abs(cblue2), sigblue2, force_nonzero=True)
+        pred1 = amp_debias(np.abs(cred1), sigred1, force_nonzero=True)
+        pred2 = amp_debias(np.abs(cred2), sigred2, force_nonzero=True)
     else:
-        p1 = np.abs(p1)
-        p2 = np.abs(p2)
-        p3 = np.abs(p3)
-        p4 = np.abs(p4)
+        pblue1 = np.abs(cblue1)
+        pblue2 = np.abs(cblue2)
+        pred1 = np.abs(cred1)
+        pred2 = np.abs(cred2)
 
     # Get snrs
-    snr1 = p1/sig1
-    snr2 = p2/sig2
-    snr3 = p3/sig3
-    snr4 = p4/sig4
+    snrblue1 = pblue1/sigblue1
+    snrblue2 = pblue2/sigblue2
+    snrred1 = pred1/sigred1
+    snrred2 = pred2/sigred2
 
     # Compute the closure amplitude and its uncertainty
     if ctype == 'camp':
-        camp = np.abs((p1*p2)/(p3*p4))
-        camperr = camp * np.sqrt(1./(snr1**2) + 1./(snr2**2) + 1./(snr3**2) + 1./(snr4**2))
+        camp = np.abs((pblue1*pblue2)/(pred1*pred2))
+        camperr = camp * np.sqrt(1./(snrblue1**2) + 1./(snrblue2**2) +
+                                 1./(snrred1**2) + 1./(snrred2**2))
 
         # Debias
         if debias:
-            camp = camp_debias(camp, snr3, snr4)
+            camp = camp_debias(camp, snrred1, snrred2)
 
     elif ctype == 'logcamp':
-        camp = np.log(np.abs(p1)) + np.log(np.abs(p2)) - np.log(np.abs(p3)) - np.log(np.abs(p4))
-        camperr = np.sqrt(1./(snr1**2) + 1./(snr2**2) + 1./(snr3**2) + 1./(snr4**2))
+        camp = (np.log(np.abs(pblue1)) + np.log(np.abs(pblue2)) -
+                np.log(np.abs(pred1)) - np.log(np.abs(pred2)))
+        camperr = np.sqrt(1./(snrblue1**2) + 1./(snrblue2**2) +
+                          1./(snrred1**2) + 1./(snrred2**2))
 
         # Debias
         if debias:
-            camp = logcamp_debias(camp, snr1, snr2, snr3, snr4)
+            camp = logcamp_debias(camp, snrblue1, snrblue2, snrred1, snrred2)
 
     return (camp, camperr)
 

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -449,22 +449,12 @@ _CIRC_VTYPES = ('rrvis', 'llvis', 'rlvis', 'lrvis')
 _LIN_VTYPES = ('xxvis', 'yyvis', 'xyvis', 'yxvis')
 _GENERIC_VTYPES = ('p1p1vis', 'p2p2vis', 'p1p2vis', 'p2p1vis')
 
-# Maps a single-correlation feed-basis vtype to the generic DTPOL_MIXED slot
-# that holds it on a homogeneous baseline of the matching feed basis.
-_MIXED_SLOT = {'rrvis': 'p1p1vis', 'xxvis': 'p1p1vis',
-               'llvis': 'p2p2vis', 'yyvis': 'p2p2vis',
-               'rlvis': 'p1p2vis', 'xyvis': 'p1p2vis',
-               'lrvis': 'p2p1vis', 'yxvis': 'p2p1vis',
-               'pvis': 'p1p2vis'}
-
-# field-name suffixes shared by every vis-family group
-_UNPACK_SUFFIXES = ('vis', 'amp', 'phase', 'snr', 'sigma', 'sigma_phase')
-
 
 def vis_component(l, vtype, polrep):
     """Return (visibility, sigma) for a single correlation `vtype` from one
        datatable `l`. Native correlations are read directly; correlations in a
        different basis are synthesized through ehtim.observing.pol_conventions
+       so the basis-transform conventions live in exactly one place.
     """
     if vtype == 'pvis':  # polarized visibility == RL == Q + iU
         vtype = 'rlvis'
@@ -474,9 +464,6 @@ def vis_component(l, vtype, polrep):
             vals, sigs = unpack_mixed_stokes(l, vtype)
             return vals, sigs
 
-    #    if vtype not in _CIRC_VTYPES + _LIN_VTYPES:
-    #        raise Exception("vis_component with polrep=='mixed' supports only single-correlation "
-    #                        f"feed-basis vtypes; got {vtype!r}")
         if vtype in _CIRC_VTYPES + _LIN_VTYPES:
             pref = vtype[:-3]    # 'rrvis' -> 'rr'; the two chars are the feed letters
             vals, sigs, n_nan = unpack_mixed_correlation(l, pref[0], pref[1])
@@ -487,12 +474,6 @@ def vis_component(l, vtype, polrep):
                     ehw.MixedPolUnpackNaNWarning)
 
             return vals, sigs
-    
-    #    slot = _MIXED_SLOT.get(vtype)
-    #    if slot is None:
-    #        raise Exception("mixed-feed closures support only single-correlation "
-    #                        f"feed-basis vtypes; got {vtype!r}")
-    #    return l[slot], l[slot[:-3] + 'sigma']
 
     if polrep == 'stokes':
         if vtype in _STOKES_VTYPES:
@@ -533,8 +514,8 @@ def vis_component(l, vtype, polrep):
 
 def unpack_generic_slot(data, slot, polrep):
     """Return (vis, sigma) for a generic feed slot ('p1p1'/'p2p2'/'p1p2'/'p2p1')
-       directly via the DTPOL title alias. 
-       Defined for circ/lin/mixed (the slot aliases the physical correlation); 
+       directly via the DTPOL title alias.
+       Defined for circ/lin/mixed (the slot aliases the physical correlation);
        stokes has no feed slots."""
     if polrep == 'stokes':
         raise Exception(f"unpack: generic slot {slot}vis has no meaning "
@@ -542,16 +523,14 @@ def unpack_generic_slot(data, slot, polrep):
     return data[slot + 'vis'], data[slot + 'sigma']
 
 
-def unpack_mixed_stokes(data,vtype):
+def unpack_mixed_stokes(data, vtype):
     """Recover stokes vtype and sigma from a MIXED datatable via
-       coherency_to_stokes, grouped by polbasis. 
+       coherency_to_stokes, grouped by polbasis.
        Valid on every row (including heterogeneous baselines)
        under the ideal-feed assumption."""
     pb = data['polbasis']
-    if len(data.shape):
-        n = len(data) # multi row data table
-    else:
-        n = 1 # single row data table
+    scalar = not len(data.shape)   # single-row np.void record
+    n = 1 if scalar else len(data)
     ivis = np.empty(n, dtype='c16')
     q = np.empty(n, dtype='c16')
     u = np.empty(n, dtype='c16')
@@ -572,15 +551,19 @@ def unpack_mixed_stokes(data,vtype):
         ivis[m], q[m], u[m], v[m] = iv, qv, uv, vv
         si[m], sq[m], su[m], sv[m] = siv, sqv, suv, svv
 
-    if vtype=='vis':
-        return ivis, si
-    if vtype=='qvis':
-        return q, sq
-    if vtype=='uvis':
-        return u, su
-    if vtype=='vvis':
-        return v, sv
-    raise Exception(f"vtype {vtype!r} not recognized in unpack_mixed_stokes")
+    if vtype == 'vis':
+        val, sig = ivis, si
+    elif vtype == 'qvis':
+        val, sig = q, sq
+    elif vtype == 'uvis':
+        val, sig = u, su
+    elif vtype == 'vvis':
+        val, sig = v, sv
+    else:
+        raise Exception(f"vtype {vtype!r} not recognized in unpack_mixed_stokes")
+    # single-row input -> scalar out, matching a direct datatable slot read
+    # (make_bispectrum / make_closure_amplitude pass one row at a time)
+    return (val[0], sig[0]) if scalar else (val, sig)
 
 def unpack_mixed_correlation(data, feed_a, feed_b):
     """Recover physical correlation feed_a * conj(feed_b) (e.g. 'r','r' -> 'rrvis')
@@ -588,10 +571,8 @@ def unpack_mixed_correlation(data, feed_a, feed_b):
        provide it, NaN elsewhere; no coherency transformation.
        Returns (vis, sigma, n_nanfilled)."""
     pb = data['polbasis']
-    if len(data.shape):
-        n = len(data) # multi row data table
-    else:
-        n = 1 # single row data table
+    scalar = not len(data.shape)   # single-row np.void record
+    n = 1 if scalar else len(data)
     out = np.full(n, np.nan, dtype='c16')
     sig = np.full(n, np.nan, dtype='f8')
     n_nan = 0
@@ -604,64 +585,9 @@ def unpack_mixed_correlation(data, feed_a, feed_b):
             continue
         out[m] = data[slot][m]
         sig[m] = data[slot[:-3] + 'sigma'][m]
-    return out, sig, n_nan
-
-"""
-def unpack_vis_mixed(data, field):
-    #Return (out, sig, ty) for a vis-family field on a MIXED datatable.
-       Row-aligned NaN-fill; warns per field when a physical correlation is
-       absent on some rows. See the dispatch note in Obsdata.unpack_dat.
-    # generic slots: direct read, all rows
-    for slot in ('p1p1', 'p2p2', 'p1p2', 'p2p1'):
-        if field in [slot + s for s in _UNPACK_SUFFIXES]:
-            return data[slot + 'vis'], data[slot + 'sigma'], 'c16'
-
-    # physical / cross correlation names: matching slot where present, else NaN
-    for visname in _CIRC_VTYPES + _LIN_VTYPES:
-        pref = visname[:-3]    # 'rrvis' -> 'rr'; the two chars are the feed letters
-        if field in [pref + s for s in _UNPACK_SUFFIXES]:
-            out, sig, n_nan = unpack_mixed_correlation(data, pref[0], pref[1])
-            if n_nan > 0:
-                warnings.warn(
-                    f"unpack({field!r}) on a mixed-feed obs: {n_nan} rows have "
-                    f"no {pref.upper()} correlation and were returned as NaN.",
-                    ehw.MixedPolUnpackNaNWarning)
-            return out, sig, 'c16'
-
-    # Stokes-derived: recover (I, Q, U, V) per row, then form the field
-    ivis, q, u, v, si, sq, su, sv = unpack_mixed_stokes(data)
-    if field in ['vis', 'amp', 'phase', 'snr', 'sigma', 'sigma_phase']:
-        return ivis, si, 'c16'
-    if field in ['qvis', 'qamp', 'qphase', 'qsnr', 'qsigma', 'qsigma_phase']:
-        return q, sq, 'c16'
-    if field in ['uvis', 'uamp', 'uphase', 'usnr', 'usigma', 'usigma_phase']:
-        return u, su, 'c16'
-    if field in ['vvis', 'vamp', 'vphase', 'vsnr', 'vsigma', 'vsigma_phase']:
-        return v, sv, 'c16'
-    if field in ['pvis', 'pamp', 'pphase', 'psnr', 'psigma', 'psigma_phase']:
-        return q + 1j * u, np.sqrt(sq**2 + su**2), 'c16'
-    if field in ['m', 'mamp', 'mphase', 'msnr', 'msigma', 'msigma_phase']:
-        out = (q + 1j * u) / ivis
-        return out, merr(si, sq, su, ivis, out), 'c16'
-    if field in ['evis', 'eamp', 'ephase', 'esnr', 'esigma', 'esigma_phase']:
-        ang = np.arctan2(data['u'], data['v'])
-        out = np.cos(2 * ang) * q + np.sin(2 * ang) * u
-        sig = np.sqrt(0.5 * ((np.cos(2 * ang) * sq)**2 + (np.sin(2 * ang) * su)**2))
-        return out, sig, 'c16'
-    if field in ['bvis', 'bamp', 'bphase', 'bsnr', 'bsigma', 'bsigma_phase']:
-        ang = np.arctan2(data['u'], data['v'])
-        out = -np.sin(2 * ang) * q + np.cos(2 * ang) * u
-        sig = np.sqrt(0.5 * ((np.sin(2 * ang) * sq)**2 + (np.cos(2 * ang) * su)**2))
-        return out, sig, 'c16'
-    if field in ['rrllvis', 'rrllamp', 'rrllphase', 'rrllsnr',
-                 'rrllsigma', 'rrllsigma_phase']:
-        out = (ivis + v) / (ivis - v)
-        sig = (2.0**0.5 * (np.abs(ivis)**2 + np.abs(v)**2)**0.5
-               / np.abs(ivis - v)**2 * (si**2 + sv**2)**0.5)
-        return out, sig, 'c16'
-
-    raise Exception(f"{field} is not a valid field for polrep 'mixed'")
-"""
+    # single-row input -> scalar out, matching a direct datatable slot read
+    # (make_bispectrum / make_closure_amplitude pass one row at a time)
+    return (out[0], sig[0], n_nan) if scalar else (out, sig, n_nan)
 
 def unpack_vis(data, field, polrep):
     """Return (out, sig, ty) for a vis-family field on a stokes/circ/lin/mixed
@@ -670,7 +596,6 @@ def unpack_vis(data, field, polrep):
        bvis/rrllvis) keep their per-basis algebra.
        Mixed dtypes NaN fill correlations following unpack_mixed_correlation.
        Raises for unsupported fields and (field, polrep) combinations."""
-    
     if field in ['vis', 'amp', 'phase', 'snr', 'sigma', 'sigma_phase']:
         out, sig = vis_component(data, 'vis', polrep)
         return out, sig, 'c16'
@@ -686,9 +611,9 @@ def unpack_vis(data, field, polrep):
     if field in ['pvis', 'pamp', 'pphase', 'psnr', 'psigma', 'psigma_phase']:
         if polrep in ('stokes', 'circ'):
             out, sig = vis_component(data, 'rlvis', polrep)  # P = RL
-        elif polrep == 'lin':
-            q, qsig = vis_component(data, 'qvis', 'lin')
-            u, usig = vis_component(data, 'uvis', 'lin')
+        elif polrep in ('lin', 'mixed'):
+            q, qsig = vis_component(data, 'qvis', polrep)
+            u, usig = vis_component(data, 'uvis', polrep)
             out = q + 1j * u
             sig = np.sqrt(qsig**2 + usig**2)
         return out, sig, 'c16'
@@ -700,10 +625,10 @@ def unpack_vis(data, field, polrep):
             out = 2 * data['rlvis'] / (data['rrvis'] + data['llvis'])
             sig = merr2(data['rlsigma'], data['rrsigma'], data['llsigma'],
                         0.5 * (data['rrvis'] + data['llvis']), out)
-        elif polrep == 'lin':
-            ivis, isig = vis_component(data, 'vis', 'lin')
-            q, qsig = vis_component(data, 'qvis', 'lin')
-            u, usig = vis_component(data, 'uvis', 'lin')
+        elif polrep in ('lin', 'mixed'):
+            ivis, isig = vis_component(data, 'vis', polrep)
+            q, qsig = vis_component(data, 'qvis', polrep)
+            u, usig = vis_component(data, 'uvis', polrep)
             out = (q + 1j * u) / ivis
             sig = merr(isig, qsig, usig, ivis, out)
         return out, sig, 'c16'
@@ -756,6 +681,12 @@ def unpack_vis(data, field, polrep):
             out = data['rrvis'] / data['llvis']
             sig = np.sqrt(np.abs(data['rrsigma'] / data['llvis'])**2
                           + np.abs(data['llsigma'] * data['rrvis'] / data['llvis'])**2)
+        elif polrep == 'mixed':
+            ivis, isig = vis_component(data, 'vis', 'mixed')
+            v, vsig = vis_component(data, 'vvis', 'mixed')
+            out = (ivis + v) / (ivis - v)
+            sig = (2.0**0.5 * (np.abs(ivis)**2 + np.abs(v)**2)**0.5
+                   / np.abs(ivis - v)**2 * (isig**2 + vsig**2)**0.5)
         else:
             raise Exception(f"unpack: field {field!r} not supported for "
                             f"polrep {polrep!r}")

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -42,9 +42,8 @@ import ehtim.warnings as ehw
 warnings.filterwarnings("ignore", message="divide by zero encountered in double_scalars")
 
 ##################################################################################################
-# Other Functions
+# Observing & uv Functions
 ##################################################################################################
-
 
 def compute_uv_coordinates(array, site1, site2, time, mjd, ra, dec, rf, timetype='UTC',
                            elevmin=ehc.ELEV_LOW,  elevmax=ehc.ELEV_HIGH, no_elevcut_space=False,
@@ -219,7 +218,228 @@ def compute_uv_coordinates(array, site1, site2, time, mjd, ra, dec, rf, timetype
     # return times and uv points where we have  data
     return (time, u, v)
 
+def earthrot(vecs, thetas):
+    """Rotate a vector / array of vectors about the z-direction by theta / array of thetas (radian)
+    """
 
+    if len(vecs.shape) == 1:
+        vecs = np.array([vecs])
+    if np.isscalar(thetas):
+        thetas = np.array([thetas for i in range(len(vecs))])
+
+    # equal numbers of sites and angles
+    if len(thetas) == len(vecs):
+        rotvec = np.array([np.dot(np.array(((np.cos(thetas[i]), -np.sin(thetas[i]), 0),
+                                            (np.sin(thetas[i]), np.cos(thetas[i]), 0),
+                                            (0, 0, 1))),
+                                  vecs[i])
+                           for i in range(len(vecs))])
+
+    # only one rotation angle, many sites
+    elif len(thetas) == 1:
+        rotvec = np.array([np.dot(np.array(((np.cos(thetas[0]), -np.sin(thetas[0]), 0),
+                                            (np.sin(thetas[0]), np.cos(thetas[0]), 0),
+                                            (0, 0, 1))),
+                                  vecs[i])
+                           for i in range(len(vecs))])
+
+    # only one site, many angles
+    elif len(vecs) == 1:
+        rotvec = np.array([np.dot(np.array(((np.cos(thetas[i]), -np.sin(thetas[i]), 0),
+                                            (np.sin(thetas[i]), np.cos(thetas[i]), 0),
+                                            (0, 0, 1))),
+                                  vecs[0])
+                           for i in range(len(thetas))])
+    else:
+        raise Exception("Unequal numbers of vectors and angles in earthrot(vecs, thetas)!")
+
+    return rotvec
+
+
+def earthshadow_mask(obsvecs, sourcevec):
+    """Return a mask corresponding to obsvecs which are not Earth-shadowed
+       along the line of sight to sourcevec.
+       obsvec can be an array of vectors but sourcevec can ONLY be a single vector
+
+    """
+
+    if len(obsvecs.shape) == 1:
+        obsvecs = np.array([obsvecs])
+    LOS_projection = np.array([np.dot(obsvec,sourcevec) for obsvec in obsvecs])
+    norms = np.array([np.linalg.norm(obsvec) for obsvec in obsvecs])
+    projected_radii = np.sqrt(norms**2-LOS_projection**2)
+    #Earth-shadowed points must have projected radii < earth radius and a negative LOS projection
+    bad_mask = (LOS_projection<0) * (projected_radii < 6.371e6)
+    return ~bad_mask
+
+
+def elev(obsvecs, sourcevec):
+    """Return the elevation of a source with respect to an observer/observers in radians
+       obsvec can be an array of vectors but sourcevec can ONLY be a single vector
+    """
+
+    if len(obsvecs.shape) == 1:
+        obsvecs = np.array([obsvecs])
+
+    anglebtw = np.array([np.dot(obsvec, sourcevec)/np.linalg.norm(obsvec) /
+                         np.linalg.norm(sourcevec) for obsvec in obsvecs])
+    el = 0.5*np.pi - np.arccos(anglebtw)
+
+    return el
+
+
+def elevcut(obsvecs, sourcevec, elevmin=ehc.ELEV_LOW, elevmax=ehc.ELEV_HIGH):
+    """Return True if a source is observable by a telescope vector
+    """
+
+    angles = elev(obsvecs, sourcevec)/ehc.DEGREE
+
+    return (angles > elevmin) * (angles < elevmax)
+
+
+def hr_angle(gst, lon, ra):
+    """Computes the hour angle for a source at RA, observer at longitude long, and GMST time gst
+       gst in hours, ra & lon ALL in radian, longitude positive east
+    """
+
+    hr_angle = np.mod(gst + lon - ra, 2*np.pi)
+
+    return hr_angle
+
+
+def par_angle(hr_angle, lat, dec):
+    """Compute the parallactic angle for a source at hr_angle and dec
+       for an observer with latitude lat.
+       All angles in radian
+    """
+
+    num = np.sin(hr_angle)*np.cos(lat)
+    denom = np.sin(lat)*np.cos(dec) - np.cos(lat)*np.sin(dec)*np.cos(hr_angle)
+
+    return np.arctan2(num, denom)
+
+
+def xyz_2_latlong(obsvecs):
+    """Compute the (geocentric) latitude and longitude of a site at geocentric position x,y,z
+       The output is in radians
+    """
+
+    if len(obsvecs.shape) == 1:
+        obsvecs = np.array([obsvecs])
+    out = []
+    for obsvec in obsvecs:
+        x = obsvec[0]
+        y = obsvec[1]
+        z = obsvec[2]
+        lon = np.array(np.arctan2(y, x))
+        lat = np.array(np.arctan2(z, np.sqrt(x**2+y**2)))
+        out.append([lat, lon])
+
+    out = np.array(out)
+
+    return out
+
+def sat_skyfield_from_elements(satname, epoch_mjd, perigee_mjd,
+                               period_days, eccentricity,
+                               inclination, arg_perigee, long_ascending):
+
+    """skyfield EarthSatellite object from keplerian orbital elements
+       perfect keplerian orbit is assumed, no derivatives
+       epoch, pericenter given in mjd
+       period given in days
+       inclination, arg_perigee, long_ascending given in degrees
+    """
+
+    if not(0<=eccentricity<1):
+        raise Exception("eccentricity must be between 0 and 1")
+    if not(0<=inclination<=180):
+        raise Exception("inclination must be between 0 and 180")
+    if not(0<=arg_perigee<=180):
+        raise Exception("arg_perigee must be between 0 and 180")
+    if not(0<=long_ascending<=360):
+        raise Exception("arg_perigee must be between 0 and 360")
+
+    satrec = Satrec()
+    ts = skyfield.api.load.timescale()
+    ref_mjd = 33281. # mjd 1949 December 31 00:00 UT
+    epoch_wrt_ref = epoch_mjd - ref_mjd
+
+    inclination_rad = inclination*ehc.DEGREE
+    arg_perigee_rad = arg_perigee*ehc.DEGREE
+    long_ascending_rad = long_ascending*ehc.DEGREE
+
+    mean_motion = 2*np.pi/(period_days*24.*60.) # radians/minute
+
+    mean_anomaly = mean_motion*(epoch_mjd - perigee_mjd)
+    mean_anomaly = np.mod(mean_anomaly, 2*np.pi)
+
+    satrec.sgp4init(
+        WGS72,           # gravity model
+        'i',             # 'a' = old AFSPC mode, 'i' = improved mode
+        1,               # satnum: Satellite number
+        epoch_wrt_ref,     # epoch: days since 1949 December 31 00:00 UT
+        0.0,             # bstar: drag coefficient (/earth radii)
+        0.0,             # ndot: ballistic coefficient (revs/day)
+        0.0,             # nddot: second derivative of mean motion (revs/day^3)
+        eccentricity,    # ecco: eccentricity
+        arg_perigee_rad,     # argpo: argument of perigee (radians)
+        inclination_rad,     # inclo: inclination (radians)
+        mean_anomaly,    # mo: mean anomaly (radians)
+        mean_motion,     # no_kozai: mean motion (radians/minute)
+        long_ascending_rad,    # nodeo: right ascension of ascending node (radians)
+    )
+    sat_skyfield = skyfield.api.EarthSatellite.from_satrec(satrec, ts)
+
+    return sat_skyfield
+
+def sat_skyfield_from_tle(satname, line1, line2):
+    ts = skyfield.api.load.timescale()
+    sat_skyfield = skyfield.api.EarthSatellite(line1, line2, satname, ts)
+    return sat_skyfield
+
+def sat_skyfield_from_ephementry(satname, ephem, epoch_mjd):
+    if len(ephem[satname])==3: # TLE
+        line1 = ephem[satname][1]
+        line2 = ephem[satname][2]
+        sat = sat_skyfield_from_tle(satname, line1, line2)
+    elif len(ephem[satname])==6: #keplerian elements
+        elements = ephem[satname]
+        sat = sat_skyfield_from_elements(satname, epoch_mjd,
+                                         elements[0],elements[1],elements[2],elements[3],elements[4],elements[5])
+    else:
+        raise Exception(f"ephemeris format not recognized for {satname}")
+
+    return sat
+
+def orbit_skyfield(sat, fracmjds, whichout='itrs'):
+
+    """uses skyfield to propagate a earth satellite orbit and return x,y,z coordinates in co-rotating earth frame
+       sat is a skyfield.sgp4lib.EarthSatellite object
+       times is a list of fractional mjds
+       whichout is 'itrs' (co-rotating) or 'gcrs' (fixed x-axis to equinox)
+    """
+
+    #fractional days of orbit in jd
+    mjd_to_jd = 2400000.5
+    ts = skyfield.api.load.timescale()
+    t = ts.ut1_jd(mjd_to_jd+fracmjds)
+
+    # propagate orbit
+    time_data = sat.at(t)
+
+    if whichout=='gcrs':
+        # GCRS coordinates in km
+        positions = time_data.xyz.m
+
+    elif whichout=='itrs':
+        # get coordinates in earth frame (WGS84 ellipsiod)
+        geographic_position = skyfield.api.wgs84.geographic_position_of(time_data)
+        positions = geographic_position.itrs_xyz.m
+
+    else:
+        raise Exception("orbit_skyfield whichout must be 'itrs' or 'gcrs'")
+
+    return positions
 ##################################################################################################
 # Unpack Helpers
 ##################################################################################################
@@ -658,597 +878,6 @@ def make_closure_amplitude(blue1, blue2, red1, red2, vtype,
 
     return (camp, camperr)
 
-
-def amp_debias(amp, sigma, force_nonzero=False):
-    """Return debiased visibility amplitudes
-    """
-
-    deb2 = np.abs(amp)**2 - np.abs(sigma)**2
-
-    # puts amplitude at 0 if snr < 1
-    deb2 *= (np.nan_to_num(np.abs(amp)) > np.nan_to_num(np.abs(sigma)))
-
-    # raises amplitude to sigma to force nonzero
-    if force_nonzero:
-        deb2 += (np.nan_to_num(np.abs(amp)) < np.nan_to_num(np.abs(sigma))) * np.abs(sigma)**2
-    out = np.sqrt(deb2)
-
-    return out
-
-
-def camp_debias(camp, snr3, snr4):
-    """Debias closure amplitudes
-       snr3 and snr4 are snr of visibility amplitudes #3 and 4.
-    """
-
-    camp_debias = camp / (1 + 1./(snr3**2) + 1./(snr4**2))
-    return camp_debias
-
-
-def logcamp_debias(log_camp, snr1, snr2, snr3, snr4):
-    """Debias log closure amplitudes
-       The snrs are the snr of the component visibility amplitudes
-    """
-
-    log_camp_debias = log_camp + 0.5*(1./(snr1**2) + 1./(snr2**2) - 1./(snr3**2) - 1./(snr4**2))
-    return log_camp_debias
-
-
-def gauss_uv(u, v, flux, beamparams, x=0., y=0.):
-    """Return the value of the Gaussian FT with
-       beamparams is [FWHMmaj, FWHMmin, theta, x, y], all in radian
-       x,y are the center coordinates
-    """
-
-    sigma_maj = beamparams[0]/(2*np.sqrt(2*np.log(2)))
-    sigma_min = beamparams[1]/(2*np.sqrt(2*np.log(2)))
-    theta = -beamparams[2]  # theta needs to be negative in this convention!
-
-    # Covariance matrix
-    a = (sigma_min * np.cos(theta))**2 + (sigma_maj*np.sin(theta))**2
-    b = (sigma_maj * np.cos(theta))**2 + (sigma_min*np.sin(theta))**2
-    c = (sigma_min**2 - sigma_maj**2) * np.cos(theta) * np.sin(theta)
-    m = np.array([[a, c], [c, b]])
-
-    uv = np.array([[u[i], v[i]] for i in range(len(u))])
-    x2 = np.array([np.dot(uvi, np.dot(m, uvi)) for uvi in uv])
-
-    g = np.exp(-2 * np.pi**2 * x2)
-    p = np.exp(-2j * np.pi * (u*x + v*y))
-
-    return flux * g * p
-
-
-def rbf_kernel_covariance(x, sigma):
-    """Compute a covariance matrix from an RBF kernel
-
-    Args:
-        x (ndarray): 1D data points for which to compute the covariance
-        sigma (float): std for the covariance. Controls correlation length / time.
-
-    Returns:
-       cov (ndarray): Covariance matrix
-    """
-    x = np.expand_dims(x, 1) if x.ndim == 1 else x
-    norm = -0.5 * scipy.spatial.distance.cdist(x, x, 'sqeuclidean') / sigma**2
-    cov = np.exp(norm)
-    cov *= 1.0 / cov.sum(axis=0)
-    return cov
-
-
-def sgra_kernel_uv(rf, u, v):
-    """Return the value of the Sgr A* scattering kernel at a given u,v (in lambda)
-
-    Args:
-        rf (float): The observation frequency in Hz
-        u (float or ndarray): an array of u coordinates
-        v (float or ndarray): an array of v coordinates
-
-    Returns:
-       g (float ndarray): Sgr A* scattering kernel
-    """
-    u = np.array(u)
-    v = np.array(v)
-    assert u.size == v.size, 'u and v should have the same size'
-
-    lcm = (ehc.C / rf) * 100  # in cm
-    sigma_maj = ehc.FWHM_MAJ * (lcm ** 2) / (2 * np.sqrt(2 * np.log(2))) * ehc.RADPERUAS
-    sigma_min = ehc.FWHM_MIN * (lcm ** 2) / (2 * np.sqrt(2 * np.log(2))) * ehc.RADPERUAS
-    theta = -ehc.POS_ANG * ehc.DEGREE  # theta needs to be negative in this convention!
-
-    # Covariance matrix
-    a = (sigma_min * np.cos(theta)) ** 2 + (sigma_maj * np.sin(theta)) ** 2
-    b = (sigma_maj * np.cos(theta)) ** 2 + (sigma_min * np.sin(theta)) ** 2
-    c = (sigma_min ** 2 - sigma_maj ** 2) * np.cos(theta) * np.sin(theta)
-    m = np.array([[a, c], [c, b]])
-    uv = np.array([u, v])
-
-    x2 = (uv * np.dot(m, uv)).sum(axis=0)
-    g = np.exp(-2 * np.pi ** 2 * x2)
-
-    return g
-
-
-def sgra_kernel_params(rf):
-    """Return elliptical gaussian parameters in radian for the Sgr A* scattering ellipse
-       at a given frequency rf
-    """
-
-    lcm = (ehc.C/rf) * 100  # in cm
-    fwhm_maj_rf = ehc.FWHM_MAJ * (lcm**2) * ehc.RADPERUAS
-    fwhm_min_rf = ehc.FWHM_MIN * (lcm**2) * ehc.RADPERUAS
-    theta = ehc.POS_ANG * ehc.DEGREE
-
-    return np.array([fwhm_maj_rf, fwhm_min_rf, theta])
-
-
-def blnoise(sefd1, sefd2, tint, bw):
-    """Determine the standard deviation of Gaussian thermal noise on a baseline
-       This is the noise on the rr/ll/rl/lr product, not the Stokes parameter
-       2-bit quantization is responsible for the 0.88 factor
-    """
-
-    noise = np.sqrt(sefd1*sefd2/(2*bw*tint))/0.88
-    # noise = np.sqrt(sefd1*sefd2/(bw*tint))/0.88
-
-    return noise
-
-
-def merr(sigma, qsigma, usigma, I, m):
-    """Return the error in mbreve real and imaginary parts given stokes input
-    """
-
-    err = np.sqrt((qsigma**2 + usigma**2 + (sigma*np.abs(m))**2)/(np.abs(I) ** 2))
-
-    return err
-
-
-def merr2(rlsigma, rrsigma, llsigma, I, m):
-    """Return the error in mbreve real and imaginary parts given polprod input
-    """
-
-    err = np.sqrt((rlsigma**2 + (rrsigma**2 + llsigma**2)*np.abs(m)**2)/(np.abs(I) ** 2))
-
-    return err
-
-
-def cerror(sigma):
-    """Return a complex number drawn from a circular complex Gaussian of zero mean
-    """
-
-    noise = np.random.normal(loc=0, scale=sigma) + 1j*np.random.normal(loc=0, scale=sigma)
-    return noise
-
-
-def cerror_hash(sigma, *args):
-    """Return a complex number drawn from a circular complex Gaussian of zero mean
-    """
-
-    reargs = list(args)
-    reargs.append('re')
-    np.random.seed(hash(",".join(map(repr, reargs))) % 4294967295)
-    re = np.random.randn()
-
-    imargs = list(args)
-    imargs.append('im')
-    np.random.seed(hash(",".join(map(repr, imargs))) % 4294967295)
-    im = np.random.randn()
-
-    err = sigma * (re + 1j*im)
-
-    return err
-
-
-def hashmultivariaterandn(size, cov, *args):
-    """set the seed according to a collection of arguments and return random multivariate gaussian var
-    """
-    np.random.seed(hash(",".join(map(repr, args))) % 4294967295)
-    mean = np.zeros(size)
-    noise = np.random.multivariate_normal(mean, cov, check_valid='ignore')
-    return noise
-
-
-def hashrandn(*args):
-    """set the seed according to a collection of arguments and return random gaussian var
-    """
-
-    np.random.seed(hash(",".join(map(repr, args))) % 4294967295)
-    noise = np.random.randn()
-    return noise
-
-
-def hashrand(*args):
-    """set the seed according to a collection of arguments and return random number in 0,1
-    """
-
-    np.random.seed(hash(",".join(map(repr, args))) % 4294967295)
-    noise = np.random.rand()
-    return noise
-
-
-def image_centroid(im):
-    """Return the image centroid (in radians)
-    """
-
-    xlist = np.arange(0, -im.xdim, -1)*im.psize + (im.psize*im.xdim)/2.0 - im.psize/2.0
-    ylist = np.arange(0, -im.ydim, -1)*im.psize + (im.psize*im.ydim)/2.0 - im.psize/2.0
-
-    x0 = np.sum(np.outer(0.0*ylist+1.0, xlist).ravel()*im.imvec)/np.sum(im.imvec)
-    y0 = np.sum(np.outer(ylist, 0.0*xlist+1.0).ravel()*im.imvec)/np.sum(im.imvec)
-
-    return np.array([x0, y0])
-
-
-def ftmatrix(pdim, xdim, ydim, uvlist, pulse=ehc.PULSE_DEFAULT, mask=[]):
-    """Return a DFT matrix for the xdim*ydim image with pixel width pdim
-       that extracts spatial frequencies of the uv points in uvlist.
-    """
-
-    xlist = np.arange(0, -xdim, -1)*pdim + (pdim*xdim)/2.0 - pdim/2.0
-    ylist = np.arange(0, -ydim, -1)*pdim + (pdim*ydim)/2.0 - pdim/2.0
-
-    # original sign convention
-    # ftmatrices = [pulse(2*np.pi*uv[0], 2*np.pi*uv[1], pdim, dom="F") *
-    #              np.outer(np.exp(-2j*np.pi*ylist*uv[1]), np.exp(-2j*np.pi*xlist*uv[0]))
-    #              for uv in uvlist]
-
-    # changed the sign convention to agree with BU data (Jan 2017)
-    # this is correct for a u,v definition from site 1-2 as (x1-x2)/lambda
-    ftmatrices = [pulse(2*np.pi*uv[0], 2*np.pi*uv[1], pdim, dom="F") *
-                  np.outer(np.exp(2j*np.pi*ylist*uv[1]), np.exp(2j*np.pi*xlist*uv[0]))
-                  for uv in uvlist]
-    ftmatrices = np.reshape(np.array(ftmatrices), (len(uvlist), xdim*ydim))
-
-    if len(mask):
-        ftmatrices = ftmatrices[:, mask]
-
-    return ftmatrices
-
-
-def ftmatrix_centered(im, pdim, xdim, ydim, uvlist, pulse=ehc.PULSE_DEFAULT):
-    """Return a DFT matrix for the xdim*ydim image with pixel width pdim
-       that extracts spatial frequencies of the uv points in uvlist.
-       in this version, it puts the image centroid at the origin
-    """
-
-    # TODO : there is a residual value for the center being around 0,
-    # maybe we should chop this off to be exactly 0?
-    xlist = np.arange(0, -xdim, -1)*pdim + (pdim*xdim)/2.0 - pdim/2.0
-    ylist = np.arange(0, -ydim, -1)*pdim + (pdim*ydim)/2.0 - pdim/2.0
-    x0 = np.sum(np.outer(0.0*ylist+1.0, xlist).ravel()*im)/np.sum(im)
-    y0 = np.sum(np.outer(ylist, 0.0*xlist+1.0).ravel()*im)/np.sum(im)
-
-    # Now shift the lists
-    xlist = xlist - x0
-    ylist = ylist - y0
-
-    # list of matrices at each spatial freq
-    ftmatrices = [pulse(2*np.pi*uv[0], 2*np.pi*uv[1], pdim, dom="F") *
-                  np.outer(np.exp(-2j*np.pi*ylist*uv[1]), np.exp(-2j*np.pi*xlist*uv[0]))
-                  for uv in uvlist]
-    ftmatrices = np.reshape(np.array(ftmatrices), (len(uvlist), xdim*ydim))
-    return ftmatrices
-
-
-def ticks(axisdim, psize, nticks=8):
-    """Return a list of ticklocs and ticklabels
-       psize should be in desired units
-    """
-
-    axisdim = int(axisdim)
-    nticks = int(nticks)
-    if not axisdim % 2:
-        axisdim += 1
-    if nticks % 2:
-        nticks -= 1
-    tickspacing = float(axisdim-1)/nticks
-    ticklocs = np.arange(0, axisdim+1, tickspacing) - 0.5
-    ticklabels = np.around(psize * np.arange((axisdim-1)/2.0, -
-                                             (axisdim)/2.0, -tickspacing), decimals=1)
-
-    return (ticklocs, ticklabels)
-
-
-def power_of_two(target):
-    """Finds the next greatest power of two
-    """
-    cur = 1
-    if target > 1:
-        for i in range(0, int(target)):
-            if (cur >= target):
-                return cur
-            else:
-                cur *= 2
-    else:
-        return 1
-
-
-def paritycompare(perm1, perm2):
-    """Compare the parity of two permutations.
-       Assume both lists are equal length and with same elements
-       Copied from: http://stackoverflow.com/questions/1503072/how-to-check-if-permutations-have-equal-parity
-    """
-
-    perm2 = list(perm2)
-    perm2_map = dict((v, i) for i, v in enumerate(perm2))
-    transCount = 0
-    for loc, p1 in enumerate(perm1):
-        p2 = perm2[loc]
-        if p1 != p2:
-            sloc = perm2_map[p1]
-            perm2[loc], perm2[sloc] = p1, p2
-            perm2_map[p1], perm2_map[p2] = sloc, loc
-            transCount += 1
-
-    if not (transCount % 2):
-        return 1
-    else:
-        return -1
-
-
-def sigtype(datatype):
-    """Return the type of noise corresponding to the data type
-    """
-
-    datatype = str(datatype)
-    if datatype in ['vis', 'amp']:
-        sigmatype = 'sigma'
-    elif datatype in ['qvis', 'qamp']:
-        sigmatype = 'qsigma'
-    elif datatype in ['uvis', 'uamp']:
-        sigmatype = 'usigma'
-    elif datatype in ['vvis', 'vamp']:
-        sigmatype = 'vsigma'
-    elif datatype in ['pvis', 'pamp']:
-        sigmatype = 'psigma'
-    elif datatype in ['evis', 'eamp']:
-        sigmatype = 'esigma'
-    elif datatype in ['bvis', 'bamp']:
-        sigmatype = 'esigma'
-    elif datatype in ['rrvis', 'rramp']:
-        sigmatype = 'rrsigma'
-    elif datatype in ['llvis', 'llamp']:
-        sigmatype = 'llsigma'
-    elif datatype in ['rlvis', 'rlamp']:
-        sigmatype = 'rlsigma'
-    elif datatype in ['lrvis', 'lramp']:
-        sigmatype = 'lrsigma'
-    elif datatype in ['rrllvis', 'rrllamp']:
-        sigmatype = 'rrllsigma'
-    elif datatype in ['m', 'mamp']:
-        sigmatype = 'msigma'
-    elif datatype in ['phase']:
-        sigmatype = 'sigma_phase'
-    elif datatype in ['qphase']:
-        sigmatype = 'qsigma_phase'
-    elif datatype in ['uphase']:
-        sigmatype = 'usigma_phase'
-    elif datatype in ['vphase']:
-        sigmatype = 'vsigma_phase'
-    elif datatype in ['pphase']:
-        sigmatype = 'psigma_phase'
-    elif datatype in ['ephase']:
-        sigmatype = 'esigma_phase'
-    elif datatype in ['bphase']:
-        sigmatype = 'bsigma_phase'
-    elif datatype in ['mphase']:
-        sigmatype = 'msigma_phase'
-    elif datatype in ['rrphase']:
-        sigmatype = 'rrsigma_phase'
-    elif datatype in ['llphase']:
-        sigmatype = 'llsigma_phase'
-    elif datatype in ['rlphase']:
-        sigmatype = 'rlsigma_phase'
-    elif datatype in ['lrphase']:
-        sigmatype = 'lrsigma_phase'
-    elif datatype in ['rrllphase']:
-        sigmatype = 'rrllsigma_phase'
-
-    else:
-        sigmatype = False
-
-    return sigmatype
-
-
-def rastring(ra):
-    """Convert a ra in fractional hours to formatted string
-    """
-    h = int(ra)
-    m = int((ra-h)*60.)
-    s = (ra-h-m/60.)*3600.
-    out = f"{h:2d} h {m:2d} m {s:2.4f} s"
-
-    return out
-
-
-def decstring(dec):
-    """Convert a dec in fractional degrees to formatted string
-    """
-
-    deg = int(dec)
-    m = int((abs(dec)-abs(deg))*60.)
-    s = (abs(dec)-abs(deg)-m/60.)*3600.
-    out = f"{deg:2d} deg {m:2d} m {s:2.4f} s"
-
-    return out
-
-
-def gmtstring(gmt):
-    """Convert a gmt in fractional hours to formatted string
-    """
-
-    if gmt > 24.0:
-        gmt = gmt-24.0
-    h = int(gmt)
-    m = int((gmt-h)*60.)
-    s = (gmt-h-m/60.)*3600.
-    out = f"{h:02d}:{m:02d}:{s:2.4f}"
-
-    return out
-
-# TODO fix this hacky way to do it!!
-
-
-def gmst_to_utc(gmst, mjd):
-    """Convert gmst times in hours to utc hours using astropy.
-
-    Inverse of :func:`utc_to_gmst` on the canonical solar day of ``mjd``:
-    returns UTC in [0, 24). The local sidereal rate is sampled directly
-    from astropy across that day (mean GMST is polynomial in UT, so
-    within a day it's linear to ~1e-14 hours -- no iteration needed).
-
-    Note: an obs that spans > ~23.93 solar hours aliases in GMST and
-    cannot be uniquely round-tripped through this inverse; callers
-    must keep their obs inside a single sidereal day.
-    """
-
-    mjd = int(mjd)
-    t0 = at.Time(mjd, format='mjd', scale='utc')
-    t1 = at.Time(mjd + 1, format='mjd', scale='utc')
-    s0 = t0.sidereal_time('mean', 'greenwich').hour
-    s1 = t1.sidereal_time('mean', 'greenwich').hour
-    # Sidereal hours elapsed in 24 solar hours (~24.0657)
-    sidereal_per_day = ((s1 - s0) % 24.0) + 24.0
-    # Wrap into [0, 24) sidereal so utc lands in [0, 24) of mjd
-    delta_sidereal = (gmst - s0) % 24.0
-    time_utc = delta_sidereal * 24.0 / sidereal_per_day
-
-    return time_utc
-
-
-def utc_to_gmst(utc, mjd):
-    """Convert utc times in hours to gmst using astropy
-    """
-
-    mjd = int(mjd)  # MJD should always be an integer, but was float in older versions of the code
-    time_obj = at.Time(utc/24.0 + np.floor(mjd), format='mjd', scale='utc')
-    time_sidereal = time_obj.sidereal_time('mean', 'greenwich').hour
-
-    return time_sidereal
-
-
-def earthrot(vecs, thetas):
-    """Rotate a vector / array of vectors about the z-direction by theta / array of thetas (radian)
-    """
-
-    if len(vecs.shape) == 1:
-        vecs = np.array([vecs])
-    if np.isscalar(thetas):
-        thetas = np.array([thetas for i in range(len(vecs))])
-
-    # equal numbers of sites and angles
-    if len(thetas) == len(vecs):
-        rotvec = np.array([np.dot(np.array(((np.cos(thetas[i]), -np.sin(thetas[i]), 0),
-                                            (np.sin(thetas[i]), np.cos(thetas[i]), 0),
-                                            (0, 0, 1))),
-                                  vecs[i])
-                           for i in range(len(vecs))])
-
-    # only one rotation angle, many sites
-    elif len(thetas) == 1:
-        rotvec = np.array([np.dot(np.array(((np.cos(thetas[0]), -np.sin(thetas[0]), 0),
-                                            (np.sin(thetas[0]), np.cos(thetas[0]), 0),
-                                            (0, 0, 1))),
-                                  vecs[i])
-                           for i in range(len(vecs))])
-
-    # only one site, many angles
-    elif len(vecs) == 1:
-        rotvec = np.array([np.dot(np.array(((np.cos(thetas[i]), -np.sin(thetas[i]), 0),
-                                            (np.sin(thetas[i]), np.cos(thetas[i]), 0),
-                                            (0, 0, 1))),
-                                  vecs[0])
-                           for i in range(len(thetas))])
-    else:
-        raise Exception("Unequal numbers of vectors and angles in earthrot(vecs, thetas)!")
-
-    return rotvec
-
-
-def earthshadow_mask(obsvecs, sourcevec):
-    """Return a mask corresponding to obsvecs which are not Earth-shadowed
-       along the line of sight to sourcevec.
-       obsvec can be an array of vectors but sourcevec can ONLY be a single vector
-
-    """
-
-    if len(obsvecs.shape) == 1:
-        obsvecs = np.array([obsvecs])
-    LOS_projection = np.array([np.dot(obsvec,sourcevec) for obsvec in obsvecs])
-    norms = np.array([np.linalg.norm(obsvec) for obsvec in obsvecs])
-    projected_radii = np.sqrt(norms**2-LOS_projection**2)
-    #Earth-shadowed points must have projected radii < earth radius and a negative LOS projection
-    bad_mask = (LOS_projection<0) * (projected_radii < 6.371e6)
-    return ~bad_mask
-
-
-def elev(obsvecs, sourcevec):
-    """Return the elevation of a source with respect to an observer/observers in radians
-       obsvec can be an array of vectors but sourcevec can ONLY be a single vector
-    """
-
-    if len(obsvecs.shape) == 1:
-        obsvecs = np.array([obsvecs])
-
-    anglebtw = np.array([np.dot(obsvec, sourcevec)/np.linalg.norm(obsvec) /
-                         np.linalg.norm(sourcevec) for obsvec in obsvecs])
-    el = 0.5*np.pi - np.arccos(anglebtw)
-
-    return el
-
-
-def elevcut(obsvecs, sourcevec, elevmin=ehc.ELEV_LOW, elevmax=ehc.ELEV_HIGH):
-    """Return True if a source is observable by a telescope vector
-    """
-
-    angles = elev(obsvecs, sourcevec)/ehc.DEGREE
-
-    return (angles > elevmin) * (angles < elevmax)
-
-
-def hr_angle(gst, lon, ra):
-    """Computes the hour angle for a source at RA, observer at longitude long, and GMST time gst
-       gst in hours, ra & lon ALL in radian, longitude positive east
-    """
-
-    hr_angle = np.mod(gst + lon - ra, 2*np.pi)
-
-    return hr_angle
-
-
-def par_angle(hr_angle, lat, dec):
-    """Compute the parallactic angle for a source at hr_angle and dec
-       for an observer with latitude lat.
-       All angles in radian
-    """
-
-    num = np.sin(hr_angle)*np.cos(lat)
-    denom = np.sin(lat)*np.cos(dec) - np.cos(lat)*np.sin(dec)*np.cos(hr_angle)
-
-    return np.arctan2(num, denom)
-
-
-def xyz_2_latlong(obsvecs):
-    """Compute the (geocentric) latitude and longitude of a site at geocentric position x,y,z
-       The output is in radians
-    """
-
-    if len(obsvecs.shape) == 1:
-        obsvecs = np.array([obsvecs])
-    out = []
-    for obsvec in obsvecs:
-        x = obsvec[0]
-        y = obsvec[1]
-        z = obsvec[2]
-        lon = np.array(np.arctan2(y, x))
-        lat = np.array(np.arctan2(z, np.sqrt(x**2+y**2)))
-        out.append([lat, lon])
-
-    out = np.array(out)
-
-    return out
-
-
 def tri_minimal_set(sites, tarr, tkey):
     """returns a minimal set of triangles for bispectra and closure phase"""
 
@@ -1445,16 +1074,327 @@ def reduce_quad_minimal(obs, datarr, ctype='camp'):
         out = np.array(out, dtype=dtype)
     return out
 
+##################################################################################################
+# Debiasing Functions
+##################################################################################################
+def amp_debias(amp, sigma, force_nonzero=False):
+    """Return debiased visibility amplitudes
+    """
 
-def qimage(iimage, mimage, chiimage):
-    """Return the Q image from m and chi"""
-    return iimage * mimage * np.cos(2*chiimage)
+    deb2 = np.abs(amp)**2 - np.abs(sigma)**2
+
+    # puts amplitude at 0 if snr < 1
+    deb2 *= (np.nan_to_num(np.abs(amp)) > np.nan_to_num(np.abs(sigma)))
+
+    # raises amplitude to sigma to force nonzero
+    if force_nonzero:
+        deb2 += (np.nan_to_num(np.abs(amp)) < np.nan_to_num(np.abs(sigma))) * np.abs(sigma)**2
+    out = np.sqrt(deb2)
+
+    return out
+
+def camp_debias(camp, snr3, snr4):
+    """Debias closure amplitudes
+       snr3 and snr4 are snr of visibility amplitudes #3 and 4.
+    """
+
+    camp_debias = camp / (1 + 1./(snr3**2) + 1./(snr4**2))
+    return camp_debias
 
 
-def uimage(iimage, mimage, chiimage):
-    """Return the U image from m and chi"""
-    return iimage * mimage * np.sin(2*chiimage)
+def logcamp_debias(log_camp, snr1, snr2, snr3, snr4):
+    """Debias log closure amplitudes
+       The snrs are the snr of the component visibility amplitudes
+    """
 
+    log_camp_debias = log_camp + 0.5*(1./(snr1**2) + 1./(snr2**2) - 1./(snr3**2) - 1./(snr4**2))
+    return log_camp_debias
+
+##################################################################################################
+# Scattering Functions
+##################################################################################################
+
+def gauss_uv(u, v, flux, beamparams, x=0., y=0.):
+    """Return the value of the Gaussian FT with
+       beamparams is [FWHMmaj, FWHMmin, theta, x, y], all in radian
+       x,y are the center coordinates
+    """
+
+    sigma_maj = beamparams[0]/(2*np.sqrt(2*np.log(2)))
+    sigma_min = beamparams[1]/(2*np.sqrt(2*np.log(2)))
+    theta = -beamparams[2]  # theta needs to be negative in this convention!
+
+    # Covariance matrix
+    a = (sigma_min * np.cos(theta))**2 + (sigma_maj*np.sin(theta))**2
+    b = (sigma_maj * np.cos(theta))**2 + (sigma_min*np.sin(theta))**2
+    c = (sigma_min**2 - sigma_maj**2) * np.cos(theta) * np.sin(theta)
+    m = np.array([[a, c], [c, b]])
+
+    uv = np.array([[u[i], v[i]] for i in range(len(u))])
+    x2 = np.array([np.dot(uvi, np.dot(m, uvi)) for uvi in uv])
+
+    g = np.exp(-2 * np.pi**2 * x2)
+    p = np.exp(-2j * np.pi * (u*x + v*y))
+
+    return flux * g * p
+
+
+def rbf_kernel_covariance(x, sigma):
+    """Compute a covariance matrix from an RBF kernel
+
+    Args:
+        x (ndarray): 1D data points for which to compute the covariance
+        sigma (float): std for the covariance. Controls correlation length / time.
+
+    Returns:
+       cov (ndarray): Covariance matrix
+    """
+    x = np.expand_dims(x, 1) if x.ndim == 1 else x
+    norm = -0.5 * scipy.spatial.distance.cdist(x, x, 'sqeuclidean') / sigma**2
+    cov = np.exp(norm)
+    cov *= 1.0 / cov.sum(axis=0)
+    return cov
+
+
+def sgra_kernel_uv(rf, u, v):
+    """Return the value of the Sgr A* scattering kernel at a given u,v (in lambda)
+
+    Args:
+        rf (float): The observation frequency in Hz
+        u (float or ndarray): an array of u coordinates
+        v (float or ndarray): an array of v coordinates
+
+    Returns:
+       g (float ndarray): Sgr A* scattering kernel
+    """
+    u = np.array(u)
+    v = np.array(v)
+    assert u.size == v.size, 'u and v should have the same size'
+
+    lcm = (ehc.C / rf) * 100  # in cm
+    sigma_maj = ehc.FWHM_MAJ * (lcm ** 2) / (2 * np.sqrt(2 * np.log(2))) * ehc.RADPERUAS
+    sigma_min = ehc.FWHM_MIN * (lcm ** 2) / (2 * np.sqrt(2 * np.log(2))) * ehc.RADPERUAS
+    theta = -ehc.POS_ANG * ehc.DEGREE  # theta needs to be negative in this convention!
+
+    # Covariance matrix
+    a = (sigma_min * np.cos(theta)) ** 2 + (sigma_maj * np.sin(theta)) ** 2
+    b = (sigma_maj * np.cos(theta)) ** 2 + (sigma_min * np.sin(theta)) ** 2
+    c = (sigma_min ** 2 - sigma_maj ** 2) * np.cos(theta) * np.sin(theta)
+    m = np.array([[a, c], [c, b]])
+    uv = np.array([u, v])
+
+    x2 = (uv * np.dot(m, uv)).sum(axis=0)
+    g = np.exp(-2 * np.pi ** 2 * x2)
+
+    return g
+
+
+def sgra_kernel_params(rf):
+    """Return elliptical gaussian parameters in radian for the Sgr A* scattering ellipse
+       at a given frequency rf
+    """
+
+    lcm = (ehc.C/rf) * 100  # in cm
+    fwhm_maj_rf = ehc.FWHM_MAJ * (lcm**2) * ehc.RADPERUAS
+    fwhm_min_rf = ehc.FWHM_MIN * (lcm**2) * ehc.RADPERUAS
+    theta = ehc.POS_ANG * ehc.DEGREE
+
+    return np.array([fwhm_maj_rf, fwhm_min_rf, theta])
+
+##################################################################################################
+# Noise Functions
+##################################################################################################
+
+def blnoise(sefd1, sefd2, tint, bw):
+    """Determine the standard deviation of Gaussian thermal noise on a baseline
+       This is the noise on the rr/ll/rl/lr product, not the Stokes parameter
+       2-bit quantization is responsible for the 0.88 factor
+    """
+
+    noise = np.sqrt(sefd1*sefd2/(2*bw*tint))/0.88
+    # noise = np.sqrt(sefd1*sefd2/(bw*tint))/0.88
+
+    return noise
+
+
+def merr(sigma, qsigma, usigma, I, m):
+    """Return the error in mbreve real and imaginary parts given stokes input
+    """
+
+    err = np.sqrt((qsigma**2 + usigma**2 + (sigma*np.abs(m))**2)/(np.abs(I) ** 2))
+
+    return err
+
+
+def merr2(rlsigma, rrsigma, llsigma, I, m):
+    """Return the error in mbreve real and imaginary parts given polprod input
+    """
+
+    err = np.sqrt((rlsigma**2 + (rrsigma**2 + llsigma**2)*np.abs(m)**2)/(np.abs(I) ** 2))
+
+    return err
+
+
+def cerror(sigma):
+    """Return a complex number drawn from a circular complex Gaussian of zero mean
+    """
+
+    noise = np.random.normal(loc=0, scale=sigma) + 1j*np.random.normal(loc=0, scale=sigma)
+    return noise
+
+
+def cerror_hash(sigma, *args):
+    """Return a complex number drawn from a circular complex Gaussian of zero mean
+    """
+
+    reargs = list(args)
+    reargs.append('re')
+    np.random.seed(hash(",".join(map(repr, reargs))) % 4294967295)
+    re = np.random.randn()
+
+    imargs = list(args)
+    imargs.append('im')
+    np.random.seed(hash(",".join(map(repr, imargs))) % 4294967295)
+    im = np.random.randn()
+
+    err = sigma * (re + 1j*im)
+
+    return err
+
+
+def hashmultivariaterandn(size, cov, *args):
+    """set the seed according to a collection of arguments and return random multivariate gaussian var
+    """
+    np.random.seed(hash(",".join(map(repr, args))) % 4294967295)
+    mean = np.zeros(size)
+    noise = np.random.multivariate_normal(mean, cov, check_valid='ignore')
+    return noise
+
+
+def hashrandn(*args):
+    """set the seed according to a collection of arguments and return random gaussian var
+    """
+
+    np.random.seed(hash(",".join(map(repr, args))) % 4294967295)
+    noise = np.random.randn()
+    return noise
+
+
+def hashrand(*args):
+    """set the seed according to a collection of arguments and return random number in 0,1
+    """
+
+    np.random.seed(hash(",".join(map(repr, args))) % 4294967295)
+    noise = np.random.rand()
+    return noise
+
+##################################################################################################
+# Time Functions
+##################################################################################################
+
+def gmst_to_utc(gmst, mjd):
+    """Convert gmst times in hours to utc hours using astropy.
+
+    Inverse of :func:`utc_to_gmst` on the canonical solar day of ``mjd``:
+    returns UTC in [0, 24). The local sidereal rate is sampled directly
+    from astropy across that day (mean GMST is polynomial in UT, so
+    within a day it's linear to ~1e-14 hours -- no iteration needed).
+
+    Note: an obs that spans > ~23.93 solar hours aliases in GMST and
+    cannot be uniquely round-tripped through this inverse; callers
+    must keep their obs inside a single sidereal day.
+    """
+
+    mjd = int(mjd)
+    t0 = at.Time(mjd, format='mjd', scale='utc')
+    t1 = at.Time(mjd + 1, format='mjd', scale='utc')
+    s0 = t0.sidereal_time('mean', 'greenwich').hour
+    s1 = t1.sidereal_time('mean', 'greenwich').hour
+    # Sidereal hours elapsed in 24 solar hours (~24.0657)
+    sidereal_per_day = ((s1 - s0) % 24.0) + 24.0
+    # Wrap into [0, 24) sidereal so utc lands in [0, 24) of mjd
+    delta_sidereal = (gmst - s0) % 24.0
+    time_utc = delta_sidereal * 24.0 / sidereal_per_day
+
+    return time_utc
+
+
+def utc_to_gmst(utc, mjd):
+    """Convert utc times in hours to gmst using astropy
+    """
+
+    mjd = int(mjd)  # MJD should always be an integer, but was float in older versions of the code
+    time_obj = at.Time(utc/24.0 + np.floor(mjd), format='mjd', scale='utc')
+    time_sidereal = time_obj.sidereal_time('mean', 'greenwich').hour
+
+    return time_sidereal
+
+##################################################################################################
+# DFT Functions
+##################################################################################################
+
+def image_centroid(im):
+    """Return the image centroid (in radians)
+    """
+
+    xlist = np.arange(0, -im.xdim, -1)*im.psize + (im.psize*im.xdim)/2.0 - im.psize/2.0
+    ylist = np.arange(0, -im.ydim, -1)*im.psize + (im.psize*im.ydim)/2.0 - im.psize/2.0
+
+    x0 = np.sum(np.outer(0.0*ylist+1.0, xlist).ravel()*im.imvec)/np.sum(im.imvec)
+    y0 = np.sum(np.outer(ylist, 0.0*xlist+1.0).ravel()*im.imvec)/np.sum(im.imvec)
+
+    return np.array([x0, y0])
+
+
+def ftmatrix(pdim, xdim, ydim, uvlist, pulse=ehc.PULSE_DEFAULT, mask=[]):
+    """Return a DFT matrix for the xdim*ydim image with pixel width pdim
+       that extracts spatial frequencies of the uv points in uvlist.
+    """
+
+    xlist = np.arange(0, -xdim, -1)*pdim + (pdim*xdim)/2.0 - pdim/2.0
+    ylist = np.arange(0, -ydim, -1)*pdim + (pdim*ydim)/2.0 - pdim/2.0
+
+    # original sign convention
+    # ftmatrices = [pulse(2*np.pi*uv[0], 2*np.pi*uv[1], pdim, dom="F") *
+    #              np.outer(np.exp(-2j*np.pi*ylist*uv[1]), np.exp(-2j*np.pi*xlist*uv[0]))
+    #              for uv in uvlist]
+
+    # changed the sign convention to agree with BU data (Jan 2017)
+    # this is correct for a u,v definition from site 1-2 as (x1-x2)/lambda
+    ftmatrices = [pulse(2*np.pi*uv[0], 2*np.pi*uv[1], pdim, dom="F") *
+                  np.outer(np.exp(2j*np.pi*ylist*uv[1]), np.exp(2j*np.pi*xlist*uv[0]))
+                  for uv in uvlist]
+    ftmatrices = np.reshape(np.array(ftmatrices), (len(uvlist), xdim*ydim))
+
+    if len(mask):
+        ftmatrices = ftmatrices[:, mask]
+
+    return ftmatrices
+
+
+def ftmatrix_centered(im, pdim, xdim, ydim, uvlist, pulse=ehc.PULSE_DEFAULT):
+    """Return a DFT matrix for the xdim*ydim image with pixel width pdim
+       that extracts spatial frequencies of the uv points in uvlist.
+       in this version, it puts the image centroid at the origin
+    """
+
+    # TODO : there is a residual value for the center being around 0,
+    # maybe we should chop this off to be exactly 0?
+    xlist = np.arange(0, -xdim, -1)*pdim + (pdim*xdim)/2.0 - pdim/2.0
+    ylist = np.arange(0, -ydim, -1)*pdim + (pdim*ydim)/2.0 - pdim/2.0
+    x0 = np.sum(np.outer(0.0*ylist+1.0, xlist).ravel()*im)/np.sum(im)
+    y0 = np.sum(np.outer(ylist, 0.0*xlist+1.0).ravel()*im)/np.sum(im)
+
+    # Now shift the lists
+    xlist = xlist - x0
+    ylist = ylist - y0
+
+    # list of matrices at each spatial freq
+    ftmatrices = [pulse(2*np.pi*uv[0], 2*np.pi*uv[1], pdim, dom="F") *
+                  np.outer(np.exp(-2j*np.pi*ylist*uv[1]), np.exp(-2j*np.pi*xlist*uv[0]))
+                  for uv in uvlist]
+    ftmatrices = np.reshape(np.array(ftmatrices), (len(uvlist), xdim*ydim))
+    return ftmatrices
 
 ##################################################################################################
 # FFT & NFFT helper functions
@@ -1786,6 +1726,171 @@ def recarr_to_ndarr(x, typ):
     y = x.astype(dt).view(typ).reshape(shape)
     return y
 
+def qimage(iimage, mimage, chiimage):
+    """Return the Q image from m and chi"""
+    return iimage * mimage * np.cos(2*chiimage)
+
+
+def uimage(iimage, mimage, chiimage):
+    """Return the U image from m and chi"""
+    return iimage * mimage * np.sin(2*chiimage)
+
+
+def ticks(axisdim, psize, nticks=8):
+    """Return a list of ticklocs and ticklabels
+       psize should be in desired units
+    """
+
+    axisdim = int(axisdim)
+    nticks = int(nticks)
+    if not axisdim % 2:
+        axisdim += 1
+    if nticks % 2:
+        nticks -= 1
+    tickspacing = float(axisdim-1)/nticks
+    ticklocs = np.arange(0, axisdim+1, tickspacing) - 0.5
+    ticklabels = np.around(psize * np.arange((axisdim-1)/2.0, -
+                                             (axisdim)/2.0, -tickspacing), decimals=1)
+
+    return (ticklocs, ticklabels)
+
+
+def power_of_two(target):
+    """Finds the next greatest power of two
+    """
+    cur = 1
+    if target > 1:
+        for i in range(0, int(target)):
+            if (cur >= target):
+                return cur
+            else:
+                cur *= 2
+    else:
+        return 1
+
+
+def paritycompare(perm1, perm2):
+    """Compare the parity of two permutations.
+       Assume both lists are equal length and with same elements
+       Copied from: http://stackoverflow.com/questions/1503072/how-to-check-if-permutations-have-equal-parity
+    """
+
+    perm2 = list(perm2)
+    perm2_map = dict((v, i) for i, v in enumerate(perm2))
+    transCount = 0
+    for loc, p1 in enumerate(perm1):
+        p2 = perm2[loc]
+        if p1 != p2:
+            sloc = perm2_map[p1]
+            perm2[loc], perm2[sloc] = p1, p2
+            perm2_map[p1], perm2_map[p2] = sloc, loc
+            transCount += 1
+
+    if not (transCount % 2):
+        return 1
+    else:
+        return -1
+
+
+def sigtype(datatype):
+    """Return the type of noise corresponding to the data type
+    """
+
+    datatype = str(datatype)
+    if datatype in ['vis', 'amp']:
+        sigmatype = 'sigma'
+    elif datatype in ['qvis', 'qamp']:
+        sigmatype = 'qsigma'
+    elif datatype in ['uvis', 'uamp']:
+        sigmatype = 'usigma'
+    elif datatype in ['vvis', 'vamp']:
+        sigmatype = 'vsigma'
+    elif datatype in ['pvis', 'pamp']:
+        sigmatype = 'psigma'
+    elif datatype in ['evis', 'eamp']:
+        sigmatype = 'esigma'
+    elif datatype in ['bvis', 'bamp']:
+        sigmatype = 'esigma'
+    elif datatype in ['rrvis', 'rramp']:
+        sigmatype = 'rrsigma'
+    elif datatype in ['llvis', 'llamp']:
+        sigmatype = 'llsigma'
+    elif datatype in ['rlvis', 'rlamp']:
+        sigmatype = 'rlsigma'
+    elif datatype in ['lrvis', 'lramp']:
+        sigmatype = 'lrsigma'
+    elif datatype in ['rrllvis', 'rrllamp']:
+        sigmatype = 'rrllsigma'
+    elif datatype in ['m', 'mamp']:
+        sigmatype = 'msigma'
+    elif datatype in ['phase']:
+        sigmatype = 'sigma_phase'
+    elif datatype in ['qphase']:
+        sigmatype = 'qsigma_phase'
+    elif datatype in ['uphase']:
+        sigmatype = 'usigma_phase'
+    elif datatype in ['vphase']:
+        sigmatype = 'vsigma_phase'
+    elif datatype in ['pphase']:
+        sigmatype = 'psigma_phase'
+    elif datatype in ['ephase']:
+        sigmatype = 'esigma_phase'
+    elif datatype in ['bphase']:
+        sigmatype = 'bsigma_phase'
+    elif datatype in ['mphase']:
+        sigmatype = 'msigma_phase'
+    elif datatype in ['rrphase']:
+        sigmatype = 'rrsigma_phase'
+    elif datatype in ['llphase']:
+        sigmatype = 'llsigma_phase'
+    elif datatype in ['rlphase']:
+        sigmatype = 'rlsigma_phase'
+    elif datatype in ['lrphase']:
+        sigmatype = 'lrsigma_phase'
+    elif datatype in ['rrllphase']:
+        sigmatype = 'rrllsigma_phase'
+
+    else:
+        sigmatype = False
+
+    return sigmatype
+
+
+def rastring(ra):
+    """Convert a ra in fractional hours to formatted string
+    """
+    h = int(ra)
+    m = int((ra-h)*60.)
+    s = (ra-h-m/60.)*3600.
+    out = f"{h:2d} h {m:2d} m {s:2.4f} s"
+
+    return out
+
+
+def decstring(dec):
+    """Convert a dec in fractional degrees to formatted string
+    """
+
+    deg = int(dec)
+    m = int((abs(dec)-abs(deg))*60.)
+    s = (abs(dec)-abs(deg)-m/60.)*3600.
+    out = f"{deg:2d} deg {m:2d} m {s:2.4f} s"
+
+    return out
+
+
+def gmtstring(gmt):
+    """Convert a gmt in fractional hours to formatted string
+    """
+
+    if gmt > 24.0:
+        gmt = gmt-24.0
+    h = int(gmt)
+    m = int((gmt-h)*60.)
+    s = (gmt-h-m/60.)*3600.
+    out = f"{h:02d}:{m:02d}:{s:2.4f}"
+
+    return out
 
 def prog_msg(nscan, totscans, msgtype='bar', nscan_last=0):
     """print a progress method for calibration
@@ -1877,105 +1982,5 @@ def prog_msg(nscan, totscans, msgtype='bar', nscan_last=0):
         sys.stdout.write(printstr % barparams)
         sys.stdout.flush()
 
-def sat_skyfield_from_elements(satname, epoch_mjd, perigee_mjd,
-                               period_days, eccentricity,
-                               inclination, arg_perigee, long_ascending):
 
-    """skyfield EarthSatellite object from keplerian orbital elements
-       perfect keplerian orbit is assumed, no derivatives
-       epoch, pericenter given in mjd
-       period given in days
-       inclination, arg_perigee, long_ascending given in degrees
-    """
-
-    if not(0<=eccentricity<1):
-        raise Exception("eccentricity must be between 0 and 1")
-    if not(0<=inclination<=180):
-        raise Exception("inclination must be between 0 and 180")
-    if not(0<=arg_perigee<=180):
-        raise Exception("arg_perigee must be between 0 and 180")
-    if not(0<=long_ascending<=360):
-        raise Exception("arg_perigee must be between 0 and 360")
-
-    satrec = Satrec()
-    ts = skyfield.api.load.timescale()
-    ref_mjd = 33281. # mjd 1949 December 31 00:00 UT
-    epoch_wrt_ref = epoch_mjd - ref_mjd
-
-    inclination_rad = inclination*ehc.DEGREE
-    arg_perigee_rad = arg_perigee*ehc.DEGREE
-    long_ascending_rad = long_ascending*ehc.DEGREE
-
-    mean_motion = 2*np.pi/(period_days*24.*60.) # radians/minute
-
-    mean_anomaly = mean_motion*(epoch_mjd - perigee_mjd)
-    mean_anomaly = np.mod(mean_anomaly, 2*np.pi)
-
-    satrec.sgp4init(
-        WGS72,           # gravity model
-        'i',             # 'a' = old AFSPC mode, 'i' = improved mode
-        1,               # satnum: Satellite number
-        epoch_wrt_ref,     # epoch: days since 1949 December 31 00:00 UT
-        0.0,             # bstar: drag coefficient (/earth radii)
-        0.0,             # ndot: ballistic coefficient (revs/day)
-        0.0,             # nddot: second derivative of mean motion (revs/day^3)
-        eccentricity,    # ecco: eccentricity
-        arg_perigee_rad,     # argpo: argument of perigee (radians)
-        inclination_rad,     # inclo: inclination (radians)
-        mean_anomaly,    # mo: mean anomaly (radians)
-        mean_motion,     # no_kozai: mean motion (radians/minute)
-        long_ascending_rad,    # nodeo: right ascension of ascending node (radians)
-    )
-    sat_skyfield = skyfield.api.EarthSatellite.from_satrec(satrec, ts)
-
-    return sat_skyfield
-
-def sat_skyfield_from_tle(satname, line1, line2):
-    ts = skyfield.api.load.timescale()
-    sat_skyfield = skyfield.api.EarthSatellite(line1, line2, satname, ts)
-    return sat_skyfield
-
-def sat_skyfield_from_ephementry(satname, ephem, epoch_mjd):
-    if len(ephem[satname])==3: # TLE
-        line1 = ephem[satname][1]
-        line2 = ephem[satname][2]
-        sat = sat_skyfield_from_tle(satname, line1, line2)
-    elif len(ephem[satname])==6: #keplerian elements
-        elements = ephem[satname]
-        sat = sat_skyfield_from_elements(satname, epoch_mjd,
-                                         elements[0],elements[1],elements[2],elements[3],elements[4],elements[5])
-    else:
-        raise Exception(f"ephemeris format not recognized for {satname}")
-
-    return sat
-
-def orbit_skyfield(sat, fracmjds, whichout='itrs'):
-
-    """uses skyfield to propagate a earth satellite orbit and return x,y,z coordinates in co-rotating earth frame
-       sat is a skyfield.sgp4lib.EarthSatellite object
-       times is a list of fractional mjds
-       whichout is 'itrs' (co-rotating) or 'gcrs' (fixed x-axis to equinox)
-    """
-
-    #fractional days of orbit in jd
-    mjd_to_jd = 2400000.5
-    ts = skyfield.api.load.timescale()
-    t = ts.ut1_jd(mjd_to_jd+fracmjds)
-
-    # propagate orbit
-    time_data = sat.at(t)
-
-    if whichout=='gcrs':
-        # GCRS coordinates in km
-        positions = time_data.xyz.m
-
-    elif whichout=='itrs':
-        # get coordinates in earth frame (WGS84 ellipsiod)
-        geographic_position = skyfield.api.wgs84.geographic_position_of(time_data)
-        positions = geographic_position.itrs_xyz.m
-
-    else:
-        raise Exception("orbit_skyfield whichout must be 'itrs' or 'gcrs'")
-
-    return positions
 

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -465,17 +465,34 @@ def vis_component(l, vtype, polrep):
     """Return (visibility, sigma) for a single correlation `vtype` from one
        datatable `l`. Native correlations are read directly; correlations in a
        different basis are synthesized through ehtim.observing.pol_conventions
-       so the basis-transform conventions live in exactly one place.
     """
     if vtype == 'pvis':  # polarized visibility == RL == Q + iU
         vtype = 'rlvis'
 
     if polrep == 'mixed':
-        slot = _MIXED_SLOT.get(vtype)
-        if slot is None:
-            raise Exception("mixed-feed closures support only single-correlation "
-                            f"feed-basis vtypes; got {vtype!r}")
-        return l[slot], l[slot[:-3] + 'sigma']
+        if vtype in _STOKES_VTYPES:
+            vals, sigs = unpack_mixed_stokes(l, vtype)
+            return vals, sigs
+
+    #    if vtype not in _CIRC_VTYPES + _LIN_VTYPES:
+    #        raise Exception("vis_component with polrep=='mixed' supports only single-correlation "
+    #                        f"feed-basis vtypes; got {vtype!r}")
+        if vtype in _CIRC_VTYPES + _LIN_VTYPES:
+            pref = vtype[:-3]    # 'rrvis' -> 'rr'; the two chars are the feed letters
+            vals, sigs, n_nan = unpack_mixed_correlation(l, pref[0], pref[1])
+            if n_nan > 0:
+                warnings.warn(
+                    f"vis_component on a mixed-feed obs: {n_nan} rows have "
+                    f"no {pref.upper()} correlation and were returned as NaN.",
+                    ehw.MixedPolUnpackNaNWarning)
+
+            return vals, sigs
+    
+    #    slot = _MIXED_SLOT.get(vtype)
+    #    if slot is None:
+    #        raise Exception("mixed-feed closures support only single-correlation "
+    #                        f"feed-basis vtypes; got {vtype!r}")
+    #    return l[slot], l[slot[:-3] + 'sigma']
 
     if polrep == 'stokes':
         if vtype in _STOKES_VTYPES:
@@ -516,20 +533,25 @@ def vis_component(l, vtype, polrep):
 
 def unpack_generic_slot(data, slot, polrep):
     """Return (vis, sigma) for a generic feed slot ('p1p1'/'p2p2'/'p1p2'/'p2p1')
-       read directly via the DTPOL title alias. Defined for circ/lin/mixed (the
-       slot aliases the physical correlation); stokes has no feed slots."""
+       directly via the DTPOL title alias. 
+       Defined for circ/lin/mixed (the slot aliases the physical correlation); 
+       stokes has no feed slots."""
     if polrep == 'stokes':
         raise Exception(f"unpack: generic slot {slot}vis has no meaning "
                         "for polrep 'stokes'")
     return data[slot + 'vis'], data[slot + 'sigma']
 
 
-def unpack_mixed_stokes(data):
-    """Recover per-row (I, Q, U, V) and their sigmas from a MIXED datatable via
-       coherency_to_stokes, grouped by polbasis. Valid on every row (including
-       heterogeneous baselines) under the ideal-feed assumption."""
+def unpack_mixed_stokes(data,vtype):
+    """Recover stokes vtype and sigma from a MIXED datatable via
+       coherency_to_stokes, grouped by polbasis. 
+       Valid on every row (including heterogeneous baselines)
+       under the ideal-feed assumption."""
     pb = data['polbasis']
-    n = len(data)
+    if len(data.shape):
+        n = len(data) # multi row data table
+    else:
+        n = 1 # single row data table
     ivis = np.empty(n, dtype='c16')
     q = np.empty(n, dtype='c16')
     u = np.empty(n, dtype='c16')
@@ -549,15 +571,27 @@ def unpack_mixed_stokes(data):
             data['p1p2sigma'][m], data['p2p1sigma'][m], t1f, t2f)
         ivis[m], q[m], u[m], v[m] = iv, qv, uv, vv
         si[m], sq[m], su[m], sv[m] = siv, sqv, suv, svv
-    return ivis, q, u, v, si, sq, su, sv
 
+    if vtype=='vis':
+        return ivis, si
+    if vtype=='qvis':
+        return q, sq
+    if vtype=='uvis':
+        return u, su
+    if vtype=='vvis':
+        return v, sv
+    raise Exception(f"vtype {vtype!r} not recognized in unpack_mixed_stokes")
 
 def unpack_mixed_correlation(data, feed_a, feed_b):
-    """Per-row physical correlation feed_a * conj(feed_b) (e.g. 'r','r' -> RR)
-       from a MIXED datatable: the matching generic slot where the row's feeds
-       provide it, NaN elsewhere. Returns (vis, sigma, n_nanfilled)."""
+    """Recover physical correlation feed_a * conj(feed_b) (e.g. 'r','r' -> 'rrvis')
+       from a MIXED datatable. Return the matching generic slot where the row's feeds
+       provide it, NaN elsewhere; no coherency transformation.
+       Returns (vis, sigma, n_nanfilled)."""
     pb = data['polbasis']
-    n = len(data)
+    if len(data.shape):
+        n = len(data) # multi row data table
+    else:
+        n = 1 # single row data table
     out = np.full(n, np.nan, dtype='c16')
     sig = np.full(n, np.nan, dtype='f8')
     n_nan = 0
@@ -572,11 +606,11 @@ def unpack_mixed_correlation(data, feed_a, feed_b):
         sig[m] = data[slot[:-3] + 'sigma'][m]
     return out, sig, n_nan
 
-
+"""
 def unpack_vis_mixed(data, field):
-    """Return (out, sig, ty) for a vis-family field on a MIXED datatable.
+    #Return (out, sig, ty) for a vis-family field on a MIXED datatable.
        Row-aligned NaN-fill; warns per field when a physical correlation is
-       absent on some rows. See the dispatch note in Obsdata.unpack_dat."""
+       absent on some rows. See the dispatch note in Obsdata.unpack_dat.
     # generic slots: direct read, all rows
     for slot in ('p1p1', 'p2p2', 'p1p2', 'p2p1'):
         if field in [slot + s for s in _UNPACK_SUFFIXES]:
@@ -627,14 +661,16 @@ def unpack_vis_mixed(data, field):
         return out, sig, 'c16'
 
     raise Exception(f"{field} is not a valid field for polrep 'mixed'")
+"""
 
-
-def unpack_vis_standard(data, field, polrep):
-    """Return (out, sig, ty) for a vis-family field on a stokes/circ/lin
+def unpack_vis(data, field, polrep):
+    """Return (out, sig, ty) for a vis-family field on a stokes/circ/lin/mixed
        datatable. Direct correlations route through vis_component (so all basis
        transforms come from pol_conventions); the derived fields (pvis/m/evis/
-       bvis/rrllvis) keep their per-basis algebra. Raises for unsupported fields
-       and (field, polrep) combinations."""
+       bvis/rrllvis) keep their per-basis algebra.
+       Mixed dtypes NaN fill correlations following unpack_mixed_correlation.
+       Raises for unsupported fields and (field, polrep) combinations."""
+    
     if field in ['vis', 'amp', 'phase', 'snr', 'sigma', 'sigma_phase']:
         out, sig = vis_component(data, 'vis', polrep)
         return out, sig, 'c16'
@@ -765,14 +801,14 @@ def valid_closure_vtypes(polrep):
     if polrep == 'lin':
         return _LIN_VTYPES + _STOKES_VTYPES
     if polrep == 'mixed':
-        # Permissive: feed-basis names pass here so the per-triangle filter
+        # Permissive: all feed-basis names pass here so the per-triangle filter
         # (closure_skip_polbasis) can reject Stokes/generic vtypes in the body.
         return _STOKES_VTYPES + _CIRC_VTYPES + _LIN_VTYPES + _GENERIC_VTYPES
     raise Exception(f"unsupported polrep {polrep!r} for closure quantities")
 
 
 def closure_skip_polbasis(vtype):
-    """For a mixed-feed observation, the homogeneous per-baseline polbasis that a
+    """For a mixed-feed observation, return the homogeneous per-baseline polbasis that a
        closure of this vtype requires. Raises for vtypes with no single-baseline
        feed-basis meaning (Stokes or generic p1p1vis-style)."""
     if vtype in _CIRC_VTYPES or vtype == 'pvis':
@@ -780,7 +816,7 @@ def closure_skip_polbasis(vtype):
     if vtype in _LIN_VTYPES:
         return 'xyxy'
     raise Exception(
-        f"closure quantity vtype={vtype!r} is not physical on a mixed-feed "
+        f"closure quantity vtype={vtype!r} is not implemented on a mixed-feed "
         "observation: only single-correlation feed-basis vtypes "
         "(rrvis/llvis/rlvis/lrvis or xxvis/yyvis/xyvis/yxvis) can be formed per "
         "triangle. Stokes and generic p1p1vis-style closures need a homogeneous "
@@ -966,8 +1002,6 @@ def reduce_tri_minimal(obs, datarr):
 
 # TODO This returns A minimal set if input is maximal, but it is not necessarily the same
 # minimal set as we would from  calling c_amplitudes(count='min'). This is because of  inverses.
-
-
 def reduce_quad_minimal(obs, datarr, ctype='camp'):
     """Reduce a closure amplitude or log closure amplitude array
        FROM a maximal set TO a minimal set

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -37,6 +37,7 @@ import scipy.spatial.distance
 
 import ehtim.const_def as ehc
 import ehtim.observing.pol_conventions as pc
+import ehtim.warnings as ehw
 
 warnings.filterwarnings("ignore", message="divide by zero encountered in double_scalars")
 
@@ -220,7 +221,7 @@ def compute_uv_coordinates(array, site1, site2, time, mjd, ra, dec, rf, timetype
 
 
 ##################################################################################################
-# Closure Quantity Construction
+# Unpack Helpers
 ##################################################################################################
 
 _STOKES_VTYPES = ('vis', 'qvis', 'uvis', 'vvis')
@@ -236,53 +237,8 @@ _MIXED_SLOT = {'rrvis': 'p1p1vis', 'xxvis': 'p1p1vis',
                'lrvis': 'p2p1vis', 'yxvis': 'p2p1vis',
                'pvis': 'p1p2vis'}
 
-
-def valid_closure_vtypes(polrep):
-    """Visibility types from which closure quantities can be formed for a polrep.
-
-       Stokes is the complete basis: it can synthesize both circular and linear
-       correlations. Each feed basis can give its own correlations plus Stokes,
-       but not the other feed basis directly (that would need the two-step
-       circ<->stokes<->lin composition, which is out of scope for the kernels).
-    """
-    if polrep == 'stokes':
-        return _STOKES_VTYPES + _CIRC_VTYPES + _LIN_VTYPES
-    if polrep == 'circ':
-        return _CIRC_VTYPES + _STOKES_VTYPES
-    if polrep == 'lin':
-        return _LIN_VTYPES + _STOKES_VTYPES
-    if polrep == 'mixed':
-        # Permissive: feed-basis names pass here so the per-triangle filter
-        # (closure_skip_polbasis) can reject Stokes/generic vtypes in the body.
-        return _STOKES_VTYPES + _CIRC_VTYPES + _LIN_VTYPES + _GENERIC_VTYPES
-    raise Exception(f"unsupported polrep {polrep!r} for closure quantities")
-
-
-def closure_skip_polbasis(vtype):
-    """For a mixed-feed observation, the homogeneous per-baseline polbasis that a
-       closure of this vtype requires. Raises for vtypes with no single-baseline
-       feed-basis meaning (Stokes or generic p1p1vis-style)."""
-    if vtype in _CIRC_VTYPES or vtype == 'pvis':
-        return 'rlrl'
-    if vtype in _LIN_VTYPES:
-        return 'xyxy'
-    raise Exception(
-        f"closure quantity vtype={vtype!r} is not physical on a mixed-feed "
-        "observation: only single-correlation feed-basis vtypes "
-        "(rrvis/llvis/rlvis/lrvis or xxvis/yyvis/xyvis/yxvis) can be formed per "
-        "triangle. Stokes and generic p1p1vis-style closures need a homogeneous "
-        "feed basis; use switch_polrep('stokes') after calibration instead.")
-
-
-def closure_skip_message(n_skipped, count, kind='triangles'):
-    """Message for MixedPolClosureSkipWarning when feed-mixing baselines are
-       dropped. For minimal sets, note that the (site-based) minimal set is not
-       baseline-aware, so some recoverable closures may be lost."""
-    msg = (f"{n_skipped} {kind} skipped: closures require baselines between "
-           "stations with the same polarization basis.")
-    if count in ('min', 'min-cut0bl'):
-        msg += " Minimal set is site-based, not baseline-aware; use count='max' to keep all."
-    return msg
+# field-name suffixes shared by every vis-family group
+_UNPACK_SUFFIXES = ('vis', 'amp', 'phase', 'snr', 'sigma', 'sigma_phase')
 
 
 def vis_component(l, vtype, polrep):
@@ -336,6 +292,174 @@ def vis_component(l, vtype, polrep):
             return vals[vtype], sigs[vtype]
 
     raise Exception(f"vtype {vtype!r} not supported for polrep {polrep!r}")
+
+
+def unpack_generic_slot(data, slot, polrep):
+    """Return (vis, sigma) for a generic feed slot ('p1p1'/'p2p2'/'p1p2'/'p2p1')
+       read directly via the DTPOL title alias. Defined for circ/lin/mixed (the
+       slot aliases the physical correlation); stokes has no feed slots."""
+    if polrep == 'stokes':
+        raise Exception(f"unpack: generic slot {slot}vis has no meaning "
+                        "for polrep 'stokes'")
+    return data[slot + 'vis'], data[slot + 'sigma']
+
+
+def unpack_mixed_stokes(data):
+    """Recover per-row (I, Q, U, V) and their sigmas from a MIXED datatable via
+       coherency_to_stokes, grouped by polbasis. Valid on every row (including
+       heterogeneous baselines) under the ideal-feed assumption."""
+    pb = data['polbasis']
+    n = len(data)
+    ivis = np.empty(n, dtype='c16')
+    q = np.empty(n, dtype='c16')
+    u = np.empty(n, dtype='c16')
+    v = np.empty(n, dtype='c16')
+    si = np.empty(n, dtype='f8')
+    sq = np.empty(n, dtype='f8')
+    su = np.empty(n, dtype='f8')
+    sv = np.empty(n, dtype='f8')
+    for code in np.unique(pb):    # loop over unique polbasis values
+        m = (pb == code)
+        t1f, t2f = str(code)[:2], str(code)[2:]    # t1 and t2 feed types
+        iv, qv, uv, vv = pc.coherency_to_stokes(
+            data['p1p1vis'][m], data['p2p2vis'][m],
+            data['p1p2vis'][m], data['p2p1vis'][m], t1f, t2f)
+        siv, sqv, suv, svv = pc.coherency_to_stokes_sigma(
+            data['p1p1sigma'][m], data['p2p2sigma'][m],
+            data['p1p2sigma'][m], data['p2p1sigma'][m], t1f, t2f)
+        ivis[m], q[m], u[m], v[m] = iv, qv, uv, vv
+        si[m], sq[m], su[m], sv[m] = siv, sqv, suv, svv
+    return ivis, q, u, v, si, sq, su, sv
+
+
+def unpack_mixed_correlation(data, feed_a, feed_b):
+    """Per-row physical correlation feed_a * conj(feed_b) (e.g. 'r','r' -> RR)
+       from a MIXED datatable: the matching generic slot where the row's feeds
+       provide it, NaN elsewhere. Returns (vis, sigma, n_nanfilled)."""
+    pb = data['polbasis']
+    n = len(data)
+    out = np.full(n, np.nan, dtype='c16')
+    sig = np.full(n, np.nan, dtype='f8')
+    n_nan = 0
+    for code in np.unique(pb):    # loop over unique polbasis values
+        m = (pb == code)
+        # which generic slot holds this correlation on this feed pairing (or None)
+        slot = pc.correlation_slot(str(code)[:2], str(code)[2:], feed_a, feed_b)
+        if slot is None:
+            n_nan += int(np.sum(m))
+            continue
+        out[m] = data[slot][m]
+        sig[m] = data[slot[:-3] + 'sigma'][m]
+    return out, sig, n_nan
+
+
+def unpack_vis_mixed(data, field):
+    """Return (out, sig, ty) for a vis-family field on a MIXED datatable.
+       Row-aligned NaN-fill; warns per field when a physical correlation is
+       absent on some rows. See the dispatch note in Obsdata.unpack_dat."""
+    # generic slots: direct read, all rows
+    for slot in ('p1p1', 'p2p2', 'p1p2', 'p2p1'):
+        if field in [slot + s for s in _UNPACK_SUFFIXES]:
+            return data[slot + 'vis'], data[slot + 'sigma'], 'c16'
+
+    # physical / cross correlation names: matching slot where present, else NaN
+    for visname in _CIRC_VTYPES + _LIN_VTYPES:
+        pref = visname[:-3]    # 'rrvis' -> 'rr'; the two chars are the feed letters
+        if field in [pref + s for s in _UNPACK_SUFFIXES]:
+            out, sig, n_nan = unpack_mixed_correlation(data, pref[0], pref[1])
+            if n_nan > 0:
+                warnings.warn(
+                    f"unpack({field!r}) on a mixed-feed obs: {n_nan} rows have "
+                    f"no {pref.upper()} correlation and were returned as NaN.",
+                    ehw.MixedPolUnpackNaNWarning)
+            return out, sig, 'c16'
+
+    # Stokes-derived: recover (I, Q, U, V) per row, then form the field
+    ivis, q, u, v, si, sq, su, sv = unpack_mixed_stokes(data)
+    if field in ['vis', 'amp', 'phase', 'snr', 'sigma', 'sigma_phase']:
+        return ivis, si, 'c16'
+    if field in ['qvis', 'qamp', 'qphase', 'qsnr', 'qsigma', 'qsigma_phase']:
+        return q, sq, 'c16'
+    if field in ['uvis', 'uamp', 'uphase', 'usnr', 'usigma', 'usigma_phase']:
+        return u, su, 'c16'
+    if field in ['vvis', 'vamp', 'vphase', 'vsnr', 'vsigma', 'vsigma_phase']:
+        return v, sv, 'c16'
+    if field in ['pvis', 'pamp', 'pphase', 'psnr', 'psigma', 'psigma_phase']:
+        return q + 1j * u, np.sqrt(sq**2 + su**2), 'c16'
+    if field in ['m', 'mamp', 'mphase', 'msnr', 'msigma', 'msigma_phase']:
+        out = (q + 1j * u) / ivis
+        return out, merr(si, sq, su, ivis, out), 'c16'
+    if field in ['evis', 'eamp', 'ephase', 'esnr', 'esigma', 'esigma_phase']:
+        ang = np.arctan2(data['u'], data['v'])
+        out = np.cos(2 * ang) * q + np.sin(2 * ang) * u
+        sig = np.sqrt(0.5 * ((np.cos(2 * ang) * sq)**2 + (np.sin(2 * ang) * su)**2))
+        return out, sig, 'c16'
+    if field in ['bvis', 'bamp', 'bphase', 'bsnr', 'bsigma', 'bsigma_phase']:
+        ang = np.arctan2(data['u'], data['v'])
+        out = -np.sin(2 * ang) * q + np.cos(2 * ang) * u
+        sig = np.sqrt(0.5 * ((np.sin(2 * ang) * sq)**2 + (np.cos(2 * ang) * su)**2))
+        return out, sig, 'c16'
+    if field in ['rrllvis', 'rrllamp', 'rrllphase', 'rrllsnr',
+                 'rrllsigma', 'rrllsigma_phase']:
+        out = (ivis + v) / (ivis - v)
+        sig = (2.0**0.5 * (np.abs(ivis)**2 + np.abs(v)**2)**0.5
+               / np.abs(ivis - v)**2 * (si**2 + sv**2)**0.5)
+        return out, sig, 'c16'
+
+    raise Exception(f"{field} is not a valid field for polrep 'mixed'")
+
+
+##################################################################################################
+# Closure Quantity Construction
+##################################################################################################
+
+
+def valid_closure_vtypes(polrep):
+    """Visibility types from which closure quantities can be formed for a polrep.
+
+       Stokes is the complete basis: it can synthesize both circular and linear
+       correlations. Each feed basis can give its own correlations plus Stokes,
+       but not the other feed basis directly (that would need the two-step
+       circ<->stokes<->lin composition, which is out of scope for the kernels).
+    """
+    if polrep == 'stokes':
+        return _STOKES_VTYPES + _CIRC_VTYPES + _LIN_VTYPES
+    if polrep == 'circ':
+        return _CIRC_VTYPES + _STOKES_VTYPES
+    if polrep == 'lin':
+        return _LIN_VTYPES + _STOKES_VTYPES
+    if polrep == 'mixed':
+        # Permissive: feed-basis names pass here so the per-triangle filter
+        # (closure_skip_polbasis) can reject Stokes/generic vtypes in the body.
+        return _STOKES_VTYPES + _CIRC_VTYPES + _LIN_VTYPES + _GENERIC_VTYPES
+    raise Exception(f"unsupported polrep {polrep!r} for closure quantities")
+
+
+def closure_skip_polbasis(vtype):
+    """For a mixed-feed observation, the homogeneous per-baseline polbasis that a
+       closure of this vtype requires. Raises for vtypes with no single-baseline
+       feed-basis meaning (Stokes or generic p1p1vis-style)."""
+    if vtype in _CIRC_VTYPES or vtype == 'pvis':
+        return 'rlrl'
+    if vtype in _LIN_VTYPES:
+        return 'xyxy'
+    raise Exception(
+        f"closure quantity vtype={vtype!r} is not physical on a mixed-feed "
+        "observation: only single-correlation feed-basis vtypes "
+        "(rrvis/llvis/rlvis/lrvis or xxvis/yyvis/xyvis/yxvis) can be formed per "
+        "triangle. Stokes and generic p1p1vis-style closures need a homogeneous "
+        "feed basis; use switch_polrep('stokes') after calibration instead.")
+
+
+def closure_skip_message(n_skipped, count, kind='triangles'):
+    """Message for MixedPolClosureSkipWarning when feed-mixing baselines are
+       dropped. For minimal sets, note that the (site-based) minimal set is not
+       baseline-aware, so some recoverable closures may be lost."""
+    msg = (f"{n_skipped} {kind} skipped: closures require baselines between "
+           "stations with the same polarization basis.")
+    if count in ('min', 'min-cut0bl'):
+        msg += " Minimal set is site-based, not baseline-aware; use count='max' to keep all."
+    return msg
 
 
 def make_bispectrum(l1, l2, l3, vistype, polrep='stokes'):

--- a/ehtim/observing/pol_conventions.py
+++ b/ehtim/observing/pol_conventions.py
@@ -331,7 +331,7 @@ _FEED_VEC = {
 }
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def feed_matrix(feed_type):
     """2x2 matrix F mapping an (X, Y) field to a station's two feeds.
 
@@ -349,7 +349,7 @@ def feed_matrix(feed_type):
     return F
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _coherency_matrix(t1_feed, t2_feed):
     """Cached 4x4 complex operator M with
        (I, Q, U, V) = M @ (p1p1, p2p2, p1p2, p2p1)

--- a/ehtim/observing/pol_conventions.py
+++ b/ehtim/observing/pol_conventions.py
@@ -405,6 +405,20 @@ def coherency_to_stokes_sigma(s_p1p1, s_p2p2, s_p1p2, s_p2p1, t1_feed, t2_feed):
     return out[0], out[1], out[2], out[3]
 
 
+def correlation_slot(t1_feed, t2_feed, feed_a, feed_b):
+    """Return the generic DTPOL_MIXED slot name ('p1p1vis'/'p1p2vis'/'p2p1vis'/
+       'p2p2vis') holding the correlation feed_a * conj(feed_b) for a baseline
+       with these station feed types, or None if the baseline does not measure
+       it (a station lacks the required feed). Resolves by feed-letter position,
+       so it is correct for reordered/hybrid feeds (e.g. 'lr', 'rx') too."""
+    i = t1_feed.find(feed_a)
+    j = t2_feed.find(feed_b)
+    if i < 0 or j < 0:
+        return None
+    return {(0, 0): 'p1p1vis', (0, 1): 'p1p2vis',
+            (1, 0): 'p2p1vis', (1, 1): 'p2p2vis'}[(i, j)]
+
+
 # ---------------------------------------------------------------------------
 # Jones-matrix scaffolding
 # ---------------------------------------------------------------------------

--- a/ehtim/observing/pol_conventions.py
+++ b/ehtim/observing/pol_conventions.py
@@ -342,8 +342,9 @@ def feed_matrix(feed_type):
     non-orthogonal) -- which is fine, coherency recovery uses inv(), not the
     adjoint. The returned array is cached and read-only.
     """
-    if len(feed_type) != 2 or any(c not in _FEED_VEC for c in feed_type):
-        raise ValueError(f"feed_matrix: unsupported feed_type {feed_type!r}")
+    if (len(feed_type) != 2 or feed_type[0] == feed_type[1]
+            or any(c not in _FEED_VEC for c in feed_type)):
+        raise ValueError(f"feed_matrix: degenerate or unsupported feed_type {feed_type!r}")
     F = np.array([_FEED_VEC[feed_type[0]], _FEED_VEC[feed_type[1]]])
     F.flags.writeable = False
     return F

--- a/ehtim/observing/pol_conventions.py
+++ b/ehtim/observing/pol_conventions.py
@@ -412,6 +412,10 @@ def correlation_slot(t1_feed, t2_feed, feed_a, feed_b):
        with these station feed types, or None if the baseline does not measure
        it (a station lacks the required feed). Resolves by feed-letter position,
        so it is correct for reordered/hybrid feeds (e.g. 'lr', 'rx') too."""
+    if len(t1_feed) != 2 or t1_feed[0] == t1_feed[1]:
+        raise ValueError(f"correlation_slot: invalid feed {t1_feed!r}")
+    if len(t2_feed) != 2 or t2_feed[0] == t2_feed[1]:
+        raise ValueError(f"correlation_slot: invalid feed {t2_feed!r}")
     i = t1_feed.find(feed_a)
     j = t2_feed.find(feed_b)
     if i < 0 or j < 0:

--- a/ehtim/observing/pol_conventions.py
+++ b/ehtim/observing/pol_conventions.py
@@ -42,6 +42,7 @@ A ``MixedPolConventionWarning`` fires once per session on the first
 non-identity transform call.
 """
 
+import functools
 import warnings
 
 import numpy as np
@@ -298,6 +299,110 @@ def stokes_to_lin_sigma(sigma, qsigma, usigma, vsigma):
     xx_yy = np.sqrt(sigma**2 + qsigma**2)
     xy_yx = np.sqrt(usigma**2 + vsigma**2)
     return xx_yy, xx_yy, xy_yx, xy_yx
+
+
+# ---------------------------------------------------------------------------
+# General coherency <-> Stokes for arbitrary feed pairings (mixed-pol)
+# ---------------------------------------------------------------------------
+#
+# Under ideal feeds (D = 0, gains calibrated -- the same assumption every
+# transform here makes), a baseline between stations with feed matrices F1, F2
+# measures the full coherency
+#
+#     V = F1 @ B @ F2^dagger,   B = [[XX, XY], [YX, YY]]   (sky brightness, XY basis)
+#
+# so B = F1^{-1} V (F2^dagger)^{-1} recovers Stokes from ANY feed pairing,
+# including heterogeneous ones (e.g. circular x linear) and hybrid feeds whose
+# F is invertible but not unitary. The feed matrices are built from
+# BASIS_LIN_TO_CIRC (engineering convention R = (X + iY)/sqrt(2)), so
+# these reduce to circ_to_stokes / lin_to_stokes on homogeneous pairings -- a
+# property asserted by the cross-validation tests.
+#
+# Field rotation / parallactic angle is assumed already corrected (as for all
+# transforms in this module). Slot order is the generic DTPOL_MIXED order
+# (p1p1, p2p2, p1p2, p2p1); Stokes order is (I, Q, U, V).
+
+# Each feed letter as its (X, Y) projection vector (rows of the feed matrix).
+_FEED_VEC = {
+    'x': np.array([1.0, 0.0], dtype=complex),
+    'y': np.array([0.0, 1.0], dtype=complex),
+    'r': BASIS_LIN_TO_CIRC[0].copy(),   # R = (X + iY)/sqrt(2)
+    'l': BASIS_LIN_TO_CIRC[1].copy(),   # L = (X - iY)/sqrt(2)
+}
+
+
+@functools.lru_cache(maxsize=None)
+def feed_matrix(feed_type):
+    """2x2 matrix F mapping an (X, Y) field to a station's two feeds.
+
+    Rows are the station's feeds (in feed order), columns are (X, Y). Built
+    from BASIS_LIN_TO_CIRC, so feed_matrix('rl') == BASIS_LIN_TO_CIRC and
+    feed_matrix('xy') == identity. Always invertible; unitary for orthogonal
+    feed pairs (rl/lr/xy/yx) but NOT for hybrid feeds (e.g. 'rx': R and X are
+    non-orthogonal) -- which is fine, coherency recovery uses inv(), not the
+    adjoint. The returned array is cached and read-only.
+    """
+    if len(feed_type) != 2 or any(c not in _FEED_VEC for c in feed_type):
+        raise ValueError(f"feed_matrix: unsupported feed_type {feed_type!r}")
+    F = np.array([_FEED_VEC[feed_type[0]], _FEED_VEC[feed_type[1]]])
+    F.flags.writeable = False
+    return F
+
+
+@functools.lru_cache(maxsize=None)
+def _coherency_matrix(t1_feed, t2_feed):
+    """Cached 4x4 complex operator M with
+       (I, Q, U, V) = M @ (p1p1, p2p2, p1p2, p2p1)
+       for a baseline of the given station feed types. Read-only."""
+    f1inv = np.linalg.inv(feed_matrix(t1_feed))
+    f2invH = np.linalg.inv(feed_matrix(t2_feed)).conj().T
+    M = np.zeros((4, 4), dtype=complex)
+    for j in range(4):
+        # j-th unit correlation in (p1p1, p2p2, p1p2, p2p1) order
+        slots = np.zeros(4, dtype=complex)
+        slots[j] = 1.0
+        Vmat = np.array([[slots[0], slots[2]],
+                         [slots[3], slots[1]]])
+        B = f1inv @ Vmat @ f2invH          # sky coherency in (X, Y) basis
+        M[0, j] = 0.5 * (B[0, 0] + B[1, 1])         # I = (XX + YY)/2
+        M[1, j] = 0.5 * (B[0, 0] - B[1, 1])         # Q = (XX - YY)/2
+        M[2, j] = 0.5 * (B[0, 1] + B[1, 0])         # U = (XY + YX)/2
+        M[3, j] = 0.5j * (B[1, 0] - B[0, 1])        # V = i(YX - XY)/2
+    M.flags.writeable = False
+    return M
+
+
+def coherency_to_stokes(p1p1, p2p2, p1p2, p2p1, t1_feed, t2_feed):
+    """Recover (I, Q, U, V) from the four generic-slot correlations of a single
+       feed pairing (arrays of equal shape, or scalars). Ideal-feed assumption."""
+    _maybe_warn_convention()
+    M = _coherency_matrix(t1_feed, t2_feed)
+    corr = np.stack([np.asarray(p1p1), np.asarray(p2p2),
+                     np.asarray(p1p2), np.asarray(p2p1)])
+    stokes = np.tensordot(M, corr, axes=([1], [0]))
+    return stokes[0], stokes[1], stokes[2], stokes[3]
+
+
+def stokes_to_coherency(i, q, u, v, t1_feed, t2_feed):
+    """Inverse of coherency_to_stokes: build the four generic-slot correlations
+       (p1p1, p2p2, p1p2, p2p1) for a feed pairing from Stokes."""
+    _maybe_warn_convention()
+    Minv = np.linalg.inv(_coherency_matrix(t1_feed, t2_feed))
+    stokes = np.stack([np.asarray(i), np.asarray(q),
+                       np.asarray(u), np.asarray(v)])
+    corr = np.tensordot(Minv, stokes, axes=([1], [0]))
+    return corr[0], corr[1], corr[2], corr[3]
+
+
+def coherency_to_stokes_sigma(s_p1p1, s_p2p2, s_p1p2, s_p2p1, t1_feed, t2_feed):
+    """Marginal (diagonal, covariance-dropping) sigma propagation of the four
+       slot sigmas to (sigma_I, sigma_Q, sigma_U, sigma_V), matching the lossy
+       convention of the other *_sigma helpers here."""
+    W = np.abs(_coherency_matrix(t1_feed, t2_feed))**2
+    var = np.stack([np.asarray(s_p1p1)**2, np.asarray(s_p2p2)**2,
+                    np.asarray(s_p1p2)**2, np.asarray(s_p2p1)**2])
+    out = np.sqrt(np.tensordot(W, var, axes=([1], [0])))
+    return out[0], out[1], out[2], out[3]
 
 
 # ---------------------------------------------------------------------------

--- a/ehtim/warnings.py
+++ b/ehtim/warnings.py
@@ -36,3 +36,13 @@ class MixedPolClosureSkipWarning(UserWarning):
     Jones-level conversion. The warning summarizes, per call, how many
     triangles or quadrangles were skipped and why.
     """
+
+
+class MixedPolUnpackNaNWarning(UserWarning):
+    """Emitted when ``Obsdata.unpack`` of a physical correlation (e.g. 'rrvis')
+    on a mixed-feed observation returns NaN for rows whose feed basis does not
+    measure that correlation (e.g. RR on a circular x linear baseline).
+
+    The warning reports, per field, how many rows were NaN-filled. It is
+    deliberately verbose; suppress with the standard machinery if needed.
+    """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,19 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
+requires-python = ">=3.10"
+
 dependencies = [
-    "numpy>=1.24",
-    "scipy>=1.9.3",
-    "astropy>=5.0.4",
-    "matplotlib>=3.7.3",
+    "numpy>=2.0",
+    "scipy>=1.13",
+    "astropy>=6.1",
+    "matplotlib>=3.9",
     "finufft>=2.2",
     "skyfield",
     "h5py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,19 +20,14 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.8",
 ]
 
-requires-python = ">=3.10"
-
 dependencies = [
-    "numpy>=2.0",
-    "scipy>=1.13",
-    "astropy>=6.1",
-    "matplotlib>=3.9",
+    "numpy>=1.24",
+    "scipy>=1.9.3",
+    "astropy>=5.0.4",
+    "matplotlib>=3.7.3",
     "finufft>=2.2",
     "skyfield",
     "h5py",

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -297,9 +297,6 @@ def test_remove_site_also_removes_ephem_entry():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="Bug in Array.add_satellite_tle (array.py:264): "
-                          "body references `tlearr` but the kwarg is `tlelist`. "
-                          "Fixed by PR #260 which renames the kwarg to `tlearr`.")
 def test_add_satellite_tle_appends_row(eht_array):
     tle = ["SAT1", "tle_line_1", "tle_line_2"]
     out = eht_array.add_satellite_tle(tle, sefd=8000)

--- a/tests/test_imager_e2e.py
+++ b/tests/test_imager_e2e.py
@@ -17,6 +17,8 @@ Covers all three transform types (direct / fast / nfft) and both
 Stokes-I and polarimetric (IP) imaging.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -152,12 +154,14 @@ class TestEndToEndReconstruction:
         )
         assert errors[0] > STOKES_I_NXCORR_MIN
 
-    def test_stokes_i_closure_imaging_polrep_transparent(self, gauss_im, observe):
+    @pytest.mark.parametrize("polrep", ["circ", "lin"])
+    def test_stokes_i_closure_imaging_polrep_transparent(self, gauss_im, observe, polrep):
         """Stokes-I closure imaging is independent of the obs polrep.
 
-        Imaging from a circ-polrep observation forms its amp/cphase/logcamp
-        data terms by synthesizing Stokes I from rr/ll (the mixed-pol closure
-        kernels), and must reproduce the stokes-obs reconstruction exactly.
+        Imaging from a circ- or lin-polrep observation forms its amp/cphase/
+        logcamp data terms by synthesizing Stokes I from rr/ll (or xx/yy) via
+        the mixed-pol unpack path, and must reproduce the stokes-obs
+        reconstruction. The source is unpolarized, so the synthesis is exact.
         """
         obs_stokes = observe(gauss_im, ttype="direct", seed=42)
         prior = _independent_prior(gauss_im.total_flux())
@@ -170,13 +174,17 @@ class TestEndToEndReconstruction:
             return imgr.make_image_I(niter=3, show_updates=False)
 
         out_stokes = image(obs_stokes)
-        out_circ = image(obs_stokes.switch_polrep("circ"))
+        # singlepol_hand selects the surviving parallel hand: R for circ, X for lin
+        hand = 'X' if polrep == 'lin' else 'R'
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # polrep vs feed_type mismatch + convention
+            out_other = image(obs_stokes.switch_polrep(polrep, singlepol_hand=hand))
 
-        (errors, _, _) = out_circ.compare_images(
+        (errors, _, _) = out_other.compare_images(
             gauss_im, metric=["nxcorr"], blur_frac=0.0)
         assert errors[0] > STOKES_I_NXCORR_MIN
-        # circ closures synthesize I exactly, so the reconstruction is identical
-        np.testing.assert_allclose(out_circ.imvec, out_stokes.imvec,
+        # unpolarized source -> exact I synthesis -> identical reconstruction
+        np.testing.assert_allclose(out_other.imvec, out_stokes.imvec,
                                    rtol=0, atol=1e-10)
 
     def test_recovers_gaussian_polarimetric_ip(self, gauss_im_pol, observe):

--- a/tests/test_imager_e2e.py
+++ b/tests/test_imager_e2e.py
@@ -178,14 +178,23 @@ class TestEndToEndReconstruction:
         hand = 'X' if polrep == 'lin' else 'R'
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")  # polrep vs feed_type mismatch + convention
-            out_other = image(obs_stokes.switch_polrep(polrep, singlepol_hand=hand))
+            obs_other = obs_stokes.switch_polrep(polrep, singlepol_hand=hand)
+
+        # unpolarized source -> exact I synthesis -> data products identical to machine precision
+        for f in ['vis', 'amp']:
+            np.testing.assert_allclose(obs_other.unpack(f)[f], obs_stokes.unpack(f)[f],
+                                       rtol=0, atol=1e-12)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            out_other = image(obs_other)
 
         (errors, _, _) = out_other.compare_images(
             gauss_im, metric=["nxcorr"], blur_frac=0.0)
         assert errors[0] > STOKES_I_NXCORR_MIN
-        # unpolarized source -> exact I synthesis -> identical reconstruction
-        np.testing.assert_allclose(out_other.imvec, out_stokes.imvec,
-                                   rtol=0, atol=1e-10)
+        (xcorr, _, _) = out_other.compare_images(
+            out_stokes, metric=["nxcorr"], blur_frac=0.0)
+        assert xcorr[0] > 0.99
 
     def test_recovers_gaussian_polarimetric_ip(self, gauss_im_pol, observe):
         """Simultaneous Stokes I + P imaging on a polarized Gaussian source.

--- a/tests/test_imager_e2e.py
+++ b/tests/test_imager_e2e.py
@@ -152,6 +152,33 @@ class TestEndToEndReconstruction:
         )
         assert errors[0] > STOKES_I_NXCORR_MIN
 
+    def test_stokes_i_closure_imaging_polrep_transparent(self, gauss_im, observe):
+        """Stokes-I closure imaging is independent of the obs polrep.
+
+        Imaging from a circ-polrep observation forms its amp/cphase/logcamp
+        data terms by synthesizing Stokes I from rr/ll (the mixed-pol closure
+        kernels), and must reproduce the stokes-obs reconstruction exactly.
+        """
+        obs_stokes = observe(gauss_im, ttype="direct", seed=42)
+        prior = _independent_prior(gauss_im.total_flux())
+
+        def image(obs):
+            imgr = eh.imager.Imager(
+                obs, prior, prior_im=prior, flux=gauss_im.total_flux(),
+                **_imager_kwargs_stokes_i("direct"),
+            )
+            return imgr.make_image_I(niter=3, show_updates=False)
+
+        out_stokes = image(obs_stokes)
+        out_circ = image(obs_stokes.switch_polrep("circ"))
+
+        (errors, _, _) = out_circ.compare_images(
+            gauss_im, metric=["nxcorr"], blur_frac=0.0)
+        assert errors[0] > STOKES_I_NXCORR_MIN
+        # circ closures synthesize I exactly, so the reconstruction is identical
+        np.testing.assert_allclose(out_circ.imvec, out_stokes.imvec,
+                                   rtol=0, atol=1e-10)
+
     def test_recovers_gaussian_polarimetric_ip(self, gauss_im_pol, observe):
         """Simultaneous Stokes I + P imaging on a polarized Gaussian source.
 

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -1579,3 +1579,186 @@ def test_data_conj_mixed_multibaseline_polbasis():
         # the reverse-station row must also be present with swapped halves
         mate = pb[2:] + pb[:2]
         assert mate in set(str(s) for s in dc['polbasis'])
+
+
+# ============================================================================
+#  Closures (bispectra / c_phases / c_amplitudes) on lin / mixed
+# ============================================================================
+
+
+def _lin_tri_obs():
+    """3-station all-'xy' LIN obs, one timestamp -> one triangle."""
+    d = _lin_data(['S0', 'S0', 'S1'], ['S1', 'S2', 'S2'])
+    return eo.Obsdata(0., 0., 230e9, 1e9, d, _tarr(['xy', 'xy', 'xy']),
+                      polrep='lin')
+
+
+def _lin_4st_obs():
+    """4-station all-'xy' LIN obs, one timestamp -> non-trivial closure set."""
+    t1s = ['S0', 'S0', 'S0', 'S1', 'S1', 'S2']
+    t2s = ['S1', 'S2', 'S3', 'S2', 'S3', 'S3']
+    d = _lin_data(t1s, t2s)
+    return eo.Obsdata(0., 0., 230e9, 1e9, d, _tarr(['xy', 'xy', 'xy', 'xy']),
+                      polrep='lin')
+
+
+def _mixed_tri_obs():
+    """3-station mixed obs (S0,S1='rl', S2='xy'): the only triangle is feed-mixing."""
+    d = _mixed_data(['S0', 'S0', 'S1'], ['S1', 'S2', 'S2'])
+    return eo.Obsdata(0., 0., 230e9, 1e9, d, _tarr(['rl', 'rl', 'xy']),
+                      polrep='mixed')
+
+
+def _mixed_4st_obs():
+    """4-station mixed obs (S0,S1,S2='rl', S3='xy'): exactly one all-circular
+       triangle (S0,S1,S2); the other three triangles touch the linear station."""
+    t1s = ['S0', 'S0', 'S0', 'S1', 'S1', 'S2']
+    t2s = ['S1', 'S2', 'S3', 'S2', 'S3', 'S3']
+    d = _mixed_data(t1s, t2s)
+    return eo.Obsdata(0., 0., 230e9, 1e9, d, _tarr(['rl', 'rl', 'rl', 'xy']),
+                      polrep='mixed')
+
+
+# ----- lin closures match the stokes-converted observation ------------------
+
+def test_bispectra_lin_matches_stokes():
+    obs_l = _lin_tri_obs()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        bl = obs_l.bispectra(vtype='vis')
+        bs = obs_l.switch_polrep('stokes').bispectra(vtype='vis')
+    assert len(bl) == len(bs) == 1
+    np.testing.assert_allclose(bl['bispec'], bs['bispec'], rtol=1e-10)
+
+
+def test_bispectra_lin_native_slot():
+    # vtype='xxvis' bispectrum is the product of xxvis around the triangle.
+    obs_l = _lin_tri_obs()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        b = obs_l.bispectra(vtype='xxvis')
+    d = obs_l.data
+    expected = d['xxvis'][0] * d['xxvis'][2] * np.conj(d['xxvis'][1])
+    # triangle (S0,S1),(S1,S2),(S2,S0): third leg is conj of (S0,S2)
+    assert len(b) == 1
+    np.testing.assert_allclose(np.abs(b['bispec'][0]), np.abs(expected), rtol=1e-10)
+
+
+def test_c_phases_lin_matches_stokes():
+    obs_l = _lin_tri_obs()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        cl = obs_l.c_phases(vtype='vis')
+        cs = obs_l.switch_polrep('stokes').c_phases(vtype='vis')
+    assert len(cl) == len(cs) == 1
+    np.testing.assert_allclose(cl['cphase'], cs['cphase'], rtol=1e-9)
+
+
+# ----- vtype validity is polrep-specific ------------------------------------
+
+def test_bispectra_lin_rejects_circular_vtype():
+    obs_l = _lin_tri_obs()
+    with pytest.raises(Exception, match="vtype"):
+        obs_l.bispectra(vtype='rrvis')
+
+
+def test_bispectra_circ_rejects_linear_vtype():
+    obs_c = _stokes_obs().switch_polrep('circ')
+    with pytest.raises(Exception, match="vtype"):
+        obs_c.bispectra(vtype='xxvis')
+
+
+# ----- mixed-feed: skip feed-mixing triangles -------------------------------
+
+def test_bispectra_mixed_skips_cross_feed_triangle():
+    obs = _mixed_tri_obs()
+    with pytest.warns(ehw.MixedPolClosureSkipWarning):
+        b = obs.bispectra(vtype='rrvis', count='max')
+    assert len(b) == 0
+
+
+def test_bispectra_mixed_keeps_homogeneous_subtriangle():
+    obs = _mixed_4st_obs()
+    with pytest.warns(ehw.MixedPolClosureSkipWarning):
+        b = obs.bispectra(vtype='rrvis', count='max')
+    # only the all-circular triangle survives
+    assert len(b) == 1
+    assert set((b['t1'][0], b['t2'][0], b['t3'][0])) == {'S0', 'S1', 'S2'}
+
+
+def test_c_phases_mixed_skips_cross_feed_triangle():
+    obs = _mixed_tri_obs()
+    with pytest.warns(ehw.MixedPolClosureSkipWarning):
+        c = obs.c_phases(vtype='rrvis', count='max')
+    assert len(c) == 0
+
+
+# ----- mixed-feed: Stokes / generic vtypes are not closure-able -------------
+
+def test_bispectra_mixed_stokes_vtype_raises():
+    obs = _mixed_tri_obs()
+    with pytest.raises(Exception, match="mixed-feed"):
+        obs.bispectra(vtype='vis')
+
+
+def test_bispectra_mixed_generic_vtype_raises():
+    obs = _mixed_tri_obs()
+    with pytest.raises(Exception, match="mixed-feed"):
+        obs.bispectra(vtype='p1p1vis')
+
+
+# ----- minimal-set caveat is surfaced ---------------------------------------
+
+def test_mixed_skip_warning_minimal_set_caveat():
+    obs = _mixed_4st_obs()
+    with pytest.warns(ehw.MixedPolClosureSkipWarning, match="baseline-aware"):
+        obs.bispectra(vtype='rrvis', count='min')
+
+
+def test_mixed_skip_warning_no_caveat_for_maxset():
+    obs = _mixed_4st_obs()
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter('always')
+        obs.bispectra(vtype='rrvis', count='max')
+    msgs = [str(w.message) for w in rec
+            if issubclass(w.category, ehw.MixedPolClosureSkipWarning)]
+    assert msgs and all('baseline-aware' not in m for m in msgs)
+
+
+# ----- single-triangle helper guards ----------------------------------------
+
+def test_cphase_tri_mixed_heterogeneous_returns_empty():
+    obs = _mixed_tri_obs()
+    with pytest.warns(ehw.MixedPolClosureSkipWarning):
+        out = obs.cphase_tri('S0', 'S1', 'S2', vtype='rrvis')
+    assert len(out) == 0
+
+
+# ----- diagonal closures on lin / mixed -------------------------------------
+
+def test_c_phases_diag_lin_matches_stokes():
+    obs_l = _lin_4st_obs()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        dl = obs_l.c_phases_diag(vtype='vis')
+        ds = obs_l.switch_polrep('stokes').c_phases_diag(vtype='vis')
+    # one timestamp; compare the diagonalized closure-phase values
+    np.testing.assert_allclose(dl[0][0]['cphase'], ds[0][0]['cphase'], rtol=1e-8)
+    np.testing.assert_allclose(dl[0][0]['sigmacp'], ds[0][0]['sigmacp'], rtol=1e-8)
+
+
+def test_c_log_amplitudes_diag_lin_matches_stokes():
+    obs_l = _lin_4st_obs()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        dl = obs_l.c_log_amplitudes_diag(vtype='vis')
+        ds = obs_l.switch_polrep('stokes').c_log_amplitudes_diag(vtype='vis')
+    np.testing.assert_allclose(dl[0][0]['camp'], ds[0][0]['camp'], rtol=1e-8)
+
+
+def test_c_phases_diag_mixed_skips_cross_feed():
+    # only the all-circular sub-triangle survives; diag runs on it with a warning
+    obs = _mixed_4st_obs()
+    with pytest.warns(ehw.MixedPolClosureSkipWarning):
+        d = obs.c_phases_diag(vtype='rrvis')
+    assert len(d) >= 1

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -1619,6 +1619,21 @@ def _mixed_4st_obs():
                       polrep='mixed')
 
 
+def _mixed_5st_obs():
+    """5-station mixed obs (S0-S3='rl', S4='xy'): the all-circular S0-S3
+       quadrangle survives; every baseline touching S4 is cross-feed and
+       skipped. Exercises the diag covariance NaN-filter on a surviving quad."""
+    sites = ['S0', 'S1', 'S2', 'S3', 'S4']
+    t1s, t2s = [], []
+    for i in range(5):
+        for j in range(i + 1, 5):
+            t1s.append(sites[i])
+            t2s.append(sites[j])
+    d = _mixed_data(t1s, t2s)
+    return eo.Obsdata(0., 0., 230e9, 1e9, d,
+                      _tarr(['rl', 'rl', 'rl', 'rl', 'xy']), polrep='mixed')
+
+
 # ----- lin closures match the stokes-converted observation ------------------
 
 def test_bispectra_lin_matches_stokes():
@@ -1762,6 +1777,29 @@ def test_c_phases_diag_mixed_skips_cross_feed():
     with pytest.warns(ehw.MixedPolClosureSkipWarning):
         d = obs.c_phases_diag(vtype='rrvis')
     assert len(d) >= 1
+    # cross-feed baselines must not poison the surviving triangle's covariance
+    sigmacp = np.concatenate([x[0]['sigmacp'] for x in d])
+    assert np.all(np.isfinite(sigmacp))
+
+
+def test_c_log_amplitudes_diag_mixed_no_quad_returns_empty():
+    # 4 stations, only 3 circular -> no all-circular quadrangle survives.
+    # Must return empty without raising (previously crashed with IndexError).
+    obs = _mixed_4st_obs()
+    with pytest.warns(ehw.MixedPolClosureSkipWarning):
+        d = obs.c_log_amplitudes_diag(vtype='rrvis')
+    assert d == []
+
+
+def test_c_log_amplitudes_diag_mixed_skips_cross_feed():
+    # the all-circular S0-S3 quad survives; cross-feed baselines must not
+    # poison its covariance
+    obs = _mixed_5st_obs()
+    with pytest.warns(ehw.MixedPolClosureSkipWarning):
+        d = obs.c_log_amplitudes_diag(vtype='rrvis')
+    assert len(d) >= 1
+    sigmaca = np.concatenate([x[0]['sigmaca'] for x in d])
+    assert np.all(np.isfinite(sigmaca))
 
 
 # ============================================================================

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -1837,3 +1837,34 @@ def test_unpack_mixed_correlation_absent_everywhere():
     with pytest.warns(ehw.MixedPolUnpackNaNWarning):
         xx = obs.unpack('xxvis')['xxvis']
     assert np.all(np.isnan(xx))
+
+
+# ============================================================================
+#  load_uvfits mixed-pol detection stop-gap
+# ============================================================================
+
+def test_load_uvfits_rejects_noncircular_poltya():
+    from astropy.io import fits
+    path = os.path.join(os.path.dirname(__file__), '..', 'data', 'sample.uvfits')
+    hdul = fits.open(path)
+    hdul['AIPS AN'].data['POLTYA'][:] = 'X'   # pretend the AN table flags linear feeds
+    with pytest.raises(NotImplementedError, match="mixed-pol"):
+        eo.load_uvfits(hdul)
+
+
+def test_load_uvfits_rejects_hybrid_poltyb():
+    # POLTYA stays circular but POLTYB is linear (a hybrid R/X feed) -> caught
+    from astropy.io import fits
+    path = os.path.join(os.path.dirname(__file__), '..', 'data', 'sample.uvfits')
+    hdul = fits.open(path)
+    hdul['AIPS AN'].data['POLTYB'][:] = 'X'
+    with pytest.raises(NotImplementedError, match="mixed-pol"):
+        eo.load_uvfits(hdul)
+
+
+def test_load_uvfits_circular_unaffected():
+    # all-'R' POLTYA (the sample file) loads normally through the new check
+    path = os.path.join(os.path.dirname(__file__), '..', 'data', 'sample.uvfits')
+    obs = eo.load_uvfits(path)
+    assert obs.polrep in ('stokes', 'circ')
+    assert set(obs.tarr['feed_type']) == {'rl'}

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -1453,3 +1453,129 @@ def test_switch_polrep_tarr_unchanged():
     # tarr.feed_type is physical-array description; switch_polrep does not
     # touch it.
     np.testing.assert_array_equal(obs_l.tarr['feed_type'], obs_c.tarr['feed_type'])
+
+
+# ============================================================================
+#  data_conj — conjugate-baseline generalization (lin / mixed)
+# ============================================================================
+
+
+def _circ_data_1bl():
+    """Single-baseline (S0, S1) DTPOL_CIRC table with known values."""
+    d = np.zeros(1, dtype=ehc.DTPOL_CIRC)
+    d['t1'] = 'S0'
+    d['t2'] = 'S1'
+    d['u'] = 1e6
+    d['v'] = 1e5
+    d['rrvis'] = 1 + 2j
+    d['llvis'] = 3 + 4j
+    d['rlvis'] = 5 + 6j
+    d['lrvis'] = 7 + 8j
+    d['rrsigma'] = 0.1
+    d['llsigma'] = 0.2
+    d['rlsigma'] = 0.3
+    d['lrsigma'] = 0.4
+    return d
+
+
+def _stokes_data_1bl():
+    """Single-baseline (S0, S1) DTPOL_STOKES table with known values."""
+    d = np.zeros(1, dtype=ehc.DTPOL_STOKES)
+    d['t1'] = 'S0'
+    d['t2'] = 'S1'
+    d['u'] = 1e6
+    d['v'] = 1e5
+    d['vis'] = 1 + 2j
+    d['qvis'] = 3 + 4j
+    d['uvis'] = 5 + 6j
+    d['vvis'] = 7 + 8j
+    d['sigma'] = 0.1
+    d['qsigma'] = 0.2
+    d['usigma'] = 0.3
+    d['vsigma'] = 0.4
+    return d
+
+
+def test_data_conj_circ_unchanged():
+    # Regression: the circ conjugate transform is the same as before 4c.
+    obs = eo.Obsdata(0., 0., 230e9, 1e9, _circ_data_1bl(),
+                     _tarr(['rl', 'rl']), polrep='circ')
+    dc = obs.data_conj()
+    assert len(dc) == 2
+    conj = dc[dc['u'] < 0][0]
+    assert conj['t1'] == 'S1' and conj['t2'] == 'S0'
+    # diagonal slots: conjugate only
+    assert conj['rrvis'] == np.conj(1 + 2j)
+    assert conj['llvis'] == np.conj(3 + 4j)
+    # cross-hand slots: conjugate and swap
+    assert conj['rlvis'] == np.conj(7 + 8j)
+    assert conj['lrvis'] == np.conj(5 + 6j)
+    # diagonal sigmas unchanged; cross-hand sigmas swap
+    assert conj['rrsigma'] == 0.1
+    assert conj['llsigma'] == 0.2
+    assert conj['rlsigma'] == 0.4
+    assert conj['lrsigma'] == 0.3
+
+
+def test_data_conj_stokes_unchanged():
+    # Regression: stokes conjugates all four vis fields, no sigma swap.
+    obs = eo.Obsdata(0., 0., 230e9, 1e9, _stokes_data_1bl(),
+                     _tarr(['rl', 'rl']), polrep='stokes')
+    dc = obs.data_conj()
+    conj = dc[dc['u'] < 0][0]
+    assert conj['vis'] == np.conj(1 + 2j)
+    assert conj['qvis'] == np.conj(3 + 4j)
+    assert conj['uvis'] == np.conj(5 + 6j)
+    assert conj['vvis'] == np.conj(7 + 8j)
+    # stokes sigmas are not swapped
+    assert conj['usigma'] == 0.3
+    assert conj['vsigma'] == 0.4
+
+
+def test_data_conj_lin():
+    # xx/yy conjugate; xy <-> yx conjugate-and-swap; cross sigmas swap.
+    obs = eo.Obsdata(0., 0., 230e9, 1e9, _lin_data(['S0'], ['S1']),
+                     _tarr(['xy', 'xy']), polrep='lin')
+    dc = obs.data_conj()
+    conj = dc[dc['u'] < 0][0]
+    assert conj['xxvis'] == np.conj(1 + 2j)
+    assert conj['yyvis'] == np.conj(3 + 4j)
+    assert conj['xyvis'] == np.conj(7 + 8j)
+    assert conj['yxvis'] == np.conj(5 + 6j)
+    assert conj['xxsigma'] == 0.1
+    assert conj['yysigma'] == 0.2
+    assert conj['xysigma'] == 0.4
+    assert conj['yxsigma'] == 0.3
+
+
+def test_data_conj_mixed_swap_and_polbasis_flip():
+    # Heterogeneous baseline (S0='rl', S1='xy'): generic-slot conj/swap, and
+    # the polbasis halves flip on the conjugate row ('rlxy' -> 'xyrl').
+    obs = eo.Obsdata(0., 0., 230e9, 1e9, _mixed_data(['S0'], ['S1']),
+                     _tarr(['rl', 'xy']), polrep='mixed')
+    dc = obs.data_conj()
+    orig = dc[dc['u'] > 0][0]
+    conj = dc[dc['u'] < 0][0]
+    assert orig['polbasis'] == 'rlxy'
+    assert conj['polbasis'] == 'xyrl'
+    assert conj['p1p1vis'] == np.conj(1 + 2j)
+    assert conj['p2p2vis'] == np.conj(3 + 4j)
+    assert conj['p1p2vis'] == np.conj(7 + 8j)
+    assert conj['p2p1vis'] == np.conj(5 + 6j)
+    assert conj['p1p2sigma'] == 0.4
+    assert conj['p2p1sigma'] == 0.3
+
+
+def test_data_conj_mixed_multibaseline_polbasis():
+    # 3-station mixed array: every conjugate row's polbasis is the half-swap
+    # of its original, and the table doubles in length.
+    obs = eo.Obsdata(0., 0., 230e9, 1e9,
+                     _mixed_data(['S0', 'S0', 'S1'], ['S1', 'S2', 'S2']),
+                     _tarr(['rl', 'rl', 'xy']), polrep='mixed')
+    dc = obs.data_conj()
+    assert len(dc) == 2 * len(obs.data)
+    for row in dc:
+        pb = str(row['polbasis'])
+        # the reverse-station row must also be present with swapped halves
+        mate = pb[2:] + pb[:2]
+        assert mate in set(str(s) for s in dc['polbasis'])

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -1839,6 +1839,38 @@ def test_unpack_mixed_correlation_absent_everywhere():
     assert np.all(np.isnan(xx))
 
 
+# Stokes-derived fields (pvis/m/rrllvis) are recoverable on every mixed row
+# under the ideal-feed assumption. Each is checked as the algebraic
+# combination of the already-trusted Stokes components.
+
+def test_unpack_mixed_pvis():
+    obs = _mixed_obs()
+    q = obs.unpack('qvis')['qvis']
+    u = obs.unpack('uvis')['uvis']
+    pvis = obs.unpack('pvis')['pvis']
+    assert np.all(np.isfinite(pvis))
+    np.testing.assert_allclose(pvis, q + 1j * u, atol=1e-12)
+
+
+def test_unpack_mixed_m():
+    obs = _mixed_obs()
+    ivis = obs.unpack('vis')['vis']
+    q = obs.unpack('qvis')['qvis']
+    u = obs.unpack('uvis')['uvis']
+    m = obs.unpack('m')['m']
+    assert np.all(np.isfinite(m))
+    np.testing.assert_allclose(m, (q + 1j * u) / ivis, atol=1e-12)
+
+
+def test_unpack_mixed_rrllvis():
+    obs = _mixed_obs()
+    ivis = obs.unpack('vis')['vis']
+    v = obs.unpack('vvis')['vvis']
+    rrll = obs.unpack('rrllvis')['rrllvis']
+    assert np.all(np.isfinite(rrll))
+    np.testing.assert_allclose(rrll, (ivis + v) / (ivis - v), atol=1e-12)
+
+
 # ============================================================================
 #  load_uvfits mixed-pol detection stop-gap
 # ============================================================================

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -1804,7 +1804,36 @@ def test_unpack_generic_slot_stokes_raises():
         obs_s.unpack('p1p1vis')
 
 
-def test_unpack_mixed_not_yet_implemented():
+def test_unpack_mixed_stokes_recovered_all_rows():
+    # Stokes I is recoverable on every row, including cross-feed (rlxy) ones.
     obs = _mixed_obs()
-    with pytest.raises(NotImplementedError, match="mixed"):
-        obs.unpack('vis')
+    vis = obs.unpack('vis')['vis']
+    assert np.all(np.isfinite(vis))
+    pb = obs.data['polbasis']
+    m = (pb == 'rlrl')  # on circular baselines I = 0.5(RR + LL)
+    np.testing.assert_allclose(
+        vis[m], 0.5 * (obs.data['p1p1vis'][m] + obs.data['p2p2vis'][m]), atol=1e-12)
+
+
+def test_unpack_mixed_generic_slot():
+    obs = _mixed_obs()
+    np.testing.assert_array_equal(obs.unpack('p1p1vis')['p1p1vis'], obs.data['p1p1vis'])
+    np.testing.assert_array_equal(obs.unpack('p2p1vis')['p2p1vis'], obs.data['p2p1vis'])
+
+
+def test_unpack_mixed_physical_nanfill_and_warns():
+    # rrvis exists only on rl-rl baselines; rl-xy baselines have no RR -> NaN.
+    obs = _mixed_obs()
+    pb = obs.data['polbasis']
+    with pytest.warns(ehw.MixedPolUnpackNaNWarning, match="RR correlation"):
+        rr = obs.unpack('rrvis')['rrvis']
+    np.testing.assert_array_equal(rr[pb == 'rlrl'], obs.data['p1p1vis'][pb == 'rlrl'])
+    assert np.all(np.isnan(rr[pb != 'rlrl']))
+
+
+def test_unpack_mixed_correlation_absent_everywhere():
+    # No baseline has two linear stations, so XX is NaN on every row.
+    obs = _mixed_obs()
+    with pytest.warns(ehw.MixedPolUnpackNaNWarning):
+        xx = obs.unpack('xxvis')['xxvis']
+    assert np.all(np.isnan(xx))

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -1950,6 +1950,31 @@ def test_unpack_mixed_rrllvis():
     np.testing.assert_allclose(rrll, (ivis + v) / (ivis - v), atol=1e-12)
 
 
+def test_unpack_mixed_recovers_known_stokes():
+    # independent ground truth: build the obs from KNOWN Stokes via
+    # stokes_to_coherency per row, assert unpack recovers them on the rlxy rows
+    from ehtim.observing import pol_conventions as pc
+    t1s, t2s = ['S0', 'S0', 'S1'], ['S1', 'S2', 'S2']
+    feeds = [('rl', 'rl'), ('rl', 'xy'), ('rl', 'xy')]  # rlrl, rlxy, rlxy
+    I = np.array([1.0, 2.0, 1.5])
+    Q = np.array([0.1, -0.2, 0.05])
+    U = np.array([-0.05, 0.15, 0.2])
+    V = np.array([0.02, -0.03, 0.01])
+    d = _mixed_data(t1s, t2s)
+    for k, (f1, f2) in enumerate(feeds):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            p11, p22, p12, p21 = pc.stokes_to_coherency(I[k], Q[k], U[k], V[k], f1, f2)
+        d['p1p1vis'][k], d['p2p2vis'][k] = p11, p22
+        d['p1p2vis'][k], d['p2p1vis'][k] = p12, p21
+    obs = eo.Obsdata(0., 0., 230e9, 1e9, d, _tarr(['rl', 'rl', 'xy']), polrep='mixed')
+    assert set(obs.data['polbasis']) == {'rlrl', 'rlxy'}
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        for name, truth in [('vis', I), ('qvis', Q), ('uvis', U), ('vvis', V)]:
+            np.testing.assert_allclose(obs.unpack(name)[name], truth, atol=1e-12)
+
+
 # ============================================================================
 #  load_uvfits mixed-pol detection stop-gap
 # ============================================================================

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -1708,6 +1708,47 @@ def test_c_phases_mixed_skips_cross_feed_triangle():
     assert len(c) == 0
 
 
+# ----- closure amplitudes match / skip on lin / mixed -----------------------
+
+def test_c_amplitudes_lin_matches_stokes():
+    # closure amplitudes from a lin obs match the stokes-converted obs
+    obs_l = _lin_4st_obs()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        for ctype in ('camp', 'logcamp'):
+            cl = obs_l.c_amplitudes(vtype='vis', ctype=ctype)
+            cs = obs_l.switch_polrep('stokes').c_amplitudes(vtype='vis', ctype=ctype)
+            assert len(cl) == len(cs) >= 1
+            np.testing.assert_allclose(cl['camp'], cs['camp'], rtol=1e-9)
+
+
+def test_camp_quad_lin_matches_stokes():
+    obs_l = _lin_4st_obs()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        q = obs_l.camp_quad('S0', 'S1', 'S2', 'S3', vtype='vis', ctype='logcamp')
+        qs = obs_l.switch_polrep('stokes').camp_quad(
+            'S0', 'S1', 'S2', 'S3', vtype='vis', ctype='logcamp')
+    assert len(q) == len(qs) >= 1
+    np.testing.assert_allclose(q['camp'], qs['camp'], rtol=1e-9)
+
+
+def test_c_amplitudes_mixed_skips_cross_feed_quad():
+    # no all-circular quadrangle survives on the 4-station mixed obs
+    obs = _mixed_4st_obs()
+    with pytest.warns(ehw.MixedPolClosureSkipWarning):
+        c = obs.c_amplitudes(vtype='rrvis', ctype='logcamp')
+    assert len(c) == 0
+
+
+def test_c_amplitudes_mixed_keeps_homogeneous_quad():
+    # the all-circular S0-S3 quadrangle survives
+    obs = _mixed_5st_obs()
+    with pytest.warns(ehw.MixedPolClosureSkipWarning):
+        c = obs.c_amplitudes(vtype='rrvis', ctype='logcamp')
+    assert len(c) >= 1
+
+
 # ----- mixed-feed: Stokes / generic vtypes are not closure-able -------------
 
 def test_bispectra_mixed_stokes_vtype_raises():

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -1762,3 +1762,49 @@ def test_c_phases_diag_mixed_skips_cross_feed():
     with pytest.warns(ehw.MixedPolClosureSkipWarning):
         d = obs.c_phases_diag(vtype='rrvis')
     assert len(d) >= 1
+
+
+# ============================================================================
+#  unpack on lin / mixed
+# ============================================================================
+
+
+def test_unpack_lin_vis_matches_switch_polrep():
+    # unpack('vis') on a lin obs must equal switch_polrep('stokes') then unpack
+    # (both route through pol_conventions), the key lin<->circ symmetry.
+    obs_l = _lin_obs()
+    obs_s = obs_l.switch_polrep('stokes')
+    for f in ['vis', 'qvis', 'uvis', 'vvis']:
+        np.testing.assert_allclose(obs_l.unpack(f)[f], obs_s.unpack(f)[f], atol=1e-12)
+
+
+def test_unpack_lin_native_and_amp():
+    obs_l = _lin_obs()
+    np.testing.assert_array_equal(obs_l.unpack('xxvis')['xxvis'], obs_l.data['xxvis'])
+    # Stokes-I amplitude from linear feeds: 0.5|XX + YY|
+    expected = np.abs(0.5 * (obs_l.data['xxvis'] + obs_l.data['yyvis']))
+    np.testing.assert_allclose(obs_l.unpack('amp')['amp'], expected, atol=1e-12)
+
+
+def test_unpack_generic_slot_lin():
+    obs_l = _lin_obs()
+    np.testing.assert_array_equal(obs_l.unpack('p1p1vis')['p1p1vis'], obs_l.data['xxvis'])
+    np.testing.assert_array_equal(obs_l.unpack('p2p1vis')['p2p1vis'], obs_l.data['yxvis'])
+
+
+def test_unpack_lin_rejects_circular_name():
+    obs_l = _lin_obs()
+    with pytest.raises(Exception, match="not supported"):
+        obs_l.unpack('rrvis')
+
+
+def test_unpack_generic_slot_stokes_raises():
+    obs_s = _stokes_obs()
+    with pytest.raises(Exception, match="no meaning"):
+        obs_s.unpack('p1p1vis')
+
+
+def test_unpack_mixed_not_yet_implemented():
+    obs = _mixed_obs()
+    with pytest.raises(NotImplementedError, match="mixed"):
+        obs.unpack('vis')

--- a/tests/test_obsdata.py
+++ b/tests/test_obsdata.py
@@ -551,6 +551,16 @@ def test_unpack_pvis_stokes_vs_circ(obs_pol_direct):
     np.testing.assert_allclose(stokes, circ, atol=1e-12)
 
 
+@pytest.mark.parametrize("field", ["evis", "bvis", "m", "rrllvis",
+                                   "rrvis", "llvis", "rlvis", "lrvis"])
+def test_unpack_moved_fields_stokes_vs_circ(obs_pol_direct, field):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        stokes = obs_pol_direct.unpack([field])[field]
+        circ = obs_pol_direct.switch_polrep("circ").unpack([field])[field]
+    np.testing.assert_allclose(stokes, circ, atol=1e-12)
+
+
 def test_unpack_time_gmst_round_trips(obs_direct):
     utc_times = obs_direct.unpack(["time"], timetype="UTC")["time"]
     gmst_times = obs_direct.unpack(["time"], timetype="GMST")["time"]

--- a/tests/test_pol_conventions.py
+++ b/tests/test_pol_conventions.py
@@ -283,3 +283,103 @@ def test_warning_fires_from_jones_application():
         warnings.simplefilter("always", category=MixedPolConventionWarning)
         pc.apply_inverse_jones_to_coherency(V, J, J)
     assert any(issubclass(w.category, MixedPolConventionWarning) for w in caught)
+
+
+# ---------------------------------------------------------------------------
+# General coherency <-> Stokes (arbitrary feed pairings)
+# ---------------------------------------------------------------------------
+
+def _stokes_sample():
+    return (np.array([1.0, 1.2]),    # I
+            np.array([0.3, -0.1]),   # Q
+            np.array([0.2, 0.25]),   # U
+            np.array([0.05, -0.04])) # V
+
+
+def test_feed_matrix_values():
+    np.testing.assert_allclose(pc.feed_matrix('rl'), pc.BASIS_LIN_TO_CIRC)
+    np.testing.assert_allclose(pc.feed_matrix('xy'), np.eye(2))
+
+
+def test_feed_matrix_unitary_for_orthogonal_pairs():
+    # Orthogonal feed pairs give unitary matrices...
+    for ft in ['rl', 'lr', 'xy', 'yx']:
+        F = pc.feed_matrix(ft)
+        np.testing.assert_allclose(F @ F.conj().T, np.eye(2), atol=1e-14)
+
+
+def test_feed_matrix_hybrid_invertible_not_unitary():
+    # ...but hybrid feeds (e.g. R and X) are non-orthogonal: still invertible,
+    # which is all coherency_to_stokes needs (it uses inv, not the adjoint).
+    for ft in ['rx', 'ly', 'xr', 'yr']:
+        F = pc.feed_matrix(ft)
+        assert not np.allclose(F @ F.conj().T, np.eye(2))
+        assert abs(np.linalg.det(F)) > 1e-9
+
+
+def test_feed_matrix_cached_readonly():
+    with pytest.raises(ValueError):
+        pc.feed_matrix('rl')[0, 0] = 0.0
+    with pytest.raises(ValueError):
+        pc._coherency_matrix('rl', 'xy')[0, 0] = 0.0
+
+
+def test_feed_matrix_rejects_bad_type():
+    with pytest.raises(ValueError):
+        pc.feed_matrix('??')
+
+
+def test_coherency_to_stokes_matches_circ():
+    # Homogeneous circular pairing must reproduce circ_to_stokes exactly.
+    rr = np.array([1.05 + 0.0j, 1.16])
+    ll = np.array([0.95 + 0.0j, 1.24])
+    rl = np.array([0.05 + 0.02j, -0.1 + 0.0j])
+    lr = np.array([0.05 - 0.02j, -0.1 + 0.0j])
+    i0, q0, u0, v0 = pc.circ_to_stokes(rr, ll, rl, lr)
+    # generic-slot order: p1p1=rr, p2p2=ll, p1p2=rl, p2p1=lr
+    i1, q1, u1, v1 = pc.coherency_to_stokes(rr, ll, rl, lr, 'rl', 'rl')
+    np.testing.assert_allclose([i1, q1, u1, v1], [i0, q0, u0, v0], atol=1e-13)
+
+
+def test_coherency_to_stokes_matches_lin():
+    xx = np.array([1.3 + 0.0j, 0.9])
+    yy = np.array([0.7 + 0.0j, 1.1])
+    xy = np.array([0.1 + 0.05j, -0.03 + 0.0j])
+    yx = np.array([0.1 - 0.05j, -0.03 + 0.0j])
+    i0, q0, u0, v0 = pc.lin_to_stokes(xx, yy, xy, yx)
+    i1, q1, u1, v1 = pc.coherency_to_stokes(xx, yy, xy, yx, 'xy', 'xy')
+    np.testing.assert_allclose([i1, q1, u1, v1], [i0, q0, u0, v0], atol=1e-13)
+
+
+@pytest.mark.parametrize("t1,t2", [('rl', 'rl'), ('xy', 'xy'), ('rl', 'xy'),
+                                   ('xy', 'rl'), ('lr', 'xy'), ('rx', 'ly')])
+def test_stokes_coherency_roundtrip(t1, t2):
+    i, q, u, v = _stokes_sample()
+    p11, p22, p12, p21 = pc.stokes_to_coherency(i, q, u, v, t1, t2)
+    i2, q2, u2, v2 = pc.coherency_to_stokes(p11, p22, p12, p21, t1, t2)
+    np.testing.assert_allclose([i2, q2, u2, v2], [i, q, u, v], atol=1e-12)
+
+
+def test_coherency_recovers_stokes_on_heterogeneous_baseline():
+    # The whole point: a circular x linear baseline still carries full Stokes.
+    i, q, u, v = _stokes_sample()
+    p11, p22, p12, p21 = pc.stokes_to_coherency(i, q, u, v, 'rl', 'xy')
+    i2, q2, u2, v2 = pc.coherency_to_stokes(p11, p22, p12, p21, 'rl', 'xy')
+    np.testing.assert_allclose([i2, q2, u2, v2], [i, q, u, v], atol=1e-12)
+
+
+def test_coherency_sigma_matches_circ_and_lin():
+    s = (np.array([0.1, 0.2]), np.array([0.1, 0.2]),
+         np.array([0.3, 0.1]), np.array([0.3, 0.1]))
+    # circ: slot order p1p1=rr, p2p2=ll, p1p2=rl, p2p1=lr
+    ci, cq, cu, cv = pc.circ_to_stokes_sigma(s[0], s[1], s[2], s[3])
+    gi, gq, gu, gv = pc.coherency_to_stokes_sigma(s[0], s[1], s[2], s[3], 'rl', 'rl')
+    np.testing.assert_allclose([gi, gq, gu, gv], [ci, cq, cu, cv], atol=1e-13)
+    li, lq, lu, lv = pc.lin_to_stokes_sigma(s[0], s[1], s[2], s[3])
+    gi, gq, gu, gv = pc.coherency_to_stokes_sigma(s[0], s[1], s[2], s[3], 'xy', 'xy')
+    np.testing.assert_allclose([gi, gq, gu, gv], [li, lq, lu, lv], atol=1e-13)
+
+
+def test_coherency_to_stokes_scalar_inputs():
+    i, q, u, v = pc.coherency_to_stokes(1.0, 1.0, 0.0, 0.0, 'rl', 'rl')
+    assert np.isclose(i, 1.0) and np.isclose(v, 0.0)

--- a/tests/test_pol_conventions.py
+++ b/tests/test_pol_conventions.py
@@ -329,6 +329,13 @@ def test_feed_matrix_rejects_bad_type():
         pc.feed_matrix('??')
 
 
+def test_feed_matrix_rejects_degenerate_feed():
+    # same-feed codes build a singular matrix; reject at the boundary
+    for ft in ('rr', 'll', 'xx', 'yy'):
+        with pytest.raises(ValueError):
+            pc.feed_matrix(ft)
+
+
 def test_coherency_to_stokes_matches_circ():
     # Homogeneous circular pairing must reproduce circ_to_stokes exactly.
     rr = np.array([1.05 + 0.0j, 1.16])

--- a/tests/test_pol_conventions.py
+++ b/tests/test_pol_conventions.py
@@ -336,6 +336,15 @@ def test_feed_matrix_rejects_degenerate_feed():
             pc.feed_matrix(ft)
 
 
+def test_correlation_slot_resolves_and_guards():
+    assert pc.correlation_slot('rl', 'rl', 'r', 'r') == 'p1p1vis'
+    assert pc.correlation_slot('rl', 'xy', 'l', 'x') == 'p2p1vis'
+    assert pc.correlation_slot('rl', 'xy', 'x', 'r') is None  # absent feed
+    for bad in ('rr', 'r', 'rrr'):  # corrupt polbasis fails loudly
+        with pytest.raises(ValueError):
+            pc.correlation_slot(bad, 'rl', 'r', 'r')
+
+
 def test_coherency_to_stokes_matches_circ():
     # Homogeneous circular pairing must reproduce circ_to_stokes exactly.
     rr = np.array([1.05 + 0.0j, 1.16])


### PR DESCRIPTION
Widen Obsdata's data_conj, closure quantities, and unpack to the 'lin' and 'mixed' polreps. 

- data_conj: generic poldict-driven conjugate/swap for circ/lin/mixed; flips the polbasis halves on conjugate rows.
- Closures (bispectra / c_phases / c_amplitudes + diag + tri/quad): make_bispectrum / make_closure_amplitude consolidated onto one per-correlation helper (vis_component) that routes basis synthesis through pol_conventions. Mixed: skip feed-mixing triangles/quads with MixedPolClosureSkipWarning (+ minimal-set caveat); Stokes/generic-slot vtypes raise.
- pol_conventions: new coherency_to_stokes / stokes_to_coherency (+ sigma) and correlation_slot. Under ideal feeds every baseline measures the full coherency, so Stokes is recoverable from any feed pairing, including
  heterogeneous and hybrid feeds.
- unpack: lin via the vis_component consolidation (matches switch_polrep exactly); mixed via row-aligned NaN-fill (physical names -> matching slot or NaN with a per-field MixedPolUnpackNaNWarning; Stokes-derived recovered on
  every row via coherency_to_stokes; generic slots direct). All vis-family dispatch lives in obs_helpers.unpack_vis
- load_uvfits: detect non-R/L POLTYA/POLTYB and raise (full parse is Phase 7)

## transforms in current unpack and closure behavior are somewhat inconsistent: worth more discussion
mixed -> Stokes synthesis is now defined (per-row, ideal-feed) and used by unpack, but raises in closures
mixed -> coherency synthesis only returns native components and nans (unpack) or skips (closures) undefined components rather than performing a feed transform 'circ' polrep will not return 'lin' quantities and vice versa. 'Stokes' polrep will return both.  object-level switch_polrep involving input our output polrep=='mixed' still raises.

## Verification
- Full suite green (test_mixedpol, test_obsdata, test_pol_conventions, test_io, test_imager_e2e): 412 passed, 1 skipped.
- Cross-checked against v1.3 on data/sample.uvfits and the HOPS M87 file: closure tables and unpack outputs are bit-identical for stokes and circ across all legacy fields; only synthesized-vtype bispectrum sigmas differ at
  ~1e-13 (sqrt/square round-trip, machine precision).
- New e2e test: Stokes-I closure imaging is polrep-transparent (circ and lin reproduce the stokes-obs reconstruction).
