### PR TITLE
Add package build + twine check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           fail_ci_if_error: false
+
+  package:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install build twine
+      - run: python -m build
+      - run: twine check --strict dist/*


### PR DESCRIPTION
## What
Adds a `package` job to `ci.yml` that builds the sdist/wheel (`python -m build`) and runs `twine check --strict dist/*`.

## Why
The v1.3.1 PyPI publish failed on `twine check --strict` (a README RST underline error in `long_description`) — nothing was uploaded. Future releases flow `dev-backend → dev → main`, so validating the package on `dev-backend` PRs catches metadata/README rendering breakage long before a release.

This runs the exact same check the PyPI publish action performs, so a green CI means the publish step's validation will pass.

## How to test
- CI runs the new `package` job on this PR; it should pass.
- Introducing a malformed README should fail the job.

## Notes
- Uses Python 3.12.
- Lives in `ci.yml` rather than a new workflow file — same triggers, one status-check surface.