### PR TITLE
Fix wrong V-pol (IV) imaging gradient: chisqgrad_vvis drops the rho gradient

### DIFF
--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -547,7 +547,11 @@ def chisqgrad_vvis(imarr, Amatrix, v, sigmav, pol_solve=POL_SOLVE_DEFAULT_V):
         gradi = -np.real(vfimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
         gradout[0] = gradi
 
-    if pol_solve[1]!=0:
+    # The physical rho gradient is needed whenever V is solved: the vcv transform
+    # expresses V via vprime, and vcv_grad's vprime chain rule uses it
+    # (out[2] = drho_dvprime*grad_rho + dpsi_dvprime*grad_psi). Computing it only
+    # when pol_solve[1] is set dropped the dominant drho_dvprime term for pol='IV'.
+    if pol_solve[1]!=0 or pol_solve[3]!=0:
         gradv = -np.real(iimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
         gradrho = gradv*np.sin(psiimage)
         gradout[1] = gradrho
@@ -766,7 +770,9 @@ def chisqgrad_vvis_nfft(imarr, A, v, sigmav,pol_solve=POL_SOLVE_DEFAULT):
         gradi = np.real(vfimage*vpart)
         gradout[0] = gradi
 
-    if pol_solve[1]!=0:
+    # See chisqgrad_vvis: the physical rho gradient is needed whenever V is solved,
+    # because vcv_grad's vprime chain rule uses it (dropped the dominant term for IV).
+    if pol_solve[1]!=0 or pol_solve[3]!=0:
         gradv = np.real(iimage*vpart)
         gradrho = gradv*np.sin(psiimage)
         gradout[1] = gradrho

--- a/tests/test_imager_e2e.py
+++ b/tests/test_imager_e2e.py
@@ -195,6 +195,34 @@ class TestEndToEndReconstruction:
         assert p_total == pytest.approx(p_truth, rel=0.5), (
             f"total polarized flux {p_total:.3e} off from truth {p_truth:.3e}")
 
+    def test_iv_gradient_matches_finite_difference(self, obs_pol_direct, gauss_im_pol, gauss_prior):
+        """IV (circular-pol) analytic gradient must match finite differences.
+
+        Regression for the vcv / chisqgrad_vvis bug: vcv_grad's vprime chain rule
+        uses the physical rho gradient, which chisqgrad_vvis previously skipped for
+        pol='IV' (pol_solve=[1,0,0,1]), making the V-angle gradient badly wrong
+        (~99% off; FD median was ~6e-2 before, ~3e-10 after).
+        """
+        imgr = eh.imager.Imager(
+            obs_pol_direct, gauss_prior, prior_im=gauss_prior, flux=gauss_im_pol.total_flux(),
+            data_term={"amp": 100, "vvis": 100}, reg_term={"simple": 1},
+            ttype="direct", pol="IV", transform=["log", "vcv"], maxit=100,
+        )
+        imgr.init_imager()
+        rng = np.random.default_rng(4)
+        x = np.asarray(imgr._init_vec, float) + 0.10 * rng.standard_normal(imgr._init_vec.size)
+        g = np.asarray(imgr.objgrad(x))
+        idx = np.argsort(np.abs(g))[-40:]  # best-conditioned components
+        fd = np.empty(40)
+        for k, j in enumerate(idx):
+            a, b = x.copy(), x.copy()
+            a[j] += 1e-6
+            b[j] -= 1e-6
+            fd[k] = (imgr.objfunc(a) - imgr.objfunc(b)) / 2e-6
+        frac = np.abs((fd - g[idx]) / (np.abs(g[idx]) + 1e-100))
+        assert np.median(frac) < 1e-3
+        assert np.max(frac) < 1e-2
+
 
 def test_imager_fast_ttype_warns_deprecated(gauss_im, observe):
     """Constructing an Imager with ttype='fast' emits the imaging-context


### PR DESCRIPTION
Fixes a real correctness bug in **IV (Stokes I + circular pol) imaging**: the analytic gradient `chisqgrad_vvis` dropped the physical **ρ-gradient**, making the V-angle gradient ~99% wrong. NumPy IV reconstructions have been converging against a bad gradient.

### Root cause
`pol_solve` masks **physical** gradient rows inside `chisqgrad_vvis`, but the `vcv` transform is non-diagonal — its Jacobian couples the V solver variable (`vprime`) to **both** physical ρ and ψ:

```
vcv_grad.out[2] = drho_dvprime * grad_rho  +  dpsi_dvprime * grad_psi
```

For `pol='IV'` (`pol_solve=[1,0,0,1]`), `chisqgrad_vvis` computed only rows 0 and 3 — leaving `grad_rho` (row 1) = 0 — so the **dominant `drho_dvprime · grad_rho` term was dropped**.

Why the other pol modes escaped:
- **IP** (`mcv`): the un-computed row is ψ, but its coupling coefficient `dpsi_dmprime = 0` at `vfrac=0` → harmless.
- **IPV** (`polcv`): the transform is diagonal and `pol_solve[1]=1` anyway → ρ-gradient is computed.

So the bug is **IV-specific**: only `vcv` has a *nonzero* coupling to the row `pol_solve` skipped.

### Fix
Compute the physical ρ-gradient whenever V is solved (`pol_solve[1] or pol_solve[3]`), in both `chisqgrad_vvis` and its nfft twin `chisqgrad_vvis_nfft`. Two-line condition change + comments.

### Validation
- IV `objgrad` now matches central finite differences to **median 2.8e-10, max 1.6e-9** (was ~99% wrong).
- New FD-based regression test `test_iv_gradient_matches_finite_difference`.
- The 26 existing pol `chisqgrad` parity tests (direct + nfft) and the IP recon test are unchanged (the fix is consistent across direct + nfft, so parity holds). Ruff clean.

### How it was found
Surfaced by the JAX autodiff objective port (#295): jax autodiff **and** finite differences agreed, while the hand-written analytic disagreed — the same discovery mechanism as the `stv_pol_grad` fix (#240).

### Notes
- This affects **released** numpy IV imaging, so like #240 it targets `dev` for a fast main release. Rebased onto `dev` locally so the diff is just the fix (not the jax development on `dev-backend`); once merged it can propagate dev→dev-backend→dev-backend-mixpol and be cherry-picked to main.
- **Audit done** (`chisqgrad_p`/`chisqgrad_m`, follow-up to this fix): IP (mcv), IQUV (polcv), and IV (vcv, post-fix) all match finite differences to ~1e-9. The same-class fragility in `chisqgrad_p`/`m` is **latent only** — `mcv` is always used at vfrac=0, where its psi coupling coefficient is exactly 0 — so they are correct in every real mode and **no code change is needed**. This PR is scoped to the reproduced IV fix only.



