### PR TITLE
Add PyPI publish workflow on tagged releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install build
+      - run: python -m build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # required for trusted publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,6 +26,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: pypi
+    if: ${{ !github.event.release.prerelease }}
     permissions:
       id-token: write   # required for trusted publishing (OIDC)
     steps:
@@ -30,4 +34,6 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        with:
+          skip-existing: true


### PR DESCRIPTION
## What
Adds `.github/workflows/publish.yml`: builds an sdist + wheel and uploads to PyPI when a GitHub **release** is published.

## How it works
- Trigger: `on: release: [published]` (creating a GitHub Release with a tag fires it).
- Uses **PyPI trusted publishing (OIDC)** via `pypa/gh-action-pypi-publish` — no API token stored in secrets.
- Build job pinned to **Python 3.11** (current `main` only supports <=3.11; bump when `dev` merges).
- `publish` job runs in a `pypi` environment, giving an optional manual-approval gate.

## Required one-time setup before first publish
1. **PyPI**: add a trusted publisher for project `ehtim` — owner `achael`, repo `eht-imaging`, workflow `publish.yml`, environment `pypi`.
2. **GitHub**: create an Environment named `pypi` (optionally with a required-reviewer protection rule).

## How to test
After the setup above, draft a GitHub Release on a tag and publish it; the workflow builds and uploads to PyPI.