### PR TITLE
Zero ptv gradient back-neighbor terms at the image boundary

### DIFF
--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -892,12 +892,22 @@ def reggrad_ptv(imarr, mask, **kwargs):
     d3 = np.sqrt(np.abs(im_r2 - im)**2 + np.abs(im_l1r2 - im_r2)**2)
     # Numerators below use cos/sin of the single-angle difference between
     # neighbors, from d|P_l1 - P|^2/d|P| = 2|P| - 2|P_l1|*cos(angle(P_l1) - angle(P)).
+    # The back-neighbor magnitude numerators m2/m3 keep a |P| term that does not
+    # vanish at the zero-pad, so the first row/col would pick up a neighbor that
+    # does not exist; zero those terms there as reggrad_tv/reggrad_vtv do. (The
+    # phase numerators c2/c3 carry a |P_neighbor| factor and self-zero there.)
+    mask1 = np.zeros(im.shape, dtype=bool)
+    mask2 = np.zeros(im.shape, dtype=bool)
+    mask1[0, :] = True
+    mask2[:, 0] = True
     gradout = np.zeros(imarr.shape)
     if pol_solve[0] != 0:
         # dS/dI numerators (chain through |P| = I*m)
         m1 = 2*np.abs(im*im) - np.abs(im*im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im*im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im*im) - np.abs(im*im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im*im) - np.abs(im*im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        m2[mask1] = 0
+        m3[mask2] = 0
         gradout[0] = (1./iimage) * (m1/d1 + m2/d2 + m3/d3).flatten()
     if pol_solve[1] != 0:
         # dS/dm numerators; m enters via |P| = I*m, so dS/dm = I * dS/d|P|.
@@ -905,6 +915,8 @@ def reggrad_ptv(imarr, mask, **kwargs):
         m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        m2[mask1] = 0
+        m3[mask2] = 0
         gradm = iimage * (m1/d1 + m2/d2 + m3/d3).flatten()
         gradout[1] = gradm * np.cos(psiimage)
     if pol_solve[2] != 0:
@@ -920,6 +932,8 @@ def reggrad_ptv(imarr, mask, **kwargs):
         m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        m2[mask1] = 0
+        m3[mask2] = 0
         gradm = iimage * (m1/d1 + m2/d2 + m3/d3).flatten()
         gradout[3] = gradm * (-mimage * np.tan(psiimage))
     g = gradout / norm

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -298,6 +298,46 @@ class TestPolRegularizerGradients:
             f"{rtype} max fractional gradient diff = {max_frac:.6f} (tol={max_tol})"
         )
 
+    def test_reggrad_ptv_matches_fd_on_boundary(self):
+        """ptv gradient is correct on the first row/column, not just the interior.
+
+        The back-neighbor magnitude numerators do not vanish at the zero-pad,
+        so the first row/col would otherwise pick up a neighbor that does not
+        exist. The random-pixel FD check above rarely lands on the boundary;
+        this checks every pixel of a small full-mask grid so the edges are
+        exercised directly.
+        """
+        rng = np.random.default_rng(0)
+        ny = nx = 6
+        n = ny * nx
+        imarr = np.array([rng.uniform(0.5, 2.0, n), rng.uniform(0.1, 0.5, n),
+                          rng.uniform(-1.0, 1.0, n), rng.uniform(-0.5, 0.5, n)])
+        mask = np.ones(n, dtype=bool)
+        kw = dict(flux=float(imarr[0].sum()), xdim=nx, ydim=ny, psize=1.0,
+                  beam_size=2.0, norm_reg=True)
+        g_an = np.asarray(pu.reggrad_ptv(imarr, mask,
+                                         pol_solve=np.array([1, 1, 1, 1]), **kw))
+        dx = 1e-6
+        g_fd = np.zeros_like(imarr)
+        for slot in range(4):
+            for j in range(n):
+                a = imarr.copy()
+                a[slot, j] += dx
+                fp = pu.reg_ptv(a, mask, **kw)
+                a = imarr.copy()
+                a[slot, j] -= dx
+                fm = pu.reg_ptv(a, mask, **kw)
+                g_fd[slot, j] = (fp - fm) / (2 * dx)
+        edge = np.zeros((ny, nx), dtype=bool)
+        edge[0, :] = True
+        edge[:, 0] = True
+        edge = edge.flatten()
+        for slot in range(4):
+            assert np.max(np.abs(g_an[slot] - g_fd[slot])) < 1e-5, (
+                f"slot {slot} ptv gradient disagrees with FD "
+                f"(max boundary diff {np.max(np.abs((g_an[slot] - g_fd[slot])[edge])):.2e})"
+            )
+
 
 def _pol_gradient_check(polreg_setup, rtype):
     """FD-vs-analytic check across N pixels in each pol_solve-active slot."""


### PR DESCRIPTION
`reggrad_ptv` (the pol total-variation gradient) was missing the first-row /first-column boundary zeroing that `reggrad_tv` and `reggrad_vtv` both apply. As a result the **entire first row and first column** of the `|P|`-magnitude gradient slots (I, m, psi — `pol_solve` 0/1/3) were wrong; the phase slot (2) was correct.

## Root cause

`reg_ptv` zero-pads the image and sums forward differences. The gradient has a self term plus back-neighbor terms (`m2` from the up-neighbor, `m3` from the left-neighbor). At the top/left edge those back-neighbors are the zero-pad, i.e. not real pixels, so their contribution must be dropped — which is exactly what `reggrad_tv`/`reggrad_vtv` do with `mask1`/`mask2`.

The phase numerators `c2 = 2|P·P_neighbor|·sin(...)` carry a `|P_neighbor|` factor that is identically 0 at the pad, so they self-zero — which is why the phase slot was already correct. The magnitude numerators `m2 = |P| − |P_neighbor|·cos(...)` keep the `|P|` term, which does **not** vanish at the pad, so the edge picked up a spurious neighbor that doesn't exist.

## Fix

Define `mask1` (first row) / `mask2` (first col) and zero `m2`/`m3` there in the three magnitude blocks — the same pattern the sibling regularizers use.

## Validation

Central finite-difference of `reg_ptv` is the ground truth (it knows nothing about the analytic code). On a 6×6 full-mask grid with pol structure on every pixel:

| | corner (0,0), `m`-slot | max |analytic − FD| over all pixels |
|---|---|---|
| before | 0.140 (FD says 0.032) — **4× wrong** | 7.8e-1 (first row + col) |
| after | 0.032 = 0.032 | 1.2e-10 (every slot, incl. boundary) |

New regression test `test_reggrad_ptv_matches_fd_on_boundary` checks every pixel of a full grid (the existing random-pixel FD checks rarely sample the edge, which is why this stayed latent). It **fails on the pre-fix source, passes after**.

## Note

This overlaps `reggrad_ptv` with #295 (which adds the `epsilon_tv` guard to the same function); whichever lands second resolves a small same-function conflict. Surfaced by the jax autodiff-vs-analytic gradient comparison being built in #295.
