### PR TITLE
IV gradient fix to main (v1.3.2)

### DIFF
--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -660,7 +660,11 @@ def chisqgrad_vvis(imarr, Amatrix, v, sigmav, pol_solve=POL_SOLVE_DEFAULT_V):
         gradi = -np.real(vfimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
         gradout[0] = gradi
 
-    if pol_solve[1]!=0:
+    # The physical rho gradient is needed whenever V is solved: the vcv transform
+    # expresses V via vprime, and vcv_grad's vprime chain rule uses it
+    # (out[2] = drho_dvprime*grad_rho + dpsi_dvprime*grad_psi). Computing it only
+    # when pol_solve[1] is set dropped the dominant drho_dvprime term for pol='IV'.
+    if pol_solve[1]!=0 or pol_solve[3]!=0:
         gradv = -np.real(iimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
         gradrho = gradv*np.sin(psiimage)
         gradout[1] = gradrho
@@ -879,8 +883,10 @@ def chisqgrad_vvis_nfft(imarr, A, v, sigmav,pol_solve=POL_SOLVE_DEFAULT):
         gradi = np.real(vfimage*vpart)
         gradout[0] = gradi
         
-    if pol_solve[1]!=0:
-        gradv = np.real(iimage*vpart) 
+    # See chisqgrad_vvis: the physical rho gradient is needed whenever V is solved,
+    # because vcv_grad's vprime chain rule uses it (dropped the dominant term for IV).
+    if pol_solve[1]!=0 or pol_solve[3]!=0:
+        gradv = np.real(iimage*vpart)
         gradrho = gradv*np.sin(psiimage)
         gradout[1] = gradrho
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ehtim"
-version = "1.3.1"
+version = "1.3.2"
 description = "Imaging, analysis, and simulation software for radio interferometry"
 readme = "README.rst"
 license = { text = "GPLv3" }
@@ -50,7 +50,7 @@ docs = [
 
 [project.urls]
 Homepage = "https://github.com/achael/eht-imaging"
-Download = "https://github.com/achael/eht-imaging/archive/v1.3.1.tar.gz"
+Download = "https://github.com/achael/eht-imaging/archive/v1.3.2.tar.gz"
 
 # --- setuptools-specific config ---
 


### PR DESCRIPTION
Cherry-picks the **IV (Stokes I+V) imaging gradient fix** to `main` as a patch release, and bumps the version to **1.3.2**.

`chisqgrad_vvis` / `chisqgrad_vvis_nfft` dropped the physical ρ-gradient for `pol='IV'` imaging (the `vcv` transform couples the V solver variable to both ρ and ψ, and the dominant `dρ/dv'` term was skipped). The V-angle gradient was ~99% wrong on released numpy IV imaging. Fix: compute the ρ-gradient whenever V is solved (`pol_solve[1] or pol_solve[3]`).

`main` is pre-refactor and has no `tests/` infrastructure, so this is the 2-line source fix only. The FD regression test (`test_iv_gradient_matches_finite_difference`) lives on the refactored branches.

Same fix already merged to `dev` (#296), `dev-backend` (#299), and `dev-backend-mixpol` (#300); FD-validated there (analytic vs central differences, median ~3e-10 after vs ~99% wrong before). This completes the cascade to `main`.

Bumps `pyproject.toml` version + download URL 1.3.1 → 1.3.2. Ready for tagging.
