### PR TITLE
Add package build + twine check CI on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install build twine
+      - run: python -m build
+      - run: twine check --strict dist/*


### PR DESCRIPTION
Adds a `.github/workflows/ci.yml` to `main` containing only the `package` job from the dev-branch CI: a build + `twine check --strict` to catch packaging regressions on PRs to and pushes on `main`.

## What changed
- New `.github/workflows/ci.yml` with a single `package` job (`python -m build` + `twine check --strict dist/*`).
- Triggered on push/PR to `main`.
- Uses Python 3.11.

## Why
`main` had no CI; this guards against broken sdist/wheel metadata before release without pulling in the lint/test matrix used on the dev branches.