### PR TITLE
Release prep for v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## v1.4.0 (2026-06-02)
+
+### Highlights
+
+- **Pure-function imaging backend.** `Imager` now delegates the math to `ehtim.imaging.imager_backend`, paving the way for JAX support.
+- **NFFT migration.** PyNFFT replaced by `finufft` (in core deps; auto-installed). Faster, easier install, JAX-ready.
+- **Optional dependencies.** `pandas` and `paramsurvey` moved to the `[dev]` extra. Legacy closure-quantity helpers in `ehtim.statistics.dataframes` still work when pandas is installed.
+- **Interactive plotting.** New `ehtim.plotting.interactive` module: `dashboard`, `plot_bl`, `plotall`, `plot_gains`.
+
+### Breaking changes
+
+- **Python 3.11 or 3.12** (3.10 dropped).
+- **NumPy >= 2.0, SciPy >= 1.13, Astropy >= 6.0**.
+- **finufft** required for `ttype='nfft'`. PyNFFT removed.
+- **pandas**, **paramsurvey** moved from core to the `[dev]` extra. Install via `pip install ehtim[dev]` or `pip install pandas paramsurvey`.
+- **`ttype='fast'`** emits `DeprecationWarning`. ~30% gradient error in the FFT path is documented; use `direct` (DFT) or `nfft` (finufft) instead.
+
+### Bug fixes
+
+- `stv_pol_grad` factor-of-2 + neighbour-roll (#240).
+- `polchisq` `psi = arcsin(V / (I * rho))` + `gmst_to_utc` inverse (#251).
+- `_diag` chisq NumPy >= 1.24 compatibility (#233).
+- Simultaneous IP/IV imaging chain rule (#228).
+- Inverse-variance time averaging (#230, #252).
+- `load_uvfits` RA error-message format-specifier typos (#243).
+- `array.py` `except NameError` to `except KeyError`: the "no ephemeris for site X" exception path now fires.
+- `obs_simulate.add_jones_and_noise` / `add_noise`: thermal noise is now seed-aware via `cerror_hash`. With the same `seed=` value, runs are bit-for-bit reproducible; with `seed=False` (default), noise is now deterministic per (site1, site2, time, polarization product) rather than drawn from process-global RNG state.
+
+### Tests
+
+1460+ tests; ~482 MB peak RSS baseline.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,41 @@
 ehtim (eht-imaging)
 ===================
-.. image:: https://zenodo.org/badge/42943499.svg
+
+|pypi| |license| |docs| |doi|
+
+|ci| |coverage-main| |coverage-dev| |ruff|
+
+.. |pypi| image:: https://img.shields.io/pypi/v/ehtim.svg
+   :target: https://pypi.org/project/ehtim/
+   :alt: PyPI version
+
+.. |license| image:: https://img.shields.io/github/license/achael/eht-imaging.svg
+   :target: https://github.com/achael/eht-imaging/blob/main/LICENSE.txt
+   :alt: License: GPLv3
+
+.. |docs| image:: https://img.shields.io/badge/docs-stable-blue.svg
+   :target: https://achael.github.io/eht-imaging/
+   :alt: Documentation
+
+.. |doi| image:: https://zenodo.org/badge/42943499.svg
    :target: https://zenodo.org/badge/latestdoi/42943499
+   :alt: DOI
+
+.. |ci| image:: https://github.com/achael/eht-imaging/actions/workflows/ci.yml/badge.svg?branch=dev-backend
+   :target: https://github.com/achael/eht-imaging/actions/workflows/ci.yml
+   :alt: CI
+
+.. |coverage-main| image:: https://img.shields.io/codecov/c/github/achael/eht-imaging/main?label=coverage%20%28main%29
+   :target: https://codecov.io/gh/achael/eht-imaging/branch/main
+   :alt: Coverage (main)
+
+.. |coverage-dev| image:: https://img.shields.io/codecov/c/github/achael/eht-imaging/dev?label=coverage%20%28dev%29
+   :target: https://codecov.io/gh/achael/eht-imaging/branch/dev
+   :alt: Coverage (dev)
+
+.. |ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+   :target: https://github.com/astral-sh/ruff
+   :alt: Code style: Ruff
 
 Python modules for simulating and manipulating VLBI data and producing images with regularized maximum likelihood methods. This version is an early release so please raise an issue, submit a pull request, or email achael@outlook.com if you have trouble or need help for your application.
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ ehtim (eht-imaging)
 
 |pypi| |license| |docs| |doi|
 
-|ci| |coverage-main| |coverage-dev| |ruff|
+|ci| |codecov| |ruff|
 
 .. |pypi| image:: https://img.shields.io/pypi/v/ehtim.svg
    :target: https://pypi.org/project/ehtim/
@@ -17,21 +17,17 @@ ehtim (eht-imaging)
    :target: https://achael.github.io/eht-imaging/
    :alt: Documentation
 
-.. |doi| image:: https://zenodo.org/badge/42943499.svg
-   :target: https://zenodo.org/badge/latestdoi/42943499
+.. |doi| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.2614008.svg
+   :target: https://doi.org/10.5281/zenodo.2614008
    :alt: DOI
 
 .. |ci| image:: https://github.com/achael/eht-imaging/actions/workflows/ci.yml/badge.svg?branch=dev-backend
    :target: https://github.com/achael/eht-imaging/actions/workflows/ci.yml
    :alt: CI
 
-.. |coverage-main| image:: https://img.shields.io/codecov/c/github/achael/eht-imaging/main?label=coverage%20%28main%29
-   :target: https://codecov.io/gh/achael/eht-imaging/branch/main
-   :alt: Coverage (main)
-
-.. |coverage-dev| image:: https://img.shields.io/codecov/c/github/achael/eht-imaging/dev?label=coverage%20%28dev%29
+.. |codecov| image:: https://img.shields.io/codecov/c/github/achael/eht-imaging/dev
    :target: https://codecov.io/gh/achael/eht-imaging/branch/dev
-   :alt: Coverage (dev)
+   :alt: codecov
 
 .. |ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
    :target: https://github.com/astral-sh/ruff

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,8 +5,42 @@
 
 ehtim (eht-imaging)
 ===================
-.. image:: https://zenodo.org/badge/42943499.svg
+
+|pypi| |license| |docs| |doi|
+
+|ci| |coverage-main| |coverage-dev| |ruff|
+
+.. |pypi| image:: https://img.shields.io/pypi/v/ehtim.svg
+   :target: https://pypi.org/project/ehtim/
+   :alt: PyPI version
+
+.. |license| image:: https://img.shields.io/github/license/achael/eht-imaging.svg
+   :target: https://github.com/achael/eht-imaging/blob/main/LICENSE.txt
+   :alt: License: GPLv3
+
+.. |docs| image:: https://img.shields.io/badge/docs-stable-blue.svg
+   :target: https://achael.github.io/eht-imaging/
+   :alt: Documentation
+
+.. |doi| image:: https://zenodo.org/badge/42943499.svg
    :target: https://zenodo.org/badge/latestdoi/42943499
+   :alt: DOI
+
+.. |ci| image:: https://github.com/achael/eht-imaging/actions/workflows/ci.yml/badge.svg?branch=dev-backend
+   :target: https://github.com/achael/eht-imaging/actions/workflows/ci.yml
+   :alt: CI
+
+.. |coverage-main| image:: https://img.shields.io/codecov/c/github/achael/eht-imaging/main?label=coverage%20%28main%29
+   :target: https://codecov.io/gh/achael/eht-imaging/branch/main
+   :alt: Coverage (main)
+
+.. |coverage-dev| image:: https://img.shields.io/codecov/c/github/achael/eht-imaging/dev?label=coverage%20%28dev%29
+   :target: https://codecov.io/gh/achael/eht-imaging/branch/dev
+   :alt: Coverage (dev)
+
+.. |ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+   :target: https://github.com/astral-sh/ruff
+   :alt: Code style: Ruff
 
 
 Python modules for simulating and manipulating VLBI data and producing images with regularized maximum likelihood methods. This version is an early release so please raise an issue, submit a pull request, or email achael@princeton.edu if you have trouble or need help for your application.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ ehtim (eht-imaging)
 
 |pypi| |license| |docs| |doi|
 
-|ci| |coverage-main| |coverage-dev| |ruff|
+|ci| |codecov| |ruff|
 
 .. |pypi| image:: https://img.shields.io/pypi/v/ehtim.svg
    :target: https://pypi.org/project/ehtim/
@@ -22,21 +22,17 @@ ehtim (eht-imaging)
    :target: https://achael.github.io/eht-imaging/
    :alt: Documentation
 
-.. |doi| image:: https://zenodo.org/badge/42943499.svg
-   :target: https://zenodo.org/badge/latestdoi/42943499
+.. |doi| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.2614008.svg
+   :target: https://doi.org/10.5281/zenodo.2614008
    :alt: DOI
 
 .. |ci| image:: https://github.com/achael/eht-imaging/actions/workflows/ci.yml/badge.svg?branch=dev-backend
    :target: https://github.com/achael/eht-imaging/actions/workflows/ci.yml
    :alt: CI
 
-.. |coverage-main| image:: https://img.shields.io/codecov/c/github/achael/eht-imaging/main?label=coverage%20%28main%29
-   :target: https://codecov.io/gh/achael/eht-imaging/branch/main
-   :alt: Coverage (main)
-
-.. |coverage-dev| image:: https://img.shields.io/codecov/c/github/achael/eht-imaging/dev?label=coverage%20%28dev%29
+.. |codecov| image:: https://img.shields.io/codecov/c/github/achael/eht-imaging/dev
    :target: https://codecov.io/gh/achael/eht-imaging/branch/dev
-   :alt: Coverage (dev)
+   :alt: codecov
 
 .. |ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
    :target: https://github.com/astral-sh/ruff

--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -57,7 +57,7 @@ class Array:
                 sitename = str(line['site'])
                 try:
                     elen = len(ephem[sitename])
-                except NameError:
+                except KeyError:
                     raise Exception(f'no ephemeris for site {sitename} !')
                 if elen != 3:
                     raise Exception(f'wrong ephemeris format for site {sitename} !')

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -21,6 +21,7 @@
 import copy
 import itertools as it
 import sys
+import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -31,11 +32,14 @@ import scipy.spatial as spatial
 try:
     import pandas as pd
 except ImportError:
-    print("Warning: pandas not installed!")
-    print("Please install pandas to use statistics package!")
-
-
-import warnings
+    pd = None
+    warnings.warn(
+        "pandas is not installed; the legacy ehtim.statistics.dataframes helpers "
+        "and the Obsdata flag-file / scan-id helpers will be unavailable. "
+        "Install via `pip install pandas`.",
+        ImportWarning,
+        stacklevel=2,
+    )
 
 import ehtim.const_def as ehc
 import ehtim.image

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -1019,8 +1019,12 @@ def add_jones_and_noise(obs, add_th_noise=True,
 
         # Add noise
         if add_th_noise:
-            noise_matrix = np.array([[obsh.cerror(sig_rr[i]), obsh.cerror(sig_rl[i])],
-                                     [obsh.cerror(sig_lr[i]), obsh.cerror(sig_ll[i])]])
+            noise_matrix = np.array([
+                [obsh.cerror_hash(sig_rr[i], t1[i], t2[i], times[i], 'rr', seed),
+                 obsh.cerror_hash(sig_rl[i], t1[i], t2[i], times[i], 'rl', seed)],
+                [obsh.cerror_hash(sig_lr[i], t1[i], t2[i], times[i], 'lr', seed),
+                 obsh.cerror_hash(sig_ll[i], t1[i], t2[i], times[i], 'll', seed)],
+            ])
             corr_matrix_corrupt += noise_matrix
 
         # Put the corrupted data back into the data table
@@ -1371,10 +1375,23 @@ def add_noise(obs, add_th_noise=True, opacitycal=True, ampcal=True, phasecal=Tru
     sigma_est4 = sigma_perf4 * gain_true * tau_est
 
     if add_th_noise:
-        vis1 = (vis1 + obsh.cerror(sigma_true1))
-        vis2 = (vis2 + obsh.cerror(sigma_true2))
-        vis3 = (vis3 + obsh.cerror(sigma_true3))
-        vis4 = (vis4 + obsh.cerror(sigma_true4))
+        n = len(times)
+        noise1 = np.fromiter(
+            (obsh.cerror_hash(sigma_true1[i], sites[i, 0], sites[i, 1], times[i], 'p1', seed)
+             for i in range(n)), complex, count=n)
+        noise2 = np.fromiter(
+            (obsh.cerror_hash(sigma_true2[i], sites[i, 0], sites[i, 1], times[i], 'p2', seed)
+             for i in range(n)), complex, count=n)
+        noise3 = np.fromiter(
+            (obsh.cerror_hash(sigma_true3[i], sites[i, 0], sites[i, 1], times[i], 'p3', seed)
+             for i in range(n)), complex, count=n)
+        noise4 = np.fromiter(
+            (obsh.cerror_hash(sigma_true4[i], sites[i, 0], sites[i, 1], times[i], 'p4', seed)
+             for i in range(n)), complex, count=n)
+        vis1 = vis1 + noise1
+        vis2 = vis2 + noise2
+        vis3 = vis3 + noise3
+        vis4 = vis4 + noise4
 
     # Add the gain error to the true visibilities
     vis1 = vis1 * gain_true * tau_est / tau_true

--- a/tests/test_obs_simulate.py
+++ b/tests/test_obs_simulate.py
@@ -624,6 +624,12 @@ class TestAddJonesAndNoise:
         ratio = np.std(residual.real) / np.mean(obsdat["sigma"])
         assert 0.5 < ratio < 2.0
 
+    def test_seed_reproducible_with_noise(self, obs):
+        """Same seed gives bit-identical thermal noise."""
+        o1 = os_sim.add_jones_and_noise(obs, add_th_noise=True, verbose=False, seed=42)
+        o2 = os_sim.add_jones_and_noise(obs, add_th_noise=True, verbose=False, seed=42)
+        np.testing.assert_array_equal(o1["vis"], o2["vis"])
+
     def test_ampcal_false_deviates_amplitude(self, obs):
         out = os_sim.add_jones_and_noise(obs, add_th_noise=False, ampcal=False,
                                          verbose=False, seed=42)
@@ -878,6 +884,12 @@ class TestAddNoiseLegacy:
         residual = out["vis"] - obs.data["vis"]
         ratio = np.std(residual.real) / np.mean(out["sigma"])
         assert 0.5 < ratio < 2.0
+
+    def test_seed_reproducible_with_noise(self, obs):
+        """Same seed gives bit-identical thermal noise."""
+        o1 = os_sim.add_noise(obs, add_th_noise=True, verbose=False, seed=42)
+        o2 = os_sim.add_noise(obs, add_th_noise=True, verbose=False, seed=42)
+        np.testing.assert_array_equal(o1["vis"], o2["vis"])
 
 
 def test_observe_fast_ttype_warns_deprecated(gauss_im, observe):


### PR DESCRIPTION
Documentation + small fixes ahead of the v1.4.0 release merge.

- CHANGELOG.md with the v1.4.0 entry (highlights, breaking changes, bug fixes).
- Status badges (PyPI, license, docs, Zenodo DOI, CI, codecov, ruff) on README and docs index.
- obsdata.py: use warnings.warn instead of print when pandas is missing.
- array.py: catch KeyError (not NameError) so the "no ephemeris for site X" error fires.
- obs_simulate.py: thermal noise is now seed-aware via cerror_hash, so add_jones_and_noise / add_noise are reproducible with a fixed seed. Default seed=False noise is now deterministic per datapoint rather than from process-global RNG.

Full suite green; +2 reproducibility tests.
