### PR TITLE
Bump version to 1.3.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ The package contains several primary classes for loading, simulating, and manipu
 Installation
 ------------
 
-The latest stable version (`1.3 <https://github.com/achael/eht-imaging/releases/tag/v1.3>`_) is available on `PyPi <https://pypi.org/project/ehtim/>`_. Simply install pip and run
+The latest stable version (`1.3.1 <https://github.com/achael/eht-imaging/releases/tag/v1.3.1>`_) is available on `PyPi <https://pypi.org/project/ehtim/>`_. Simply install pip and run
 
 .. code-block:: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ehtim"
-version = "1.3.0"
+version = "1.3.1"
 description = "Imaging, analysis, and simulation software for radio interferometry"
 readme = "README.rst"
 license = { text = "GPLv3" }
@@ -46,7 +46,7 @@ dev = [
 
 [project.urls]
 Homepage = "https://github.com/achael/eht-imaging"
-Download = "https://github.com/achael/eht-imaging/archive/v1.2.11.tar.gz"
+Download = "https://github.com/achael/eht-imaging/archive/v1.3.1.tar.gz"
 
 # --- setuptools-specific config ---
 


### PR DESCRIPTION
## What
Bumps the package version `1.3.0 → 1.3.1` ahead of cutting the `v1.3.1` release.

- `pyproject.toml`: `version` → `1.3.1`; `Download` URL → `archive/v1.3.1.tar.gz` (was stale at `v1.2.11`).
- `README.rst`: stable-version link → `1.3.1` / `releases/tag/v1.3.1` (was `v1.3`).

## Why
Land before publishing the `v1.3.1` GitHub release so the PyPI upload and the (newly automated) docs version both report `1.3.1`. Depends on the PyPI publish + docs workflows (#292, #293) merging first.

## How to test
`pip install -e .` then `python -c "import importlib.metadata as m; print(m.version('ehtim'))"` → `1.3.1`.
