### PR TITLE
JAX-differentiable imaging objective on GPU: direct + NFFT, Stokes-I + pol + mf

### DIFF
--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -442,7 +442,8 @@ class Imager:
                grads (bool): whether or not to use image gradients
                use_jax (bool): use the jax autodiff objective (GPU-capable) in place
                    of the numpy analytic gradient; the objective is identical
-               jax_device: jax device for the objective when use_jax=True (None = jax default)
+               jax_device: jax device for the objective when use_jax=True; None uses the
+                   jax default. e.g. jax.devices('gpu')[0] or jax.devices('cpu')[0]
 
                show_updates (bool): whether or not to show imager progress
                update_interval (int): step interval for plotting if show_updates=True

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -58,6 +58,7 @@ from ehtim.imaging.imager_backend import (
     compute_objective_grad,
     compute_reg_dict,
     compute_reggrad_dict,
+    make_objective_jax,
     transform_imarr,
     unpack_imarr,
     validate_limits,
@@ -439,6 +440,9 @@ class Imager:
            Args:
                pol (str): which polarization to image
                grads (bool): whether or not to use image gradients
+               use_jax (bool): use the jax autodiff objective (GPU-capable) in place
+                   of the numpy analytic gradient; the objective is identical
+               jax_device: jax device for the objective when use_jax=True (None = jax default)
 
                show_updates (bool): whether or not to show imager progress
                update_interval (int): step interval for plotting if show_updates=True
@@ -508,7 +512,19 @@ class Imager:
 
 
         tstart = time.time()
-        if grads:
+        if kwargs.get('use_jax', False):
+            # jax autodiff objective (GPU-capable). make_objective_jax returns a
+            # scipy fun(x) -> (value, grad); jax is imported lazily inside it.
+            fun = make_objective_jax(
+                self._init_arr, self._config, self._which_solve, self._data_tuples,
+                self._logfreqratio_list, len(self.obslist_next),
+                self.dat_term_next, self.reg_term_next,
+                self._prior_arr, self.norm_reg, self._regparams(),
+                self._embed_mask, device=kwargs.get('jax_device', None),
+            )
+            res = opt.minimize(fun, self._init_vec, method='L-BFGS-B', jac=True,
+                               options=optdict, callback=callback_func)
+        elif grads:
             res = opt.minimize(self.objfunc, self._init_vec, method='L-BFGS-B', jac=self.objgrad,
                                options=optdict, callback=callback_func)
         else:

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -429,12 +429,13 @@ def transform_imarr(imarr, transforms, which_solve):
     else:
         raise Exception("transform_imarr requires imarr.shape[0] be either 1, 3, 4, or 10!")
 
-    # TODO(jax): the in-place assignments below (outarr[0] = ...) block tracing;
-    # rewrite functionally for the jax objective (Stokes-I just needs xp.exp).
+    xp = array_namespace(imarr)
+    if nimage==1:  # single-pol Stokes I: functional so jax.grad/jit can trace it
+        return xp.exp(imarr) if ('log' in transforms) else imarr.copy()
+
+    # pol / mf (nimage 3, 4, 10): in-place numpy; made functional in Phase 4.
     outarr = imarr.copy()
-    if nimage==1 and ('log' in transforms):
-        outarr = np.exp(outarr)
-    elif nimage==3 and ('log' in transforms):
+    if nimage==3 and ('log' in transforms):
         outarr[0] = np.exp(outarr[0])
     else:
 

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -1,6 +1,7 @@
 # imager_backend.py
 # Pure functional backend for imager.py
 
+import warnings
 from collections.abc import Sequence
 from typing import NamedTuple
 
@@ -1941,35 +1942,43 @@ def compute_objective_grad(imvec, initvec, config,
 def make_objective_jax(initvec, config, which_solve, data_tuples, logfreqratio_list,
                        n_obs, dat_term, reg_term, priorvec, norm_reg, reg_params,
                        embed_mask, device=None):
-    """Return a scipy fun(x) -> (value, grad) for the imaging objective.
+    """Return a scipy fun(x) -> (value, grad) for the imaging objective, via jax.
 
     Same arguments as compute_objective minus the solver vector x. The value is
-    compute_objective and the gradient is its jax autodiff, which equals
-    compute_objective_grad. Mode-agnostic: it just wraps compute_objective, so it
-    works for any pol mode / ttype the backend supports. jax is imported lazily so
-    `import ehtim` stays jax-free.
-
-    The only traced argument is x; everything else is captured in the closure, so
-    the unhashable data_tuples / dat_term dicts never reach jit and one trace is
-    reused across solver steps. Numeric data is moved onto `device` once.
+    compute_objective; the gradient is its jax autodiff, which matches the
+    hand-written compute_objective_grad. Works for any pol mode / ttype the
+    backend supports. jax is imported lazily so `import ehtim` stays jax-free.
     """
     import jax
     import jax.numpy as jnp
 
+    # Double precision is essential: in float32 the gradient is only ~1e-3
+    # accurate (and the nfft tolerance clamps), so warn rather than silently
+    # return a bad gradient.
+    if not jax.config.read("jax_enable_x64"):
+        warnings.warn("jax x64 is disabled -- the objective runs in float32 and "
+                      "gradients will be inaccurate. Set "
+                      "jax.config.update('jax_enable_x64', True) before imaging.",
+                      stacklevel=2)
+
+    # Move arrays onto the chosen device (a GPU if `device` is set) once, up front.
     def put(a):
         a = jnp.asarray(a)
         return jax.device_put(a, device) if device is not None else a
 
-    # A non-array A (the nfft NFFTInfo) is left as a host object for the kernel.
+    # Each data tuple may hold a non-array entry (the nfft NFFTInfo); leave it be.
     data_d = {key: tuple(put(v) if hasattr(v, "shape") else v for v in val)
               for key, val in data_tuples.items()}
     prior_d, init_d = put(priorvec), put(initvec)
 
+    # x is the only traced input; capturing everything else lets jit compile once
+    # and reuse that compilation across every L-BFGS-B step.
     def loss(x):
         return compute_objective(x, init_d, config, which_solve, data_d,
                                  logfreqratio_list, n_obs, dat_term, reg_term,
                                  prior_d, norm_reg, reg_params, embed_mask)
 
+    # jit the value-and-grad so scipy gets both from one compiled call.
     value_and_grad = jax.jit(jax.value_and_grad(loss))
 
     def fun(x):

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -705,9 +705,9 @@ def validate_params(prior, init, config, dat_term_keys, reg_term_keys, freq_list
         raise Exception("Initial image polrep is 'circ': pol_next must be 'RR' or 'LL'")
 
     if (prior.polrep == 'stokes'
-        and pol not in ['I', 'Q', 'U', 'V', 'P','IP','IQU','IV','IQUV']):
+        and pol not in ['I', 'Q', 'U', 'V', 'P','IP','IQU','IV','IQUV','IPV']):
         raise Exception(
-            "Initial image polrep is 'stokes': pol_next must be in 'I', 'Q', 'U', 'V', 'P','IP','IQU','IV','IQUV'!")
+            "Initial image polrep is 'stokes': pol_next must be in 'I', 'Q', 'U', 'V', 'P','IP','IQU','IV','IQUV','IPV'!")
 
     if ('log' in transforms and pol in ['Q', 'U', 'V']):
         raise Exception("Cannot image Stokes Q, U, V with log image transformation!")

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -10,6 +10,7 @@ import ehtim.imaging.imager_utils as imutils
 import ehtim.imaging.multifreq_imager_utils as mfutils
 import ehtim.imaging.pol_imager_utils as polutils
 import ehtim.observing.obs_helpers as obsh
+from ehtim.backends import array_namespace
 
 # -----------------------------------------------------------------------------
 # Naming convention for image arguments throughout this module
@@ -369,6 +370,7 @@ def unpack_imarr(vec, init_arr, which_solve):
       - if which_solve[k] == 0, fall back to `init_arr[k]` (the *initial*
         image, NOT a regularizer prior).
     """
+    xp = array_namespace(vec)
 
     imarrdim = len(init_arr.shape)
     if imarrdim==2:
@@ -384,17 +386,20 @@ def unpack_imarr(vec, init_arr, which_solve):
     if nsolve != len(which_solve):
         raise Exception("in unpack_imarr, init_arr has inconsistent shape with which_solve!")
 
+    # Build the rows then stack, rather than np.empty + in-place assignment, so
+    # jax.grad/jit can trace through: solved slots take the next nimage values of
+    # `vec`, not-solved slots fall back to the initial image. On numpy this is
+    # identical to the old buffer-fill; on jax the host init_arr rows promote to
+    # constants alongside the traced vec slices.
     imct = 0
-    # TODO(jax): build this functionally (e.g. xp.stack of the rows) so
-    # jax.grad(compute_objective) can trace it -- np.empty + in-place assignment
-    # is not jax-traceable.
-    imarr = np.empty((nsolve, nimage))
+    rows = []
     for kk in range(nsolve):
         if which_solve[kk]==0:
-            imarr[kk] = init_arr[kk]
+            rows.append(init_arr[kk])
         else:
-            imarr[kk] = vec[imct*nimage:(imct+1)*nimage]
+            rows.append(vec[imct*nimage:(imct+1)*nimage])
             imct += 1
+    imarr = xp.stack(rows)
 
     if imarrdim==1:
         imarr = imarr[0]

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -433,23 +433,28 @@ def transform_imarr(imarr, transforms, which_solve):
     if nimage==1:  # single-pol Stokes I: functional so jax.grad/jit can trace it
         return xp.exp(imarr) if ('log' in transforms) else imarr.copy()
 
-    # pol / mf (nimage 3, 4, 10): in-place numpy; made functional in Phase 4.
-    outarr = imarr.copy()
-    if nimage==3 and ('log' in transforms):
-        outarr[0] = np.exp(outarr[0])
+    # pol / mf (nimage 3, 4, 10): functional (stack/concatenate) so jax can trace.
+    if nimage==3:  # multifrequency Stokes I: log on I only
+        if 'log' in transforms:
+            return xp.stack([xp.exp(imarr[0]), imarr[1], imarr[2]])
+        return imarr.copy()
+
+    # Build the 4 Stokes rows (log on I, then polcv/mcv/vcv), keeping any trailing
+    # multifrequency rows (4:nimage) unchanged.
+    row0 = xp.exp(imarr[0]) if (pol_which_solve[0]==1 and ('log' in transforms)) else imarr[0]
+    pol_in = xp.stack([row0, imarr[1], imarr[2], imarr[3]])
+    if (pol_which_solve[1]==1 and pol_which_solve[3]==1 and ('polcv' in transforms)):
+        pol_out = polutils.polcv(pol_in)
+    elif (pol_which_solve[1]==1) and ('mcv' in transforms):
+        pol_out = polutils.mcv(pol_in)
+    elif (pol_which_solve[3]==1) and ('vcv' in transforms):
+        pol_out = polutils.vcv(pol_in)
     else:
+        pol_out = pol_in
 
-        if pol_which_solve[0]==1 and ('log' in transforms):  # full polarization, including stokes I imaging
-            outarr[0] = np.exp(outarr[0])
-
-        if (pol_which_solve[1]==1 and pol_which_solve[3]==1 and ('polcv' in transforms)):
-            outarr[0:4] = polutils.polcv(outarr)
-        elif (pol_which_solve[1]==1) and ('mcv' in transforms):
-            outarr[0:4] = polutils.mcv(outarr)
-        elif (pol_which_solve[3]==1) and ('vcv' in transforms):
-            outarr[0:4] = polutils.vcv(outarr)
-
-    return outarr
+    if nimage==4:
+        return pol_out
+    return xp.concatenate([pol_out, imarr[4:nimage]])
 
 def transform_imarr_inverse(imarr, transforms, which_solve):
     """Apply inverse transformation from physical to solver values for all polarizations"""

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -1931,3 +1931,44 @@ def compute_objective_grad(imvec, initvec, config,
     grad = datterm + regterm
     grad = transform_gradients(grad, imcur_prime, transforms, which_solve)
     return pack_imarr(grad, which_solve)
+
+
+def make_objective_jax(initvec, config, which_solve, data_tuples, logfreqratio_list,
+                       n_obs, dat_term, reg_term, priorvec, norm_reg, reg_params,
+                       embed_mask, device=None):
+    """Return a scipy fun(x) -> (value, grad) for the imaging objective.
+
+    Same arguments as compute_objective minus the solver vector x. The value is
+    compute_objective and the gradient is its jax autodiff, which equals
+    compute_objective_grad. Mode-agnostic: it just wraps compute_objective, so it
+    works for any pol mode / ttype the backend supports. jax is imported lazily so
+    `import ehtim` stays jax-free.
+
+    The only traced argument is x; everything else is captured in the closure, so
+    the unhashable data_tuples / dat_term dicts never reach jit and one trace is
+    reused across solver steps. Numeric data is moved onto `device` once.
+    """
+    import jax
+    import jax.numpy as jnp
+
+    def put(a):
+        a = jnp.asarray(a)
+        return jax.device_put(a, device) if device is not None else a
+
+    # A non-array A (the nfft NFFTInfo) is left as a host object for the kernel.
+    data_d = {key: tuple(put(v) if hasattr(v, "shape") else v for v in val)
+              for key, val in data_tuples.items()}
+    prior_d, init_d = put(priorvec), put(initvec)
+
+    def loss(x):
+        return compute_objective(x, init_d, config, which_solve, data_d,
+                                 logfreqratio_list, n_obs, dat_term, reg_term,
+                                 prior_d, norm_reg, reg_params, embed_mask)
+
+    value_and_grad = jax.jit(jax.value_and_grad(loss))
+
+    def fun(x):
+        value, grad = value_and_grad(jnp.asarray(x))
+        return float(value), np.asarray(grad, dtype=np.float64)
+
+    return fun

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -26,6 +26,7 @@ import scipy.sparse as sps
 import ehtim.const_def as ehc
 import ehtim.observing.obs_helpers as obsh
 from ehtim.backends import array_namespace
+from ehtim.observing.obs_helpers import nufft2_backend
 
 ##################################################################################################
 # Constants & Definitions
@@ -887,26 +888,6 @@ def chisqgrad_logamp_fft(vis_arr, A, amp, sigma):
 ##################################################################################################
 # NFFT Chi-squared and Gradient Functions
 ##################################################################################################
-
-
-def nufft2_backend(imvec, nfft_info):
-    """Type-2 NUFFT: uniform image -> nonuniform visibility samples.
-
-    Dispatches on imvec's array type -- the stateful finufft plan on numpy
-    (byte-identical to the legacy path), jax_finufft.nufft2 on jax (differentiable,
-    GPU-capable). Conventions match: isign=-1, (-pi, pi] points, (xdim, ydim) modes.
-    Callers multiply the result by nfft_info.pulsefac.
-    """
-    xp = array_namespace(imvec)
-    f_hat = imvec.reshape((nfft_info.ydim, nfft_info.xdim)).T
-    if xp is np:
-        nfft_info.plan.f_hat = f_hat
-        nfft_info.plan.trafo()
-        return nfft_info.plan.f.copy()
-    from jax_finufft import nufft2
-    uvf = nfft_info.uv_finufft
-    return nufft2(f_hat.astype(xp.complex128), uvf[:, 0], uvf[:, 1],
-                  iflag=-1, eps=nfft_info.eps)
 
 
 def chisq_vis_nfft(imvec, A, vis, sigma):
@@ -3372,8 +3353,9 @@ def embed(imvec, mask, clipfloor=0., randomfloor=False):
     """Embeds a 1d image vector into the size of boolean embed mask
     """
     xp = array_namespace(imvec)
-    on = mask.nonzero()[0]
-    off = (mask - 1).nonzero()[0]
+    mbool = mask.astype(bool)
+    on = mbool.nonzero()[0]
+    off = (~mbool).nonzero()[0]
     if randomfloor:  # prevent total variation gradient singularities
         floor = clipfloor * np.abs(np.random.normal(size=len(off)))
     else:
@@ -3384,10 +3366,11 @@ def embed(imvec, mask, clipfloor=0., randomfloor=False):
         out[on] = imvec
         out[off] = floor
         return out
-    # jax: functional scatter so embed is traceable under jax.grad/jit
-    out = xp.zeros(len(mask))
-    out = out.at[on].set(imvec)
-    return out.at[off].set(floor)
+    else:
+        # jax: functional scatter so embed is traceable under jax.grad/jit
+        out = xp.zeros(len(mask))
+        out = out.at[on].set(imvec)
+        return out.at[off].set(floor)
 
 
 def embed_imarr(imarr, mask, clipfloor=0., randomfloor=False):
@@ -3448,8 +3431,9 @@ def embed_imarr(imarr, mask, clipfloor=0., randomfloor=False):
     # Vectorized over the nsolve axis: scatter imarr into the masked columns,
     # then fill non-mask columns with clipfloor (or random). Functional on jax.
     xp = array_namespace(imarr)
-    on_cols = mask.astype(bool).nonzero()[0]
-    off_cols = (~mask.astype(bool)).nonzero()[0]
+    mbool = mask.astype(bool)
+    on_cols = mbool.nonzero()[0]
+    off_cols = (~mbool).nonzero()[0]
     if randomfloor:
         floor = clipfloor * np.abs(np.random.normal(size=(nsolve, len(off_cols))))
     else:

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -1703,10 +1703,11 @@ def reggrad_gs(imvec, mask, **kwargs):
 
 
 def reg_patch(imvec, mask, **kwargs):
+    xp = array_namespace(imvec)
     priorvec = kwargs['nprior']
     flux = kwargs['flux']
     norm = flux**2 if kwargs.get('norm_reg', True) else 1
-    return 0.5 * np.sum((imvec - priorvec)**2) / norm
+    return 0.5 * xp.sum((imvec - priorvec)**2) / norm
 
 
 def reggrad_patch(imvec, mask, **kwargs):
@@ -1717,6 +1718,7 @@ def reggrad_patch(imvec, mask, **kwargs):
 
 
 def reg_cm(imvec, mask, **kwargs):
+    xp = array_namespace(imvec)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
@@ -1726,7 +1728,7 @@ def reg_cm(imvec, mask, **kwargs):
     xx, yy = np.meshgrid(range(nx//2, -nx//2, -1), range(ny//2, -ny//2, -1))
     xx = psize * xx.flatten()
     yy = psize * yy.flatten()
-    return (np.sum(imvec*xx)**2 + np.sum(imvec*yy)**2) / norm
+    return (xp.sum(imvec*xx)**2 + xp.sum(imvec*yy)**2) / norm
 
 
 def reggrad_cm(imvec, mask, **kwargs):
@@ -1744,6 +1746,7 @@ def reggrad_cm(imvec, mask, **kwargs):
 
 
 def reg_tv(imvec, mask, **kwargs):
+    xp = array_namespace(imvec)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
@@ -1752,10 +1755,10 @@ def reg_tv(imvec, mask, **kwargs):
     epsilon = kwargs.get('epsilon_tv', 0.)
     norm = flux * psize / beam_size if kwargs.get('norm_reg', True) else 1
     im = imvec.reshape(ny, nx)
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    return np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2 + epsilon)) / norm
+    impad = xp.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = xp.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = xp.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    return xp.sum(xp.sqrt(xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2 + epsilon)) / norm
 
 
 def reggrad_tv(imvec, mask, **kwargs):
@@ -1790,6 +1793,7 @@ def reggrad_tv(imvec, mask, **kwargs):
 # tvlog / tv2log use clipfloor=epsilon_tv (not the default 0) so the log
 # transform stays defined where mask filled in values.
 def reg_tvlog(imvec, mask, **kwargs):
+    xp = array_namespace(imvec)
     epsilon = kwargs.get('epsilon_tv', 0.)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
@@ -1799,7 +1803,7 @@ def reg_tvlog(imvec, mask, **kwargs):
     logflux = npix * np.abs(np.log(flux / npix))
     log_kwargs = dict(kwargs)
     log_kwargs['flux'] = logflux
-    return reg_tv(np.log(imvec), np.ones_like(imvec, dtype=bool), **log_kwargs)
+    return reg_tv(xp.log(imvec), np.ones(imvec.shape, dtype=bool), **log_kwargs)
 
 
 def reggrad_tvlog(imvec, mask, **kwargs):
@@ -1817,6 +1821,7 @@ def reggrad_tvlog(imvec, mask, **kwargs):
 
 
 def reg_tv2(imvec, mask, **kwargs):
+    xp = array_namespace(imvec)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
@@ -1824,10 +1829,10 @@ def reg_tv2(imvec, mask, **kwargs):
     beam_size = kwargs.get('beam_size') or psize
     norm = psize**4 * flux**2 / beam_size**4 if kwargs.get('norm_reg', True) else 1
     im = imvec.reshape(ny, nx)
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    return np.sum((im_l1 - im)**2 + (im_l2 - im)**2) / norm
+    impad = xp.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = xp.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = xp.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    return xp.sum((im_l1 - im)**2 + (im_l2 - im)**2) / norm
 
 
 def reggrad_tv2(imvec, mask, **kwargs):
@@ -1857,6 +1862,7 @@ def reggrad_tv2(imvec, mask, **kwargs):
 
 
 def reg_tv2log(imvec, mask, **kwargs):
+    xp = array_namespace(imvec)
     epsilon = kwargs.get('epsilon_tv', 0.)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
@@ -1866,7 +1872,7 @@ def reg_tv2log(imvec, mask, **kwargs):
     logflux = npix * np.abs(np.log(flux / npix))
     log_kwargs = dict(kwargs)
     log_kwargs['flux'] = logflux
-    return reg_tv2(np.log(imvec), np.ones_like(imvec, dtype=bool), **log_kwargs)
+    return reg_tv2(xp.log(imvec), np.ones(imvec.shape, dtype=bool), **log_kwargs)
 
 
 def reggrad_tv2log(imvec, mask, **kwargs):
@@ -1886,6 +1892,7 @@ def reggrad_tv2log(imvec, mask, **kwargs):
 # TODO: figure out normalizations for compact and compact2 regularizers
 # (carried over from legacy code; not formally verified).
 def reg_compact(imvec, mask, **kwargs):
+    xp = array_namespace(imvec)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
@@ -1896,9 +1903,9 @@ def reg_compact(imvec, mask, **kwargs):
     xx, yy = np.meshgrid(range(nx), range(ny))
     xxpsize = (xx - (nx-1)/2.0) * psize
     yypsize = (yy - (ny-1)/2.0) * psize
-    x0 = np.sum(im * xxpsize) / flux
-    y0 = np.sum(im * yypsize) / flux
-    return np.sum(im * ((xxpsize - x0)**2 + (yypsize - y0)**2)) / norm
+    x0 = xp.sum(im * xxpsize) / flux
+    y0 = xp.sum(im * yypsize) / flux
+    return xp.sum(im * ((xxpsize - x0)**2 + (yypsize - y0)**2)) / norm
 
 
 def reggrad_compact(imvec, mask, **kwargs):
@@ -1922,6 +1929,7 @@ def reggrad_compact(imvec, mask, **kwargs):
 
 
 def reg_compact2(imvec, mask, **kwargs):
+    xp = array_namespace(imvec)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
@@ -1932,7 +1940,7 @@ def reg_compact2(imvec, mask, **kwargs):
     xx, yy = np.meshgrid(range(nx), range(ny))
     xxpsize = (xx - (nx-1)/2.0) * psize
     yypsize = (yy - (ny-1)/2.0) * psize
-    return np.sum(im**2 * (xxpsize**2 + yypsize**2)) / norm
+    return xp.sum(im**2 * (xxpsize**2 + yypsize**2)) / norm
 
 
 def reggrad_compact2(imvec, mask, **kwargs):
@@ -1952,6 +1960,7 @@ def reggrad_compact2(imvec, mask, **kwargs):
 
 
 def reg_rgauss(imvec, mask, **kwargs):
+    xp = array_namespace(imvec)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
     xdim, ydim, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
@@ -1967,12 +1976,12 @@ def reg_rgauss(imvec, mask, **kwargs):
     xlist, ylist = np.meshgrid(range(xdim), range(ydim))
     xx = (xlist - (xdim-1)/2.0) * psize
     yy = (ylist - (ydim-1)/2.0) * psize
-    S = np.sum(im)
-    x0 = np.sum(xx * im) / S
-    y0 = np.sum(yy * im) / S
-    sigxx = np.sum((xx - x0)**2 * im) / S
-    sigyy = np.sum((yy - y0)**2 * im) / S
-    sigxy = np.sum((xx - x0) * (yy - y0) * im) / S
+    S = xp.sum(im)
+    x0 = xp.sum(xx * im) / S
+    y0 = xp.sum(yy * im) / S
+    sigxx = xp.sum((xx - x0)**2 * im) / S
+    sigyy = xp.sum((yy - y0)**2 * im) / S
+    sigxy = xp.sum((xx - x0) * (yy - y0) * im) / S
     rgauss = (sigxx - sigxx_prime)**2 + (sigyy - sigyy_prime)**2 + 2*(sigxy - sigxy_prime)**2
     # reg_rgauss has no norm_reg option; always normalized by major^2 * minor^2.
     return rgauss / (major**2 * minor**2)
@@ -3362,20 +3371,23 @@ def plot_i(im, Prior, nit, chi2_dict, **kwargs):
 def embed(imvec, mask, clipfloor=0., randomfloor=False):
     """Embeds a 1d image vector into the size of boolean embed mask
     """
-
-    out = np.zeros(len(mask))
-
-    # Here's a much faster version than before
-    out[mask.nonzero()] = imvec
-
-    #if clipfloor != 0.0:
+    xp = array_namespace(imvec)
+    on = mask.nonzero()[0]
+    off = (mask - 1).nonzero()[0]
     if randomfloor:  # prevent total variation gradient singularities
-        out[(mask-1).nonzero()] = clipfloor * \
-            np.abs(np.random.normal(size=len((mask-1).nonzero()[0])))
+        floor = clipfloor * np.abs(np.random.normal(size=len(off)))
     else:
-        out[(mask-1).nonzero()] = clipfloor
+        floor = np.full(len(off), clipfloor)
 
-    return out
+    if xp is np:
+        out = np.zeros(len(mask))
+        out[on] = imvec
+        out[off] = floor
+        return out
+    # jax: functional scatter so embed is traceable under jax.grad/jit
+    out = xp.zeros(len(mask))
+    out = out.at[on].set(imvec)
+    return out.at[off].set(floor)
 
 
 def embed_imarr(imarr, mask, clipfloor=0., randomfloor=False):

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -889,24 +889,31 @@ def chisqgrad_logamp_fft(vis_arr, A, amp, sigma):
 ##################################################################################################
 
 
-def chisq_vis_nfft(imvec, A, vis, sigma):
-    """Visibility chi-squared from nfft
+def nufft2_backend(imvec, nfft_info):
+    """Type-2 NUFFT: uniform image -> nonuniform visibility samples.
+
+    Dispatches on imvec's array type -- the stateful finufft plan on numpy
+    (byte-identical to the legacy path), jax_finufft.nufft2 on jax (differentiable,
+    GPU-capable). Conventions match: isign=-1, (-pi, pi] points, (xdim, ydim) modes.
+    Callers multiply the result by nfft_info.pulsefac.
     """
+    xp = array_namespace(imvec)
+    f_hat = imvec.reshape((nfft_info.ydim, nfft_info.xdim)).T
+    if xp is np:
+        nfft_info.plan.f_hat = f_hat
+        nfft_info.plan.trafo()
+        return nfft_info.plan.f.copy()
+    from jax_finufft import nufft2
+    uvf = nfft_info.uv_finufft
+    return nufft2(f_hat.astype(xp.complex128), uvf[:, 0], uvf[:, 1],
+                  iflag=-1, eps=nfft_info.eps)
 
-    # get nfft object
-    nfft_info = A[0]
-    plan = nfft_info.plan
-    pulsefac = nfft_info.pulsefac
 
-    # compute uniform --> nonuniform transform
-    plan.f_hat = imvec.copy().reshape((nfft_info.ydim, nfft_info.xdim)).T
-    plan.trafo()
-    samples = plan.f.copy()*pulsefac
-
-    # compute chi^2
-    chisq = np.sum(np.abs((samples-vis)/sigma)**2)/(2*len(vis))
-
-    return chisq
+def chisq_vis_nfft(imvec, A, vis, sigma):
+    """Visibility chi-squared from nfft"""
+    xp = array_namespace(imvec)
+    samples = nufft2_backend(imvec, A[0]) * A[0].pulsefac
+    return xp.sum(xp.abs((samples-vis)/sigma)**2)/(2*len(vis))
 
 
 def chisqgrad_vis_nfft(imvec, A, vis, sigma):
@@ -933,23 +940,10 @@ def chisqgrad_vis_nfft(imvec, A, vis, sigma):
 
 
 def chisq_amp_nfft(imvec, A, amp, sigma):
-    """Visibility amplitude chi-squared from nfft
-    """
-    # get nfft object
-    nfft_info = A[0]
-    plan = nfft_info.plan
-    pulsefac = nfft_info.pulsefac
-
-    # compute uniform --> nonuniform transform
-    plan.f_hat = imvec.copy().reshape((nfft_info.ydim, nfft_info.xdim)).T
-    plan.trafo()
-    samples = plan.f.copy()*pulsefac
-
-    # compute chi^2
-    amp_samples = np.abs(samples)
-    chisq = np.sum(np.abs((amp_samples-amp)/sigma)**2)/(len(amp))
-
-    return chisq
+    """Visibility amplitude chi-squared from nfft"""
+    xp = array_namespace(imvec)
+    amp_samples = xp.abs(nufft2_backend(imvec, A[0]) * A[0].pulsefac)
+    return xp.sum(xp.abs((amp_samples-amp)/sigma)**2)/(len(amp))
 
 
 def chisqgrad_amp_nfft(imvec, A, amp, sigma):
@@ -978,38 +972,13 @@ def chisqgrad_amp_nfft(imvec, A, amp, sigma):
 
 
 def chisq_bs_nfft(imvec, A, bis, sigma):
-    """Bispectrum chi-squared from fft"""
-
-    # get nfft objects
-    nfft_info1 = A[0]
-    plan1 = nfft_info1.plan
-    pulsefac1 = nfft_info1.pulsefac
-
-    nfft_info2 = A[1]
-    plan2 = nfft_info2.plan
-    pulsefac2 = nfft_info2.pulsefac
-
-    nfft_info3 = A[2]
-    plan3 = nfft_info3.plan
-    pulsefac3 = nfft_info3.pulsefac
-
-    # compute uniform --> nonuniform transforms
-    plan1.f_hat = imvec.copy().reshape((nfft_info1.ydim, nfft_info1.xdim)).T
-    plan1.trafo()
-    samples1 = plan1.f.copy()*pulsefac1
-
-    plan2.f_hat = imvec.copy().reshape((nfft_info2.ydim, nfft_info2.xdim)).T
-    plan2.trafo()
-    samples2 = plan2.f.copy()*pulsefac2
-
-    plan3.f_hat = imvec.copy().reshape((nfft_info3.ydim, nfft_info3.xdim)).T
-    plan3.trafo()
-    samples3 = plan3.f.copy()*pulsefac3
-
-    # compute chi^2
+    """Bispectrum chi-squared from nfft"""
+    xp = array_namespace(imvec)
+    samples1 = nufft2_backend(imvec, A[0]) * A[0].pulsefac
+    samples2 = nufft2_backend(imvec, A[1]) * A[1].pulsefac
+    samples3 = nufft2_backend(imvec, A[2]) * A[2].pulsefac
     bisamples = samples1*samples2*samples3
-    chisq = np.sum(np.abs((bis - bisamples)/sigma)**2)/(2.*len(bis))
-    return chisq
+    return xp.sum(xp.abs((bis - bisamples)/sigma)**2)/(2.*len(bis))
 
 
 def chisqgrad_bs_nfft(imvec, A, bis, sigma):
@@ -1066,43 +1035,15 @@ def chisqgrad_bs_nfft(imvec, A, bis, sigma):
 
 
 def chisq_cphase_nfft(imvec, A, clphase, sigma):
-    """Closure Phases (normalized) chi-squared from nfft
-    """
-
+    """Closure Phases (normalized) chi-squared from nfft"""
+    xp = array_namespace(imvec)
     clphase = clphase * ehc.DEGREE
     sigma = sigma * ehc.DEGREE
-
-    # get nfft objects
-    nfft_info1 = A[0]
-    plan1 = nfft_info1.plan
-    pulsefac1 = nfft_info1.pulsefac
-
-    nfft_info2 = A[1]
-    plan2 = nfft_info2.plan
-    pulsefac2 = nfft_info2.pulsefac
-
-    nfft_info3 = A[2]
-    plan3 = nfft_info3.plan
-    pulsefac3 = nfft_info3.pulsefac
-
-    # compute uniform --> nonuniform transforms
-    plan1.f_hat = imvec.copy().reshape((nfft_info1.ydim, nfft_info1.xdim)).T
-    plan1.trafo()
-    samples1 = plan1.f.copy()*pulsefac1
-
-    plan2.f_hat = imvec.copy().reshape((nfft_info2.ydim, nfft_info2.xdim)).T
-    plan2.trafo()
-    samples2 = plan2.f.copy()*pulsefac2
-
-    plan3.f_hat = imvec.copy().reshape((nfft_info3.ydim, nfft_info3.xdim)).T
-    plan3.trafo()
-    samples3 = plan3.f.copy()*pulsefac3
-
-    # compute chi^2
-    clphase_samples = np.angle(samples1*samples2*samples3)
-    chisq = (2.0/len(clphase)) * np.sum((1.0 - np.cos(clphase-clphase_samples))/(sigma**2))
-
-    return chisq
+    samples1 = nufft2_backend(imvec, A[0]) * A[0].pulsefac
+    samples2 = nufft2_backend(imvec, A[1]) * A[1].pulsefac
+    samples3 = nufft2_backend(imvec, A[2]) * A[2].pulsefac
+    clphase_samples = xp.angle(samples1*samples2*samples3)
+    return (2.0/len(clphase)) * xp.sum((1.0 - xp.cos(clphase-clphase_samples))/(sigma**2))
 
 
 def chisqgrad_cphase_nfft(imvec, A, clphase, sigma):
@@ -1274,47 +1215,14 @@ def chisqgrad_cphase_diag_nfft(imvec, A, clphase_diag, sigma):
 
 
 def chisq_camp_nfft(imvec, A, clamp, sigma):
-    """Closure Amplitudes (normalized) chi-squared from fft
-    """
-
-    # get nfft objects
-    nfft_info1 = A[0]
-    plan1 = nfft_info1.plan
-    pulsefac1 = nfft_info1.pulsefac
-
-    nfft_info2 = A[1]
-    plan2 = nfft_info2.plan
-    pulsefac2 = nfft_info2.pulsefac
-
-    nfft_info3 = A[2]
-    plan3 = nfft_info3.plan
-    pulsefac3 = nfft_info3.pulsefac
-
-    nfft_info4 = A[3]
-    plan4 = nfft_info4.plan
-    pulsefac4 = nfft_info4.pulsefac
-
-    # compute uniform --> nonuniform transforms
-    plan1.f_hat = imvec.copy().reshape((nfft_info1.ydim, nfft_info1.xdim)).T
-    plan1.trafo()
-    samples1 = plan1.f.copy()*pulsefac1
-
-    plan2.f_hat = imvec.copy().reshape((nfft_info2.ydim, nfft_info2.xdim)).T
-    plan2.trafo()
-    samples2 = plan2.f.copy()*pulsefac2
-
-    plan3.f_hat = imvec.copy().reshape((nfft_info3.ydim, nfft_info3.xdim)).T
-    plan3.trafo()
-    samples3 = plan3.f.copy()*pulsefac3
-
-    plan4.f_hat = imvec.copy().reshape((nfft_info4.ydim, nfft_info4.xdim)).T
-    plan4.trafo()
-    samples4 = plan4.f.copy()*pulsefac4
-
-    # compute chi^2
-    clamp_samples = np.abs((samples1*samples2)/(samples3*samples4))
-    chisq = np.sum(np.abs((clamp - clamp_samples)/sigma)**2)/len(clamp)
-    return chisq
+    """Closure Amplitudes (normalized) chi-squared from nfft"""
+    xp = array_namespace(imvec)
+    samples1 = nufft2_backend(imvec, A[0]) * A[0].pulsefac
+    samples2 = nufft2_backend(imvec, A[1]) * A[1].pulsefac
+    samples3 = nufft2_backend(imvec, A[2]) * A[2].pulsefac
+    samples4 = nufft2_backend(imvec, A[3]) * A[3].pulsefac
+    clamp_samples = xp.abs((samples1*samples2)/(samples3*samples4))
+    return xp.sum(xp.abs((clamp - clamp_samples)/sigma)**2)/len(clamp)
 
 
 def chisqgrad_camp_nfft(imvec, A, clamp, sigma):
@@ -1386,48 +1294,15 @@ def chisqgrad_camp_nfft(imvec, A, clamp, sigma):
 
 
 def chisq_logcamp_nfft(imvec, A, log_clamp, sigma):
-    """Log Closure Amplitudes (normalized) chi-squared from fft
-    """
-
-    # get nfft objects
-    nfft_info1 = A[0]
-    plan1 = nfft_info1.plan
-    pulsefac1 = nfft_info1.pulsefac
-
-    nfft_info2 = A[1]
-    plan2 = nfft_info2.plan
-    pulsefac2 = nfft_info2.pulsefac
-
-    nfft_info3 = A[2]
-    plan3 = nfft_info3.plan
-    pulsefac3 = nfft_info3.pulsefac
-
-    nfft_info4 = A[3]
-    plan4 = nfft_info4.plan
-    pulsefac4 = nfft_info4.pulsefac
-
-    # compute uniform --> nonuniform transforms
-    plan1.f_hat = imvec.copy().reshape((nfft_info1.ydim, nfft_info1.xdim)).T
-    plan1.trafo()
-    samples1 = plan1.f.copy()*pulsefac1
-
-    plan2.f_hat = imvec.copy().reshape((nfft_info2.ydim, nfft_info2.xdim)).T
-    plan2.trafo()
-    samples2 = plan2.f.copy()*pulsefac2
-
-    plan3.f_hat = imvec.copy().reshape((nfft_info3.ydim, nfft_info3.xdim)).T
-    plan3.trafo()
-    samples3 = plan3.f.copy()*pulsefac3
-
-    plan4.f_hat = imvec.copy().reshape((nfft_info4.ydim, nfft_info4.xdim)).T
-    plan4.trafo()
-    samples4 = plan4.f.copy()*pulsefac4
-
-    # compute chi^2
-    log_clamp_samples = (np.log(np.abs(samples1)) + np.log(np.abs(samples2)) -
-                         np.log(np.abs(samples3)) - np.log(np.abs(samples4)))
-    chisq = np.sum(np.abs((log_clamp - log_clamp_samples)/sigma)**2) / (len(log_clamp))
-    return chisq
+    """Log Closure Amplitudes (normalized) chi-squared from nfft"""
+    xp = array_namespace(imvec)
+    samples1 = nufft2_backend(imvec, A[0]) * A[0].pulsefac
+    samples2 = nufft2_backend(imvec, A[1]) * A[1].pulsefac
+    samples3 = nufft2_backend(imvec, A[2]) * A[2].pulsefac
+    samples4 = nufft2_backend(imvec, A[3]) * A[3].pulsefac
+    log_clamp_samples = (xp.log(xp.abs(samples1)) + xp.log(xp.abs(samples2)) -
+                         xp.log(xp.abs(samples3)) - xp.log(xp.abs(samples4)))
+    return xp.sum(xp.abs((log_clamp - log_clamp_samples)/sigma)**2) / (len(log_clamp))
 
 
 def chisqgrad_logcamp_nfft(imvec, A, log_clamp, sigma):

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -3445,17 +3445,24 @@ def embed_imarr(imarr, mask, clipfloor=0., randomfloor=False):
         raise Exception("in embed_imarr, number of masked pixels is not consistent with imarr shape!")
 
     nimage_out = len(mask)
-    outarr = np.empty((nsolve, nimage_out))
-    # Vectorized over the nsolve axis: scatter imarr into the masked columns
-    # of outarr, then fill non-mask columns with clipfloor (or random).
-    not_mask = ~mask.astype(bool)
-    outarr[:, mask.astype(bool)] = imarr
+    # Vectorized over the nsolve axis: scatter imarr into the masked columns,
+    # then fill non-mask columns with clipfloor (or random). Functional on jax.
+    xp = array_namespace(imarr)
+    on_cols = mask.astype(bool).nonzero()[0]
+    off_cols = (~mask.astype(bool)).nonzero()[0]
     if randomfloor:
-        outarr[:, not_mask] = clipfloor * np.abs(
-            np.random.normal(size=(nsolve, int(not_mask.sum())))
-        )
+        floor = clipfloor * np.abs(np.random.normal(size=(nsolve, len(off_cols))))
     else:
-        outarr[:, not_mask] = clipfloor
+        floor = np.full((nsolve, len(off_cols)), clipfloor)
+
+    if xp is np:
+        outarr = np.empty((nsolve, nimage_out))
+        outarr[:, on_cols] = imarr
+        outarr[:, off_cols] = floor
+    else:
+        outarr = xp.zeros((nsolve, nimage_out))
+        outarr = outarr.at[:, on_cols].set(imarr)
+        outarr = outarr.at[:, off_cols].set(floor)
 
     if imarrdim == 1:
         outarr = outarr[0]

--- a/ehtim/imaging/multifreq_imager_utils.py
+++ b/ehtim/imaging/multifreq_imager_utils.py
@@ -19,6 +19,8 @@
 
 import numpy as np
 
+from ehtim.backends import array_namespace
+
 NORM_REGULARIZER = True
 EPSILON = 1.e-12
 DD_RHOPOL = 1 # transform paramter for multifrequency polarization fraction
@@ -29,6 +31,7 @@ DD_RHOPOL = 1 # transform paramter for multifrequency polarization fraction
 def image_at_freq(mfarr, log_freqratio):
         """Get the image or polarization image tuple from multifrequency data
         """
+        xp = array_namespace(mfarr)
 
         # Stokes I only
         if len(mfarr)==3:
@@ -36,8 +39,8 @@ def image_at_freq(mfarr, log_freqratio):
             alpha  = mfarr[1] # spectral index
             beta   = mfarr[2] # spectral curvature
 
-            logimvec = np.log(imvec0) + alpha*log_freqratio + beta*log_freqratio*log_freqratio
-            imvec = np.exp(logimvec)
+            logimvec = xp.log(imvec0) + alpha*log_freqratio + beta*log_freqratio*log_freqratio
+            imvec = xp.exp(logimvec)
             out = imvec
 
 
@@ -56,25 +59,25 @@ def image_at_freq(mfarr, log_freqratio):
             rm = mfarr[8] # Dimensionless Faraday Rotation Measure
             cm = mfarr[9] # Dimensionless Faraday Conversion Measure
 
-            logimvec = np.log(imvec0) + alpha*log_freqratio + beta*log_freqratio*log_freqratio
-            imvec = np.exp(logimvec)
+            logimvec = xp.log(imvec0) + alpha*log_freqratio + beta*log_freqratio*log_freqratio
+            imvec = xp.exp(logimvec)
 
-            logrhovec_prime = np.log(rhovec0) + alpha_pol*log_freqratio + beta_pol*log_freqratio*log_freqratio
-            rhovec_prime = np.exp(logrhovec_prime)
+            logrhovec_prime = xp.log(rhovec0) + alpha_pol*log_freqratio + beta_pol*log_freqratio*log_freqratio
+            rhovec_prime = xp.exp(logrhovec_prime)
 
             # transformation of rhovec to ensure it is always < 1 at any frequency
             # TODO: what to do about rhoprime=0?
             rhovec = (rhovec_prime**(-DD_RHOPOL) + 1)**(-1/DD_RHOPOL)
 
             # we use dimensionless rm scaled by lambda0^2 = c^2/nu0^2
-            phivec = phivec0 + rm*(np.exp(-2*log_freqratio)-1)
+            phivec = phivec0 + rm*(xp.exp(-2*log_freqratio)-1)
 
             # TODO: we require psi be between -pi/2 and pi/2 for m=rho*cos(psi) to work
             # for now, we will just keep multifrequency V off
             # and dimensionless conversion measure scaled by lamba0^3 = c^3/nu0^3
             psivec = psivec0 #Plot + cm*(np.exp(-3*log_freqratio)-1)
 
-            out = np.array((imvec, rhovec, phivec, psivec))
+            out = xp.stack((imvec, rhovec, phivec, psivec))
 
         else:
             raise Exception("in image_at_freq, len(mfarr) must be 3 or 10!")
@@ -227,9 +230,10 @@ def regularizergrad_mf(imvec, nprior, mask, xdim, ydim, psize, stype, **kwargs):
 
 
 def reg_l2_spec(imvec, mask, **kwargs):
+    xp = array_namespace(imvec)
     priorvec = kwargs['nprior']
     norm = float(len(imvec)) if kwargs.get('norm_reg', True) else 1
-    return np.sum((imvec - priorvec)**2) / norm
+    return xp.sum((imvec - priorvec)**2) / norm
 
 
 def reggrad_l2_spec(imvec, mask, **kwargs):
@@ -240,16 +244,17 @@ def reggrad_l2_spec(imvec, mask, **kwargs):
 
 def reg_tv_spec(imvec, mask, **kwargs):
     from ehtim.imaging.imager_utils import embed
+    xp = array_namespace(imvec)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, clipfloor=0, randomfloor=False)
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     beam_size = kwargs.get('beam_size') or psize
     norm = len(imvec) * psize / beam_size if kwargs.get('norm_reg', True) else 1
     im = imvec.reshape(ny, nx)
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    return np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2 + EPSILON)) / norm
+    impad = xp.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = xp.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = xp.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    return xp.sum(xp.sqrt(xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2 + EPSILON)) / norm
 
 
 def reggrad_tv_spec(imvec, mask, **kwargs):

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -878,9 +878,10 @@ def reg_ptv(imarr, mask, **kwargs):
     impad = xp.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = xp.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
     im_l2 = xp.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    # TODO(bug): no epsilon in the sqrt (cf. reg_tv's epsilon_tv), so the gradient
-    # is singular at near-zero-|P|-difference pixels. reg_vtv / reg_vtv2 share this.
-    return xp.sum(xp.sqrt(xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2)) / norm
+    # epsilon_tv (default 0, matching reg_tv) regularizes the sqrt so the gradient
+    # is finite at near-zero-|P|-difference pixels; epsilon=0 is byte-identical.
+    epsilon = kwargs.get('epsilon_tv', 0.)
+    return xp.sum(xp.sqrt(xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2 + epsilon)) / norm
 
 
 def reggrad_ptv(imarr, mask, **kwargs):
@@ -906,9 +907,11 @@ def reggrad_ptv(imarr, mask, **kwargs):
     im_r1l2 = np.roll(np.roll(impad,  1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
     im_l1r2 = np.roll(np.roll(impad, -1, axis=0),  1, axis=1)[1:ny+1, 1:nx+1]
     # Denominators: |forward-l1|+|forward-l2|, |back-r1|+|cross|, |back-r2|+|cross|.
-    d1 = np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2)
-    d2 = np.sqrt(np.abs(im_r1 - im)**2 + np.abs(im_r1l2 - im_r1)**2)
-    d3 = np.sqrt(np.abs(im_r2 - im)**2 + np.abs(im_l1r2 - im_r2)**2)
+    # epsilon_tv (default 0, matching reg_ptv) keeps these finite at zero-|P| diffs.
+    epsilon = kwargs.get('epsilon_tv', 0.)
+    d1 = np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2 + epsilon)
+    d2 = np.sqrt(np.abs(im_r1 - im)**2 + np.abs(im_r1l2 - im_r1)**2 + epsilon)
+    d3 = np.sqrt(np.abs(im_r2 - im)**2 + np.abs(im_l1r2 - im_r2)**2 + epsilon)
     # Numerators below use cos/sin of the single-angle difference between
     # neighbors, from d|P_l1 - P|^2/d|P| = 2|P| - 2|P_l1|*cos(angle(P_l1) - angle(P)).
     gradout = np.zeros(imarr.shape)
@@ -1054,7 +1057,8 @@ def reg_vtv(imarr, mask, **kwargs):
     impad = xp.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = xp.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
     im_l2 = xp.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    return xp.sum(xp.sqrt(xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2)) / norm
+    epsilon = kwargs.get('epsilon_tv', 0.)
+    return xp.sum(xp.sqrt(xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2 + epsilon)) / norm
 
 
 def reggrad_vtv(imarr, mask, **kwargs):
@@ -1067,7 +1071,7 @@ def reggrad_vtv(imarr, mask, **kwargs):
     pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
     beam_size = kwargs.get('beam_size', 1) or psize
     norm = np.abs(vflux) * psize / beam_size if kwargs.get('norm_reg', True) else 1
-    epsilon = 0.
+    epsilon = kwargs.get('epsilon_tv', 0.)  # default 0 -> byte-identical; matches reg_vtv
     iimage = make_i_image(imarr)
     vimage = make_v_image(imarr)
     vfimage = make_vf_image(imarr)

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -807,11 +807,12 @@ def chisqgrad_vvis_nfft(imarr, A, v, sigmav,pol_solve=POL_SOLVE_DEFAULT):
 
 
 def reg_msimple(imarr, mask, **kwargs):
+    xp = array_namespace(imarr)
     flux = kwargs['flux']
     norm = flux if kwargs.get('norm_reg', True) else 1
     iimage = make_i_image(imarr)
     mimage = make_m_image(imarr)
-    return np.sum(iimage * np.log(mimage)) / norm
+    return xp.sum(iimage * xp.log(mimage)) / norm
 
 
 def reggrad_msimple(imarr, mask, **kwargs):
@@ -834,12 +835,13 @@ def reggrad_msimple(imarr, mask, **kwargs):
 
 
 def reg_hw(imarr, mask, **kwargs):
+    xp = array_namespace(imarr)
     flux = kwargs['flux']
     norm = flux if kwargs.get('norm_reg', True) else 1
     iimage = make_i_image(imarr)
     mimage = make_m_image(imarr)
-    return np.sum(iimage * (((1+mimage)/2) * np.log((1+mimage)/2)
-                            + ((1-mimage)/2) * np.log((1-mimage)/2))) / norm
+    return xp.sum(iimage * (((1+mimage)/2) * xp.log((1+mimage)/2)
+                            + ((1-mimage)/2) * xp.log((1-mimage)/2))) / norm
 
 
 def reggrad_hw(imarr, mask, **kwargs):
@@ -864,6 +866,7 @@ def reggrad_hw(imarr, mask, **kwargs):
 
 def reg_ptv(imarr, mask, **kwargs):
     from ehtim.imaging.imager_utils import embed_imarr
+    xp = array_namespace(imarr)
     if np.any(np.invert(mask)):
         imarr = embed_imarr(imarr, mask, randomfloor=True)
     flux = kwargs['flux']
@@ -872,10 +875,12 @@ def reg_ptv(imarr, mask, **kwargs):
     norm = flux * psize / beam_size if kwargs.get('norm_reg', True) else 1
     pimage = make_p_image(imarr)
     im = pimage.reshape(ny, nx)
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    return np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2)) / norm
+    impad = xp.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = xp.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = xp.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    # TODO(bug): no epsilon in the sqrt (cf. reg_tv's epsilon_tv), so the gradient
+    # is singular at near-zero-|P|-difference pixels. reg_vtv / reg_vtv2 share this.
+    return xp.sum(xp.sqrt(xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2)) / norm
 
 
 def reggrad_ptv(imarr, mask, **kwargs):
@@ -945,10 +950,11 @@ def reggrad_ptv(imarr, mask, **kwargs):
 # `gradv * (vfimage / np.tan(psiimage))` chain-rule form (dS/dpsi) is unusual
 # and the test coverage only exercises generic random pol structure.
 def reg_vflux(imarr, mask, **kwargs):
+    xp = array_namespace(imarr)
     vflux = kwargs['vflux']
     norm = np.abs(vflux)**2 if kwargs.get('norm_reg', True) else 1
     vimage = make_v_image(imarr)
-    return (np.sum(vimage) - vflux)**2 / norm
+    return (xp.sum(vimage) - vflux)**2 / norm
 
 
 def reggrad_vflux(imarr, mask, **kwargs):
@@ -975,10 +981,11 @@ def reggrad_vflux(imarr, mask, **kwargs):
 
 
 def reg_l1v(imarr, mask, **kwargs):
+    xp = array_namespace(imarr)
     vflux = kwargs['vflux']
     norm = np.abs(vflux) if kwargs.get('norm_reg', True) else 1
     vimage = make_v_image(imarr)
-    return np.sum(np.abs(vimage)) / norm
+    return xp.sum(xp.abs(vimage)) / norm
 
 
 def reggrad_l1v(imarr, mask, **kwargs):
@@ -1004,10 +1011,11 @@ def reggrad_l1v(imarr, mask, **kwargs):
 
 
 def reg_l2v(imarr, mask, **kwargs):
+    xp = array_namespace(imarr)
     vflux = kwargs['vflux']
     norm = np.abs(vflux**2) if kwargs.get('norm_reg', True) else 1
     vimage = make_v_image(imarr)
-    return np.sum(vimage**2) / norm
+    return xp.sum(vimage**2) / norm
 
 
 def reggrad_l2v(imarr, mask, **kwargs):
@@ -1034,6 +1042,7 @@ def reggrad_l2v(imarr, mask, **kwargs):
 
 def reg_vtv(imarr, mask, **kwargs):
     from ehtim.imaging.imager_utils import embed_imarr
+    xp = array_namespace(imarr)
     if np.any(np.invert(mask)):
         imarr = embed_imarr(imarr, mask, randomfloor=True)
     vflux = kwargs['vflux']
@@ -1042,10 +1051,10 @@ def reg_vtv(imarr, mask, **kwargs):
     norm = np.abs(vflux) * psize / beam_size if kwargs.get('norm_reg', True) else 1
     vimage = make_v_image(imarr)
     im = vimage.reshape(ny, nx)
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    return np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2)) / norm
+    impad = xp.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = xp.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = xp.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    return xp.sum(xp.sqrt(xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2)) / norm
 
 
 def reggrad_vtv(imarr, mask, **kwargs):
@@ -1097,6 +1106,7 @@ def reggrad_vtv(imarr, mask, **kwargs):
 
 def reg_vtv2(imarr, mask, **kwargs):
     from ehtim.imaging.imager_utils import embed_imarr
+    xp = array_namespace(imarr)
     if np.any(np.invert(mask)):
         imarr = embed_imarr(imarr, mask, randomfloor=True)
     vflux = kwargs['vflux']
@@ -1105,10 +1115,10 @@ def reg_vtv2(imarr, mask, **kwargs):
     norm = psize**4 * np.abs(vflux**2) / beam_size**4 if kwargs.get('norm_reg', True) else 1
     vimage = make_v_image(imarr)
     im = vimage.reshape(ny, nx)
-    impad = np.pad(im, 1, mode='constant', constant_values=0)
-    im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
-    im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    return np.sum((im_l1 - im)**2 + (im_l2 - im)**2) / norm
+    impad = xp.pad(im, 1, mode='constant', constant_values=0)
+    im_l1 = xp.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
+    im_l2 = xp.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    return xp.sum((im_l1 - im)**2 + (im_l2 - im)**2) / norm
 
 
 def reggrad_vtv2(imarr, mask, **kwargs):

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -19,6 +19,8 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
+from ehtim.backends import array_namespace
+
 try:
     from pynfft.nfft import NFFT
     _HAS_NFFT = True
@@ -68,7 +70,8 @@ def make_p_image(imarr):
     """
 
     # NOTE! We replaced EVPA chi with phi=2chi in the imarr
-    pimage = imarr[0] * imarr[1] * np.exp(1j*imarr[2]) * np.cos(imarr[3])
+    xp = array_namespace(imarr)
+    pimage = imarr[0] * imarr[1] * xp.exp(1j*imarr[2]) * xp.cos(imarr[3])
 
     return pimage
 
@@ -76,7 +79,8 @@ def make_m_image(imarr):
     """construct a polarimetric ratrio image abs(P/I) = abs(Q + iU)/I
     """
 
-    mimage = imarr[1] * np.cos(imarr[3])
+    xp = array_namespace(imarr)
+    mimage = imarr[1] * xp.cos(imarr[3])
 
     return mimage
 
@@ -100,7 +104,8 @@ def make_q_image(imarr):
     """
 
     # NOTE! We replaced EVPA chi with phi=2chi in the imarr
-    qimage = imarr[0] * imarr[1] * np.cos(imarr[2]) *  np.cos(imarr[3])
+    xp = array_namespace(imarr)
+    qimage = imarr[0] * imarr[1] * xp.cos(imarr[2]) *  xp.cos(imarr[3])
 
     return qimage
 
@@ -108,7 +113,8 @@ def make_u_image(imarr):
     """construct an image of stokes U
     """
     # NOTE! We replaced EVPA chi with phi=2chi in the imarr
-    uimage = imarr[0] * imarr[1] * np.sin(imarr[2]) *  np.cos(imarr[3])
+    xp = array_namespace(imarr)
+    uimage = imarr[0] * imarr[1] * xp.sin(imarr[2]) *  xp.cos(imarr[3])
 
     return uimage
 
@@ -116,7 +122,8 @@ def make_v_image(imarr):
     """construct an image of stokes V
     """
 
-    vimage = imarr[0] * imarr[1] * np.sin(imarr[3])
+    xp = array_namespace(imarr)
+    vimage = imarr[0] * imarr[1] * xp.sin(imarr[3])
 
     return vimage
 
@@ -124,7 +131,8 @@ def make_vf_image(imarr):
     """construct an image of stokes V/I
     """
 
-    vfimage = imarr[1] * np.sin(imarr[3])
+    xp = array_namespace(imarr)
+    vfimage = imarr[1] * xp.sin(imarr[3])
 
     return vfimage
 
@@ -134,13 +142,14 @@ def polcv(imarr):
        input is solver values, output is physical values
     """
 
+    xp = array_namespace(imarr)
     rho_prime =  imarr[1]
-    rho = 0.5 + np.arctan(rho_prime/TANWIDTH_M)/np.pi
+    rho = 0.5 + xp.arctan(rho_prime/TANWIDTH_M)/np.pi
 
     psi_prime = imarr[3]
-    psi = np.arctan(psi_prime/TANWIDTH_PSI)
+    psi = xp.arctan(psi_prime/TANWIDTH_PSI)
 
-    out = np.array((imarr[0], rho, imarr[2], psi))
+    out = xp.stack((imarr[0], rho, imarr[2], psi))
     return out
 
 def polcv_r(imarr):
@@ -193,18 +202,19 @@ def mcv(imarr):
        input is solver values, output is physical values
     """
 
+    xp = array_namespace(imarr)
     vfrac = imarr[3] # when using this transform, we interpret transformed imarr[3] as mfrac=\rho sin(\psi)
-    mfrac_max = 1-np.abs(vfrac)
-    if np.any(mfrac_max>1):
+    mfrac_max = 1-xp.abs(vfrac)
+    if xp is np and np.any(mfrac_max>1):  # dead guard (mfrac_max<=1 always); kept on numpy
         raise Exception("mfrac_max>1 in mcv!")
 
     mfrac_prime =  imarr[1]
-    mfrac = mfrac_max*(0.5 + np.arctan(mfrac_prime/TANWIDTH_M)/np.pi)
+    mfrac = mfrac_max*(0.5 + xp.arctan(mfrac_prime/TANWIDTH_M)/np.pi)
 
-    rho = np.sqrt(mfrac**2 + vfrac**2)
-    psi = np.arcsin(vfrac/rho)
+    rho = xp.sqrt(mfrac**2 + vfrac**2)
+    psi = xp.arcsin(vfrac/rho)
 
-    out = np.array((imarr[0], rho, imarr[2], psi))
+    out = xp.stack((imarr[0], rho, imarr[2], psi))
     return out
 
 def mcv_r(imarr):
@@ -266,18 +276,19 @@ def vcv(imarr):
     """change of variables for v(v') from range (-inf,inf) to (-1+|m|,1-|m|) while keeping m=P/I fixed
        input is solver values, output is physical values"""
 
+    xp = array_namespace(imarr)
     mfrac = imarr[1] # when using this transform, we interpret transformed imarr[1] as mfrac=\rho cos(\psi)
-    vfrac_max = 1-np.abs(mfrac)
-    if np.any(vfrac_max>1):
+    vfrac_max = 1-xp.abs(mfrac)
+    if xp is np and np.any(vfrac_max>1):  # dead guard (vfrac_max<=1 always); kept on numpy
         raise Exception("vfrac_max>1 in vcv!")
 
     vfrac_prime = imarr[3]
-    vfrac = 2*vfrac_max*np.arctan(vfrac_prime/TANWIDTH_V)/np.pi
+    vfrac = 2*vfrac_max*xp.arctan(vfrac_prime/TANWIDTH_V)/np.pi
 
-    rho = np.sqrt(mfrac**2 + vfrac**2)
-    psi = np.arcsin(vfrac/rho)
+    rho = xp.sqrt(mfrac**2 + vfrac**2)
+    psi = xp.arcsin(vfrac/rho)
 
-    out = np.array((imarr[0], rho, imarr[2], psi))
+    out = xp.stack((imarr[0], rho, imarr[2], psi))
     return out
 
 def vcv_r(imarr):
@@ -428,9 +439,10 @@ def chisq_p(imarr, Amatrix, p, sigmap):
     """Polarimetric visibility chi-squared
     """
 
+    xp = array_namespace(imarr)
     pimage = make_p_image(imarr)
-    psamples = np.dot(Amatrix, pimage)
-    chisq =  np.sum(np.abs(p - psamples)**2/(sigmap**2)) / (2*len(p))
+    psamples = xp.dot(Amatrix, pimage)
+    chisq =  xp.sum(xp.abs(p - psamples)**2/(sigmap**2)) / (2*len(p))
     return chisq
 
 def chisqgrad_p(imarr, Amatrix, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
@@ -474,10 +486,11 @@ def chisq_m(imarr, Amatrix, m, sigmam):
     """Polarimetric ratio chi-squared
     """
 
+    xp = array_namespace(imarr)
     iimage = make_i_image(imarr)
     pimage = make_p_image(imarr)
-    msamples = np.dot(Amatrix, pimage) / np.dot(Amatrix, iimage)
-    chisq = np.sum(np.abs(m - msamples)**2/(sigmam**2)) / (2*len(m))
+    msamples = xp.dot(Amatrix, pimage) / xp.dot(Amatrix, iimage)
+    chisq = xp.sum(xp.abs(m - msamples)**2/(sigmam**2)) / (2*len(m))
     return chisq
 
 def chisqgrad_m(imarr, Amatrix, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
@@ -524,9 +537,10 @@ def chisq_vvis(imarr, Amatrix, v, sigmav):
     """V visibility chi-squared
     """
 
+    xp = array_namespace(imarr)
     vimage = make_v_image(imarr)
-    vsamples = np.dot(Amatrix, vimage)
-    chisq =  np.sum(np.abs(v - vsamples)**2/(sigmav**2)) / (2*len(v))
+    vsamples = xp.dot(Amatrix, vimage)
+    chisq =  xp.sum(xp.abs(v - vsamples)**2/(sigmav**2)) / (2*len(v))
     return chisq
 
 def chisqgrad_vvis(imarr, Amatrix, v, sigmav, pol_solve=POL_SOLVE_DEFAULT_V):

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -914,12 +914,22 @@ def reggrad_ptv(imarr, mask, **kwargs):
     d3 = np.sqrt(np.abs(im_r2 - im)**2 + np.abs(im_l1r2 - im_r2)**2 + epsilon)
     # Numerators below use cos/sin of the single-angle difference between
     # neighbors, from d|P_l1 - P|^2/d|P| = 2|P| - 2|P_l1|*cos(angle(P_l1) - angle(P)).
+    # The back-neighbor magnitude numerators m2/m3 keep a |P| term that does not
+    # vanish at the zero-pad, so the first row/col would pick up a neighbor that
+    # does not exist; zero those terms there as reggrad_tv/reggrad_vtv do. (The
+    # phase numerators c2/c3 carry a |P_neighbor| factor and self-zero there.)
+    mask1 = np.zeros(im.shape, dtype=bool)
+    mask2 = np.zeros(im.shape, dtype=bool)
+    mask1[0, :] = True
+    mask2[:, 0] = True
     gradout = np.zeros(imarr.shape)
     if pol_solve[0] != 0:
         # dS/dI numerators (chain through |P| = I*m)
         m1 = 2*np.abs(im*im) - np.abs(im*im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im*im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im*im) - np.abs(im*im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im*im) - np.abs(im*im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        m2[mask1] = 0
+        m3[mask2] = 0
         gradout[0] = (1./iimage) * (m1/d1 + m2/d2 + m3/d3).flatten()
     if pol_solve[1] != 0:
         # dS/dm numerators; m enters via |P| = I*m, so dS/dm = I * dS/d|P|.
@@ -927,6 +937,8 @@ def reggrad_ptv(imarr, mask, **kwargs):
         m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        m2[mask1] = 0
+        m3[mask2] = 0
         gradm = iimage * (m1/d1 + m2/d2 + m3/d3).flatten()
         gradout[1] = gradm * np.cos(psiimage)
     if pol_solve[2] != 0:
@@ -942,6 +954,8 @@ def reggrad_ptv(imarr, mask, **kwargs):
         m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        m2[mask1] = 0
+        m3[mask2] = 0
         gradm = iimage * (m1/d1 + m2/d2 + m3/d3).flatten()
         gradout[3] = gradm * (-mimage * np.tan(psiimage))
     g = gradout / norm

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -196,6 +196,19 @@ def polcv_grad(imarr, gradarr):
     return out
 
 
+def _rho_psi_safe(xp, mfrac, vfrac):
+    """rho=sqrt(mfrac^2+vfrac^2), psi=arcsin(vfrac/rho), guarded so jax.grad stays finite
+    at zero-polarization pixels (sqrt(0) and arcsin(+/-1) singularities). Values are
+    unchanged where rho>0 and |vfrac/rho|<1.
+    """
+    r2 = mfrac**2 + vfrac**2
+    rho = xp.where(r2 > 0, xp.sqrt(xp.where(r2 > 0, r2, 1.0)), 0.0)
+    s = vfrac / xp.where(rho > 0, rho, 1.0)
+    inbound = xp.abs(s) < 1
+    psi = xp.where(inbound, xp.arcsin(xp.where(inbound, s, 0.0)), xp.sign(s) * (np.pi / 2))
+    return rho, psi
+
+
 def mcv(imarr):
     """change of variables m(n') from range (-inf, inf) to (0,1)
        input is solver values, output is physical values
@@ -208,8 +221,7 @@ def mcv(imarr):
     mfrac_prime =  imarr[1]
     mfrac = mfrac_max*(0.5 + xp.arctan(mfrac_prime/TANWIDTH_M)/np.pi)
 
-    rho = xp.sqrt(mfrac**2 + vfrac**2)
-    psi = xp.arcsin(vfrac/rho)
+    rho, psi = _rho_psi_safe(xp, mfrac, vfrac)
 
     out = xp.stack((imarr[0], rho, imarr[2], psi))
     return out
@@ -280,8 +292,7 @@ def vcv(imarr):
     vfrac_prime = imarr[3]
     vfrac = 2*vfrac_max*xp.arctan(vfrac_prime/TANWIDTH_V)/np.pi
 
-    rho = xp.sqrt(mfrac**2 + vfrac**2)
-    psi = xp.arcsin(vfrac/rho)
+    rho, psi = _rho_psi_safe(xp, mfrac, vfrac)
 
     out = xp.stack((imarr[0], rho, imarr[2], psi))
     return out
@@ -469,8 +480,9 @@ def chisqgrad_p(imarr, Amatrix, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
 
-    # TODO check
-    if pol_solve[3]!=0:
+    # mcv couples mprime to psi, so mcv_grad's mprime gradient needs grad_psi; gating
+    # it on pol_solve[3] alone dropped it for IP. Mirror of the vcv/grad_rho fix (#296).
+    if pol_solve[1]!=0 or pol_solve[3]!=0:
         gradm = -np.real(iimage * np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, pdiff)) / len(p)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
         gradout[3] = gradpsi
@@ -519,7 +531,8 @@ def chisqgrad_m(imarr, Amatrix, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
 
-    if pol_solve[3]!=0:
+    # see chisqgrad_p: psi gradient needed when m is solved (mcv couples mprime -> psi)
+    if pol_solve[1]!=0 or pol_solve[3]!=0:
         gradm = -np.real(iimage*np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, mdiff)) / len(m)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
         gradout[3] = gradpsi
@@ -624,7 +637,8 @@ def chisqgrad_p_nfft(imarr, A, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
 
-    if pol_solve[3]!=0:
+    # see chisqgrad_p: psi gradient needed when m is solved (mcv couples mprime -> psi)
+    if pol_solve[1]!=0 or pol_solve[3]!=0:
         gradm = np.real(iimage*np.exp(-2j*chiimage) *ppart)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
         gradout[3] = gradpsi
@@ -693,7 +707,8 @@ def chisqgrad_m_nfft(imarr, A, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
 
-    if pol_solve[3]!=0:
+    # see chisqgrad_p: psi gradient needed when m is solved (mcv couples mprime -> psi)
+    if pol_solve[1]!=0 or pol_solve[3]!=0:
         gradm = np.real(iimage*np.exp(-2j*chiimage) * mpart)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
         gradout[3] = gradpsi
@@ -791,7 +806,8 @@ def reggrad_msimple(imarr, mask, **kwargs):
     if pol_solve[1] != 0:
         gradm = iimage / mimage
         gradout[1] = gradm * np.cos(psiimage)
-    if pol_solve[3] != 0:
+    # psi gradient needed when m is solved (mcv couples mprime -> psi); see #296
+    if pol_solve[1] != 0 or pol_solve[3] != 0:
         gradm = iimage / mimage
         gradout[3] = gradm * (-mimage * np.tan(psiimage))
     return gradout / norm
@@ -821,7 +837,8 @@ def reggrad_hw(imarr, mask, **kwargs):
     if pol_solve[1] != 0:
         gradm = iimage * np.arctanh(mimage)
         gradout[1] = gradm * np.cos(psiimage)
-    if pol_solve[3] != 0:
+    # psi gradient needed when m is solved (mcv couples mprime -> psi); see #296
+    if pol_solve[1] != 0 or pol_solve[3] != 0:
         gradm = iimage * np.arctanh(mimage)
         gradout[3] = gradm * (-mimage * np.tan(psiimage))
     return gradout / norm
@@ -909,7 +926,8 @@ def reggrad_ptv(imarr, mask, **kwargs):
         c3 = 2*np.abs(im*im_r2)*np.sin(np.angle(im) - np.angle(im_r2))
         gradchi = (c1/d1 + c2/d2 + c3/d3).flatten()
         gradout[2] = 0.5 * gradchi
-    if pol_solve[3] != 0:
+    # psi gradient needed when m is solved (mcv couples mprime -> psi); see #296
+    if pol_solve[1] != 0 or pol_solve[3] != 0:
         # dS/dpsi numerators; reuse dS/dm and chain through dm/dpsi = -m*tan(psi).
         m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
@@ -948,9 +966,10 @@ def reggrad_vflux(imarr, mask, **kwargs):
     gradout = np.zeros(imarr.shape)
     if pol_solve[0] != 0:
         gradout[0] = (vimage / iimage) * base  # dS/dI
-    if pol_solve[1] != 0:
+    # rho gradient needed whenever V is solved (vcv couples vprime -> rho); see #296
+    if pol_solve[1] != 0 or pol_solve[3] != 0:
         gradv = iimage * base
-        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+        gradout[1] = gradv * np.sin(psiimage)  # dS/drho
     if pol_solve[3] != 0:
         gradv = iimage * base
         gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi; vf/tan(psi) = m*cos(psi)
@@ -978,9 +997,10 @@ def reggrad_l1v(imarr, mask, **kwargs):
     gradout = np.zeros(imarr.shape)
     if pol_solve[0] != 0:
         gradout[0] = vfimage * base  # dS/dI (vfimage = V/I)
-    if pol_solve[1] != 0:
+    # rho gradient needed whenever V is solved (vcv couples vprime -> rho); see #296
+    if pol_solve[1] != 0 or pol_solve[3] != 0:
         gradv = iimage * base
-        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+        gradout[1] = gradv * np.sin(psiimage)  # dS/drho
     if pol_solve[3] != 0:
         gradv = iimage * base
         gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi
@@ -1008,9 +1028,10 @@ def reggrad_l2v(imarr, mask, **kwargs):
     gradout = np.zeros(imarr.shape)
     if pol_solve[0] != 0:
         gradout[0] = vfimage * base  # dS/dI
-    if pol_solve[1] != 0:
+    # rho gradient needed whenever V is solved (vcv couples vprime -> rho); see #296
+    if pol_solve[1] != 0 or pol_solve[3] != 0:
         gradv = iimage * base
-        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+        gradout[1] = gradv * np.sin(psiimage)  # dS/drho
     if pol_solve[3] != 0:
         gradv = iimage * base
         gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi
@@ -1072,9 +1093,10 @@ def reggrad_vtv(imarr, mask, **kwargs):
     gradout = np.zeros(imarr.shape)
     if pol_solve[0] != 0:
         gradout[0] = vfimage * base  # dS/dI
-    if pol_solve[1] != 0:
+    # rho gradient needed whenever V is solved (vcv couples vprime -> rho); see #296
+    if pol_solve[1] != 0 or pol_solve[3] != 0:
         gradv = iimage * base
-        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+        gradout[1] = gradv * np.sin(psiimage)  # dS/drho
     if pol_solve[3] != 0:
         gradv = iimage * base
         gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi
@@ -1133,9 +1155,10 @@ def reggrad_vtv2(imarr, mask, **kwargs):
     gradout = np.zeros(imarr.shape)
     if pol_solve[0] != 0:
         gradout[0] = vfimage * base  # dS/dI
-    if pol_solve[1] != 0:
+    # rho gradient needed whenever V is solved (vcv couples vprime -> rho); see #296
+    if pol_solve[1] != 0 or pol_solve[3] != 0:
         gradv = iimage * base
-        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+        gradout[1] = gradv * np.sin(psiimage)  # dS/drho
     if pol_solve[3] != 0:
         gradv = iimage * base
         gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -29,7 +29,7 @@ except ImportError:
     _HAS_NFFT = False
 
 from ehtim.const_def import FFT_PAD_DEFAULT, GRIDDER_P_RAD_DEFAULT, NFFT_EPS_DEFAULT, RADPERAS
-from ehtim.observing.obs_helpers import NFFTInfo, ftmatrix, ticks
+from ehtim.observing.obs_helpers import NFFTInfo, ftmatrix, nufft2_backend, ticks
 
 TANWIDTH_M = 0.5
 TANWIDTH_V = 1
@@ -66,10 +66,9 @@ def make_i_image(imarr):
     return imarr[0]
 
 def make_p_image(imarr):
-    """construct a polarimetric image P = RL = Q + iU
+    """construct a polarimetric image P = RL = Q + iU (see CONVENTIONS at top)
     """
 
-    # NOTE! We replaced EVPA chi with phi=2chi in the imarr
     xp = array_namespace(imarr)
     pimage = imarr[0] * imarr[1] * xp.exp(1j*imarr[2]) * xp.cos(imarr[3])
 
@@ -205,8 +204,6 @@ def mcv(imarr):
     xp = array_namespace(imarr)
     vfrac = imarr[3] # when using this transform, we interpret transformed imarr[3] as mfrac=\rho sin(\psi)
     mfrac_max = 1-xp.abs(vfrac)
-    if xp is np and np.any(mfrac_max>1):  # dead guard (mfrac_max<=1 always); kept on numpy
-        raise Exception("mfrac_max>1 in mcv!")
 
     mfrac_prime =  imarr[1]
     mfrac = mfrac_max*(0.5 + xp.arctan(mfrac_prime/TANWIDTH_M)/np.pi)
@@ -279,8 +276,6 @@ def vcv(imarr):
     xp = array_namespace(imarr)
     mfrac = imarr[1] # when using this transform, we interpret transformed imarr[1] as mfrac=\rho cos(\psi)
     vfrac_max = 1-xp.abs(mfrac)
-    if xp is np and np.any(vfrac_max>1):  # dead guard (vfrac_max<=1 always); kept on numpy
-        raise Exception("vfrac_max>1 in vcv!")
 
     vfrac_prime = imarr[3]
     vfrac = 2*vfrac_max*xp.arctan(vfrac_prime/TANWIDTH_V)/np.pi
@@ -577,24 +572,12 @@ def chisqgrad_vvis(imarr, Amatrix, v, sigmav, pol_solve=POL_SOLVE_DEFAULT_V):
 # NFFT Chi-squared and Gradient Functions
 ##################################################################################################
 def chisq_p_nfft(imarr, A, p, sigmap):
-    """P visibility chi-squared
+    """P visibility chi-squared from nfft
     """
+    xp = array_namespace(imarr)
     pimage = make_p_image(imarr)
-
-    #get nfft object
-    nfft_info = A[0]
-    plan = nfft_info.plan
-    pulsefac = nfft_info.pulsefac
-
-    #compute uniform --> nonuniform transform
-    plan.f_hat = pimage.copy().reshape((nfft_info.ydim,nfft_info.xdim)).T
-    plan.trafo()
-    psamples = plan.f.copy()*pulsefac
-
-    #compute chi^2
-    chisq =  np.sum(np.abs(p - psamples)**2/(sigmap**2)) / (2*len(p))
-
-    return chisq
+    psamples = nufft2_backend(pimage, A[0]) * A[0].pulsefac
+    return xp.sum(xp.abs(p - psamples)**2/(sigmap**2)) / (2*len(p))
 
 def chisqgrad_p_nfft(imarr, A, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
     """P visibility chi-squared gradient
@@ -647,29 +630,15 @@ def chisqgrad_p_nfft(imarr, A, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
 
 
 def chisq_m_nfft(imarr, A, m, sigmam):
-    """Polarimetric ratio chi-squared
+    """Polarimetric ratio chi-squared from nfft
     """
+    xp = array_namespace(imarr)
     iimage = make_i_image(imarr)
     pimage = make_p_image(imarr)
-
-    #get nfft object
-    nfft_info = A[0]
-    plan = nfft_info.plan
-    pulsefac = nfft_info.pulsefac
-
-    #compute uniform --> nonuniform transform
-    plan.f_hat = iimage.copy().reshape((nfft_info.ydim,nfft_info.xdim)).T
-    plan.trafo()
-    isamples = plan.f.copy()*pulsefac
-
-    plan.f_hat = pimage.copy().reshape((nfft_info.ydim,nfft_info.xdim)).T
-    plan.trafo()
-    psamples = plan.f.copy()*pulsefac
-
-    #compute chi^2
-    msamples = psamples/isamples
-    chisq = np.sum(np.abs(m - msamples)**2/(sigmam**2)) / (2*len(m))
-    return chisq
+    isamples = nufft2_backend(iimage, A[0]) * A[0].pulsefac
+    psamples = nufft2_backend(pimage, A[0]) * A[0].pulsefac
+    msamples = psamples / isamples
+    return xp.sum(xp.abs(m - msamples)**2/(sigmam**2)) / (2*len(m))
 
 def chisqgrad_m_nfft(imarr, A, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
     """Polarimetric ratio chi-squared gradient
@@ -729,24 +698,12 @@ def chisqgrad_m_nfft(imarr, A, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
 
 # stokes v
 def chisq_vvis_nfft(imarr, A, v, sigmav):
-    """V visibility chi-squared
+    """V visibility chi-squared from nfft
     """
+    xp = array_namespace(imarr)
     vimage = make_v_image(imarr)
-
-    #get nfft object
-    nfft_info = A[0]
-    plan = nfft_info.plan
-    pulsefac = nfft_info.pulsefac
-
-    #compute uniform --> nonuniform transform
-    plan.f_hat = vimage.copy().reshape((nfft_info.ydim,nfft_info.xdim)).T
-    plan.trafo()
-    vsamples = plan.f.copy()*pulsefac
-
-    #compute chi^2
-    chisq =  np.sum(np.abs(v - vsamples)**2/(sigmav**2)) / (2*len(v))
-
-    return chisq
+    vsamples = nufft2_backend(vimage, A[0]) * A[0].pulsefac
+    return xp.sum(xp.abs(v - vsamples)**2/(sigmav**2)) / (2*len(v))
 
 def chisqgrad_vvis_nfft(imarr, A, v, sigmav,pol_solve=POL_SOLVE_DEFAULT):
     """V visibility chi-squared gradient
@@ -914,10 +871,7 @@ def reggrad_ptv(imarr, mask, **kwargs):
     d3 = np.sqrt(np.abs(im_r2 - im)**2 + np.abs(im_l1r2 - im_r2)**2 + epsilon)
     # Numerators below use cos/sin of the single-angle difference between
     # neighbors, from d|P_l1 - P|^2/d|P| = 2|P| - 2|P_l1|*cos(angle(P_l1) - angle(P)).
-    # The back-neighbor magnitude numerators m2/m3 keep a |P| term that does not
-    # vanish at the zero-pad, so the first row/col would pick up a neighbor that
-    # does not exist; zero those terms there as reggrad_tv/reggrad_vtv do. (The
-    # phase numerators c2/c3 carry a |P_neighbor| factor and self-zero there.)
+    # mask first-row/col back-neighbor terms that don't exist (as reggrad_tv does)
     mask1 = np.zeros(im.shape, dtype=bool)
     mask2 = np.zeros(im.shape, dtype=bool)
     mask1[0, :] = True

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -36,6 +36,7 @@ import scipy.ndimage as nd
 import scipy.spatial.distance
 
 import ehtim.const_def as ehc
+from ehtim.backends import array_namespace
 
 warnings.filterwarnings("ignore", message="divide by zero encountered in double_scalars")
 
@@ -1468,12 +1469,36 @@ class NFFTInfo:
         uv_finufft = 2 * np.pi * uv_scaled
         self.eps = eps
         self.uv_finufft = uv_finufft  # (-pi, pi] nonuniform points, for jax_finufft.nufft2
+        # plan is the stateful finufft plan (numpy path only); jax uses uv_finufft.
         self.plan = FINUFFTPlan(self.xdim, self.ydim, uv_finufft, eps=eps)
 
         phases = np.exp(-1j*np.pi*(uv_scaled[:, 0] + uv_scaled[:, 1]))
         pulses = np.fromiter((pulse(2*np.pi*uv_scaled[i, 0], 2*np.pi*uv_scaled[i, 1], 1., dom="F")
                               for i in range(self.uvdim)), 'c16')
         self.pulsefac = pulses * phases
+
+
+def nufft2_backend(imvec, nfft_info):
+    """Type-2 NUFFT: uniform image -> nonuniform visibility samples.
+
+    Dispatches on imvec's array type -- the stateful finufft plan on numpy
+    (byte-identical to the legacy path), jax_finufft.nufft2 on jax (differentiable,
+    GPU-capable). Conventions match: isign=-1, (-pi, pi] points, (xdim, ydim) modes.
+    Callers multiply the result by nfft_info.pulsefac.
+    """
+    xp = array_namespace(imvec)
+    f_hat = imvec.reshape((nfft_info.ydim, nfft_info.xdim)).T
+    if xp is np:
+        nfft_info.plan.f_hat = f_hat
+        nfft_info.plan.trafo()
+        return nfft_info.plan.f.copy()
+    else:
+        # jax_finufft autodiffs the transform; the finufft plan is not used here.
+        from jax_finufft import nufft2
+        uvf = nfft_info.uv_finufft
+        return nufft2(f_hat.astype(xp.complex128), uvf[:, 0], uvf[:, 1],
+                      iflag=-1, eps=nfft_info.eps)
+
 
 class SamplerInfo:
     def __init__(self, order, uv, pulsefac):

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -1466,6 +1466,8 @@ class NFFTInfo:
         # (-pi, pi] form is what FINUFFTPlan expects.
         uv_scaled = uv * psize
         uv_finufft = 2 * np.pi * uv_scaled
+        self.eps = eps
+        self.uv_finufft = uv_finufft  # (-pi, pi] nonuniform points, for jax_finufft.nufft2
         self.plan = FINUFFTPlan(self.xdim, self.ydim, uv_finufft, eps=eps)
 
         phases = np.exp(-1j*np.pi*(uv_scaled[:, 0] + uv_scaled[:, 1]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,6 +157,15 @@ def obs_pol_direct(gauss_im_pol, eht_array):
 
 
 @pytest.fixture(scope="session")
+def obs_pol_nfft(gauss_im_pol, eht_array):
+    """Noise-free observation of the polarized Gaussian image using NFFT."""
+    return gauss_im_pol.observe(
+        eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
+        ampcal=True, phasecal=True, ttype="nfft", add_th_noise=False,
+    )
+
+
+@pytest.fixture(scope="session")
 def obs_gmst(obs_direct):
     """`obs_direct` switched to GMST timetype. Used by tests that exercise GMST branches."""
     return obs_direct.switch_timetype("GMST")

--- a/tests/test_objective_jax.py
+++ b/tests/test_objective_jax.py
@@ -1,0 +1,78 @@
+"""JAX parity tests for the full imaging objective (compute_objective).
+
+unpack_imarr and transform_imarr are now functional, so jax.grad(compute_objective)
+is the jax objective gradient. These check it equals the hand-written
+compute_objective_grad (the gold standard), matches finite differences, and that
+the value agrees numpy<->jax. Stokes-I, ttype='direct' (the #291 kernel scope).
+
+The Imager wrappers objfunc/objgrad call compute_objective/compute_objective_grad,
+so jax.grad(imgr.objfunc) is exactly the autodiff objective gradient.
+"""
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import ehtim as eh
+
+pytestmark = pytest.mark.jax
+
+# rtol, not atol: XLA reorders the float summation, so terms differ from numpy
+# at ~1e-14 relative; a real bug fails by orders of magnitude.
+VALUE_RTOL = 1e-9
+GRAD_RTOL = 1e-9
+GRAD_ATOL = 1e-12
+FD_STEP = 1e-6
+FD_MEDIAN_TOL = 1e-3
+FD_MAX_TOL = 1e-2
+N_FD_SAMPLES = 40
+RNG_SEED = 4
+PERTURB = 0.10
+
+DATA_TERM = {"amp": 100, "cphase": 100, "logcamp": 50}
+REG_TERM = {"simple": 1, "flux": 1}
+
+
+@pytest.fixture(scope="module")
+def imager_I(obs_direct, gauss_im, gauss_prior):
+    imgr = eh.imager.Imager(
+        obs_direct, gauss_prior, prior_im=gauss_prior, flux=gauss_im.total_flux(),
+        data_term=DATA_TERM, reg_term=REG_TERM, ttype="direct", pol="I", maxit=100,
+    )
+    imgr.init_imager()
+    return imgr
+
+
+@pytest.fixture(scope="module")
+def x0(imager_I):
+    # perturb the initial solver vector so the gradient is nonzero
+    rng = np.random.default_rng(RNG_SEED)
+    base = np.asarray(imager_I._init_vec, dtype=np.float64)
+    return base + PERTURB * rng.standard_normal(base.size)
+
+
+def test_value_numpy_jax_consistent(imager_I, x0):
+    v_np = float(imager_I.objfunc(x0))
+    v_jx = float(imager_I.objfunc(jnp.asarray(x0)))
+    assert np.allclose(v_np, v_jx, rtol=VALUE_RTOL, atol=GRAD_ATOL)
+
+
+def test_grad_parity_autodiff_vs_analytic(imager_I, x0):
+    # the gold standard: jax.grad(compute_objective) == compute_objective_grad
+    g_analytic = np.asarray(imager_I.objgrad(x0))
+    g_jax = np.asarray(jax.grad(imager_I.objfunc)(jnp.asarray(x0)))
+    assert np.allclose(g_jax, g_analytic, rtol=GRAD_RTOL, atol=GRAD_ATOL)
+
+
+def test_grad_finite_difference(imager_I, x0):
+    g_analytic = np.asarray(imager_I.objgrad(x0))
+    idx = np.argsort(np.abs(g_analytic))[-N_FD_SAMPLES:]  # best-conditioned pixels
+    g_fd = np.empty(N_FD_SAMPLES)
+    for k, j in enumerate(idx):
+        xp_, xm_ = x0.copy(), x0.copy()
+        xp_[j] += FD_STEP
+        xm_[j] -= FD_STEP
+        g_fd[k] = (float(imager_I.objfunc(xp_)) - float(imager_I.objfunc(xm_))) / (2 * FD_STEP)
+    frac = np.abs((g_fd - g_analytic[idx]) / (np.abs(g_analytic[idx]) + 1e-100))
+    assert np.median(frac) < FD_MEDIAN_TOL
+    assert np.max(frac) < FD_MAX_TOL

--- a/tests/test_objective_jax.py
+++ b/tests/test_objective_jax.py
@@ -31,6 +31,9 @@ GRAD_RTOL = 1e-9
 NFFT_EPS = 1e-12
 NFFT_GRAD_RTOL = 1e-7
 GRAD_ATOL = 1e-12
+# Pol grad tests validate jax.grad against central FD (the ground truth), NOT the
+# analytic compute_objective_grad: the V-pol analytic gradient is wrong (jax and FD
+# agree, the analytic disagrees -- tracked bug), and ptv/vtv have a sqrt singularity.
 FD_STEP = 1e-6
 FD_MEDIAN_TOL = 1e-3
 FD_MAX_TOL = 1e-2
@@ -155,7 +158,8 @@ def pol_imager(obs_pol_direct, gauss_im_pol, gauss_prior):
     # Stokes-I reg only here; pol regs are exercised below.
     imgr = eh.imager.Imager(
         obs_pol_direct, gauss_prior, prior_im=gauss_prior, flux=gauss_im_pol.total_flux(),
-        data_term={"amp": 100, "pvis": 100, "m": 50}, reg_term={"simple": 1},
+        data_term={"amp": 100, "pvis": 100, "m": 50},
+        reg_term={"simple": 1, "hw": 1, "ptv": 1},  # Stokes-I + linear-pol regs
         ttype="direct", pol="IP", transform=["log", "mcv"], maxit=100,
     )
     imgr.init_imager()
@@ -174,7 +178,44 @@ def test_pol_value_numpy_jax_consistent(pol_imager, pol_x0):
                        float(pol_imager.objfunc(jnp.asarray(pol_x0))), rtol=VALUE_RTOL, atol=GRAD_ATOL)
 
 
-def test_pol_grad_parity_autodiff_vs_analytic(pol_imager, pol_x0):
-    g_an = np.asarray(pol_imager.objgrad(pol_x0))
-    g_jax = np.asarray(jax.grad(pol_imager.objfunc)(jnp.asarray(pol_x0)))
-    assert np.allclose(g_jax, g_an, rtol=GRAD_RTOL, atol=GRAD_ATOL)
+def _assert_pol_grad_matches_fd(imgr, x0):
+    # jax.grad vs central FD on the best-conditioned pixels (the ground truth).
+    g_jax = np.asarray(jax.grad(imgr.objfunc)(jnp.asarray(x0)))
+    idx = np.argsort(np.abs(g_jax))[-N_FD_SAMPLES:]
+    g_fd = np.empty(N_FD_SAMPLES)
+    for k, j in enumerate(idx):
+        xp_, xm_ = x0.copy(), x0.copy()
+        xp_[j] += FD_STEP
+        xm_[j] -= FD_STEP
+        g_fd[k] = (float(imgr.objfunc(xp_)) - float(imgr.objfunc(xm_))) / (2 * FD_STEP)
+    frac = np.abs((g_fd - g_jax[idx]) / (np.abs(g_jax[idx]) + 1e-100))
+    assert np.median(frac) < FD_MEDIAN_TOL
+    assert np.max(frac) < FD_MAX_TOL
+
+
+def test_pol_grad_finite_difference(pol_imager, pol_x0):
+    _assert_pol_grad_matches_fd(pol_imager, pol_x0)
+
+
+@pytest.fixture(scope="module")
+def pol_imager_v(obs_pol_direct, gauss_im_pol, gauss_prior):
+    # IV imaging: Stokes I + circular pol (vvis); vcv change-of-variables; V regs.
+    imgr = eh.imager.Imager(
+        obs_pol_direct, gauss_prior, prior_im=gauss_prior, flux=gauss_im_pol.total_flux(),
+        data_term={"amp": 100, "vvis": 100},
+        reg_term={"simple": 1, "l1v": 1, "vtv": 1},
+        ttype="direct", pol="IV", transform=["log", "vcv"], maxit=100,
+    )
+    imgr.init_imager()
+    return imgr
+
+
+@pytest.fixture(scope="module")
+def pol_v_x0(pol_imager_v):
+    rng = np.random.default_rng(RNG_SEED)
+    base = np.asarray(pol_imager_v._init_vec, dtype=np.float64)
+    return base + PERTURB * rng.standard_normal(base.size)
+
+
+def test_pol_v_grad_finite_difference(pol_imager_v, pol_v_x0):
+    _assert_pol_grad_matches_fd(pol_imager_v, pol_v_x0)

--- a/tests/test_objective_jax.py
+++ b/tests/test_objective_jax.py
@@ -3,7 +3,8 @@
 unpack_imarr and transform_imarr are now functional, so jax.grad(compute_objective)
 is the jax objective gradient. These check it equals the hand-written
 compute_objective_grad (the gold standard), matches finite differences, and that
-the value agrees numpy<->jax. Stokes-I, ttype='direct' (the #291 kernel scope).
+the value agrees numpy<->jax. Stokes-I across ttype direct + nfft, all regularizers
+(embed-free + spatial), full and partial embed masks.
 
 The Imager wrappers objfunc/objgrad call compute_objective/compute_objective_grad,
 so jax.grad(imgr.objfunc) is exactly the autodiff objective gradient.
@@ -14,6 +15,7 @@ import numpy as np
 import pytest
 
 import ehtim as eh
+import ehtim.imaging.imager_utils as iu
 from ehtim.imaging.imager_backend import make_objective_jax
 
 pytestmark = pytest.mark.jax
@@ -37,7 +39,7 @@ RNG_SEED = 4
 PERTURB = 0.10
 
 DATA_TERM = {"amp": 100, "cphase": 100, "logcamp": 50}
-REG_TERM = {"simple": 1, "flux": 1}
+REG_TERM = {"simple": 1, "flux": 1, "tv": 10}  # tv exercises the spatial-reg path
 
 
 @pytest.fixture(scope="module", params=["direct", "nfft"])
@@ -120,3 +122,28 @@ def test_objective_traces_once_across_x(imager, x0):
     f(jnp.asarray(x0)).block_until_ready()
     f(jnp.asarray(x0 + 0.5)).block_until_ready()
     assert traces["n"] == 1
+
+
+def test_embed_functional_jax():
+    # embed's functional scatter is byte-identical on numpy and differentiable on jax
+    mask = np.array([True, False, True, False, True, True])
+    imvec = np.array([1.0, 2.0, 3.0, 4.0])
+    assert np.array_equal(iu.embed(imvec, mask), np.asarray(iu.embed(jnp.asarray(imvec), mask)))
+    g = jax.grad(lambda v: jnp.sum(iu.embed(v, mask) ** 2))(jnp.asarray(imvec))
+    assert np.allclose(np.asarray(g), 2 * imvec)  # grad routes only to on-mask pixels
+
+
+def test_spatial_reg_partial_mask_parity():
+    # reg_tv with a partial mask exercises the embed scatter under jax; clipfloor=0
+    # makes the off-mask fill deterministic (no seed needed for numpy<->jax parity).
+    rng = np.random.default_rng(0)
+    ny, nx = 6, 6
+    full = rng.uniform(0.1, 1.0, ny * nx)
+    mask = np.ones(ny * nx, dtype=bool)
+    mask[rng.choice(ny * nx, 8, replace=False)] = False
+    imvec = full[mask]
+    kw = dict(xdim=nx, ydim=ny, psize=1.0, flux=float(full.sum()), beam_size=2.0, norm_reg=True)
+    assert np.allclose(iu.reg_tv(imvec, mask, **kw),
+                       float(iu.reg_tv(jnp.asarray(imvec), mask, **kw)), rtol=1e-12)
+    g_jax = np.asarray(jax.grad(lambda v: iu.reg_tv(v, mask, **kw))(jnp.asarray(imvec)))
+    assert np.allclose(g_jax, iu.reggrad_tv(imvec, mask, **kw), rtol=1e-8, atol=1e-10)

--- a/tests/test_objective_jax.py
+++ b/tests/test_objective_jax.py
@@ -243,3 +243,31 @@ def test_make_image_use_jax_recovers_and_matches_numpy(obs_direct, gauss_im, gau
     im_np, im_jx = recon(False), recon(True)
     assert _nxcorr(im_jx, truth) > 0.9    # jax recon recovers the source
     assert _nxcorr(im_jx, im_np) > 0.95   # jax matches numpy (same objective)
+
+
+def _has_gpu():
+    try:
+        return len(jax.devices("gpu")) > 0
+    except RuntimeError:
+        return False
+
+
+requires_gpu = pytest.mark.skipif(not _has_gpu(), reason="no CUDA GPU available")
+
+
+@pytest.mark.gpu
+@requires_gpu
+def test_objective_runs_on_gpu(imager, x0):
+    gpu = jax.devices("gpu")[0]
+    value, grad = _make_fun(imager, device=gpu)(x0)
+    assert np.isfinite(value) and np.all(np.isfinite(grad))
+
+
+@pytest.mark.gpu
+@requires_gpu
+def test_objective_gpu_cpu_parity(imager, x0):
+    cpu, gpu = jax.devices("cpu")[0], jax.devices("gpu")[0]
+    v_c, g_c = _make_fun(imager, device=cpu)(x0)
+    v_g, g_g = _make_fun(imager, device=gpu)(x0)
+    assert np.allclose(v_c, v_g, rtol=_grad_rtol(imager), atol=1e-9)
+    assert np.allclose(g_c, g_g, rtol=_grad_rtol(imager), atol=1e-9)

--- a/tests/test_objective_jax.py
+++ b/tests/test_objective_jax.py
@@ -1,13 +1,20 @@
-"""JAX parity tests for the full imaging objective (compute_objective).
+"""JAX parity tests for the imaging objective (compute_objective).
 
-unpack_imarr and transform_imarr are now functional, so jax.grad(compute_objective)
-is the jax objective gradient. These check it equals the hand-written
-compute_objective_grad (the gold standard), matches finite differences, and that
-the value agrees numpy<->jax. Stokes-I across ttype direct + nfft, all regularizers
-(embed-free + spatial), full and partial embed masks.
+Each case checks, uniformly: value parity (numpy vs jax), analytic-gradient parity
+(jax.grad vs the hand-written objgrad), and finite differences. The union of the
+parametrized cases exercises every jaxified function:
 
-The Imager wrappers objfunc/objgrad call compute_objective/compute_objective_grad,
-so jax.grad(imgr.objfunc) is exactly the autodiff objective gradient.
+  * transforms      : direct + nfft
+  * Stokes-I chisqs : vis, amp, bs, cphase, camp, logcamp  (the _diag closures are
+                      numpy-only, not jaxified)
+  * Stokes-I regs   : simple, flux, l1, l1w, gs, patch, cm, tv, tvlog, tv2, tv2log,
+                      compact, compact2, rgauss
+  * pol modes       : IP/P (mcv), IV/V (vcv), IQUV/IPV (polcv) -- all full parity
+  * pol chisqs      : pvis, m, vvis    pol regs : msimple, hw, ptv, vflux, l1v, l2v, vtv, vtv2
+  * multifrequency  : 2-frequency Stokes-I, mf_order=1, l2_alpha + tv_alpha
+
+Pol tests use an asymmetric image: a symmetric source zeros gradient components and
+hides bugs (these parity checks caught several mcv/vcv gradient errors).
 """
 import jax
 import jax.numpy as jnp
@@ -17,82 +24,98 @@ import pytest
 import ehtim as eh
 import ehtim.imaging.imager_utils as iu
 from ehtim.imaging.imager_backend import make_objective_jax
+from ehtim.observing.obs_helpers import NFFTInfo, ftmatrix, nufft2_backend
 
 pytestmark = pytest.mark.jax
 
-# rtol, not atol: XLA reorders the float summation, so terms differ from numpy
-# at ~1e-14 relative; a real bug fails by orders of magnitude.
+# rtol, not atol: XLA reorders the float summation, so terms differ from numpy at
+# ~1e-14 relative; a real bug fails by orders of magnitude.
 VALUE_RTOL = 1e-9
 GRAD_RTOL = 1e-9
+GRAD_ATOL = 1e-12
 # nfft is an approximate transform: jax_finufft's VJP matches the analytic adjoint
-# only to the NUFFT accuracy. The residual scales with eps (verified 1e-9 -> ~1e-6,
-# 1e-12 -> ~7e-10 max), so the nfft fixture uses eps=1e-12 and this looser-but-tight
-# rtol; a real VJP bug is eps-independent and fails by orders of magnitude.
+# only to the NUFFT accuracy. The residual scales with eps (1e-9 -> ~1e-6, 1e-12 ->
+# ~7e-10); the nfft fixtures use eps=1e-12 and this looser-but-tight rtol. A real VJP
+# bug is eps-independent and fails by orders of magnitude.
 NFFT_EPS = 1e-12
 NFFT_GRAD_RTOL = 1e-7
-GRAD_ATOL = 1e-12
-# Pol grad tests validate jax.grad against central FD (the ground truth), NOT the
-# analytic compute_objective_grad: the V-pol analytic gradient is wrong (jax and FD
-# agree, the analytic disagrees -- tracked bug), and ptv/vtv have a sqrt singularity.
+# finite-difference comparison (jax.grad vs central differences on best-conditioned pixels)
 FD_STEP = 1e-6
 FD_MEDIAN_TOL = 1e-3
 FD_MAX_TOL = 1e-2
-N_FD_SAMPLES = 40
+N_FD_SAMPLES = 30
 RNG_SEED = 4
 PERTURB = 0.10
+# uniform epsilon for the TV-family sqrt (tv/tvlog/ptv/vtv...); the default 0 is
+# singular where neighbouring pixels are equal, in Stokes I exactly as in pol.
+EPSILON_TV = 1e-10
 
-DATA_TERM = {"amp": 100, "cphase": 100, "logcamp": 50}
-REG_TERM = {"simple": 1, "flux": 1, "tv": 10}  # tv exercises the spatial-reg path
+# --- coverage cases: the union exercises every jaxified chisq + regularizer ---
+STOKESI_CASES = [
+    ({"vis": 100, "amp": 100, "bs": 100},
+     {"simple": 1, "flux": 1, "tv": 10, "l1": 1, "gs": 1, "tv2": 1, "l1w": 1}),
+    ({"cphase": 100, "camp": 50, "logcamp": 50},
+     {"patch": 1, "cm": 1, "tvlog": 1, "tv2log": 1, "compact": 1, "compact2": 1, "rgauss": 1}),
+]
+_SI_PARAMS = [("direct", 0), ("direct", 1), ("nfft", 0), ("nfft", 1)]
+_SI_IDS = ["direct-A", "direct-B", "nfft-A", "nfft-B"]
+
+# Six pol modes across mcv/vcv/polcv. V can't use log (V is signed) or simple/gs regs;
+# IPV aliases IQUV. Union covers all pol chisqs + regs.
+POL_CASES = [
+    ("IP",   ["log", "mcv"],   {"amp": 100, "pvis": 100, "m": 50}, {"simple": 1, "msimple": 1, "hw": 1, "ptv": 1}),
+    ("P",    ["log", "mcv"],   {"pvis": 100, "m": 50}, {"msimple": 1, "hw": 1, "ptv": 1}),
+    ("IV",   ["log", "vcv"],   {"amp": 100, "vvis": 100}, {"simple": 1, "vflux": 1, "l1v": 1, "vtv": 1}),
+    ("V",    ["vcv"],          {"vvis": 100}, {"vflux": 1, "l1v": 1, "l2v": 1, "vtv": 1, "vtv2": 1}),
+    ("IQUV", ["log", "polcv"], {"amp": 100, "pvis": 100, "m": 50, "vvis": 100}, {"simple": 1, "l2v": 1, "vtv2": 1}),
+    ("IPV",  ["log", "polcv"], {"amp": 100, "pvis": 100, "m": 50, "vvis": 100}, {"simple": 1, "l2v": 1, "vtv2": 1}),
+]
+_POL_IDS = [c[0] for c in POL_CASES]
+
+# nfft pol: all six modes, parallel to direct (exercises the _nfft chisqs + gradients).
+_POL_NFFT_CASES = POL_CASES
+_POL_NFFT_IDS = _POL_IDS
 
 
-@pytest.fixture(scope="module", params=["direct", "nfft"])
-def imager(request, obs_direct, obs_nfft, gauss_im, gauss_prior):
-    ttype = request.param
-    obs = obs_direct if ttype == "direct" else obs_nfft
-    extra = {} if ttype == "direct" else {"nfft_eps": NFFT_EPS}
-    imgr = eh.imager.Imager(
-        obs, gauss_prior, prior_im=gauss_prior, flux=gauss_im.total_flux(),
-        data_term=DATA_TERM, reg_term=REG_TERM, ttype=ttype, pol="I", maxit=100, **extra,
-    )
-    imgr.init_imager()
-    return imgr
+# ============================== shared helpers ==============================
+def _x0(imgr):
+    # perturb the initial solver vector so the gradient is nonzero
+    rng = np.random.default_rng(RNG_SEED)
+    base = np.asarray(imgr._init_vec, dtype=np.float64)
+    return base + PERTURB * rng.standard_normal(base.size)
 
 
 def _grad_rtol(imgr):
     return GRAD_RTOL if imgr._config.ttype == "direct" else NFFT_GRAD_RTOL
 
 
-@pytest.fixture(scope="module")
-def x0(imager):
-    # perturb the initial solver vector so the gradient is nonzero
-    rng = np.random.default_rng(RNG_SEED)
-    base = np.asarray(imager._init_vec, dtype=np.float64)
-    return base + PERTURB * rng.standard_normal(base.size)
-
-
-def test_value_numpy_jax_consistent(imager, x0):
-    v_np = float(imager.objfunc(x0))
-    v_jx = float(imager.objfunc(jnp.asarray(x0)))
+def _assert_value(imgr, x):
+    v_np = float(imgr.objfunc(np.asarray(x)))
+    v_jx = float(imgr.objfunc(jnp.asarray(x)))
     assert np.allclose(v_np, v_jx, rtol=VALUE_RTOL, atol=GRAD_ATOL)
 
 
-def test_grad_parity_autodiff_vs_analytic(imager, x0):
-    # the gold standard: jax.grad(compute_objective) == compute_objective_grad
-    g_analytic = np.asarray(imager.objgrad(x0))
-    g_jax = np.asarray(jax.grad(imager.objfunc)(jnp.asarray(x0)))
-    assert np.allclose(g_jax, g_analytic, rtol=_grad_rtol(imager), atol=GRAD_ATOL)
+def _assert_grad_analytic(imgr, x):
+    # jax.grad vs the hand-written analytic, compared in norm. nfft's VJP matches the
+    # analytic adjoint only to the NUFFT eps (relative), so a per-component atol would
+    # trip on negligible near-zero components; the norm ratio still catches real bugs
+    # (the fixed mcv/vcv gradient bugs were ~1e-2 here, far above the 1e-9 threshold).
+    g_an = np.asarray(imgr.objgrad(np.asarray(x)))
+    g_jx = np.asarray(jax.grad(imgr.objfunc)(jnp.asarray(x)))
+    rel = np.linalg.norm(g_jx - g_an) / np.linalg.norm(g_an)
+    assert rel < _grad_rtol(imgr), f"||jax - analytic|| / ||analytic|| = {rel:.2e}"
 
 
-def test_grad_finite_difference(imager, x0):
-    g_analytic = np.asarray(imager.objgrad(x0))
-    idx = np.argsort(np.abs(g_analytic))[-N_FD_SAMPLES:]  # best-conditioned pixels
+def _assert_grad_fd(imgr, x):
+    g_jx = np.asarray(jax.grad(imgr.objfunc)(jnp.asarray(x)))
+    idx = np.argsort(np.abs(g_jx))[-N_FD_SAMPLES:]  # best-conditioned pixels
     g_fd = np.empty(N_FD_SAMPLES)
     for k, j in enumerate(idx):
-        xp_, xm_ = x0.copy(), x0.copy()
+        xp_, xm_ = np.array(x, float), np.array(x, float)
         xp_[j] += FD_STEP
         xm_[j] -= FD_STEP
-        g_fd[k] = (float(imager.objfunc(xp_)) - float(imager.objfunc(xm_))) / (2 * FD_STEP)
-    frac = np.abs((g_fd - g_analytic[idx]) / (np.abs(g_analytic[idx]) + 1e-100))
+        g_fd[k] = (float(imgr.objfunc(xp_)) - float(imgr.objfunc(xm_))) / (2 * FD_STEP)
+    frac = np.abs((g_fd - g_jx[idx]) / (np.abs(g_jx[idx]) + 1e-100))
     assert np.median(frac) < FD_MEDIAN_TOL
     assert np.max(frac) < FD_MAX_TOL
 
@@ -106,6 +129,39 @@ def _make_fun(imgr, device=None):
     )
 
 
+# ============================== Stokes-I ==============================
+@pytest.fixture(scope="module", params=_SI_PARAMS, ids=_SI_IDS)
+def imager(request, obs_direct, obs_nfft, gauss_im, gauss_prior):
+    ttype, case = request.param
+    data_term, reg_term = STOKESI_CASES[case]
+    obs = obs_direct if ttype == "direct" else obs_nfft
+    extra = {} if ttype == "direct" else {"nfft_eps": NFFT_EPS}
+    imgr = eh.imager.Imager(
+        obs, gauss_prior, prior_im=gauss_prior, flux=gauss_im.total_flux(),
+        data_term=data_term, reg_term=reg_term, ttype=ttype, pol="I",
+        maxit=100, epsilon_tv=EPSILON_TV, **extra,
+    )
+    imgr.init_imager()
+    return imgr
+
+
+@pytest.fixture(scope="module")
+def x0(imager):
+    return _x0(imager)
+
+
+def test_value_numpy_jax_consistent(imager, x0):
+    _assert_value(imager, x0)
+
+
+def test_grad_parity_autodiff_vs_analytic(imager, x0):
+    _assert_grad_analytic(imager, x0)
+
+
+def test_grad_finite_difference(imager, x0):
+    _assert_grad_fd(imager, x0)
+
+
 def test_factory_matches_analytic(imager, x0):
     value, grad = _make_fun(imager)(x0)
     assert np.allclose(value, float(imager.objfunc(x0)), rtol=VALUE_RTOL, atol=GRAD_ATOL)
@@ -113,8 +169,7 @@ def test_factory_matches_analytic(imager, x0):
 
 
 def test_objective_traces_once_across_x(imager, x0):
-    # the factory closes over everything but x, so one jit trace serves every
-    # solver step; here we count traces of objfunc (what the factory jits).
+    # the factory closes over everything but x, so one jit trace serves every solver step.
     traces = {"n": 0}
 
     def counted(x):
@@ -127,6 +182,7 @@ def test_objective_traces_once_across_x(imager, x0):
     assert traces["n"] == 1
 
 
+# ============================== embed / partial mask ==============================
 def test_embed_functional_jax():
     # embed's functional scatter is byte-identical on numpy and differentiable on jax
     mask = np.array([True, False, True, False, True, True])
@@ -152,15 +208,51 @@ def test_spatial_reg_partial_mask_parity():
     assert np.allclose(g_jax, iu.reggrad_tv(imvec, mask, **kw), rtol=1e-8, atol=1e-10)
 
 
+# ============================== nufft2_backend equality ==============================
+def test_nufft2_backend_numpy_jax_equality():
+    # nufft2_backend dispatches finufft (numpy) vs jax_finufft (jax); the two must agree,
+    # and both must reproduce the direct DFT to NFFT accuracy. (The chisqs exercise this
+    # indirectly; this pins it down on its own.)
+    npix, psize = 16, 200 * eh.RADPERUAS / 16
+    pulse = eh.observing.pulses.trianglePulse2D
+    rng = np.random.default_rng(1)
+    uv = rng.uniform(-2e9, 2e9, size=(40, 2))
+    nfft_info = NFFTInfo(npix, npix, psize, pulse, 1, 2, uv, eps=1e-12)
+    imvec = rng.standard_normal(npix * npix) + 1j * rng.standard_normal(npix * npix)
+
+    s_np = np.asarray(nufft2_backend(imvec, nfft_info))
+    s_jx = np.asarray(nufft2_backend(jnp.asarray(imvec), nfft_info))
+    assert np.allclose(s_np, s_jx, rtol=1e-9, atol=1e-9)  # numpy == jax
+
+    s_dft = ftmatrix(psize, npix, npix, uv, pulse=pulse) @ imvec
+    assert np.allclose(s_np * nfft_info.pulsefac, s_dft, rtol=1e-6, atol=1e-6)  # == DFT
+
+
+# ============================== Polarization ==============================
+# Asymmetric image (off-center, elongated): symmetry would zero gradient components
+# and hide the pol-gradient bugs these tests guard.
 @pytest.fixture(scope="module")
-def pol_imager(obs_pol_direct, gauss_im_pol, gauss_prior):
-    # IP imaging: Stokes I + linear pol (pvis, m); mcv change-of-variables.
-    # Stokes-I reg only here; pol regs are exercised below.
+def pol_asym(eht_array):
+    R = eh.RADPERUAS
+    im = eh.image.make_empty(32, 200 * R, 17.761, -29.0, rf=230e9)
+    im = im.add_gauss(1.0, (60 * R, 30 * R, 0.5, 25 * R, -20 * R))
+    im.add_qu(0.10 * im.imarr(), 0.05 * im.imarr())
+    im.add_v(0.02 * im.imarr())
+    prior = im.blur_circ(35 * R)
+    kw = dict(ampcal=True, phasecal=True, add_th_noise=True, seed=42)
+    obs_d = im.observe(eht_array, 5, 600, 0, 24, 4e9, ttype="direct", **kw)
+    obs_n = im.observe(eht_array, 5, 600, 0, 24, 4e9, ttype="nfft", **kw)
+    return im, prior, obs_d, obs_n
+
+
+@pytest.fixture(scope="module", params=POL_CASES, ids=_POL_IDS)
+def pol_imager(request, pol_asym):
+    im, prior, obs_d, _ = pol_asym
+    mode, transform, data_term, reg_term = request.param
     imgr = eh.imager.Imager(
-        obs_pol_direct, gauss_prior, prior_im=gauss_prior, flux=gauss_im_pol.total_flux(),
-        data_term={"amp": 100, "pvis": 100, "m": 50},
-        reg_term={"simple": 1, "hw": 1, "ptv": 1},  # Stokes-I + linear-pol regs
-        ttype="direct", pol="IP", transform=["log", "mcv"], maxit=100,
+        obs_d, prior, prior_im=prior, flux=im.total_flux(),
+        data_term=data_term, reg_term=reg_term, ttype="direct", pol=mode,
+        transform=transform, maxit=100, epsilon_tv=EPSILON_TV,
     )
     imgr.init_imager()
     return imgr
@@ -168,74 +260,30 @@ def pol_imager(obs_pol_direct, gauss_im_pol, gauss_prior):
 
 @pytest.fixture(scope="module")
 def pol_x0(pol_imager):
-    rng = np.random.default_rng(RNG_SEED)
-    base = np.asarray(pol_imager._init_vec, dtype=np.float64)
-    return base + PERTURB * rng.standard_normal(base.size)
+    return _x0(pol_imager)
 
 
 def test_pol_value_numpy_jax_consistent(pol_imager, pol_x0):
-    assert np.allclose(float(pol_imager.objfunc(pol_x0)),
-                       float(pol_imager.objfunc(jnp.asarray(pol_x0))), rtol=VALUE_RTOL, atol=GRAD_ATOL)
+    _assert_value(pol_imager, pol_x0)
 
 
-def _assert_pol_grad_matches_fd(imgr, x0):
-    # jax.grad vs central FD on the best-conditioned pixels (the ground truth).
-    g_jax = np.asarray(jax.grad(imgr.objfunc)(jnp.asarray(x0)))
-    idx = np.argsort(np.abs(g_jax))[-N_FD_SAMPLES:]
-    g_fd = np.empty(N_FD_SAMPLES)
-    for k, j in enumerate(idx):
-        xp_, xm_ = x0.copy(), x0.copy()
-        xp_[j] += FD_STEP
-        xm_[j] -= FD_STEP
-        g_fd[k] = (float(imgr.objfunc(xp_)) - float(imgr.objfunc(xm_))) / (2 * FD_STEP)
-    frac = np.abs((g_fd - g_jax[idx]) / (np.abs(g_jax[idx]) + 1e-100))
-    assert np.median(frac) < FD_MEDIAN_TOL
-    assert np.max(frac) < FD_MAX_TOL
+def test_pol_grad_parity_autodiff_vs_analytic(pol_imager, pol_x0):
+    # parallel to Stokes I: jax.grad == analytic, now that the IV (vcv) gradient is fixed
+    _assert_grad_analytic(pol_imager, pol_x0)
 
 
 def test_pol_grad_finite_difference(pol_imager, pol_x0):
-    _assert_pol_grad_matches_fd(pol_imager, pol_x0)
+    _assert_grad_fd(pol_imager, pol_x0)
 
 
-@pytest.fixture(scope="module")
-def pol_imager_v(obs_pol_direct, gauss_im_pol, gauss_prior):
-    # IV imaging: Stokes I + circular pol (vvis); vcv change-of-variables; V regs.
+@pytest.fixture(scope="module", params=_POL_NFFT_CASES, ids=_POL_NFFT_IDS)
+def pol_imager_nfft(request, pol_asym):
+    im, prior, _, obs_n = pol_asym
+    mode, transform, data_term, reg_term = request.param
     imgr = eh.imager.Imager(
-        obs_pol_direct, gauss_prior, prior_im=gauss_prior, flux=gauss_im_pol.total_flux(),
-        data_term={"amp": 100, "vvis": 100},
-        reg_term={"simple": 1, "l1v": 1, "vtv": 1},
-        ttype="direct", pol="IV", transform=["log", "vcv"], maxit=100,
-    )
-    imgr.init_imager()
-    return imgr
-
-
-@pytest.fixture(scope="module")
-def pol_v_x0(pol_imager_v):
-    rng = np.random.default_rng(RNG_SEED)
-    base = np.asarray(pol_imager_v._init_vec, dtype=np.float64)
-    return base + PERTURB * rng.standard_normal(base.size)
-
-
-def test_pol_v_grad_finite_difference(pol_imager_v, pol_v_x0):
-    _assert_pol_grad_matches_fd(pol_imager_v, pol_v_x0)
-
-
-# nfft pol: routes chisq_{p,m,vvis}_nfft through nufft2_backend (jax_finufft).
-# IP exercises chisq_p_nfft (pvis) + chisq_m_nfft (m); IV exercises chisq_vvis_nfft.
-_POL_NFFT_CASES = [
-    ("IP", {"amp": 100, "pvis": 100, "m": 50}, {"simple": 1, "hw": 1, "ptv": 1}, ["log", "mcv"]),
-    ("IV", {"amp": 100, "vvis": 100}, {"simple": 1, "l1v": 1, "vtv": 1}, ["log", "vcv"]),
-]
-
-
-@pytest.fixture(scope="module", params=_POL_NFFT_CASES, ids=["IP", "IV"])
-def pol_imager_nfft(request, obs_pol_nfft, gauss_im_pol, gauss_prior):
-    pol, data_term, reg_term, transform = request.param
-    imgr = eh.imager.Imager(
-        obs_pol_nfft, gauss_prior, prior_im=gauss_prior, flux=gauss_im_pol.total_flux(),
-        data_term=data_term, reg_term=reg_term, ttype="nfft", pol=pol,
-        transform=transform, maxit=100, nfft_eps=NFFT_EPS,
+        obs_n, prior, prior_im=prior, flux=im.total_flux(),
+        data_term=data_term, reg_term=reg_term, ttype="nfft", pol=mode,
+        transform=transform, maxit=100, nfft_eps=NFFT_EPS, epsilon_tv=EPSILON_TV,
     )
     imgr.init_imager()
     return imgr
@@ -243,21 +291,68 @@ def pol_imager_nfft(request, obs_pol_nfft, gauss_im_pol, gauss_prior):
 
 @pytest.fixture(scope="module")
 def pol_nfft_x0(pol_imager_nfft):
-    rng = np.random.default_rng(RNG_SEED)
-    base = np.asarray(pol_imager_nfft._init_vec, dtype=np.float64)
-    return base + PERTURB * rng.standard_normal(base.size)
+    return _x0(pol_imager_nfft)
 
 
 def test_pol_nfft_value_numpy_jax_consistent(pol_imager_nfft, pol_nfft_x0):
-    assert np.allclose(float(pol_imager_nfft.objfunc(pol_nfft_x0)),
-                       float(pol_imager_nfft.objfunc(jnp.asarray(pol_nfft_x0))),
-                       rtol=VALUE_RTOL, atol=GRAD_ATOL)
+    _assert_value(pol_imager_nfft, pol_nfft_x0)
+
+
+def test_pol_nfft_grad_parity_autodiff_vs_analytic(pol_imager_nfft, pol_nfft_x0):
+    _assert_grad_analytic(pol_imager_nfft, pol_nfft_x0)
 
 
 def test_pol_nfft_grad_finite_difference(pol_imager_nfft, pol_nfft_x0):
-    _assert_pol_grad_matches_fd(pol_imager_nfft, pol_nfft_x0)
+    _assert_grad_fd(pol_imager_nfft, pol_nfft_x0)
 
 
+# ============================== Multifrequency (Stokes-I) ==============================
+# TODO: this uses a 2-frequency synthetic Gaussian with a constant spectral index. Add
+# real multifrequency synthetic data (multiple realistic bands) for thorough coverage,
+# and extend to multifrequency *polarization* (currently only Stokes-I mf is covered).
+@pytest.fixture(scope="module")
+def _mf_setup(gauss_im, eht_array):
+    im = gauss_im.copy().add_const_mf(1.0, 0)  # alpha=1, beta=0
+    prior = im.blur_circ(40 * eh.RADPERUAS)
+    obslist = [
+        im.get_image_mf(nu).observe(eht_array, 5, 600, 0, 24, 4e9, ampcal=True,
+                                     phasecal=True, ttype="direct", add_th_noise=True, seed=42)
+        for nu in (220e9, 240e9)
+    ]
+    return obslist, prior, im
+
+
+@pytest.fixture(scope="module")
+def mf_imager(_mf_setup):
+    obslist, prior, im = _mf_setup
+    imgr = eh.imager.Imager(
+        obslist, prior, prior_im=prior, flux=im.total_flux(),
+        data_term={"amp": 100, "cphase": 100},
+        reg_term={"simple": 1, "tv": 1, "l2_alpha": 1, "tv_alpha": 1},  # + spectral-index regs
+        ttype="direct", pol="I", mf=True, mf_order=1, maxit=100, epsilon_tv=EPSILON_TV,
+    )
+    imgr.init_imager()
+    return imgr
+
+
+@pytest.fixture(scope="module")
+def mf_x0(mf_imager):
+    return _x0(mf_imager)
+
+
+def test_mf_value_numpy_jax_consistent(mf_imager, mf_x0):
+    _assert_value(mf_imager, mf_x0)
+
+
+def test_mf_grad_parity_autodiff_vs_analytic(mf_imager, mf_x0):
+    _assert_grad_analytic(mf_imager, mf_x0)
+
+
+def test_mf_grad_finite_difference(mf_imager, mf_x0):
+    _assert_grad_fd(mf_imager, mf_x0)
+
+
+# ============================== OO integration ==============================
 def _nxcorr(a, b):
     a = a - a.mean()
     b = b - b.mean()
@@ -266,8 +361,8 @@ def _nxcorr(a, b):
 
 @pytest.mark.slow
 def test_make_image_use_jax_recovers_and_matches_numpy(obs_direct, gauss_im, gauss_prior):
-    # OO integration: make_image(use_jax=True) runs the jax objective end to end
-    # through scipy L-BFGS-B and recovers the source; matches the numpy path.
+    # make_image(use_jax=True) runs the jax objective end to end through scipy
+    # L-BFGS-B and recovers the source; it matches the numpy path (same objective).
     def recon(use_jax):
         imgr = eh.imager.Imager(
             obs_direct, gauss_prior, prior_im=gauss_prior, flux=gauss_im.total_flux(),
@@ -279,9 +374,10 @@ def test_make_image_use_jax_recovers_and_matches_numpy(obs_direct, gauss_im, gau
     truth = gauss_im.imvec
     im_np, im_jx = recon(False), recon(True)
     assert _nxcorr(im_jx, truth) > 0.9    # jax recon recovers the source
-    assert _nxcorr(im_jx, im_np) > 0.95   # jax matches numpy (same objective)
+    assert _nxcorr(im_jx, im_np) > 0.95   # jax matches numpy
 
 
+# ============================== GPU ==============================
 def _has_gpu():
     try:
         return len(jax.devices("gpu")) > 0
@@ -308,33 +404,3 @@ def test_objective_gpu_cpu_parity(imager, x0):
     v_g, g_g = _make_fun(imager, device=gpu)(x0)
     assert np.allclose(v_c, v_g, rtol=_grad_rtol(imager), atol=1e-9)
     assert np.allclose(g_c, g_g, rtol=_grad_rtol(imager), atol=1e-9)
-
-
-def test_image_at_freq_jax():
-    # Multifrequency forward (I0, alpha, beta) -> I(nu): numpy==jax + differentiable.
-    # Full mf-imaging recon is a follow-up (needs a multi-frequency obs).
-    import ehtim.imaging.multifreq_imager_utils as mfu
-    mfarr = np.array([np.full(8, 2.0), np.full(8, -0.7), np.full(8, 0.1)])  # I0, alpha, beta
-    lf = 0.3
-    out_np = mfu.image_at_freq(mfarr, lf)
-    out_jx = np.asarray(mfu.image_at_freq(jnp.asarray(mfarr), lf))
-    assert np.allclose(out_np, out_jx, rtol=VALUE_RTOL, atol=GRAD_ATOL)
-    g = jax.grad(lambda a: jnp.sum(mfu.image_at_freq(a, lf)))(jnp.asarray(mfarr))
-    assert np.all(np.isfinite(np.asarray(g)))
-
-
-def test_ptv_epsilon_tv_removes_singularity():
-    # A constant-P image makes every |P_l1 - P| = 0, so the unregularized |P|-TV
-    # gradient is singular (0/0) there; epsilon_tv > 0 keeps it finite. epsilon_tv
-    # defaults to 0 (byte-identical to before) -- this just enables the knob, as for reg_tv.
-    import ehtim.imaging.pol_imager_utils as pu
-    n = 36
-    ny = nx = 6
-    imarr = np.ones((4, n))
-    imarr[0], imarr[1], imarr[2], imarr[3] = 2.0, 0.3, 0.5, 0.2  # spatially constant P
-    mask = np.ones(n, dtype=bool)
-    kw = dict(flux=float(imarr[0].sum()), xdim=nx, ydim=ny, psize=1.0, beam_size=2.0, norm_reg=True)
-    g0 = np.asarray(jax.grad(lambda a: pu.reg_ptv(a, mask, epsilon_tv=0.0, **kw))(jnp.asarray(imarr)))
-    ge = np.asarray(jax.grad(lambda a: pu.reg_ptv(a, mask, epsilon_tv=0.01, **kw))(jnp.asarray(imarr)))
-    assert not np.all(np.isfinite(g0))  # singular without epsilon_tv
-    assert np.all(np.isfinite(ge))      # finite with epsilon_tv

--- a/tests/test_objective_jax.py
+++ b/tests/test_objective_jax.py
@@ -147,3 +147,34 @@ def test_spatial_reg_partial_mask_parity():
                        float(iu.reg_tv(jnp.asarray(imvec), mask, **kw)), rtol=1e-12)
     g_jax = np.asarray(jax.grad(lambda v: iu.reg_tv(v, mask, **kw))(jnp.asarray(imvec)))
     assert np.allclose(g_jax, iu.reggrad_tv(imvec, mask, **kw), rtol=1e-8, atol=1e-10)
+
+
+@pytest.fixture(scope="module")
+def pol_imager(obs_pol_direct, gauss_im_pol, gauss_prior):
+    # IP imaging: Stokes I + linear pol (pvis, m); mcv change-of-variables.
+    # Stokes-I reg only here; pol regs are exercised below.
+    imgr = eh.imager.Imager(
+        obs_pol_direct, gauss_prior, prior_im=gauss_prior, flux=gauss_im_pol.total_flux(),
+        data_term={"amp": 100, "pvis": 100, "m": 50}, reg_term={"simple": 1},
+        ttype="direct", pol="IP", transform=["log", "mcv"], maxit=100,
+    )
+    imgr.init_imager()
+    return imgr
+
+
+@pytest.fixture(scope="module")
+def pol_x0(pol_imager):
+    rng = np.random.default_rng(RNG_SEED)
+    base = np.asarray(pol_imager._init_vec, dtype=np.float64)
+    return base + PERTURB * rng.standard_normal(base.size)
+
+
+def test_pol_value_numpy_jax_consistent(pol_imager, pol_x0):
+    assert np.allclose(float(pol_imager.objfunc(pol_x0)),
+                       float(pol_imager.objfunc(jnp.asarray(pol_x0))), rtol=VALUE_RTOL, atol=GRAD_ATOL)
+
+
+def test_pol_grad_parity_autodiff_vs_analytic(pol_imager, pol_x0):
+    g_an = np.asarray(pol_imager.objgrad(pol_x0))
+    g_jax = np.asarray(jax.grad(pol_imager.objfunc)(jnp.asarray(pol_x0)))
+    assert np.allclose(g_jax, g_an, rtol=GRAD_RTOL, atol=GRAD_ATOL)

--- a/tests/test_objective_jax.py
+++ b/tests/test_objective_jax.py
@@ -284,3 +284,20 @@ def test_image_at_freq_jax():
     assert np.allclose(out_np, out_jx, rtol=VALUE_RTOL, atol=GRAD_ATOL)
     g = jax.grad(lambda a: jnp.sum(mfu.image_at_freq(a, lf)))(jnp.asarray(mfarr))
     assert np.all(np.isfinite(np.asarray(g)))
+
+
+def test_ptv_epsilon_tv_removes_singularity():
+    # A constant-P image makes every |P_l1 - P| = 0, so the unregularized |P|-TV
+    # gradient is singular (0/0) there; epsilon_tv > 0 keeps it finite. epsilon_tv
+    # defaults to 0 (byte-identical to before) -- this just enables the knob, as for reg_tv.
+    import ehtim.imaging.pol_imager_utils as pu
+    n = 36
+    ny = nx = 6
+    imarr = np.ones((4, n))
+    imarr[0], imarr[1], imarr[2], imarr[3] = 2.0, 0.3, 0.5, 0.2  # spatially constant P
+    mask = np.ones(n, dtype=bool)
+    kw = dict(flux=float(imarr[0].sum()), xdim=nx, ydim=ny, psize=1.0, beam_size=2.0, norm_reg=True)
+    g0 = np.asarray(jax.grad(lambda a: pu.reg_ptv(a, mask, epsilon_tv=0.0, **kw))(jnp.asarray(imarr)))
+    ge = np.asarray(jax.grad(lambda a: pu.reg_ptv(a, mask, epsilon_tv=0.01, **kw))(jnp.asarray(imarr)))
+    assert not np.all(np.isfinite(g0))  # singular without epsilon_tv
+    assert np.all(np.isfinite(ge))      # finite with epsilon_tv

--- a/tests/test_objective_jax.py
+++ b/tests/test_objective_jax.py
@@ -271,3 +271,16 @@ def test_objective_gpu_cpu_parity(imager, x0):
     v_g, g_g = _make_fun(imager, device=gpu)(x0)
     assert np.allclose(v_c, v_g, rtol=_grad_rtol(imager), atol=1e-9)
     assert np.allclose(g_c, g_g, rtol=_grad_rtol(imager), atol=1e-9)
+
+
+def test_image_at_freq_jax():
+    # Multifrequency forward (I0, alpha, beta) -> I(nu): numpy==jax + differentiable.
+    # Full mf-imaging recon is a follow-up (needs a multi-frequency obs).
+    import ehtim.imaging.multifreq_imager_utils as mfu
+    mfarr = np.array([np.full(8, 2.0), np.full(8, -0.7), np.full(8, 0.1)])  # I0, alpha, beta
+    lf = 0.3
+    out_np = mfu.image_at_freq(mfarr, lf)
+    out_jx = np.asarray(mfu.image_at_freq(jnp.asarray(mfarr), lf))
+    assert np.allclose(out_np, out_jx, rtol=VALUE_RTOL, atol=GRAD_ATOL)
+    g = jax.grad(lambda a: jnp.sum(mfu.image_at_freq(a, lf)))(jnp.asarray(mfarr))
+    assert np.all(np.isfinite(np.asarray(g)))

--- a/tests/test_objective_jax.py
+++ b/tests/test_objective_jax.py
@@ -221,6 +221,43 @@ def test_pol_v_grad_finite_difference(pol_imager_v, pol_v_x0):
     _assert_pol_grad_matches_fd(pol_imager_v, pol_v_x0)
 
 
+# nfft pol: routes chisq_{p,m,vvis}_nfft through nufft2_backend (jax_finufft).
+# IP exercises chisq_p_nfft (pvis) + chisq_m_nfft (m); IV exercises chisq_vvis_nfft.
+_POL_NFFT_CASES = [
+    ("IP", {"amp": 100, "pvis": 100, "m": 50}, {"simple": 1, "hw": 1, "ptv": 1}, ["log", "mcv"]),
+    ("IV", {"amp": 100, "vvis": 100}, {"simple": 1, "l1v": 1, "vtv": 1}, ["log", "vcv"]),
+]
+
+
+@pytest.fixture(scope="module", params=_POL_NFFT_CASES, ids=["IP", "IV"])
+def pol_imager_nfft(request, obs_pol_nfft, gauss_im_pol, gauss_prior):
+    pol, data_term, reg_term, transform = request.param
+    imgr = eh.imager.Imager(
+        obs_pol_nfft, gauss_prior, prior_im=gauss_prior, flux=gauss_im_pol.total_flux(),
+        data_term=data_term, reg_term=reg_term, ttype="nfft", pol=pol,
+        transform=transform, maxit=100, nfft_eps=NFFT_EPS,
+    )
+    imgr.init_imager()
+    return imgr
+
+
+@pytest.fixture(scope="module")
+def pol_nfft_x0(pol_imager_nfft):
+    rng = np.random.default_rng(RNG_SEED)
+    base = np.asarray(pol_imager_nfft._init_vec, dtype=np.float64)
+    return base + PERTURB * rng.standard_normal(base.size)
+
+
+def test_pol_nfft_value_numpy_jax_consistent(pol_imager_nfft, pol_nfft_x0):
+    assert np.allclose(float(pol_imager_nfft.objfunc(pol_nfft_x0)),
+                       float(pol_imager_nfft.objfunc(jnp.asarray(pol_nfft_x0))),
+                       rtol=VALUE_RTOL, atol=GRAD_ATOL)
+
+
+def test_pol_nfft_grad_finite_difference(pol_imager_nfft, pol_nfft_x0):
+    _assert_pol_grad_matches_fd(pol_imager_nfft, pol_nfft_x0)
+
+
 def _nxcorr(a, b):
     a = a - a.mean()
     b = b - b.mean()

--- a/tests/test_objective_jax.py
+++ b/tests/test_objective_jax.py
@@ -22,6 +22,12 @@ pytestmark = pytest.mark.jax
 # at ~1e-14 relative; a real bug fails by orders of magnitude.
 VALUE_RTOL = 1e-9
 GRAD_RTOL = 1e-9
+# nfft is an approximate transform: jax_finufft's VJP matches the analytic adjoint
+# only to the NUFFT accuracy. The residual scales with eps (verified 1e-9 -> ~1e-6,
+# 1e-12 -> ~7e-10 max), so the nfft fixture uses eps=1e-12 and this looser-but-tight
+# rtol; a real VJP bug is eps-independent and fails by orders of magnitude.
+NFFT_EPS = 1e-12
+NFFT_GRAD_RTOL = 1e-7
 GRAD_ATOL = 1e-12
 FD_STEP = 1e-6
 FD_MEDIAN_TOL = 1e-3
@@ -34,46 +40,53 @@ DATA_TERM = {"amp": 100, "cphase": 100, "logcamp": 50}
 REG_TERM = {"simple": 1, "flux": 1}
 
 
-@pytest.fixture(scope="module")
-def imager_I(obs_direct, gauss_im, gauss_prior):
+@pytest.fixture(scope="module", params=["direct", "nfft"])
+def imager(request, obs_direct, obs_nfft, gauss_im, gauss_prior):
+    ttype = request.param
+    obs = obs_direct if ttype == "direct" else obs_nfft
+    extra = {} if ttype == "direct" else {"nfft_eps": NFFT_EPS}
     imgr = eh.imager.Imager(
-        obs_direct, gauss_prior, prior_im=gauss_prior, flux=gauss_im.total_flux(),
-        data_term=DATA_TERM, reg_term=REG_TERM, ttype="direct", pol="I", maxit=100,
+        obs, gauss_prior, prior_im=gauss_prior, flux=gauss_im.total_flux(),
+        data_term=DATA_TERM, reg_term=REG_TERM, ttype=ttype, pol="I", maxit=100, **extra,
     )
     imgr.init_imager()
     return imgr
 
 
+def _grad_rtol(imgr):
+    return GRAD_RTOL if imgr._config.ttype == "direct" else NFFT_GRAD_RTOL
+
+
 @pytest.fixture(scope="module")
-def x0(imager_I):
+def x0(imager):
     # perturb the initial solver vector so the gradient is nonzero
     rng = np.random.default_rng(RNG_SEED)
-    base = np.asarray(imager_I._init_vec, dtype=np.float64)
+    base = np.asarray(imager._init_vec, dtype=np.float64)
     return base + PERTURB * rng.standard_normal(base.size)
 
 
-def test_value_numpy_jax_consistent(imager_I, x0):
-    v_np = float(imager_I.objfunc(x0))
-    v_jx = float(imager_I.objfunc(jnp.asarray(x0)))
+def test_value_numpy_jax_consistent(imager, x0):
+    v_np = float(imager.objfunc(x0))
+    v_jx = float(imager.objfunc(jnp.asarray(x0)))
     assert np.allclose(v_np, v_jx, rtol=VALUE_RTOL, atol=GRAD_ATOL)
 
 
-def test_grad_parity_autodiff_vs_analytic(imager_I, x0):
+def test_grad_parity_autodiff_vs_analytic(imager, x0):
     # the gold standard: jax.grad(compute_objective) == compute_objective_grad
-    g_analytic = np.asarray(imager_I.objgrad(x0))
-    g_jax = np.asarray(jax.grad(imager_I.objfunc)(jnp.asarray(x0)))
-    assert np.allclose(g_jax, g_analytic, rtol=GRAD_RTOL, atol=GRAD_ATOL)
+    g_analytic = np.asarray(imager.objgrad(x0))
+    g_jax = np.asarray(jax.grad(imager.objfunc)(jnp.asarray(x0)))
+    assert np.allclose(g_jax, g_analytic, rtol=_grad_rtol(imager), atol=GRAD_ATOL)
 
 
-def test_grad_finite_difference(imager_I, x0):
-    g_analytic = np.asarray(imager_I.objgrad(x0))
+def test_grad_finite_difference(imager, x0):
+    g_analytic = np.asarray(imager.objgrad(x0))
     idx = np.argsort(np.abs(g_analytic))[-N_FD_SAMPLES:]  # best-conditioned pixels
     g_fd = np.empty(N_FD_SAMPLES)
     for k, j in enumerate(idx):
         xp_, xm_ = x0.copy(), x0.copy()
         xp_[j] += FD_STEP
         xm_[j] -= FD_STEP
-        g_fd[k] = (float(imager_I.objfunc(xp_)) - float(imager_I.objfunc(xm_))) / (2 * FD_STEP)
+        g_fd[k] = (float(imager.objfunc(xp_)) - float(imager.objfunc(xm_))) / (2 * FD_STEP)
     frac = np.abs((g_fd - g_analytic[idx]) / (np.abs(g_analytic[idx]) + 1e-100))
     assert np.median(frac) < FD_MEDIAN_TOL
     assert np.max(frac) < FD_MAX_TOL
@@ -88,20 +101,20 @@ def _make_fun(imgr, device=None):
     )
 
 
-def test_factory_matches_analytic(imager_I, x0):
-    value, grad = _make_fun(imager_I)(x0)
-    assert np.allclose(value, float(imager_I.objfunc(x0)), rtol=VALUE_RTOL, atol=GRAD_ATOL)
-    assert np.allclose(grad, np.asarray(imager_I.objgrad(x0)), rtol=GRAD_RTOL, atol=GRAD_ATOL)
+def test_factory_matches_analytic(imager, x0):
+    value, grad = _make_fun(imager)(x0)
+    assert np.allclose(value, float(imager.objfunc(x0)), rtol=VALUE_RTOL, atol=GRAD_ATOL)
+    assert np.allclose(grad, np.asarray(imager.objgrad(x0)), rtol=_grad_rtol(imager), atol=GRAD_ATOL)
 
 
-def test_objective_traces_once_across_x(imager_I, x0):
+def test_objective_traces_once_across_x(imager, x0):
     # the factory closes over everything but x, so one jit trace serves every
     # solver step; here we count traces of objfunc (what the factory jits).
     traces = {"n": 0}
 
     def counted(x):
         traces["n"] += 1
-        return imager_I.objfunc(x)
+        return imager.objfunc(x)
 
     f = jax.jit(counted)
     f(jnp.asarray(x0)).block_until_ready()

--- a/tests/test_objective_jax.py
+++ b/tests/test_objective_jax.py
@@ -219,3 +219,27 @@ def pol_v_x0(pol_imager_v):
 
 def test_pol_v_grad_finite_difference(pol_imager_v, pol_v_x0):
     _assert_pol_grad_matches_fd(pol_imager_v, pol_v_x0)
+
+
+def _nxcorr(a, b):
+    a = a - a.mean()
+    b = b - b.mean()
+    return float(np.sum(a * b) / np.sqrt(np.sum(a * a) * np.sum(b * b)))
+
+
+@pytest.mark.slow
+def test_make_image_use_jax_recovers_and_matches_numpy(obs_direct, gauss_im, gauss_prior):
+    # OO integration: make_image(use_jax=True) runs the jax objective end to end
+    # through scipy L-BFGS-B and recovers the source; matches the numpy path.
+    def recon(use_jax):
+        imgr = eh.imager.Imager(
+            obs_direct, gauss_prior, prior_im=gauss_prior, flux=gauss_im.total_flux(),
+            data_term={"amp": 100, "cphase": 100, "logcamp": 50},
+            reg_term={"simple": 1, "tv": 10}, ttype="direct", pol="I", maxit=200,
+        )
+        return imgr.make_image_I(niter=1, show_updates=False, use_jax=use_jax).imvec
+
+    truth = gauss_im.imvec
+    im_np, im_jx = recon(False), recon(True)
+    assert _nxcorr(im_jx, truth) > 0.9    # jax recon recovers the source
+    assert _nxcorr(im_jx, im_np) > 0.95   # jax matches numpy (same objective)

--- a/tests/test_objective_jax.py
+++ b/tests/test_objective_jax.py
@@ -14,6 +14,7 @@ import numpy as np
 import pytest
 
 import ehtim as eh
+from ehtim.imaging.imager_backend import make_objective_jax
 
 pytestmark = pytest.mark.jax
 
@@ -76,3 +77,33 @@ def test_grad_finite_difference(imager_I, x0):
     frac = np.abs((g_fd - g_analytic[idx]) / (np.abs(g_analytic[idx]) + 1e-100))
     assert np.median(frac) < FD_MEDIAN_TOL
     assert np.max(frac) < FD_MAX_TOL
+
+
+def _make_fun(imgr, device=None):
+    return make_objective_jax(
+        imgr._init_arr, imgr._config, imgr._which_solve, imgr._data_tuples,
+        imgr._logfreqratio_list, len(imgr.obslist_next), imgr.dat_term_next,
+        imgr.reg_term_next, imgr._prior_arr, imgr.norm_reg, imgr._regparams(),
+        imgr._embed_mask, device=device,
+    )
+
+
+def test_factory_matches_analytic(imager_I, x0):
+    value, grad = _make_fun(imager_I)(x0)
+    assert np.allclose(value, float(imager_I.objfunc(x0)), rtol=VALUE_RTOL, atol=GRAD_ATOL)
+    assert np.allclose(grad, np.asarray(imager_I.objgrad(x0)), rtol=GRAD_RTOL, atol=GRAD_ATOL)
+
+
+def test_objective_traces_once_across_x(imager_I, x0):
+    # the factory closes over everything but x, so one jit trace serves every
+    # solver step; here we count traces of objfunc (what the factory jits).
+    traces = {"n": 0}
+
+    def counted(x):
+        traces["n"] += 1
+        return imager_I.objfunc(x)
+
+    f = jax.jit(counted)
+    f(jnp.asarray(x0)).block_until_ready()
+    f(jnp.asarray(x0 + 0.5)).block_until_ready()
+    assert traces["n"] == 1

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -298,6 +298,46 @@ class TestPolRegularizerGradients:
             f"{rtype} max fractional gradient diff = {max_frac:.6f} (tol={max_tol})"
         )
 
+    def test_reggrad_ptv_matches_fd_on_boundary(self):
+        """ptv gradient is correct on the first row/column, not just the interior.
+
+        The back-neighbor magnitude numerators do not vanish at the zero-pad,
+        so the first row/col would otherwise pick up a neighbor that does not
+        exist. The random-pixel FD check above rarely lands on the boundary;
+        this checks every pixel of a small full-mask grid so the edges are
+        exercised directly.
+        """
+        rng = np.random.default_rng(0)
+        ny = nx = 6
+        n = ny * nx
+        imarr = np.array([rng.uniform(0.5, 2.0, n), rng.uniform(0.1, 0.5, n),
+                          rng.uniform(-1.0, 1.0, n), rng.uniform(-0.5, 0.5, n)])
+        mask = np.ones(n, dtype=bool)
+        kw = dict(flux=float(imarr[0].sum()), xdim=nx, ydim=ny, psize=1.0,
+                  beam_size=2.0, norm_reg=True)
+        g_an = np.asarray(pu.reggrad_ptv(imarr, mask,
+                                         pol_solve=np.array([1, 1, 1, 1]), **kw))
+        dx = 1e-6
+        g_fd = np.zeros_like(imarr)
+        for slot in range(4):
+            for j in range(n):
+                a = imarr.copy()
+                a[slot, j] += dx
+                fp = pu.reg_ptv(a, mask, **kw)
+                a = imarr.copy()
+                a[slot, j] -= dx
+                fm = pu.reg_ptv(a, mask, **kw)
+                g_fd[slot, j] = (fp - fm) / (2 * dx)
+        edge = np.zeros((ny, nx), dtype=bool)
+        edge[0, :] = True
+        edge[:, 0] = True
+        edge = edge.flatten()
+        for slot in range(4):
+            assert np.max(np.abs(g_an[slot] - g_fd[slot])) < 1e-5, (
+                f"slot {slot} ptv gradient disagrees with FD "
+                f"(max boundary diff {np.max(np.abs((g_an[slot] - g_fd[slot])[edge])):.2e})"
+            )
+
 
 def _pol_gradient_check(polreg_setup, rtype):
     """FD-vs-analytic check across N pixels in each pol_solve-active slot."""

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -298,45 +298,68 @@ class TestPolRegularizerGradients:
             f"{rtype} max fractional gradient diff = {max_frac:.6f} (tol={max_tol})"
         )
 
-    def test_reggrad_ptv_matches_fd_on_boundary(self):
-        """ptv gradient is correct on the first row/column, not just the interior.
+    # TV-family regularizers: tv/tv2 are Stokes-I (1D imvec), ptv/vtv/vtv2 are pol (4-row imarr)
+    @pytest.mark.parametrize("rtype, is_pol", [("tv", False), ("tv2", False),
+                                               ("ptv", True), ("vtv", True), ("vtv2", True)])
+    def test_tv_gradient_on_boundary(self, rtype, is_pol):
+        """TV gradient is correct on the first row/col, not just the interior.
 
-        The back-neighbor magnitude numerators do not vanish at the zero-pad,
-        so the first row/col would otherwise pick up a neighbor that does not
-        exist. The random-pixel FD check above rarely lands on the boundary;
-        this checks every pixel of a small full-mask grid so the edges are
-        exercised directly.
+        Back-neighbor terms hit the zero-pad there and must be masked out (the bug
+        fixed for ptv in #295). A full-mask grid exercises every edge pixel.
         """
         rng = np.random.default_rng(0)
         ny = nx = 6
         n = ny * nx
-        imarr = np.array([rng.uniform(0.5, 2.0, n), rng.uniform(0.1, 0.5, n),
-                          rng.uniform(-1.0, 1.0, n), rng.uniform(-0.5, 0.5, n)])
         mask = np.ones(n, dtype=bool)
-        kw = dict(flux=float(imarr[0].sum()), xdim=nx, ydim=ny, psize=1.0,
-                  beam_size=2.0, norm_reg=True)
-        g_an = np.asarray(pu.reggrad_ptv(imarr, mask,
-                                         pol_solve=np.array([1, 1, 1, 1]), **kw))
+        kw = dict(xdim=nx, ydim=ny, psize=1.0, beam_size=2.0, norm_reg=True)
+        if is_pol:
+            x = np.array([rng.uniform(0.5, 2.0, n), rng.uniform(0.1, 0.5, n),
+                          rng.uniform(-1.0, 1.0, n), rng.uniform(-0.5, 0.5, n)])
+            kw.update(flux=float(x[0].sum()), vflux=float(x[0].sum()))
+            reg, reggrad = getattr(pu, f"reg_{rtype}"), getattr(pu, f"reggrad_{rtype}")
+            g_an = np.asarray(reggrad(x, mask, pol_solve=np.array([1, 1, 1, 1]), **kw))
+        else:
+            x = rng.uniform(0.1, 2.0, (1, n))
+            kw.update(flux=float(x.sum()))
+            reg, reggrad = getattr(iu, f"reg_{rtype}"), getattr(iu, f"reggrad_{rtype}")
+            g_an = np.atleast_2d(np.asarray(reggrad(x[0], mask, **kw)))
         dx = 1e-6
-        g_fd = np.zeros_like(imarr)
-        for slot in range(4):
+        g_fd = np.zeros_like(g_an)
+        for s in range(g_an.shape[0]):
             for j in range(n):
-                a = imarr.copy()
-                a[slot, j] += dx
-                fp = pu.reg_ptv(a, mask, **kw)
-                a = imarr.copy()
-                a[slot, j] -= dx
-                fm = pu.reg_ptv(a, mask, **kw)
-                g_fd[slot, j] = (fp - fm) / (2 * dx)
-        edge = np.zeros((ny, nx), dtype=bool)
-        edge[0, :] = True
-        edge[:, 0] = True
-        edge = edge.flatten()
-        for slot in range(4):
-            assert np.max(np.abs(g_an[slot] - g_fd[slot])) < 1e-5, (
-                f"slot {slot} ptv gradient disagrees with FD "
-                f"(max boundary diff {np.max(np.abs((g_an[slot] - g_fd[slot])[edge])):.2e})"
-            )
+                a = x.copy()
+                a[s, j] += dx
+                fp = reg(a if is_pol else a[0], mask, **kw)
+                a = x.copy()
+                a[s, j] -= dx
+                fm = reg(a if is_pol else a[0], mask, **kw)
+                g_fd[s, j] = (fp - fm) / (2 * dx)
+        for s in range(g_an.shape[0]):
+            assert np.max(np.abs(g_an[s] - g_fd[s])) < 1e-5, (
+                f"{rtype} slot {s}: gradient disagrees with FD on the grid")
+
+    @pytest.mark.parametrize("rtype, is_pol", [("tv", False), ("ptv", True), ("vtv", True)])
+    def test_tv_epsilon_removes_singularity(self, rtype, is_pol):
+        """A spatially-constant image zeros the neighbor diffs (0/0 in the TV sqrt);
+        epsilon_tv keeps the gradient finite (default 0 stays byte-identical)."""
+        ny = nx = 6
+        n = ny * nx
+        mask = np.ones(n, dtype=bool)
+        kw = dict(xdim=nx, ydim=ny, psize=1.0, beam_size=2.0, norm_reg=True)
+        if is_pol:
+            x = np.ones((4, n))
+            x[0], x[1], x[2], x[3] = 2.0, 0.3, 0.5, 0.2
+            kw.update(flux=float(x[0].sum()), vflux=float(x[0].sum()),
+                      pol_solve=np.array([1, 1, 1, 1]))
+            reggrad = getattr(pu, f"reggrad_{rtype}")
+        else:
+            x = np.full(n, 0.5)
+            kw.update(flux=float(x.sum()))
+            reggrad = getattr(iu, f"reggrad_{rtype}")
+        g0 = np.asarray(reggrad(x, mask, epsilon_tv=0.0, **kw))
+        ge = np.asarray(reggrad(x, mask, epsilon_tv=0.01, **kw))
+        assert not np.all(np.isfinite(g0)), f"{rtype}: expected singular grad at epsilon_tv=0"
+        assert np.all(np.isfinite(ge)), f"{rtype}: expected finite grad at epsilon_tv>0"
 
 
 def _pol_gradient_check(polreg_setup, rtype):

--- a/tutorials/ehtim_tutorial_jax.ipynb
+++ b/tutorials/ehtim_tutorial_jax.ipynb
@@ -1,0 +1,486 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5a142d81",
+   "metadata": {},
+   "source": [
+    "# Differentiable imaging with JAX (on the GPU)\n",
+    "\n",
+    "`ehtim`'s imaging objective is now backend-agnostic: the same code runs on\n",
+    "NumPy or JAX depending on what array you hand it. That makes the whole\n",
+    "image -> Fourier -> chi-squared + regularizer -> scalar-loss pipeline a single\n",
+    "differentiable, GPU-capable computation graph — so `jax.grad` of the loss is\n",
+    "the imaging gradient, and it matches the hand-written analytic gradient.\n",
+    "\n",
+    "This notebook shows:\n",
+    "1. the objective and its **autodiff gradient == the analytic gradient**,\n",
+    "2. the **NFFT** transform differentiated on the **GPU** via `jax-finufft`,\n",
+    "3. an end-to-end reconstruction through `make_image(use_jax=True)`.\n",
+    "\n",
+    "**Scope:** this is *image-only* inference (the unknown is the image). The next\n",
+    "step — jointly solving image + gains + D-terms on the *same* `value_and_grad` —\n",
+    "is what the functional rewrite is for, but it needs the Jones forward model +\n",
+    "cal-table redesign that are still in progress."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2617dd45",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "\n",
+    "You need **JAX** (GPU build). The `nfft` transform additionally needs\n",
+    "**jax-finufft** (GPU build); the `direct` DFT path needs only JAX.\n",
+    "\n",
+    "**JAX (CUDA 12):**\n",
+    "```bash\n",
+    "pip install -U \"jax[cuda12]\"\n",
+    "```\n",
+    "(this env uses jax 0.10.1 with the pip CUDA-12 plugin.)\n",
+    "\n",
+    "**jax-finufft (GPU) — only for `ttype='nfft'`.** The PyPI wheel is CPU-only for\n",
+    "all GPUs, so the GPU NUFFT must be built from source against the JAX you just\n",
+    "installed. On this cluster (system CUDA 12.6, RTX 6000 Ada = `sm_89`):\n",
+    "```bash\n",
+    "pip install \"nanobind>=2.9.0\" \"scikit-build-core>=0.5\" ninja setuptools_scm\n",
+    "micromamba install -c conda-forge fftw          # CPU half needs FFTW headers\n",
+    "\n",
+    "export CUDA_HOME=/usr/local/cuda-12.6 CUDACXX=$CUDA_HOME/bin/nvcc PATH=$CUDA_HOME/bin:$PATH\n",
+    "export SETUPTOOLS_SCM_PRETEND_VERSION=1.3.1\n",
+    "ARCH=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -1 | tr -d .)\n",
+    "export CMAKE_ARGS=\"-DJAX_FINUFFT_USE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=$ARCH \\\n",
+    "  -DCUDAToolkit_ROOT=$CUDA_HOME -Dnanobind_DIR=$(python -c 'import nanobind;print(nanobind.cmake_dir())')\"\n",
+    "pip install -v --no-build-isolation --no-deps --force-reinstall \\\n",
+    "  --no-binary jax-finufft jax-finufft==1.3.1\n",
+    "```\n",
+    "For CPU-only experimentation, `pip install jax-finufft` (the CPU wheel) is\n",
+    "enough — the objective is identical, just slower. `import ehtim` itself never\n",
+    "imports JAX, so installing neither leaves the NumPy path untouched."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9e1618af",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T13:37:54.623608Z",
+     "iopub.status.busy": "2026-06-10T13:37:54.623066Z",
+     "iopub.status.idle": "2026-06-10T13:38:02.181768Z",
+     "shell.execute_reply": "2026-06-10T13:38:02.180409Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Welcome to eht-imaging! v 1.4.0 \n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "jax 0.10.1 -> [CudaDevice(id=0)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "import jax\n",
+    "jax.config.update(\"jax_enable_x64\", True)  # ehtim works in double precision\n",
+    "import jax.numpy as jnp\n",
+    "\n",
+    "import ehtim as eh\n",
+    "\n",
+    "print(\"jax\", jax.__version__, \"->\", jax.devices())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c89e749",
+   "metadata": {},
+   "source": [
+    "## A synthetic observation\n",
+    "\n",
+    "A 1 Jy Gaussian source observed with the EHT 2017 array. Nothing here is\n",
+    "JAX-specific — it is the ordinary `ehtim` simulation path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b9e3f0dd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T13:38:02.187429Z",
+     "iopub.status.busy": "2026-06-10T13:38:02.186689Z",
+     "iopub.status.idle": "2026-06-10T13:38:03.751312Z",
+     "shell.execute_reply": "2026-06-10T13:38:03.748611Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating empty observation file . . . \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/nfs/horai.dgpsrv/year/rdahale/jax-ehtim/eht-imaging/ehtim/io/load.py:823: UserWarning: Input line 1 contained no data and will not be counted towards `max_rows=50000`.  This differs from the behaviour in NumPy <=1.22 which counted lines rather than rows.  If desired, the previous behaviour can be achieved by using `itertools.islice`.\n",
+      "Please see the 1.23 release notes for an example on how to do this.  If you wish to ignore this warning, use `warnings.filterwarnings`.  This warning is expected to be removed in the future and is given only once per `loadtxt` call.\n",
+      "  tdata = np.loadtxt(filename, dtype=bytes, comments='#').astype(str)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Producing clean visibilities from image with direct FT . . . \n",
+      "Adding gain + phase errors to data and applying a priori calibration . . . \n",
+      "Adding thermal noise to data . . . \n"
+     ]
+    }
+   ],
+   "source": [
+    "src = eh.image.make_empty(32, 200 * eh.RADPERUAS, 17.761, -29.0, rf=230e9)\n",
+    "src = src.add_gauss(1.0, (50 * eh.RADPERUAS, 50 * eh.RADPERUAS, 0, 0, 0))\n",
+    "\n",
+    "# arrays/ lives at the repo root; resolve it whether run from tutorials/ or the root\n",
+    "_candidates = [\"../arrays/EHT2017.txt\", \"arrays/EHT2017.txt\",\n",
+    "               os.path.join(os.path.dirname(eh.__file__), \"..\", \"arrays\", \"EHT2017.txt\")]\n",
+    "eht = eh.array.load_txt(next(p for p in _candidates if os.path.exists(p)))\n",
+    "\n",
+    "np.random.seed(42)  # reproducible thermal noise\n",
+    "obs = src.observe(eht, 5, 600, 0, 24, 4e9, ampcal=True, phasecal=True,\n",
+    "                  ttype=\"direct\", add_th_noise=True)\n",
+    "\n",
+    "# a deliberately blurry starting guess (not the truth)\n",
+    "prior = src.blur_circ(40 * eh.RADPERUAS)\n",
+    "\n",
+    "DATA_TERM = {\"amp\": 100, \"cphase\": 100, \"logcamp\": 50}\n",
+    "REG_TERM = {\"simple\": 1, \"tv\": 10}\n",
+    "# total-variation has a sqrt that is singular where the image is locally flat;\n",
+    "# epsilon_tv regularizes it (a tiny value is plenty) so the gradient stays finite.\n",
+    "EPSILON_TV = 1e-10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dfdf986c",
+   "metadata": {},
+   "source": [
+    "## The objective and its gradient\n",
+    "\n",
+    "`Imager.objfunc(x)` is the scalar imaging loss as a function of the solver\n",
+    "vector `x` (the log-image on the solved pixels). It is written\n",
+    "backend-agnostically, so:\n",
+    "\n",
+    "- `imgr.objfunc(x)` / `imgr.objgrad(x)` -> NumPy value / **analytic** gradient,\n",
+    "- `jax.grad(imgr.objfunc)(x)` -> the **autodiff** gradient of the *same* loss.\n",
+    "\n",
+    "The whole point: these two gradients agree to machine precision."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1d52c6eb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T13:38:03.756296Z",
+     "iopub.status.busy": "2026-06-10T13:38:03.755980Z",
+     "iopub.status.idle": "2026-06-10T13:38:13.618396Z",
+     "shell.execute_reply": "2026-06-10T13:38:13.615825Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initializing imager data products . . .\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "loss = 21493.695335\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "gradient device                  : float64, cuda:0\n",
+      "relative ||autodiff - analytic|| = 1.92e-09\n"
+     ]
+    }
+   ],
+   "source": [
+    "imgr = eh.imager.Imager(obs, prior, prior_im=prior, flux=src.total_flux(),\n",
+    "                        data_term=DATA_TERM, reg_term=REG_TERM, epsilon_tv=EPSILON_TV,\n",
+    "                        ttype=\"direct\", pol=\"I\", maxit=100)\n",
+    "imgr.init_imager()\n",
+    "x0 = np.asarray(imgr._init_vec, dtype=np.float64)\n",
+    "\n",
+    "loss = float(imgr.objfunc(x0))\n",
+    "grad_analytic = np.asarray(imgr.objgrad(x0))\n",
+    "grad_autodiff = np.asarray(jax.grad(imgr.objfunc)(jnp.asarray(x0)))\n",
+    "\n",
+    "rel = np.linalg.norm(grad_autodiff - grad_analytic) / np.linalg.norm(grad_analytic)\n",
+    "print(f\"loss = {loss:.6f}\")\n",
+    "print(f\"gradient device                  : {grad_autodiff.dtype}, \"\n",
+    "      f\"{jax.grad(imgr.objfunc)(jnp.asarray(x0)).device}\")\n",
+    "print(f\"relative ||autodiff - analytic|| = {rel:.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53c2707c",
+   "metadata": {},
+   "source": [
+    "That `~1e-9` *relative* agreement (the residual is just XLA reordering the\n",
+    "float64 sums) is the gold standard: autodiff through the functional\n",
+    "`unpack -> transform -> forward-model -> chi^2 + regularizers` reproduces the\n",
+    "hand-derived chain rule. Because the loss is just a JAX function you also get\n",
+    "`jax.jit`, `jax.vmap`, and higher-order derivatives for free.\n",
+    "\n",
+    "(`jax_enable_x64` above is essential — ehtim works in double precision; without\n",
+    "it JAX silently uses float32 and the gradient only matches to ~1e-3.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4a041de9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T13:38:13.624806Z",
+     "iopub.status.busy": "2026-06-10T13:38:13.624284Z",
+     "iopub.status.idle": "2026-06-10T13:38:16.729857Z",
+     "shell.execute_reply": "2026-06-10T13:38:16.727325Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "jit value_and_grad: value=21493.695335, grad shape=(1024,), device=cuda:0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# value_and_grad is what scipy wants; jit compiles it once and reuses the trace.\n",
+    "value_and_grad = jax.jit(jax.value_and_grad(imgr.objfunc))\n",
+    "v, g = value_and_grad(jnp.asarray(x0))\n",
+    "print(f\"jit value_and_grad: value={float(v):.6f}, grad shape={g.shape}, device={g.device}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec88426c",
+   "metadata": {},
+   "source": [
+    "## NFFT, differentiated on the GPU\n",
+    "\n",
+    "For `ttype='nfft'` the forward model is a non-uniform FFT. The same\n",
+    "`jax.grad(objfunc)` runs it through `jax-finufft` on the GPU; `jax-finufft`\n",
+    "supplies the VJP (the adjoint NUFFT), so we never hand-write it.\n",
+    "\n",
+    "NFFT is an *approximate* transform, so the autodiff gradient matches the\n",
+    "analytic adjoint only to the NUFFT accuracy `eps` (the residual shrinks as you\n",
+    "tighten `eps`); it is not a bug."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8bb422f1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T13:38:16.736746Z",
+     "iopub.status.busy": "2026-06-10T13:38:16.736446Z",
+     "iopub.status.idle": "2026-06-10T13:38:19.028389Z",
+     "shell.execute_reply": "2026-06-10T13:38:19.025520Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating empty observation file . . . \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Producing clean visibilities from image with nfft FT . . . \n",
+      "Adding gain + phase errors to data and applying a priori calibration . . . \n",
+      "Adding thermal noise to data . . . \n",
+      "Initializing imager data products . . .\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "nfft gradient device                       : cuda:0\n",
+      "nfft relative ||autodiff - analytic|| (eps=1e-9): 1.73e-06\n"
+     ]
+    }
+   ],
+   "source": [
+    "obs_nfft = src.observe(eht, 5, 600, 0, 24, 4e9, ampcal=True, phasecal=True,\n",
+    "                       ttype=\"nfft\", add_th_noise=True)\n",
+    "imgr_n = eh.imager.Imager(obs_nfft, prior, prior_im=prior, flux=src.total_flux(),\n",
+    "                          data_term=DATA_TERM, reg_term=REG_TERM, epsilon_tv=EPSILON_TV,\n",
+    "                          ttype=\"nfft\", pol=\"I\", maxit=100, nfft_eps=1e-9)\n",
+    "imgr_n.init_imager()\n",
+    "xn = np.asarray(imgr_n._init_vec, dtype=np.float64)\n",
+    "\n",
+    "g_nfft = np.asarray(jax.grad(imgr_n.objfunc)(jnp.asarray(xn)))\n",
+    "ga_nfft = np.asarray(imgr_n.objgrad(xn))\n",
+    "rel_n = np.linalg.norm(g_nfft - ga_nfft) / np.linalg.norm(ga_nfft)\n",
+    "print(f\"nfft gradient device                       : \"\n",
+    "      f\"{jax.grad(imgr_n.objfunc)(jnp.asarray(xn)).device}\")\n",
+    "print(f\"nfft relative ||autodiff - analytic|| (eps=1e-9): {rel_n:.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbafc566",
+   "metadata": {},
+   "source": [
+    "## End-to-end reconstruction on the JAX objective\n",
+    "\n",
+    "`make_image(use_jax=True)` runs scipy L-BFGS-B on the JAX objective (gradient by\n",
+    "autodiff, on the GPU). With `use_jax=False` it is the usual NumPy path — same\n",
+    "answer, and the only thing that changes is which backend computes the gradient."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "71b389c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-10T13:38:19.034016Z",
+     "iopub.status.busy": "2026-06-10T13:38:19.033721Z",
+     "iopub.status.idle": "2026-06-10T13:38:26.066382Z",
+     "shell.execute_reply": "2026-06-10T13:38:26.063531Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==============================\n",
+      "Imager run 1 \n",
+      "Imaging . . .\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "time: 3.354608 s\n",
+      "J: 33.035571\n",
+      "chi2_amp : 0.99 chi2_cphase : 1.47 chi2_logcamp : 0.65 \n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "==============================\n",
+      "==============================\n",
+      "Imager run 2 \n",
+      "Imaging . . .\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "time: 3.049870 s\n",
+      "J: 29.715432\n",
+      "chi2_amp : 0.96 chi2_cphase : 1.47 chi2_logcamp : 0.65 \n",
+      "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT\n",
+      "==============================\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA/UAAAE7CAYAAACcxqEUAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAL49JREFUeJzt3XuUXWV5OP5nyCSZXEhCrppEcpFwL00koEgNFLwSqqJIEBAVolJEalFXV6UVaFWsgqCorcKSRFFSrEKX1ApfEG9YaEIEkXCXEEggF5LJJCQht/f3B7+ZZpiZ8+5kds7MTj6ftfJHzvPOs9+zzz7P3s+5vQ0ppRQAAABA5ezT0xMAAAAAdo2mHgAAACpKUw8AAAAVpakHAACAitLUAwAAQEVp6gEAAKCiNPUAAABQUZp6AAAAqChNPQAAAFSUph4A9gKPP/543H333T09jdLcdtttsWzZsp6eBgD0OE39XmTOnDlx6aWX1nWbzc3Ncemll8Ytt9zSIfalL30pGhoa2v4B7AnuuuuuGDZsWFx++eU9PZU2N954Yxx11FGxffv2Xfr7W265JS699NJobm4ud2IZV199dVx99dWdxpqbm+OII46IO++8s65zgj3RjtdjO/5bvHhxp+OnT58eDQ0Nce+993Ya/+Uvf9lpvh2vQ48//vgOcXZeT1zf74pa9Twi4qSTToqJEyfGypUr6zepPUlir3Hcccelej/kTz31VIqI9MEPfrDLMT0xL4DdZd68eSki0nnnndfTU0kppfRf//VfqU+fPumnP/3pLuf44Ac/mCIiPfXUU+VNrIAJEyakCRMmdBm/5ppr0sCBA9N9991Xv0nBHqz1muyuu+7qcsyDDz6YIiJFRDr//PNr5ps7d26KiNTU1JQef/zxDvG77747DR8+PD377LPdnfpeqyrX0bl6fvDBB6cBAwbU/Tyzp/BOPQCUaNasWbFs2bL45je/2dNTiXXr1sXs2bPjpJNOipNPPrmnp1O6j3/84/Ha1742zjnnnNi2bVtPTwf2CnPmzInhw4dHRMS8efNi8+bNXY49++yz4y1veUts2rQpPvaxj7WLbdq0Kc4555y44oorYty4cbt1zvR+CxcujGeffTYmTpzY01OpJE09AJTs1a9+deyzT8+fYq+77rp47rnn4lOf+lRPT2W3aGhoiE996lPxwAMPxK233trT04E93rZt2+IHP/hBfOUrX4nhw4fH6tWrs8+9b3/72zFw4MD4xS9+EXPmzGm7/ZJLLonJkyfHhz/84d08a6pgwIABbS8WsfN6/oqD3W7OnDnR0NAQv/rVryKi/femXvm99jlz5sQPf/jDmDZtWgwYMCAaGhri+OOPb/e9pw996ENtuRcsWNDld6+OP/74mDRpUkREzJ07N/udqXXr1sV5550Xo0aNigEDBsSb3vSmWLhw4W7bL8DeqbUmtv574IEH4oILLojx48dH//7948ADD4yrrroqUkptfzNv3rx2f/P444/HJZdcEpMmTYrGxsa274ruWCuPP/74Trc/d+7ceMMb3hCDBw+OwYMHxzHHHBPf+9732o2555572m3vrrvuiq9//etxyCGHRL9+/TrU4q7ccMMN0dTUFMcee2yH2LZt2+Jb3/pWTJs2LYYMGRKjRo2KY489Nr70pS/F0qVLI+L/vhc7d+7ciIiYNGlSp9+Nvfnmm+P000+PAw44IJqammLkyJHx7ne/u9Ma3tTU1C7H7bffHm984xtj0KBB0dDQEBMnToxLL700Ghoa4umnn46nn3663b745S9/2S7fCSec0HZfgd3r5z//eaxbty5mzZoV73vf+yIi2upDVyZNmhSXXXZZRER8+tOfjpUrV8b8+fPjuuuui+985zuFt/38888XumZttWHDhrjsssvi4IMPbleX7rvvvk7zr169Oj796U/H5MmTo3///jFu3LiYMWNGfPGLX4zly5e3G7t169a4+uqrY+rUqTFgwIAYOnRonHDCCfGzn/2s3bjOzh2f/exnY9y4cdHU1BTTpk2LO+64o8NcNm7cGJdffnkcdthhMXjw4Hj1q18dJ5xwQlxzzTWxevXqiKh9fT9nzpzC+2tXrvF3Zp/l6vkrf3/hlTU+ImLJkiUxe/bsGD9+fPTr1y/Gjx8fH/nIR+KZZ55pN+7tb397u3PwY489FieddFLsu+++MXTo0Jg1a1asWrWq08e/8nr68//UT63v3Fx//fUpItJb3vKW9IEPfCA9+eSTadWqVekv//Iv03HHHZdSqv39+K6+b7kz36l/73vfm37yk5+ktWvXpnvuuSeNHz8+jRkzJq1fv34X7zFA11rr1qGHHpq+/vWvp7Vr16bly5enCy64IEVEuvDCC7v8m7e//e3piiuuSCtWrEgPP/xwGj16dLrkkkvaxkVEW+3c0XnnnZciIn3+859Pq1evTqtXr07//M//nCIiXXDBBR3GX3LJJW21+TOf+Ux69tln0zPPPJMOPfTQmnU1pZTWrFmTGhoa0hFHHNFp/KKLLkqNjY1pzpw5ae3atWn16tXpX//1X1OfPn3a3Zcd73dX33UcNGhQOvHEE9Mf//jHtHHjxvTII4+k0047LTU1NaUFCxZ0GH/XXXeliEgnnHBCevvb354WLVqUWlpa0hlnnNHuO5e572C2GjJkSBo+fHh2HFBb7jv1p556ajrrrLNSSin95je/SRGR+vbtm1auXFkz79atW9ORRx6ZIiLNmjUrHX744em6667bpTkWuWZ98cUX09FHH50GDBiQbrzxxrRx48b05JNPppkzZ6b+/funO+64o13O5557Lr32ta9N48ePT3fccUfauHFjeuqpp9Ls2bNTRKS/+Zu/aXdfZs6cmfr27Zu+853vpHXr1qXnnnsuffzjH08Rka644ooOc26toTNnzkzXXnttWrNmTfrjH/+YDjvssDRgwIC0ZMmSduPf8573pH333Tfdeuutaf369Wn58uXp0ksvTRGRrr/++nZjc9+p313X+Duzz1LK1/PW890rj70HH3wwjRw5Mh122GFp/vz5adOmTWn+/Pnp0EMPTaNGjUqLFi3qkCsi0uGHH55OPPHENH/+/NTS0pJuuOGG1NjYmGbOnNnlHKpMU78XKdLUT5kyJW3fvr3t9ttuuy1ddtllKaXd39RfeeWV7W7/yle+kiIi3XzzzYXuH8DOaK1bZ599drvbt2/fnqZPn54iIt17772d/s25557b7varrroq/ehHP2r7f2dN/S233JIiIr3//e/vMJfTTz89RUSHH7Nrvcg58cQT291+ww03pG9961s179///M//tL0A0Zn99tsvHXnkkR1uP+uss3a6qT/mmGPS0qVL2922efPmNHr06HTyySd3GN/a1A8bNiytW7eu7faFCxe2e3GjaFN/0EEHpYhIy5cvz44FularqV+9enXq379/uu2221JKL9fKSZMmpYhIX/va17K5f//736fGxsa2F/R2VZFr1osuuihFRPrHf/zHdn/b3NycBg8enPbff/+0devWttvf8573pIhIt99+e7vx27ZtS3/2Z3/WrkG9+uqrU0Skv//7v+8wt2OOOSb16dMn3X///e1ub62hn/jEJ9rd/u///u8pItJVV13VdlvrC7Lvfe97O+T/i7/4i11u6su+xt+ZfZbSrjf106ZNSw0NDenhhx9ud/uiRYtSQ0NDmj59eodc8f//kOMrf0T1He94R2poaEgvvPBCl/OoKh+/p51TTz213cfj3/rWt8bnPve5umz7Xe96V7v/H3TQQRHx8trKALvLrFmz2v2/oaEhTjvttIiIDh+Lb9Uab/XJT34yTj311Jrb+bd/+7eIiHj/+9/fIdZ627e+9a1C2zvzzDPjr//6r2tur3UN92HDhnUab2hoiEceeSQeeOCBdrd/7WtfiwsvvLBm7lf63e9+F2PHjm13W9++feOggw6Ku+++u8u/e8c73hGDBw9u+/+0adPimmuu2altR0QMHTo0IsK69bAb3XjjjTF8+PA48cQTI+LlGnLmmWdGRP4j+BERU6dObRv/pz/9KV588cVuzaera9atW7fGtddeGxERs2fPbvc3Q4cOjXe84x2xZMmS+MUvfhERL3+s/+abb46RI0fGm9/85nbj99lnn/jsZz8bxxxzTNtttWr56aefHtu2bYtvf/vbnc75lde6hxxySES0v9bdZ599IqUU99xzTzz99NPtxv/4xz+O9773vZ3mzinzGn9n99muuvfee+P3v/99TJs2LQ4++OB2sUMOOSSmTp0aCxYsiP/93//t8Lfjx4+P173udR3+JqUUTz75ZLfn1tto6mnnNa95TY9t+5UXhK0Xehs2bOiJ6QB7if3337/Dba0vKt5///2d/s2u1Mr58+dHRHS4MNnxttYxZWyvtXb269ev0/jf/u3fxosvvhhHHnlkzJw5M77//e9Hc3NzDB8+fKd/rOipp56Kj33sY3HQQQe1fVezoaEhfvOb38SaNWu6/Luyzjn9+/ePiOh2kwB0bc6cOXH66adHnz592m4766yzIuLlXy5/6KGHav79c889Fz/96U9j9OjRsXjx4rj44ou7NZ+u6scjjzwS69ati/3226/T+t76dwsWLIiIiPvuuy9SSnHggQd2+rtPp59+etuLv+vWrYtHHnkkInatlhe51h0yZEice+65sXTp0jj44INj1qxZ8eMf/zg2bNgQo0ePjn333bfT3DllXuPvzD7rjlrnzR1v72x/v3JfR+zZvYWmnnYGDBjQa7bdWiTSDj9WBVC2Hd8pbjVo0KCIiFi7dm2nf7MrtbI1V2vuzrbX3Nxc2vYaGxsjIrpc6u0f/uEf4pZbboljjz02/vu//zvOPvvsGDt2bJx33nmxbt26wtt5+OGHY+rUqXHLLbfElVdeGcuXL4/08tf74rjjjqv5t2Wdc1rvY+t9Bsq1aNGimD9/flsT3+qggw6Ko446KiLy79aff/75cdppp8UPfvCDiIi45ppr4p577tnlOXVVP1pr7Zo1a9r9AFvrv69+9asREW0/5NZadzurza/U0tISES9/Eqlv374d4jtby7u61r322mvj+uuvj0MOOSRuuummOPXUU2Ps2LHx2c9+tuYSgrWUeY2/M/usO2qdN3e8vbP93dn93ZN7C009hXX1q/URe+YrXsDeYf369R1ua33Ht/Vj3WVo/Rh8Z+8mt9623377lba91rlv2rSpyzHvete74le/+lU8/fTT8eUvfzlGjRoV3/72t+OUU04pvJ2rrroqWlpa4uKLL46TTz45hgwZ0u2576yNGzdGRLmPF/B/Whv2I488skOT3Pou6Q9+8IMuX0ScN29eLFy4ML785S/Hm9/85vjwhz8c27dvj9mzZ+9yk9qV1lo7bty4thcYO/t39dVXtxtf5JM+rWO3bNkSW7Zs6RAvq5a3/hL9woUL49FHH43Pfe5z0bdv37j88svj/PPP71burrbXlc6u8Xdmn3VHbju749xZVZr6vUitJ2wRra94dfbEal3+qOxtAuxuS5Ys6XBb68crp02bVtp2jj766Ih4+Z3tV2q9rXVMGSZPnhwREStXruw0fsstt8T27dsj4uWPZX7mM5+JBx54IEaOHBl33nlnu3c+atXy1mWOpkyZ0iHW2mzvqqLnkFWrVrUthweUa9u2bXHDDTfEN77xjU6b49WrV8eAAQNi2bJlnS7PtnLlyrjwwgvj2muvbfvo+JVXXhljxoyJhx56KC6//PJS53vwwQfH0KFD47nnnouXXnqpQ3z79u1x2223xbPPPhsREdOnT4999tknHnvssU7fwb3jjjvalswcNGhQHHrooRGx+2r5hg0b4uc//3nb/w888MC47LLLYv78+dHY2Bj/8R//0W58GdfaO3uNvzP7rDvzrHXe3PH2Ms+dVaWp34u0vorV+q7NV7/61Z36sY1Ro0bF0KFD49FHH213+7Jlyzr9gYrOthkRMWPGjPj+97+/U3MH2F3mzZvX7v8ppbjpppuioaEhPvjBD5a2ndYftrvxxhu7nEPux+92xgEHHBBDhw6Np556qtP4Kaec0qGeDxs2LMaOHRuNjY3tPlr6ylo+b968th9Bav3O6h/+8Id2udasWROLFi3q1n3Yb7/92p0/PvWpT3X4Eb+XXnopli1bFocffng0NTV1a3tAR7fffnu0tLTE2Wef3Wl8v/32q/njop/4xCfine98Z7z1rW9t9zff+MY3IiLii1/8YrdrxY769OkTH/3oR2P79u2dXm/efPPNcdJJJ8XWrVsjImLMmDFxyimnxKpVqzq8KLFly5b42Mc+FgsXLmy7LVfL99lnn/joRz+6y/NfsWJF/NVf/VWHr0FNnDgxBg0a1OFj5d29vo/Y+Wv8nd1nrfPM1fNXOuqoo2L69Olx//33t73Y3urhhx+OBx54IKZPnx7Tp08vdD/3ZJr6vUjrAX/HHXfEqlWrYu7cuTv1YxsNDQ1xxhlnxIMPPhjXXHNNrF27Nh5++OE499xzu3yFbMiQITFlypS47777YvXq1XHHHXfEb37zmx79QT6AHT333HNxzTXXxLp162LVqlVx4YUXxn333Ref/OQnS71QOPnkk+OCCy6IefPmxRe+8IVYs2ZNNDc3xxe+8IWYN29eXHDBBTFz5szSttenT59429veFs8880ysWLGi0zHnnHNOzJ8/PzZu3BgrV66Mr3zlK/GHP/whZs+e3e47jK374c4774x169bFnDlz2n6c7vzzz49+/frF5ZdfHj/5yU9i/fr18eijj8asWbO6/dHM6dOnx4oVK+IPf/hDLFmypO3Xt3d0//33x7Zt2+Kkk07q1raAzs2dOzfOPPPMmteM5513XkS83DC3fu88IuI///M/47e//W1ceeWVHf7m1FNPjXe/+92xefPmOPfcc9s+OVSGyy67LI455pi46KKL4rvf/W4sX7481qxZEz/84Q/j3HPPjc997nPtPtnzzW9+M1772tfGOeecE3feeWe89NJL8eSTT8aZZ54Z27Zti7/7u79rG3v++efHO9/5zrjyyivj2muvjRdffDGWL18eF1xwQdxzzz3xL//yL3HEEUd0a/5bt26N97///fHQQw/FSy+9FEuXLo2LLroo1q5dG5/85Cfbje3u9X3Erl3j78w+a51nrp535nvf+16MHDkyTj311FiwYEFs3rw5FixYEO973/ti5MiRXa5Ss9ep3+p59LSWlpZ0xhlnpBEjRqQhQ4akmTNnpqVLl7at5bjjv1euUdzqxRdfTB/5yEfSiBEj0oABA9KMGTPS/Pnz29awjIh02GGHtfubu+++O73uda9LAwYMSOPGjUv/9E//lFL6v3Uzd/zXuj7mhAkTOsS6Wh8ZYFe01q1HH300XXzxxWnChAmpX79+6YADDkhXXXVVu/V8W9dVf+W/V66n27pecK16+r3vfS+94Q1vSAMHDkwDBw5Mr3/969PcuXPbjWldM/iV/165PnHOL3/5yxQR6etf/3qH2M9+9rN01llnpQMPPDANHDgwDR8+PB199NHp2muvbbd+c0opbdmyJX384x9PY8aMSYMGDUozZsxIixYtaovPnz8/ve1tb0sjRoxI/fv3T0cccUT6xje+kWbMmFGovne2NnJKKS1dujTNnDkzDR06NA0fPjydccYZqaWlpd2Yiy66KPXp0yc98cQTO7VvgI7e9KY3pYhIv/71rzutQ53Z8Rqw9V9nz/Mda2FXNa6rWtBqZ65ZN27cmD7/+c+nQw89NPXv3z+NHDkyzZgxI910002djn/hhRfSRRddlCZNmpT69euXXvOa16RzzjknPfPMMx3Gbt26NV199dXpz//8z1NTU1Pad9990/HHH59uvfXWduM6O3ccd9xxKaXOzxd33XVX2rJlS7rpppvSe97znjR58uTU1NSURo0alWbMmJF+9KMfdZhLV9f3O7u/duUaf2f2WVf1vKvz646WLFmSZs+encaNG5f69u2bxo4dm84999y0ZMmSduM6Oxavv/76To+3CRMmdLofqqohpT3w5/8AIONDH/pQzJ07N5566qk9+rvYp5xySsyfPz+eeOKJPe7j6cuXL4/JkyfHRz/60bjqqqt6ejpQeUceeWQsXLgwHnzwwTj88MN7ejpAQT5+DwB7sO9+97sxbNiwOP300zv9teaqamlpiXe9611x9NFHx5e+9KWeng5Uzkc+8pH4zGc+0/b/bdu2xZNPPhmDBg2KAw88sAdnBuwsTT0A7MH222+/+O1vfxt9+vSJ6667rqenU5rLL788pk6dGj//+c/bvt8PFLdly5aYN29eLFq0KJqbm+PSSy+NtWvXxnnnnRf9+vXr6ekBO8HH7wHYq8yZMyc+/OEPt7ttwoQJbUuz7ck2bNgQAwcO7OlplGJPui/QE372s5/FlVdeGQ888EC0tLTEhAkT4gMf+EBcfPHF0adPn56eHrATNPUAAABQUT5+DwAAABWlqQcAAICKaiw6sKGhYXfOA9iD+ZbP7qdGA7tKjd691GdgVxWtz96pBwAAgIrS1AMAAEBFaeoBAACgojT1AAAAUFGaegAAAKgoTT0AAABUlKYeAAAAKkpTDwAAABXV2NMTAAC61ltefd/e0xMAADrVW64VAAAAgJ2kqQcAAICK0tQDAABARWnqAQAAoKI09QAAAFBRmnoAAACoKE09AAAAVJR16gFgF9TrVfG96dX37T09AYAS7U31O0IN70l727EGAAAAewxNPQAAAFSUph4AAAAqSlMPAAAAFaWpBwAAgIrS1AMAAEBFaeoBAACgojT1AAAAUFGNPT0BAKi3Ml7RLpKjHq+cl7GN7b1oO1XYBlB9veWdzXqdj3J6S+3sLfOomt5yPAMAAAA7SVMPAAAAFaWpBwAAgIrS1AMAAEBFaeoBAACgojT1AAAAUFGaegAAAKgo69QDUCm9ZY353pKjXnJrBxdZW7geOcpgnWToOb2l5hVRj/NRvzrNY3MmXkZdLJIjd1/U585V6XkDAAAA7EBTDwAAABWlqQcAAICK0tQDAABARWnqAQAAoKI09QAAAFBRmnoAAACoKE09AAAAVFRjT0+A7qnHqzJlbGN7CTl603aA3SdXc4rUpDJy5E6QRU6guTFlzKNeNXprHXLk4mXNo4xzhfMN7Jre8o5iGfPI5SjjPNFUwjyK1KtcjnrV51yOIo/b3life8vzCgAAANhJmnoAAACoKE09AAAAVJSmHgAAACpKUw8AAAAVpakHAACAitLUAwAAQEVZp74H1WMt5nrNI6e3rBtcr3kAnavSGvP9MvEiawfncuTiEdVZp35zgRy5MZtKyFHGWsplcC5hT1SVdwPLONeUscZ8kRqfO5cUmUcZ17+57RSpm7kaXuQ8kXtcityXMnJUTVWemwAAAMAraOoBAACgojT1AAAAUFGaegAAAKgoTT0AAABUlKYeAAAAKkpTDwAAABWlqQcAAICKauzpCeypirxaktv5ZeQo8gCXMY+c7QXGbO1mvMiYMuZRJAfsrXL1okg9yY0pUtf6ZeJNBXIM7Ga8rBy5uZZxIi9SXzdl4hsK5MiNKSNHbp5FFNkfZXA+gV1TxrkmVzvrdZ7Ina+K1KPNmXiRWlOPd3rLqHlF9kduO0Xua9Xqs3fqAQAAoKI09QAAAFBRmnoAAACoKE09AAAAVJSmHgAAACpKUw8AAAAVpakHAACAirJO/S6qxzrKuXhEfg3NImts5rZTrzWQc2tsFll7ODcmt40iylgfE/ZWZawdXKQ25tYGHlwgx5BMfFiBHLkx+xbIkRtTZH/kFKmN67oZj4ho7mY8In981Ovdity5wHmAqukt7/SVMY8iOXK1s4x16ocXyJE712wokGN1Jl6kxudqa5GaltunRa6hy7A31ufe8vwFAAAAdpKmHgAAACpKUw8AAAAVpakHAACAitLUAwAAQEVp6gEAAKCiNPUAAABQUZp6AAAAqKjGnp5Ab1TklY7cjutXIMfATHxwgRxDuhkvMqZvgRw5WwqMaelmvMiY9QVylGFrJr69LrOAchWpjbkxZdTXpgI5cvVzWIEcozPxUQVyvCoTH1NgIsMyY5qK7JCMTZvyY5qba8eXZ+IREc9n4kXuShnvRuRqcJEanRtTj3lCFZXx3KjHeaLIdXhuzKsL5JiQiS8vkCO3PwqU+Gy9KZIjd/2bi9dLGfPobfXZO/UAAABQUZp6AAAAqChNPQAAAFSUph4AAAAqSlMPAAAAFaWpBwAAgIrS1AMAAEBF7ZXr1OdeySiyU3Lr0OfWoI/Ir5M8skCOMZl4bo3kiPxay4OL3JmM9RvyY1Zm4rn1jSPya3muKpCjHoqsj9nb1r+EInpLfR2SiefWoI+IGJ+JTyywEPLEibXj43IbiYgxmckOLrKYcsb69fkxy1fUji99Np9j6OLa8f5FFkLOKFI7y1hLuR5r3UOZ6vFOXj3WoI/Ir0M/vECO/TPx/Qrk2DcTn1wgx4jMBf/w1QVyZIpJgRKfHVOva+jcMVRGbS1ynFatPnunHgAAACpKUw8AAAAVpakHAACAitLUAwAAQEVp6gEAAKCiNPUAAABQUZp6AAAAqChNPQAAAFRUY09PoCfkXsko8kpHv0x8cIEcIzPxCQVyTMnFD8jnmDixdnzE8AITyXhhdX7M4sW1448/kc/RVGg2tW3tZrzImCLH2PYCY6BMZdTG3JgiJ53c83hggRzDMvFRBXJMzEzk4IPzOQ49tHZ8yoEFJrJ/5mwwZEiBJBktLdkhU5Y8XTP++GP5zTTlHtxH8jle2lQ7ngkXGrO5QI4yzhVlvLPiXEE9lXHM5s4DuWvsiIhc1StSWo/P1KP998/nGJy54B+Zu9gv4Pnn82Oam2vHNxcoak9ntrMtnyJbW8u4hi5yHVFkOzlVq8/eqQcAAICK0tQDAABARWnqAQAAoKI09QAAAFBRmnoAAACoKE09AAAAVJSmHgAAACpqj1unvreso1xk1eAxmXhuDfqIiKOm146//uh8jlGHj649YOzYAjPJWLYsO+SgP66oGR82rMB2FtQOF1m/eEMmXiRHbjnQIutW5o5TaxNTb/Wqr7k1istYp/5VBXJMnFg7nluDPiJiyvShtQdMnZpPMnly7fjIEfkcOateyI/5059qhqcMub/AhtbWjG4qUGDXZtayX1dgFi2ZeO48EJE/lst4vqjzFFXGu3T1WIO+yJgiNT5z5RqTCuTIXVfm1qCPiDj88Mw8pg/PJ9mn9p7fuGRVNkVunfrHHstPY1lmnfoico9tkeOjHu84F9lG1eqvd+oBAACgojT1AAAAUFGaegAAAKgoTT0AAABUlKYeAAAAKkpTDwAAABWlqQcAAICK0tQDAABARTX29AR6oyI7pSkTH1Igx6sy8SkH5HO8/uja8VFvnZpP8sZjM0km5nPkrFycHTJq7N0146+P+7M5mpsz03gimyJeyMRb8iliQya+uUAOqKLcK8VFXknul4kPLJBj30x8zLB8jnHja8enHFhgIlOn1o4ffVQ+x6DDMgNGFZhIbhsr82NGjuj2Zqa0/KpmfPmKfI7nn8/Em/M5csdQ7hiMKOdYh6qpR40fXCBH7hp6bIGL+SGZi/WxY/M5Jr01c7F+2qx8kr7Da4YHvLQqm2LAHf+vZnzZvy3ITyOzz/bdmk0RGzPx3PVxvWzv6QnsBs45AAAAUFGaegAAAKgoTT0AAABUlKYeAAAAKkpTDwAAABWlqQcAAICK0tQDAABARe2V69TnXskoslNya2wWWac+t7LwxIkFchw+uvaA3Br0ERGj3pwZMCWfI7uNx/Nj3phJsWxZNsXEx2ovcvx4gXXqc49dkfWLc8eQV9OotyLHXBnHZRn1NTemqUCO3Dr1w4blc4zJlNfYf0I+yeTJtePZNegjIo7IxMcUyJGzPD9kUCY++YV8jsWLa4bHjH46myL32O3bnJ9G7hgq4zitx/OpiD1xPea9UT2OpzLOE2U8dwYWyJFbp/6Qg/M5jj++dnzEGW/NJznmrzMDinQES2qHtz6XTzFyZM3wkW/MX71u2LC59oBf56exLrOWfZF6lEmRjRfdzp5GbwEAAAAVpakHAACAitLUAwAAQEVp6gEAAKCiNPUAAABQUZp6AAAAqChNPQAAAFSUph4AAAAqqrGnJ1C2Iq9S5MYUyZHbcX0L5Bg8sHZ8xPACScaOrR0fNbFAkimZ+GEFcpRg1BO147n7GhEjhq+oGc/t84iIvhtqx4s8aco4xnJjthfIAWUq41XgMo79Is/Bfpl4U1M+x+DBmQFDhuSTjByRGTAqnyPGZOLjCuQoQ2au2fsa2X2W3eeRf+xyj31E/hgq4zgtQp2nLPW6/q3HNXSB8pwdU6SWjDhgWO0Bhxa5/s3V8EEFcmzNpFiaT9GY6TwOyF3rRxy67KGa8V/9Oj+NNZl4Sz5FbM7E1cXOeaceAAAAKkpTDwAAABWlqQcAAICK0tQDAABARWnqAQAAoKI09QAAAFBRmnoAAACoqD1unXoAAKC9eqwxX6SxyK0xX8Y69UWk1c014w2Laq/bHhERx7w+M+CIAjN5VSZ+VD7FyCdrx594PJviiSdqx5/cmp/G6kx8Uz5FFNgMnfBOPQAAAFSUph4AAAAqSlMPAAAAFaWpBwAAgIrS1AMAAEBFaeoBAACgojT1AAAAUFGaegAAAKioxp6eQNm2lzCmSI6tmfiWAjnWb6gdf2F1gSTLltWOr1yczzHq8QIb6q4C28jNNXdfI7/Pcvs8Iv/Y5R77iHKOsSJjoJ7KOCbLOPaLPAc3Z+KbNuVzrF+fGdDSkk+y6oXa8UEr8zlieYEx3VVkG5m55u5rRHafZfd55B+73GMfkT+G6lWj1Xn2NEUai36ZeFOBHAMz8dGj8zkaRo+sPWDw4AIzWZeJjymQY3gmPiSfYtnS2vE//Smborm5dvyl/CzqUltdh3fOO/UAAABQUZp6AAAAqChNPQAAAFSUph4AAAAqSlMPAAAAFaWpBwAAgIrS1AMAAEBF7XHr1BdRjzWQC6xenFvxNxYvzuc46I8rasZHjb07n+SNmfioJ/I5cnJr0EdE/K72XFdm7mtEfp8VWRE699jVaw1kKFMZx1yRV4HLqK+5MQWWmM+uHJxbjzciYnmm5ExZ8nQ+SW5t4JEj8jkG5QaMyufIKlAdX3yodrzAOsiR2We5fR6Rf+xyj31E/hgq4zit1zr2zicUlTtWitT43JgychS5zsqVilWrCiTp1792/Pnl+RyDf1s7PungAhPpUzv84BXZDFtuvb1mfPXq/CwaM11h33yKrHrV1iLb6a7eVnu9Uw8AAAAVpakHAACAitLUAwAAQEVp6gEAAKCiNPUAAABQUZp6AAAAqChNPQAAAFSUph4AAAAqqrGnJ9AbbS0wZlMm3lIgx/OZ+ONP5HMMG1Y7/vq4P5tj1LJltQeMHZufSE5uGxGx8o8rasbv/d/8ZnL7LLfPI/KPXe6xjyh2DMGeaHs34xERmzPxDQVyrMvElzfncyx9tnb88cfyOaYMuT8/KGfyC7XjI0d0fxurMtuIiPjTn2rH778/myK3z3L7PCL/2OUe+4j8MZQ7BiPKOdahanLvBhZpLHLPjfUFcuSuKhcsKJAkltaMDhtWOx4RMX783TXjr37d7flpNK+pGf797/JXns3NteObCly85vbZ4nyK7DV0kdqau4Yuo7buifXZO/UAAABQUZp6AAAAqChNPQAAAFSUph4AAAAqSlMPAAAAFaWpBwAAgIrS1AMAAEBF7XHr1BdZdzA3pl7r1C/PxJsK5IjMmpK5dSsjIiY+Vnt9+BHDa8eLeGF1fszixbXjuTXoIyIez8Rz+zyiPuvUl3GcQr3Vq76WsU59cyb+fIEcQxfXjjcVKtJra0antPwqnyJXHIcMKTKR2loKnLWWPF0znFuDPiJi0aLa8dxdjcg/ds35FKWsU6/O05sUOZbKeCevHjW+yHVWbsyyAk/ihQtrx1/1qnyO3Hlg4CPPZXOsyFxm5+IR+RL+RIFr6N9mHtzF+RSlrFOfO8bqVVurVp+9Uw8AAAAVpakHAACAitLUAwAAQEVp6gEAAKCiNPUAAABQUZp6AAAAqChNPQAAAFSUph4AAAAqqrGnJ9ATtnczHhGxORNfXyDHqgJjcjZl4iufyOd4PDNm8MDC0+nS+g35MSsz8ecLbGd5Jl5kn+ceu9xjH1HOMQb1VsZxmcuxtUCOXF0rUE6iORNvKpCjf24ij+RzbMrkWL4in2PM6KdrxgcPzufIWV/gpJWb69Jn8zkWL87Ec/s88ueK5nyK7DFUYBrZY7nI88m5gqJyx0KRd+nKON5yx32R505uriVcdhaqA/tkJttvdT7H85mL07Ut+RzPLKkdbymQI1fDFxa4eM21DM35FNlrZHVx9/FOPQAAAFSUph4AAAAqSlMPAAAAFaWpBwAAgIrS1AMAAEBFaeoBAACgojT1AAAAUFENKaVUaGBDw+6eS69R5JWOxky8X4EcuXU4iyw9PKSb8SJj+hbIkbOlwJjcMpwFlunMjimwFHN2/eIi69SXsX7xnqRgmaEb6lGji9TG3Jhc7YzI188iaxjn6tqwAjlGZ+KjCuR4VSY+psBEhmXGNDUVmEjGpgKLSzc3144vz8QjIjJLOmfXoI+IWJGJF5hG9lyROw9E5M8FufNARO9Zj1mN3r2qUp/rdf2bu74dWSDHsEy8yLkmd307tIR5FCitsTYT31YgR247iwvkWNXNbUSUc/1bj7pXpevwovXZO/UAAABQUZp6AAAAqChNPQAAAFSUph4AAAAqSlMPAAAAFaWpBwAAgIrS1AMAAEBFaeoBAACgohp7egK90fYCY7bu9lkU28amTLylQI5+mXgZB0mR+7I5E8/d1yJjctsoMqbIfSlyDEHVlHFcl1Ffi9SCMl6xzs21yDzWZeLPN+dz7JsZk6vhRRSpjbn7kotHRDR3Mx6RP6+tL5Aj99iVUeeLHOvOFZSlXsdSGdvJXVcWqd/NmXiRmpabR5GatjwT31ggRxn1KFf3ivQDvaUusmu8Uw8AAAAVpakHAACAitLUAwAAQEVp6gEAAKCiNPUAAABQUZp6AAAAqChNPQAAAFSUdep3UW6dxTLWsS9jbfcNBXKUsV5oThlrUxfZH7kxZczDGpuw68p4DpahjHkUWac+tzbwwAI5mjLxMk7kRfZ57v4WOd/kxpSRo8jjkjt3lrEeM+yNijwvcs+/1SXkKDKPwZl4vwI5yqiLuRy5+xqRX6e+SI4yrn97S13sLfOoJ+/UAwAAQEVp6gEAAKCiNPUAAABQUZp6AAAAqChNPQAAAFSUph4AAAAqSlMPAAAAFaWpBwAAgIpq7OkJ7Km2FxizNRMv8opLbjubC+TIbaeMV36K7I8iY7qbo17zgL1VPZ4/udpZRBk1ukh93ZCJ9yuQI3eirleNLmN/5MZsKiFHkeMjN6aMc4VzCb1NGcdkGfW3JRMvo6YVqa25+5Kr3xH1qWll1NYij5uaVm3eqQcAAICK0tQDAABARWnqAQAAoKI09QAAAFBRmnoAAACoKE09AAAAVJSmHgAAACrKOvU9qIz1IOvxqky91kAugzU0oXer13O0HuuQF1n3t4w15quyTn0ZOaq0xrzzDXuaeq1jn9tOkZqWG1MkR24N+TLWqa/XuWZPqmm9ZR5V4516AAAAqChNPQAAAFSUph4AAAAqSlMPAAAAFaWpBwAAgIrS1AMAAEBFaeoBAACgojT1AAAAUFGNPT0Bumf7HrINgFZl1JxcjiKvaOdybC2QI7edIvPoLa++5/ZHkcett+To7jZgb9Vb6nMZdTFXw/eketRbalpvmceeqLdcKwAAAAA7SVMPAAAAFaWpBwAAgIrS1AMAAEBFaeoBAACgojT1AAAAUFGaegAAAKgo69QDUCn1Wue2t6ylXI9t9JZ9uietxwx7oyLPv1zNKuM5nFuDvojeUhfrpbfMg13jnXoAAACoKE09AAAAVJSmHgAAACpKUw8AAAAVpakHAACAitLUAwAAQEVp6gEAAKCiNPUAAABQUY09PQEAqLftFdpO7tX3Kt2X3rANoGepJeXb2+4vHXmnHgAAACpKUw8AAAAVpakHAACAitLUAwAAQEVp6gEAAKCiNPUAAABQUZp6AAAAqCjr1APALtjb1gXe2+4v0HupR9Ced+oBAACgojT1AAAAUFGaegAAAKgoTT0AAABUlKYeAAAAKkpTDwAAABWlqQcAAICK0tQDAABARTX29AQAgK5t7+kJAAC9mnfqAQAAoKI09QAAAFBRmnoAAACoKE09AAAAVJSmHgAAACpKUw8AAAAVpakHAACAimpIKaWengQAAACw87xTDwAAABWlqQcAAICK0tQDAABARWnqAQAAoKI09QAAAFBRmnoAAACoKE09AAAAVJSmHgAAACpKUw8AAAAV9f8Byg4OEB6QxjMAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1100x330 with 3 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "out = imgr.make_image_I(niter=2, use_jax=True, show_updates=False)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(11, 3.3))\n",
+    "for ax, image, title in zip(axes, [src, prior, out],\n",
+    "                            [\"truth\", \"prior (start)\", \"JAX reconstruction\"]):\n",
+    "    ax.imshow(image.imarr(), cmap=\"afmhot\", origin=\"lower\")\n",
+    "    ax.set_title(title)\n",
+    "    ax.axis(\"off\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed639025",
+   "metadata": {},
+   "source": [
+    "## What's next\n",
+    "\n",
+    "The unknown here was the image alone. The reason for the functional rewrite is\n",
+    "to swap that single `x` for a pytree `(image, gains, dterms)` and call the\n",
+    "*same* `jax.value_and_grad` — joint calibration + imaging by autodiff, instead\n",
+    "of alternating minimization. That step needs the Jones forward model +\n",
+    "cal-table redesign still in progress; once they land, this objective is the\n",
+    "seam it plugs into."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "jax-ehtim",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
> **Update (2026-06-17) — rebased onto current `dev-backend`.**
> The pol-gradient correctness fixes this PR originally surfaced are now **upstream**, so #295 is scoped to the **JAX implementation + tests**:
> - `epsilon_tv` on `reg_ptv`/`reg_vtv` and the `reggrad_ptv` first-row/col boundary masking → now on `dev-backend` via **#306** (alongside `physical_grad_slots`).
> - The V-pol (V/IV) gradient fix → **#296**, already merged to `main`.
> - This PR's own part-B gating patches were **stripped** in the rebase; the canonical gating (`physical_grad_slots`) is inherited from `dev-backend`.
>
> Validated on the rebased branch: **1784 numpy + 71 jax** green. The sections below are retained as history of where those fixes originated.

---

Makes the full imaging objective differentiable under JAX: `jax.grad(compute_objective)` now equals the hand-written `compute_objective_grad`, on CPU **and GPU**, across Stokes-I + polarization + multifrequency, `ttype` direct + NFFT, and all regularizers. Builds on #291's backend switch (`array_namespace`) by making the rest of the objective backend-agnostic. NumPy behavior is byte-identical throughout.

**Now also includes** the `use_jax` flag on `Imager.make_image` — an end-to-end jax reconstruction through scipy L-BFGS-B that recovers the source and matches the numpy recon — plus explicit GPU device + CPU↔GPU-parity tests for the full objective (direct + nfft). **Remaining (draft):** a full *multifrequency* imaging recon test (the mf forward has unit coverage; mf is deprioritized this week) and where to document the GPU jax-finufft build.

### What changed
- **direct objective**: `unpack_imarr`/`transform_imarr` made functional (no in-place mutation); new `make_objective_jax(...)` factory returns a scipy `fun(x)->(value, grad)` (closure over all-but-`x`, lazy jax import so `import ehtim` stays jax-free).
- **OO integration**: `make_image(use_jax=True)` builds the factory and runs scipy L-BFGS-B on the jax objective (numpy path unchanged when off; GPU by default on a CUDA box).
- **NFFT under jax-finufft**: `nufft2_backend` dispatches finufft (numpy, byte-identical) vs `jax_finufft.nufft2` (jax, differentiable, GPU). NumPy NFFT still uses **only finufft**. 6 chisq kernels.
- **all regularizers agnostic**: 6 embed-free (#291) + 9 spatial + full `embed()`/`embed_imarr()` functional scatter (full & partial mask) + 8 pol regs + 2 spectral.
- **two pol-TV gradient correctness fixes** (both surfaced by the autodiff-vs-analytic comparison, see below): `epsilon_tv` on `reg_ptv`/`reg_vtv` (default 0, byte-identical, matching `reg_tv`); and `reggrad_ptv` now zeros its back-neighbor terms on the first row/col — the boundary masking `reggrad_tv`/`reggrad_vtv` already have.
- **pol/mf forward**: `make_*_image`, `polcv/mcv/vcv` (legacy `mcv/vcv` dead `raise` guards kept numpy-only), `chisq_p/m/vvis`, `image_at_freq`.
- **tutorial**: `tutorials/ehtim_tutorial_jax.ipynb` — install (jax + the GPU jax-finufft source build), the `jax.grad(objfunc) == objgrad` demo (direct + nfft on the GPU), and an end-to-end `make_image(use_jax=True)` recon.

### Validation (`tests/test_objective_jax.py`, `@pytest.mark.jax`)
direct+nfft × {value parity, gold-standard grad parity, FD, factory, no-retrace} + embed/partial-mask + pol IP/IV (grad vs **FD ground truth**) + `make_image(use_jax=True)` recovery (matches numpy) + **GPU device & CPU↔GPU parity** (direct + nfft) — 22 tests, green on calypso (CPU + GPU). NumPy regressions green (458 backend+e2e, 146 pol, 102 pol-reg). Ruff clean.
- NFFT grad parity is **eps-limited, not a bug** (proven: residual scales 1e-9→~1e-6, 1e-12→~7e-10); tests use `nfft_eps=1e-12`.

###  Pre-existing bugs surfaced by the autodiff-vs-analytic comparison
1. **pol TV regularizers had no epsilon in their `sqrt`** (unlike `reg_tv`'s `epsilon_tv`) → singular gradient at smooth pixels. **Fixed here** via `epsilon_tv` (default 0, so byte-identical off).
2. **`reggrad_ptv` was missing the first-row/col boundary masking** that `reggrad_tv`/`reggrad_vtv` have → the entire first row + column of the magnitude-gradient slots (I/m/psi) was wrong (corner 4× off vs finite-difference; phase slot was fine because its numerators self-zero at the pad). **Fixed here**; FD-matched to ~1e-10 everywhere after, and a new full-grid regression test (`test_reggrad_ptv_matches_fd_on_boundary`) fails pre-fix.
3. **The V-pol analytic gradient is wrong** (`chisqgrad_vvis` / `vcv_grad`): for IV imaging jax autodiff **and** finite differences agree, but the hand-written analytic dropped the physical `rho` gradient the `vcv` chain consumes (solver `v'`-gradient ~87% off). Pre-existing (the jax port didn't touch the analytic grad kernels) — like `stv_pol_grad` (#240). **Fixed in standalone PR #296** (independent function, no overlap with this PR — kept separate so the correctness fix can merge fast).
