### PR TITLE
pol gradient fixes to dev

### DIFF
--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -534,6 +534,30 @@ def transform_gradients(gradarr, imarr, transforms, which_solve):
     return outarr
 
 
+def physical_grad_slots(pol_solve, transforms):
+    """Physical gradout slots the gradient kernels must fill, given the DOF mask.
+
+    pol_solve is the 4-wide Stokes DOF mask (I, rho/m', chi, psi/v'); the chisq
+    and pol regularizer kernels return gradients in PHYSICAL slots (I, rho, chi,
+    psi). For diagonal transforms (polcv, or none) physical-need == DOF. mcv/vcv
+    are non-diagonal: the single solved pol DOF drives BOTH rho and psi (the
+    cross-term in {mcv,vcv}_grad), so both physical slots must be populated.
+    Mirror of the Jacobian sparsity in transform_gradients -- keep the two in sync.
+
+    The transform <-> pol-mode pairing this branches on (mcv for P/QU/IP/IQU,
+    vcv for V/IV, polcv for IPV/IQUV) is enforced in validate_params, so the
+    mcv/vcv checks here are unambiguous and mutually exclusive.
+    """
+    mask = np.array(pol_solve, dtype=int).copy()
+    if 'mcv' in transforms and pol_solve[1]:     # m' (slot 1) -> rho AND psi
+        mask[1] = 1
+        mask[3] = 1
+    elif 'vcv' in transforms and pol_solve[3]:   # v' (slot 3) -> rho AND psi
+        mask[1] = 1
+        mask[3] = 1
+    return mask
+
+
 def make_initarr(image, mask, norm_init=False, flux=1,
                  mf=False, pol=False,
                  randompol_lin=False, randompol_circ=False,

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -549,6 +549,12 @@ def physical_grad_slots(pol_solve, transforms):
     mcv/vcv checks here are unambiguous and mutually exclusive.
     """
     mask = np.array(pol_solve, dtype=int).copy()
+    # Cross-coupling only exists for the full 4-wide Stokes block. Single-pol
+    # (Stokes-I, possibly mf with [I, alpha, beta]) has no rho/psi DOFs to
+    # couple -- and may carry 'mcv' in transforms inertly, so the transform
+    # check alone is not enough. Mirror transform_gradients' shape gating.
+    if len(mask) < 4:
+        return mask
     if 'mcv' in transforms and pol_solve[1]:     # m' (slot 1) -> rho AND psi
         mask[1] = 1
         mask[3] = 1
@@ -1533,6 +1539,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, config,
 
     chi2grad_dict = {}
     pol_solve = _pol_solve_block(which_solve, pol)
+    pol_grad_slots = physical_grad_slots(pol_solve, config.transforms)
     # np.array((...)) below copies, so sharing zero_row across iterations is safe.
     zero_row = np.zeros(nimage)
     is_pol_mode = pol in POLARIZATION_MODES
@@ -1547,7 +1554,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, config,
 
             chi2grad = compute_chisqgrad_term(
                 imcur_nu, dname, A, data, sigma,
-                ttype=ttype, mask=embed_mask, pol_solve=pol_solve,
+                ttype=ttype, mask=embed_mask, pol_solve=pol_grad_slots,
             )
 
             # Pad standard (nimage,) grad to (4, nimage) Stokes block so the
@@ -1699,9 +1706,11 @@ def compute_reggrad_dict(imcur, reg_term_keys, config,
 
         if mf:
             if regname in REGULARIZERS_POL:
+                pol_grad_slots = physical_grad_slots(
+                    _pol_solve_block(which_solve, pol), config.transforms)
                 regp = compute_regularizergrad_term(
                     imcur[0:4], regname, embed_mask,
-                    pol_solve=which_solve[0:4],
+                    pol_solve=pol_grad_slots,
                     norm_reg=norm_reg, **reg_kwargs)
                 reggrad = np.zeros((len(imcur), nimage))
                 reggrad[0:4] = regp
@@ -1742,9 +1751,11 @@ def compute_reggrad_dict(imcur, reg_term_keys, config,
                 raise Exception(f"regularizer term {regname} not recognized!")
 
         elif regname in REGULARIZERS_POL:
+            pol_grad_slots = physical_grad_slots(
+                _pol_solve_block(which_solve, pol), config.transforms)
             reggrad = compute_regularizergrad_term(
                 imcur, regname, embed_mask,
-                pol_solve=which_solve, norm_reg=norm_reg, **reg_kwargs)
+                pol_solve=pol_grad_slots, norm_reg=norm_reg, **reg_kwargs)
 
         elif regname in REGULARIZERS:
             if pol in POLARIZATION_MODES:

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -33,12 +33,13 @@ import ehtim.observing.obs_helpers as obsh
 NORM_REGULARIZER = True
 DATATERMS = ['vis', 'bs', 'amp', 'cphase', 'cphase_diag',
              'camp', 'logcamp', 'logcamp_diag', 'logamp']
-REGULARIZERS = ['gs', 'tv', 'tvlog','tv2', 'tv2log','l1w', 'lA', 'patch', 'simple', 'compact', 'compact2', 'rgauss']
+REGULARIZERS = ['gs', 'tv', 'tvlog','tv2', 'tv2log','l1w', 'lA',
+                'patch', 'simple', 'compact', 'compact2', 'rgauss']
 
 nit = 0  # global variable to track the iteration number in the plotting callback
 
 ##################################################################################################
-# Wrapper Functions
+# Wrapper Functions (Backward Compatibility Shims)
 ##################################################################################################
 
 
@@ -194,6 +195,7 @@ def chisqgrad_bs(imvec, Amatrices, bis, sigma):
 
 def chisq_cphase(imvec, Amatrices, clphase, sigma):
     """Closure Phases (normalized) chi-squared"""
+
     clphase = clphase * ehc.DEGREE
     sigma = sigma * ehc.DEGREE
 
@@ -208,6 +210,7 @@ def chisq_cphase(imvec, Amatrices, clphase, sigma):
 
 def chisqgrad_cphase(imvec, Amatrices, clphase, sigma):
     """The gradient of the closure phase chi-squared"""
+
     clphase = clphase * ehc.DEGREE
     sigma = sigma * ehc.DEGREE
 
@@ -227,11 +230,12 @@ def chisqgrad_cphase(imvec, Amatrices, clphase, sigma):
 
 def chisq_cphase_diag(imvec, Amatrices, clphase_diag, sigma):
     """Diagonalized closure phases (normalized) chi-squared"""
+
     clphase_diag = np.concatenate(clphase_diag) * ehc.DEGREE
     sigma = np.concatenate(sigma) * ehc.DEGREE
 
-    A3_diag = Amatrices[0]
-    tform_mats = Amatrices[1]
+    A3_diag = Amatrices[0] # fourier matrices
+    tform_mats = Amatrices[1] # transform matrices
 
     clphase_diag_samples = []
     for iA, A3 in enumerate(A3_diag):
@@ -248,11 +252,12 @@ def chisq_cphase_diag(imvec, Amatrices, clphase_diag, sigma):
 
 def chisqgrad_cphase_diag(imvec, Amatrices, clphase_diag, sigma):
     """The gradient of the diagonalized closure phase chi-squared"""
+
     clphase_diag = clphase_diag * ehc.DEGREE
     sigma = sigma * ehc.DEGREE
 
-    A3_diag = Amatrices[0]
-    tform_mats = Amatrices[1]
+    A3_diag = Amatrices[0] # fourier matrices
+    tform_mats = Amatrices[1] # transform matrices
 
     deriv = np.zeros_like(imvec)
     for iA, A3 in enumerate(A3_diag):
@@ -359,8 +364,8 @@ def chisq_logcamp_diag(imvec, Amatrices, log_clamp_diag, sigma):
     log_clamp_diag = np.concatenate(log_clamp_diag)
     sigma = np.concatenate(sigma)
 
-    A4_diag = Amatrices[0]
-    tform_mats = Amatrices[1]
+    A4_diag = Amatrices[0] # fourier matrices
+    tform_mats = Amatrices[1] # transform matrices
 
     log_clamp_diag_samples = []
     for iA, A4 in enumerate(A4_diag):
@@ -384,8 +389,8 @@ def chisq_logcamp_diag(imvec, Amatrices, log_clamp_diag, sigma):
 def chisqgrad_logcamp_diag(imvec, Amatrices, log_clamp_diag, sigma):
     """The gradient of the diagonalized log closure amplitude chi-squared"""
 
-    A4_diag = Amatrices[0]
-    tform_mats = Amatrices[1]
+    A4_diag = Amatrices[0] # fourier matrices
+    tform_mats = Amatrices[1] # transform matrices
 
     deriv = np.zeros_like(imvec)
     for iA, A4 in enumerate(A4_diag):
@@ -1683,7 +1688,7 @@ def chisqgrad_logamp_nfft(imvec, A, amp, sigma):
 
 
 ##################################################################################################
-# Regularizer and Gradient Functions
+# Regularizer and Gradient Helper Functions
 ##################################################################################################
 
 
@@ -1709,26 +1714,34 @@ def fAgrad(imvec, I_ref=1.0, alpha_A=1.0):
 #
 # Each `reg_X` / `reggrad_X` implements a Stokes-I regularizer with the uniform
 # `(imvec, mask, **kwargs)` signature used by the `_REGULARIZER_DISPATCH` table
-# in `imager_backend.py`. Each returns the penalty value (positive; the imager
-# solver minimises it). Spatial regularizers (cm, tv, tvlog, tv2, tv2log,
-# compact, compact2, rgauss) use the embed-pre / mask-post-slice pattern; flat
-# regularizers (flux, simple, l1, l1w, lA, gs, patch) operate directly.
+# in `imager_backend.py`.
+#
+# Each returns the penalty value (defined positive; cf the old entropy style negative regularizers).
+# Spatial regularizers (cm, tv, tvlog, tv2, tv2log, compact, compact2, rgauss)
+# use the embed-pre / mask-post-slice pattern;
+# flat regularizers (flux, simple, l1, l1w, lA, gs, patch) operate directly.
 ##################################################################################################
 
 
 def reg_flux(imvec, mask, **kwargs):
+    """Total flux regularizer"""
+
     flux = kwargs['flux']
     norm = flux**2 if kwargs.get('norm_reg', True) else 1
     return (np.sum(imvec) - flux)**2 / norm
 
 
 def reggrad_flux(imvec, mask, **kwargs):
+    """Gradient of total flux regularizer"""
+
     flux = kwargs['flux']
     norm = flux**2 if kwargs.get('norm_reg', True) else 1
     return 2 * (np.sum(imvec) - flux) * np.ones(len(imvec)) / norm
 
 
 def reg_simple(imvec, mask, **kwargs):
+    """Simple entropy regularizer"""
+
     priorvec = kwargs['nprior']
     flux = kwargs['flux']
     norm = flux if kwargs.get('norm_reg', True) else 1
@@ -1736,6 +1749,8 @@ def reg_simple(imvec, mask, **kwargs):
 
 
 def reggrad_simple(imvec, mask, **kwargs):
+    """Gradient of simple entropy regularizer"""
+
     priorvec = kwargs['nprior']
     flux = kwargs['flux']
     norm = flux if kwargs.get('norm_reg', True) else 1
@@ -1743,36 +1758,42 @@ def reggrad_simple(imvec, mask, **kwargs):
 
 
 def reg_l1(imvec, mask, **kwargs):
+    """l1-norm regularizer"""
+
     flux = kwargs['flux']
     norm = flux if kwargs.get('norm_reg', True) else 1
     return np.sum(np.abs(imvec)) / norm
 
 
 def reggrad_l1(imvec, mask, **kwargs):
+    """gradient of l1-norm regularizer"""
     flux = kwargs['flux']
     norm = flux if kwargs.get('norm_reg', True) else 1
     return np.sign(imvec) / norm
 
 
 def reg_l1w(imvec, mask, **kwargs):
+    """smooth l1-w norm regularizer"""
     priorvec = kwargs['nprior']
-    epsilon = ehc.EP
-    norm = 1  # placeholder: legacy sl1w normalized by unity in both norm_reg branches
+    epsilon = ehc.EP # TODO: replace with argument like epsilon_tv?
+    norm = 1  # TODO: placeholder: legacy sl1w normalized by unity in both norm_reg branches
     num = np.sqrt(imvec**2 + epsilon)
     denom = np.sqrt(priorvec**2 + epsilon) + epsilon
     return np.sum(num / denom) / norm
 
 
 def reggrad_l1w(imvec, mask, **kwargs):
+    """gradient of the smooth l1-w norm regularizer"""
     priorvec = kwargs['nprior']
-    epsilon = ehc.EP
-    norm = 1  # placeholder: matches reg_l1w
+    epsilon = ehc.EP # TODO: replace with argument like epsilon_tv?
+    norm = 1  # TODO: placeholder: legacy sl1w normalized by unity in both norm_reg branches
     num = imvec / np.sqrt(imvec**2 + epsilon)
     denom = np.sqrt(priorvec**2 + epsilon) + epsilon
     return num / denom / norm
 
 
 def reg_lA(imvec, mask, **kwargs):
+    """lA regularizer"""
     psize = kwargs['psize']
     flux = kwargs['flux']
     beam_size = kwargs.get('beam_size') or psize
@@ -1789,6 +1810,7 @@ def reg_lA(imvec, mask, **kwargs):
 
 
 def reggrad_lA(imvec, mask, **kwargs):
+    """gradient of the lA regularizer"""
     psize = kwargs['psize']
     flux = kwargs['flux']
     beam_size = kwargs.get('beam_size') or psize
@@ -1805,6 +1827,7 @@ def reggrad_lA(imvec, mask, **kwargs):
 
 
 def reg_gs(imvec, mask, **kwargs):
+    """Gull-Skilling entropy regularizer"""
     priorvec = kwargs['nprior']
     flux = kwargs['flux']
     norm = flux if kwargs.get('norm_reg', True) else 1
@@ -1812,6 +1835,7 @@ def reg_gs(imvec, mask, **kwargs):
 
 
 def reggrad_gs(imvec, mask, **kwargs):
+    """Gradient of the Gull-Skilling entropy regularizer"""
     priorvec = kwargs['nprior']
     flux = kwargs['flux']
     norm = flux if kwargs.get('norm_reg', True) else 1
@@ -1819,6 +1843,7 @@ def reggrad_gs(imvec, mask, **kwargs):
 
 
 def reg_patch(imvec, mask, **kwargs):
+    """Patch prior regularizer (CHIRP)"""
     priorvec = kwargs['nprior']
     flux = kwargs['flux']
     norm = flux**2 if kwargs.get('norm_reg', True) else 1
@@ -1826,6 +1851,7 @@ def reg_patch(imvec, mask, **kwargs):
 
 
 def reggrad_patch(imvec, mask, **kwargs):
+    """Gradient of the patch prior regularizer"""
     priorvec = kwargs['nprior']
     flux = kwargs['flux']
     norm = flux**2 if kwargs.get('norm_reg', True) else 1
@@ -1833,12 +1859,16 @@ def reggrad_patch(imvec, mask, **kwargs):
 
 
 def reg_cm(imvec, mask, **kwargs):
+    """Center-of-mass regularizer"""
+    # embed image
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
+    # parameters and normalization
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     flux = kwargs['flux']
     beam_size = kwargs.get('beam_size') or psize
     norm = beam_size**2 * flux**2 if kwargs.get('norm_reg', True) else 1
+    # compute cm regularizer
     xx, yy = np.meshgrid(range(nx//2, -nx//2, -1), range(ny//2, -ny//2, -1))
     xx = psize * xx.flatten()
     yy = psize * yy.flatten()
@@ -1846,12 +1876,16 @@ def reg_cm(imvec, mask, **kwargs):
 
 
 def reggrad_cm(imvec, mask, **kwargs):
+    """Gradient of the center-of-mass regularizer"""
+    # embed image
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
+    # parameters and normalization
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     flux = kwargs['flux']
     beam_size = kwargs.get('beam_size') or psize
     norm = beam_size**2 * flux**2 if kwargs.get('norm_reg', True) else 1
+    # compute cm grad
     xx, yy = np.meshgrid(range(nx//2, -nx//2, -1), range(ny//2, -ny//2, -1))
     xx = psize * xx.flatten()
     yy = psize * yy.flatten()
@@ -1860,13 +1894,17 @@ def reggrad_cm(imvec, mask, **kwargs):
 
 
 def reg_tv(imvec, mask, **kwargs):
+    """Total Variation regularizer"""
+    # embed image
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
+    # parameters and normalization
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     flux = kwargs['flux']
     beam_size = kwargs.get('beam_size') or psize
     epsilon = kwargs.get('epsilon_tv', 0.)
     norm = flux * psize / beam_size if kwargs.get('norm_reg', True) else 1
+    # compute TV
     im = imvec.reshape(ny, nx)
     impad = np.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
@@ -1875,13 +1913,17 @@ def reg_tv(imvec, mask, **kwargs):
 
 
 def reggrad_tv(imvec, mask, **kwargs):
+    """Total Variation Regularizer Gradient"""
+    # embed image
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
+    # parameters and normalization
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     flux = kwargs['flux']
     beam_size = kwargs.get('beam_size') or psize
     epsilon = kwargs.get('epsilon_tv', 0.)
     norm = flux * psize / beam_size if kwargs.get('norm_reg', True) else 1
+    # shifted 2D images
     im = imvec.reshape(ny, nx)
     impad = np.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
@@ -1890,15 +1932,19 @@ def reggrad_tv(imvec, mask, **kwargs):
     im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
     im_r1l2 = np.roll(np.roll(impad,  1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
     im_l1r2 = np.roll(np.roll(impad, -1, axis=0),  1, axis=1)[1:ny+1, 1:nx+1]
+    # gradient terms
     g1 = (2*im - im_l1 - im_l2) / np.sqrt((im - im_l1)**2 + (im - im_l2)**2 + epsilon)
     g2 = (im - im_r1) / np.sqrt((im - im_r1)**2 + (im_r1l2 - im_r1)**2 + epsilon)
     g3 = (im - im_r2) / np.sqrt((im - im_r2)**2 + (im_l1r2 - im_r2)**2 + epsilon)
+    # The back-neighbor (g2, g3) terms reference a pixel that does not
+    # exist on the first row/column (it is the zero pad), so they must be zeroed
     mask1 = np.zeros(im.shape)
     mask2 = np.zeros(im.shape)
     mask1[0, :] = 1
     mask2[:, 0] = 1
     g2[mask1.astype(bool)] = 0
     g3[mask2.astype(bool)] = 0
+    # final gradient
     g = (g1 + g2 + g3).flatten() / norm
     return g[mask]
 
@@ -1906,39 +1952,51 @@ def reggrad_tv(imvec, mask, **kwargs):
 # tvlog / tv2log use clipfloor=epsilon_tv (not the default 0) so the log
 # transform stays defined where mask filled in values.
 def reg_tvlog(imvec, mask, **kwargs):
+    """Total Variation Regularizer on the log image"""
+    # embed image
     epsilon = kwargs.get('epsilon_tv', 0.)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
+    # parameters and normalization -- update kwargs
     nx, ny = kwargs['xdim'], kwargs['ydim']
     flux = kwargs['flux']
     npix = nx * ny
     logflux = npix * np.abs(np.log(flux / npix))
     log_kwargs = dict(kwargs)
     log_kwargs['flux'] = logflux
+    # compute TV on log image
     return reg_tv(np.log(imvec), np.ones_like(imvec, dtype=bool), **log_kwargs)
 
 
 def reggrad_tvlog(imvec, mask, **kwargs):
+    """Gradient of the total variation regularizer on the log image"""
+    # embed image
     epsilon = kwargs.get('epsilon_tv', 0.)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
+    # parameters and normalization -- update kwargs
     nx, ny = kwargs['xdim'], kwargs['ydim']
     flux = kwargs['flux']
     npix = nx * ny
     logflux = npix * np.abs(np.log(flux / npix))
     log_kwargs = dict(kwargs)
     log_kwargs['flux'] = logflux
+    # compute gradient of TV on log image
     g = reggrad_tv(np.log(imvec), np.ones_like(imvec, dtype=bool), **log_kwargs) / imvec
     return g[mask]
 
 
 def reg_tv2(imvec, mask, **kwargs):
+    """Total Squard Variation regularizer"""
+    # embed image
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
+    # parameters and normalization
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     flux = kwargs['flux']
     beam_size = kwargs.get('beam_size') or psize
     norm = psize**4 * flux**2 / beam_size**4 if kwargs.get('norm_reg', True) else 1
+    # compute TV2
     im = imvec.reshape(ny, nx)
     impad = np.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
@@ -1947,54 +2005,70 @@ def reg_tv2(imvec, mask, **kwargs):
 
 
 def reggrad_tv2(imvec, mask, **kwargs):
+    """Gradient of the Total Squared Variation regularizer"""
+    # embed image
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
+    # parameters and normalization
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     flux = kwargs['flux']
     beam_size = kwargs.get('beam_size') or psize
     norm = psize**4 * flux**2 / beam_size**4 if kwargs.get('norm_reg', True) else 1
+    # shifted 2D images
     im = imvec.reshape(ny, nx)
     impad = np.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
     im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
     im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
     im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
+    # gradient terms
     g1 = 2*im - im_l1 - im_l2
     g2 = im - im_r1
     g3 = im - im_r2
+    # The back-neighbor (g2, g3) terms reference a pixel that does not
+    # exist on the first row/column (it is the zero pad), so they must be zeroed
     mask1 = np.zeros(im.shape)
     mask2 = np.zeros(im.shape)
     mask1[0, :] = 1
     mask2[:, 0] = 1
     g2[mask1.astype(bool)] = 0
     g3[mask2.astype(bool)] = 0
+    # final gradient
     g = 2 * (g1 + g2 + g3).flatten() / norm
     return g[mask]
 
 
 def reg_tv2log(imvec, mask, **kwargs):
+    """TV2 regularizer on the log image"""
+    # embed image
     epsilon = kwargs.get('epsilon_tv', 0.)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
+    # parameters and normalization -- update the kwargs
     nx, ny = kwargs['xdim'], kwargs['ydim']
     flux = kwargs['flux']
     npix = nx * ny
     logflux = npix * np.abs(np.log(flux / npix))
     log_kwargs = dict(kwargs)
     log_kwargs['flux'] = logflux
+    # compute TV2 on the log image
     return reg_tv2(np.log(imvec), np.ones_like(imvec, dtype=bool), **log_kwargs)
 
 
 def reggrad_tv2log(imvec, mask, **kwargs):
+    """Gradient of the TV2 regularizer on the log image"""
+    # embed image
     epsilon = kwargs.get('epsilon_tv', 0.)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, clipfloor=epsilon, randomfloor=True)
+    # parameters and normalization -- update the kwargs
     nx, ny = kwargs['xdim'], kwargs['ydim']
     flux = kwargs['flux']
     npix = nx * ny
     logflux = npix * np.abs(np.log(flux / npix))
     log_kwargs = dict(kwargs)
     log_kwargs['flux'] = logflux
+    # compute gradient of TV2 on the log image
     g = reggrad_tv2(np.log(imvec), np.ones_like(imvec, dtype=bool), **log_kwargs) / imvec
     return g[mask]
 
@@ -2002,12 +2076,16 @@ def reggrad_tv2log(imvec, mask, **kwargs):
 # TODO: figure out normalizations for compact and compact2 regularizers
 # (carried over from legacy code; not formally verified).
 def reg_compact(imvec, mask, **kwargs):
+    """compactness regularizer"""
+    # embed image
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
+    # parameters and normalization
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     flux = kwargs['flux']
     beam_size = kwargs.get('beam_size') or psize
     norm = flux * beam_size**2 if kwargs.get('norm_reg', True) else 1
+    # compute compactness regularizer
     im = imvec.reshape(ny, nx)
     xx, yy = np.meshgrid(range(nx), range(ny))
     xxpsize = (xx - (nx-1)/2.0) * psize
@@ -2018,12 +2096,16 @@ def reg_compact(imvec, mask, **kwargs):
 
 
 def reggrad_compact(imvec, mask, **kwargs):
+    """gradient of compactness regularizer"""
+    # embed image
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
+    # parameters and normalization
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     flux = kwargs['flux']
     beam_size = kwargs.get('beam_size') or psize
     norm = flux * beam_size**2 if kwargs.get('norm_reg', True) else 1
+    # compute compactness regularizer gradient
     im = imvec.reshape(ny, nx)
     xx, yy = np.meshgrid(range(nx), range(ny))
     xxpsize = (xx - (nx-1)/2.0) * psize
@@ -2038,12 +2120,16 @@ def reggrad_compact(imvec, mask, **kwargs):
 
 
 def reg_compact2(imvec, mask, **kwargs):
+    """Compactness regularizer, version 2"""
+    # embed image
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
+    # parameters and normalization
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     flux = kwargs['flux']
     beam_size = kwargs.get('beam_size') or psize
     norm = flux**2 * beam_size**2 if kwargs.get('norm_reg', True) else 1
+    # compute compactness regularizer
     im = imvec.reshape(ny, nx)
     xx, yy = np.meshgrid(range(nx), range(ny))
     xxpsize = (xx - (nx-1)/2.0) * psize
@@ -2052,12 +2138,16 @@ def reg_compact2(imvec, mask, **kwargs):
 
 
 def reggrad_compact2(imvec, mask, **kwargs):
+    """Gradient of the version 2 compactness regularizer"""
+    # embed image
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
+    # parameters and normalization
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     flux = kwargs['flux']
     beam_size = kwargs.get('beam_size') or psize
     norm = flux**2 * beam_size**2 if kwargs.get('norm_reg', True) else 1
+    # compute gradient
     im = imvec.reshape(ny, nx)
     xx, yy = np.meshgrid(range(nx), range(ny))
     xxpsize = (xx - (nx-1)/2.0) * psize
@@ -2068,8 +2158,11 @@ def reggrad_compact2(imvec, mask, **kwargs):
 
 
 def reg_rgauss(imvec, mask, **kwargs):
+    """Rgauss regularizer (Issaoun+ 2019)"""
+    # embed image
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
+    # Gaussian parameters
     xdim, ydim, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     major = kwargs.get('major', 1.0)
     minor = kwargs.get('minor', 1.0)
@@ -2079,6 +2172,7 @@ def reg_rgauss(imvec, mask, **kwargs):
     sigxx_prime = lambda1 * np.cos(phi)**2 + lambda2 * np.sin(phi)**2
     sigyy_prime = lambda1 * np.sin(phi)**2 + lambda2 * np.cos(phi)**2
     sigxy_prime = (lambda2 - lambda1) * np.cos(phi) * np.sin(phi)
+    # compute image moments
     im = imvec.reshape(ydim, xdim)
     xlist, ylist = np.meshgrid(range(xdim), range(ydim))
     xx = (xlist - (xdim-1)/2.0) * psize
@@ -2089,14 +2183,18 @@ def reg_rgauss(imvec, mask, **kwargs):
     sigxx = np.sum((xx - x0)**2 * im) / S
     sigyy = np.sum((yy - y0)**2 * im) / S
     sigxy = np.sum((xx - x0) * (yy - y0) * im) / S
+    # rgauss regularizer
     rgauss = (sigxx - sigxx_prime)**2 + (sigyy - sigyy_prime)**2 + 2*(sigxy - sigxy_prime)**2
     # reg_rgauss has no norm_reg option; always normalized by major^2 * minor^2.
     return rgauss / (major**2 * minor**2)
 
 
 def reggrad_rgauss(imvec, mask, **kwargs):
+    """Gradient of rgauss regularizer"""
+    # embed image
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, randomfloor=True)
+    # Gaussian parameters
     xdim, ydim, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     major = kwargs.get('major', 1.0)
     minor = kwargs.get('minor', 1.0)
@@ -2106,6 +2204,7 @@ def reggrad_rgauss(imvec, mask, **kwargs):
     sigxx_prime = lambda1 * np.cos(phi)**2 + lambda2 * np.sin(phi)**2
     sigyy_prime = lambda1 * np.sin(phi)**2 + lambda2 * np.cos(phi)**2
     sigxy_prime = (lambda2 - lambda1) * np.cos(phi) * np.sin(phi)
+    # compute image moments
     im = imvec.reshape(ydim, xdim)
     xlist, ylist = np.meshgrid(range(xdim), range(ydim))
     xx = (xlist - (xdim-1)/2.0) * psize
@@ -2116,6 +2215,7 @@ def reggrad_rgauss(imvec, mask, **kwargs):
     sigxx = np.sum((xx - x0)**2 * im) / S
     sigyy = np.sum((yy - y0)**2 * im) / S
     sigxy = np.sum((xx - x0) * (yy - y0) * im) / S
+    # gradient of rgauss regularizer
     dxx = ((xx - x0)**2 - sigxx) / S
     dyy = ((yy - y0)**2 - sigyy) / S
     dxy = ((xx - x0) * (yy - y0) - sigxy) / S
@@ -2131,8 +2231,10 @@ def reggrad_rgauss(imvec, mask, **kwargs):
 # Chi^2 Data functions
 ##################################################################################################
 def apply_systematic_noise_snrcut(data_arr, systematic_noise, snrcut, pol):
-    """apply systematic noise to VISIBILITIES or AMPLITUDES
+    """apply systematic noise to VISIBILITIES or AMPLITUDES (NOT bispectra or closure quantities)
        data_arr should have fields 't1','t2','u','v','vis','amp','sigma'
+       snrcut is a single float
+       systematic_noise is a float or a per-site dict
 
        returns: (uv, vis, amp, sigma)
     """
@@ -2226,7 +2328,6 @@ def chisqdata_amp(Obsdata, Prior, mask, pol='I', **kwargs):
     data_arr = Obsdata.unpack(['t1', 't2', 'u', 'v', vtype, atype, etype], debias=debias)
 
     # apply systematic noise and SNR cut
-    # TODO -- after pre-computed??
     (uv, vis, amp, sigma) = apply_systematic_noise_snrcut(data_arr, systematic_noise, snrcut, pol)
 
     # data weighting
@@ -2244,7 +2345,6 @@ def chisqdata_bs(Obsdata, Prior, mask, pol='I', **kwargs):
     """
 
     # unpack keyword args
-    # systematic_noise = kwargs.get('systematic_noise',0.)
     maxset = kwargs.get('maxset', False)
     if maxset:
         count = 'max'
@@ -2263,9 +2363,6 @@ def chisqdata_bs(Obsdata, Prior, mask, pol='I', **kwargs):
     uv3 = np.hstack((biarr['u3'].reshape(-1, 1), biarr['v3'].reshape(-1, 1)))
     bi = biarr['bispec']
     sigma = biarr['sigmab']
-
-    # add systematic noise
-    # sigma = np.linalg.norm([biarr['sigmab'], systematic_noise*np.abs(biarr['bispec'])], axis=0)
 
     # data weighting
     if weighting == 'uniform':
@@ -2613,7 +2710,6 @@ def chisqdata_bs_fft(Obsdata, Prior, pol='I', **kwargs):
     """
 
     # unpack keyword args
-    # systematic_noise = kwargs.get('systematic_noise',0.)
     maxset = kwargs.get('maxset', False)
     if maxset:
         count = 'max'
@@ -2636,9 +2732,6 @@ def chisqdata_bs_fft(Obsdata, Prior, pol='I', **kwargs):
     uv3 = np.hstack((biarr['u3'].reshape(-1, 1), biarr['v3'].reshape(-1, 1)))
     bi = biarr['bispec']
     sigma = biarr['sigmab']
-
-    # add systematic noise
-    # sigma = np.linalg.norm([biarr['sigmab'], systematic_noise*np.abs(biarr['bispec'])], axis=0)
 
     # data weighting
     if weighting == 'uniform':
@@ -3077,7 +3170,6 @@ def chisqdata_bs_nfft(Obsdata, Prior, pol='I', **kwargs):
         raise Exception("NFFT doesn't work with odd image dimensions!")
 
     # unpack keyword args
-    # systematic_noise = kwargs.get('systematic_noise',0.)
     maxset = kwargs.get('maxset', False)
     if maxset:
         count = 'max'
@@ -3099,9 +3191,6 @@ def chisqdata_bs_nfft(Obsdata, Prior, pol='I', **kwargs):
     uv3 = np.hstack((biarr['u3'].reshape(-1, 1), biarr['v3'].reshape(-1, 1)))
     bi = biarr['bispec']
     sigma = biarr['sigmab']
-
-    # add systematic noise
-    # sigma = np.linalg.norm([biarr['sigmab'], systematic_noise*np.abs(biarr['bispec'])], axis=0)
 
     # data weighting
     if weighting == 'uniform':
@@ -3470,10 +3559,7 @@ def plot_i(im, Prior, nit, chi2_dict, **kwargs):
 # Embedding functions
 ##################################################################################################
 
-
-
-
-# TODO(achael): consolidate `embed` (1D, this function) and `embed_imarr`
+# TODO: consolidate `embed` (1D, this function) and `embed_imarr`
 # (1D or 2D, below) into a single implementation -- their bodies overlap.
 def embed(imvec, mask, clipfloor=0., randomfloor=False):
     """Embeds a 1d image vector into the size of boolean embed mask

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -819,6 +819,11 @@ def reg_msimple(imarr, mask, **kwargs):
 
 
 def reggrad_msimple(imarr, mask, **kwargs):
+    """Gradient of the 'msimple' polarimetric entropy regularizer.
+
+    pol_solve here flags the required physical gradients (I, rho, phi, psi),
+    not the solver variables.
+    """
     flux = kwargs['flux']
     pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT)
     norm = flux if kwargs.get('norm_reg', True) else 1
@@ -847,6 +852,11 @@ def reg_hw(imarr, mask, **kwargs):
 
 
 def reggrad_hw(imarr, mask, **kwargs):
+    """Gradient of the Holdaway-Wardle polarimetric entropy regularizer.
+
+    pol_solve here flags the required physical gradients (I, rho, phi, psi),
+    not the solver variables.
+    """
     flux = kwargs['flux']
     pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT)
     norm = flux if kwargs.get('norm_reg', True) else 1
@@ -874,15 +884,21 @@ def reg_ptv(imarr, mask, **kwargs):
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     beam_size = kwargs.get('beam_size', 1) or psize
     norm = flux * psize / beam_size if kwargs.get('norm_reg', True) else 1
+    epsilon = kwargs.get('epsilon_tv', 0.)
     pimage = make_p_image(imarr)
     im = pimage.reshape(ny, nx)
     impad = np.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
     im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    return np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2)) / norm
+    return np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2 + epsilon)) / norm
 
 
 def reggrad_ptv(imarr, mask, **kwargs):
+    """Gradient of the polarimetric total-variation regularizer.
+
+    pol_solve here flags the required physical gradients (I, rho, phi, psi),
+    not the solver variables.
+    """
     from ehtim.imaging.imager_utils import embed_imarr
     do_slice = np.any(np.invert(mask))
     if do_slice:
@@ -892,6 +908,7 @@ def reggrad_ptv(imarr, mask, **kwargs):
     pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT)
     beam_size = kwargs.get('beam_size', 1) or psize
     norm = flux * psize / beam_size if kwargs.get('norm_reg', True) else 1
+    epsilon = kwargs.get('epsilon_tv', 0.)
     iimage = make_i_image(imarr)
     pimage = make_p_image(imarr)
     mimage = make_m_image(imarr)
@@ -905,17 +922,25 @@ def reggrad_ptv(imarr, mask, **kwargs):
     im_r1l2 = np.roll(np.roll(impad,  1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
     im_l1r2 = np.roll(np.roll(impad, -1, axis=0),  1, axis=1)[1:ny+1, 1:nx+1]
     # Denominators: |forward-l1|+|forward-l2|, |back-r1|+|cross|, |back-r2|+|cross|.
-    d1 = np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2)
-    d2 = np.sqrt(np.abs(im_r1 - im)**2 + np.abs(im_r1l2 - im_r1)**2)
-    d3 = np.sqrt(np.abs(im_r2 - im)**2 + np.abs(im_l1r2 - im_r2)**2)
+    d1 = np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2 + epsilon)
+    d2 = np.sqrt(np.abs(im_r1 - im)**2 + np.abs(im_r1l2 - im_r1)**2 + epsilon)
+    d3 = np.sqrt(np.abs(im_r2 - im)**2 + np.abs(im_l1r2 - im_r2)**2 + epsilon)
     # Numerators below use cos/sin of the single-angle difference between
     # neighbors, from d|P_l1 - P|^2/d|P| = 2|P| - 2|P_l1|*cos(angle(P_l1) - angle(P)).
+    # The back-neighbor (m2/d2, m3/d3) terms reference a pixel that does not
+    # exist on the first row/column (it is the zero pad), so they must be zeroed
+    # there -- same masking reggrad_vtv applies. chi (slot 2) self-zeros at the
+    # pad, so it needs no masking.
+    mask1 = np.zeros(im.shape, dtype=bool); mask1[0, :] = True   # no back-neighbor in axis 0
+    mask2 = np.zeros(im.shape, dtype=bool); mask2[:, 0] = True   # no back-neighbor in axis 1
     gradout = np.zeros(imarr.shape)
     if pol_solve[0] != 0:
         # dS/dI numerators (chain through |P| = I*m)
         m1 = 2*np.abs(im*im) - np.abs(im*im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im*im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im*im) - np.abs(im*im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im*im) - np.abs(im*im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        m2[mask1] = 0
+        m3[mask2] = 0
         gradout[0] = (1./iimage) * (m1/d1 + m2/d2 + m3/d3).flatten()
     if pol_solve[1] != 0:
         # dS/dm numerators; m enters via |P| = I*m, so dS/dm = I * dS/d|P|.
@@ -923,6 +948,8 @@ def reggrad_ptv(imarr, mask, **kwargs):
         m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        m2[mask1] = 0
+        m3[mask2] = 0
         gradm = iimage * (m1/d1 + m2/d2 + m3/d3).flatten()
         gradout[1] = gradm * np.cos(psiimage)
     if pol_solve[2] != 0:
@@ -938,6 +965,8 @@ def reggrad_ptv(imarr, mask, **kwargs):
         m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        m2[mask1] = 0
+        m3[mask2] = 0
         gradm = iimage * (m1/d1 + m2/d2 + m3/d3).flatten()
         gradout[3] = gradm * (-mimage * np.tan(psiimage))
     g = gradout / norm
@@ -956,6 +985,11 @@ def reg_vflux(imarr, mask, **kwargs):
 
 
 def reggrad_vflux(imarr, mask, **kwargs):
+    """Gradient of the Stokes V total-flux regularizer.
+
+    pol_solve here flags the required physical gradients (I, rho, phi, psi),
+    not the solver variables.
+    """
     vflux = kwargs['vflux']
     pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
     norm = np.abs(vflux)**2 if kwargs.get('norm_reg', True) else 1
@@ -986,6 +1020,11 @@ def reg_l1v(imarr, mask, **kwargs):
 
 
 def reggrad_l1v(imarr, mask, **kwargs):
+    """Gradient of the Stokes V l1-norm regularizer.
+
+    pol_solve here flags the required physical gradients (I, rho, phi, psi),
+    not the solver variables.
+    """
     vflux = kwargs['vflux']
     pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
     norm = np.abs(vflux) if kwargs.get('norm_reg', True) else 1
@@ -1015,6 +1054,11 @@ def reg_l2v(imarr, mask, **kwargs):
 
 
 def reggrad_l2v(imarr, mask, **kwargs):
+    """Gradient of the Stokes V l2-norm regularizer.
+
+    pol_solve here flags the required physical gradients (I, rho, phi, psi),
+    not the solver variables.
+    """
     vflux = kwargs['vflux']
     pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
     norm = np.abs(vflux**2) if kwargs.get('norm_reg', True) else 1
@@ -1053,6 +1097,11 @@ def reg_vtv(imarr, mask, **kwargs):
 
 
 def reggrad_vtv(imarr, mask, **kwargs):
+    """Gradient of the Stokes V total-variation regularizer.
+
+    pol_solve here flags the required physical gradients (I, rho, phi, psi),
+    not the solver variables.
+    """
     from ehtim.imaging.imager_utils import embed_imarr
     do_slice = np.any(np.invert(mask))
     if do_slice:
@@ -1116,6 +1165,11 @@ def reg_vtv2(imarr, mask, **kwargs):
 
 
 def reggrad_vtv2(imarr, mask, **kwargs):
+    """Gradient of the Stokes V squared-total-variation regularizer.
+
+    pol_solve here flags the required physical gradients (I, rho, phi, psi),
+    not the solver variables.
+    """
     from ehtim.imaging.imager_utils import embed_imarr
     do_slice = np.any(np.invert(mask))
     if do_slice:

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -359,6 +359,11 @@ def polchisqgrad(imarr, A, data, sigma, dtype, ttype='direct', mask=[],
     Thin shim around imager_backend.compute_chisqgrad_term retained for
     backward compatibility. New code should call compute_chisqgrad_term
     directly.
+
+    pol_solve here is the gating mask passed straight to the kernels: it flags
+    the required physical gradients (I, rho, phi, psi), not the solver DOFs.
+    For mcv/vcv imaging pass physical_grad_slots(dof_mask, transforms), not the
+    raw DOF mask.
     """
     from ehtim.imaging.imager_backend import compute_chisqgrad_term
     if dtype not in DATATERMS_POL:

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -435,6 +435,9 @@ def chisq_p(imarr, Amatrix, p, sigmap):
 
 def chisqgrad_p(imarr, Amatrix, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
     """Polarimetric visibility chi-squared gradient
+
+    pol_solve here flags the required physical gradients (I, rho, phi, psi),
+    not the solver variables.
     """
     gradout = np.zeros(imarr.shape)
 
@@ -482,6 +485,9 @@ def chisq_m(imarr, Amatrix, m, sigmam):
 
 def chisqgrad_m(imarr, Amatrix, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
     """The gradient of the polarimetric ratio chisq
+
+    pol_solve here flags the required physical gradients (I, rho, phi, psi),
+    not the solver variables.
     """
     gradout = np.zeros(imarr.shape)
 
@@ -531,6 +537,9 @@ def chisq_vvis(imarr, Amatrix, v, sigmav):
 
 def chisqgrad_vvis(imarr, Amatrix, v, sigmav, pol_solve=POL_SOLVE_DEFAULT_V):
     """V visibility chi-squared gradient
+
+    pol_solve here flags the required physical gradients (I, rho, phi, psi),
+    not the solver variables.
     """
 
     gradout = np.zeros(imarr.shape)
@@ -547,11 +556,7 @@ def chisqgrad_vvis(imarr, Amatrix, v, sigmav, pol_solve=POL_SOLVE_DEFAULT_V):
         gradi = -np.real(vfimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
         gradout[0] = gradi
 
-    # The physical rho gradient is needed whenever V is solved: the vcv transform
-    # expresses V via vprime, and vcv_grad's vprime chain rule uses it
-    # (out[2] = drho_dvprime*grad_rho + dpsi_dvprime*grad_psi). Computing it only
-    # when pol_solve[1] is set dropped the dominant drho_dvprime term for pol='IV'.
-    if pol_solve[1]!=0 or pol_solve[3]!=0:
+    if pol_solve[1]!=0:
         gradv = -np.real(iimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
         gradrho = gradv*np.sin(psiimage)
         gradout[1] = gradrho
@@ -588,6 +593,9 @@ def chisq_p_nfft(imarr, A, p, sigmap):
 
 def chisqgrad_p_nfft(imarr, A, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
     """P visibility chi-squared gradient
+
+    pol_solve here flags the required physical gradients (I, rho, phi, psi),
+    not the solver variables.
     """
     gradout = np.zeros(imarr.shape)
 
@@ -663,6 +671,9 @@ def chisq_m_nfft(imarr, A, m, sigmam):
 
 def chisqgrad_m_nfft(imarr, A, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
     """Polarimetric ratio chi-squared gradient
+
+    pol_solve here flags the required physical gradients (I, rho, phi, psi),
+    not the solver variables.
     """
     gradout = np.zeros(imarr.shape)
 
@@ -740,6 +751,9 @@ def chisq_vvis_nfft(imarr, A, v, sigmav):
 
 def chisqgrad_vvis_nfft(imarr, A, v, sigmav,pol_solve=POL_SOLVE_DEFAULT):
     """V visibility chi-squared gradient
+
+    pol_solve here flags the required physical gradients (I, rho, phi, psi),
+    not the solver variables.
     """
     gradout = np.zeros(imarr.shape)
 
@@ -770,9 +784,7 @@ def chisqgrad_vvis_nfft(imarr, A, v, sigmav,pol_solve=POL_SOLVE_DEFAULT):
         gradi = np.real(vfimage*vpart)
         gradout[0] = gradi
 
-    # See chisqgrad_vvis: the physical rho gradient is needed whenever V is solved,
-    # because vcv_grad's vprime chain rule uses it (dropped the dominant term for IV).
-    if pol_solve[1]!=0 or pol_solve[3]!=0:
+    if pol_solve[1]!=0:
         gradv = np.real(iimage*vpart)
         gradrho = gradv*np.sin(psiimage)
         gradout[1] = gradrho

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -35,6 +35,7 @@ TANWIDTH_PSI = 1
 POL_SOLVE_DEFAULT = (0,1,1,0)
 POL_SOLVE_DEFAULT_V = (0,0,0,1)
 RANDOMFLOOR=True
+
 ##################################################################################################
 # Constants & Definitions
 ##################################################################################################
@@ -61,13 +62,14 @@ nit = 0 # global variable to track the iteration number in the plotting callback
 def make_i_image(imarr):
     """return total intensity image
     """
+
     return imarr[0]
 
 def make_p_image(imarr):
     """construct a polarimetric image P = RL = Q + iU
     """
-
     # NOTE! We replaced EVPA chi with phi=2chi in the imarr
+    # see conventions above
     pimage = imarr[0] * imarr[1] * np.exp(1j*imarr[2]) * np.cos(imarr[3])
 
     return pimage
@@ -99,7 +101,6 @@ def make_q_image(imarr):
     """construct an image of stokes Q
     """
 
-    # NOTE! We replaced EVPA chi with phi=2chi in the imarr
     qimage = imarr[0] * imarr[1] * np.cos(imarr[2]) *  np.cos(imarr[3])
 
     return qimage
@@ -107,7 +108,7 @@ def make_q_image(imarr):
 def make_u_image(imarr):
     """construct an image of stokes U
     """
-    # NOTE! We replaced EVPA chi with phi=2chi in the imarr
+
     uimage = imarr[0] * imarr[1] * np.sin(imarr[2]) *  np.cos(imarr[3])
 
     return uimage
@@ -160,7 +161,7 @@ def polcv_r(imarr):
     return out
 
 def polcv_grad(imarr, gradarr):
-    """Apply J^T @ gradarr for polcv (rho ← arctan(rho_pre/T_M); psi ← arctan(psi_pre/T_PSI)).
+    """Apply J^T @ gradarr for polcv.
 
     Diagonal Jacobian on slots 1 and 3; slot 2 (phi) passes through.
 
@@ -189,15 +190,16 @@ def polcv_grad(imarr, gradarr):
 
 
 def mcv(imarr):
-    """change of variables m(n') from range (-inf, inf) to (0,1)
+    """change of variables m(n') from range (-inf, inf) to (0,1) keeping v=V/I fixed
        input is solver values, output is physical values
     """
-
-    vfrac = imarr[3] # when using this transform, we interpret transformed imarr[3] as mfrac=\rho sin(\psi)
+    # when using this transform, transformed imarr[3] is the fixed vfrac=\rho sin(\psi)
+    vfrac = imarr[3]
     mfrac_max = 1-np.abs(vfrac)
     if np.any(mfrac_max>1):
         raise Exception("mfrac_max>1 in mcv!")
 
+    # transformed imarr[1] is m' --> the transformed mfrac = \rho cos(\psi)
     mfrac_prime =  imarr[1]
     mfrac = mfrac_max*(0.5 + np.arctan(mfrac_prime/TANWIDTH_M)/np.pi)
 
@@ -208,7 +210,7 @@ def mcv(imarr):
     return out
 
 def mcv_r(imarr):
-    """Reverse change of variables m'(m) from range (0,1-|v|) to (-inf, inf)
+    """Reverse change of variables m'(m) from range (0,1-|v|) to (-inf, inf) keeping v=V/I fixed
        input is physical values, output is solver values
     """
     rho = imarr[1]
@@ -217,18 +219,19 @@ def mcv_r(imarr):
     vfrac = rho*np.sin(psi)
     mfrac_max = 1-np.abs(vfrac)
     if np.any(mfrac_max>1):
-        raise Exception("mfrac_max>1 in mcv!")
+        raise Exception("mfrac_max>1 in mcv_r!")
 
     mfrac_prime = TANWIDTH_M*np.tan(np.pi*(mfrac/mfrac_max - 0.5))
+    # when using this transform, transformed imarr[3] is the fixed vfrac=\rho sin(\psi)
     out = np.array((imarr[0], mfrac_prime, imarr[2], vfrac))
     return out
 
 def mcv_grad(imarr, gradarr):
     """Apply J^T @ gradarr for mcv (mprime → rho, psi; vfrac held constant).
 
-    phys[1]=rho and phys[3]=psi both depend on mprime via mfrac, so the
-    Jacobian has off-diagonal terms; both are included here. Slot 3 of
-    the result is zero because vfrac is held constant.
+    phys[1]=rho and phys[3]=psi both depend on mprime via mfrac,
+    so the Jacobian has off-diagonal terms.
+    Slot 3 of the result is zero because vfrac is held constant.
 
     Parameters
     ----------
@@ -242,20 +245,27 @@ def mcv_grad(imarr, gradarr):
     out : np.ndarray, shape (3, ...)
         Gradient w.r.t. solver slots (1, 2, 3).
     """
+
+    # when using this transform, transformed imarr[3] is the fixed vfrac=\rho sin(\psi)
     vfrac = imarr[3]
     mfrac_max = 1 - np.abs(vfrac)
 
+    # transformed imarr[1] is m' --> the transformed mfrac = \rho cos(\psi)
     mprime = imarr[1]
     mfrac = mfrac_max * (0.5 + np.arctan(mprime / TANWIDTH_M) / np.pi)
     rho = np.sqrt(mfrac ** 2 + vfrac ** 2)
 
+    # gradient of m(m') transformation (from original polarimetric imaging paper)
     dm_dmprime = mfrac_max / (TANWIDTH_M * np.pi * (1 + (mprime / TANWIDTH_M) ** 2))
 
     # Avoid 0/0 when total polarization is zero; in that limit both terms vanish.
     safe_rho = np.where(rho > 0, rho, 1.0)
+
+    # Jacobian terms
     drho_dmprime = (mfrac / safe_rho) * dm_dmprime
     dpsi_dmprime = -(vfrac * np.sign(mfrac)) / (safe_rho ** 2) * dm_dmprime
 
+    # package result
     out = np.empty((3,) + gradarr.shape[1:])
     out[0] = drho_dmprime * gradarr[1] + dpsi_dmprime * gradarr[3]
     out[1] = gradarr[2]
@@ -263,14 +273,16 @@ def mcv_grad(imarr, gradarr):
     return out
 
 def vcv(imarr):
-    """change of variables for v(v') from range (-inf,inf) to (-1+|m|,1-|m|) while keeping m=P/I fixed
+    """change of variables for v(v') from range (-inf,inf) to (-1+|m|,1-|m|) keeping m=P/I fixed
        input is solver values, output is physical values"""
 
-    mfrac = imarr[1] # when using this transform, we interpret transformed imarr[1] as mfrac=\rho cos(\psi)
+    # when using this transform, transformed imarr[1] is the fixed mfrac=\rho cos(\psi)
+    mfrac = imarr[1]
     vfrac_max = 1-np.abs(mfrac)
     if np.any(vfrac_max>1):
         raise Exception("vfrac_max>1 in vcv!")
 
+    # transformed imarr[3] is v' --> the transformed vfrac = \rho sin(\psi)
     vfrac_prime = imarr[3]
     vfrac = 2*vfrac_max*np.arctan(vfrac_prime/TANWIDTH_V)/np.pi
 
@@ -292,15 +304,15 @@ def vcv_r(imarr):
         raise Exception("vfrac_max>1 in vcv_r!")
 
     vfrac_prime = TANWIDTH_V*np.tan(np.pi*vfrac/(2*vfrac_max))
+    # when using this transform, transformed imarr[1] is the fixed mfrac=\rho cos(\psi)
     out = np.array((imarr[0], mfrac, imarr[2], vfrac_prime))
     return out
 
 def vcv_grad(imarr, gradarr):
     """Apply J^T @ gradarr for vcv (vprime → rho, psi; mfrac held constant).
 
-    phys[1]=rho and phys[3]=psi both depend on vprime via vfrac, so the
-    Jacobian has off-diagonal terms. At mfrac=0 (pol='IV' regime) psi is
-    locally constant and the entire gradient flows through drho/dvprime.
+    phys[1]=rho and phys[3]=psi both depend on vprime via vfrac,
+    so the Jacobian has off-diagonal terms.
     Slot 1 of the result is zero because mfrac is held constant.
 
     Parameters
@@ -315,19 +327,26 @@ def vcv_grad(imarr, gradarr):
     out : np.ndarray, shape (3, ...)
         Gradient w.r.t. solver slots (1, 2, 3).
     """
+    # when using this transform, transformed imarr[1] is the fixed mfrac=\rho cos(\psi)
     mfrac = imarr[1]
     vfrac_max = 1 - np.abs(mfrac)
 
+    # transformed imarr[3] is v' --> the transformed vfrac = \rho sin(\psi)
     vprime = imarr[3]
     vfrac = 2 * vfrac_max * np.arctan(vprime / TANWIDTH_V) / np.pi
     rho = np.sqrt(mfrac ** 2 + vfrac ** 2)
 
+    # gradient of v(v') transformation (from M87 Paper IX)
     dv_dvprime = 2 * vfrac_max / (TANWIDTH_V * np.pi * (1 + (vprime / TANWIDTH_V) ** 2))
 
+    # Avoid 0/0 when total polarization is zero; in that limit both terms vanish.
     safe_rho = np.where(rho > 0, rho, 1.0)
+
+    # Jacobian terms
     drho_dvprime = (vfrac / safe_rho) * dv_dvprime
     dpsi_dvprime = (np.abs(mfrac) / (safe_rho ** 2)) * dv_dvprime
 
+    # package result
     out = np.empty((3,) + gradarr.shape[1:])
     out[0] = 0.0
     out[1] = gradarr[2]
@@ -336,7 +355,7 @@ def vcv_grad(imarr, gradarr):
 
 
 ##################################################################################################
-# Wrapper Functions
+# Wrapper Functions (Backward Compatibility Shims)
 ##################################################################################################
 
 def polchisq(imarr, A, data, sigma, dtype, ttype='direct', mask=[]):
@@ -455,22 +474,21 @@ def chisqgrad_p(imarr, Amatrix, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
     psamples = np.dot(Amatrix, pimage)
     pdiff = (p - psamples) / (sigmap**2)
 
-    # TODO: for now, use previous gradients and modify with chain rule
+    # dchi2/dI
     if pol_solve[0]!=0:
         gradi = -np.real(mimage * np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, pdiff)) / len(p)
         gradout[0] = gradi
-
+    # dchi2/drho
     if pol_solve[1]!=0:
         gradm = -np.real(iimage * np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, pdiff)) / len(p)
         gradrho = gradm * np.cos(psiimage)
         gradout[1] = gradrho
-
+    # dchi2/dphi
     if pol_solve[2]!=0:
         gradchi = -2 * np.imag(pimage.conj() * np.dot(Amatrix.conj().T, pdiff)) / len(p)
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
-
-    # TODO check
+    # dchi2/dpsi
     if pol_solve[3]!=0:
         gradm = -np.real(iimage * np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, pdiff)) / len(p)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
@@ -507,21 +525,22 @@ def chisqgrad_m(imarr, Amatrix, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
     msamples = psamples/isamples
     mdiff = (m - msamples) / (isamples.conj() * sigmam**2)
 
+    # dchi2/dI
     if pol_solve[0]!=0:
         gradi = (-np.real(mimage * np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, mdiff)) / len(m) +
                   np.real(np.dot(Amatrix.conj().T, msamples.conj() * mdiff)) / len(m))
         gradout[0] = gradi
-
+    # dchi2/drho
     if pol_solve[1]!=0:
         gradm = -np.real(iimage*np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, mdiff)) / len(m)
         gradrho = gradm * np.cos(psiimage)
         gradout[1] = gradrho
-
+    # dchi2/dphi
     if pol_solve[2]!=0:
         gradchi = -2 * np.imag(pimage.conj() * np.dot(Amatrix.conj().T, mdiff)) / len(m)
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
-
+    # dchi2/dpsi
     if pol_solve[3]!=0:
         gradm = -np.real(iimage*np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, mdiff)) / len(m)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
@@ -530,7 +549,6 @@ def chisqgrad_m(imarr, Amatrix, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
 
     return gradout
 
-# stokes v
 def chisq_vvis(imarr, Amatrix, v, sigmav):
     """V visibility chi-squared
     """
@@ -557,15 +575,16 @@ def chisqgrad_vvis(imarr, Amatrix, v, sigmav, pol_solve=POL_SOLVE_DEFAULT_V):
     vsamples = np.dot(Amatrix, vimage)
     vdiff = (v - vsamples) / (sigmav**2)
 
+    # dchi2/dI
     if pol_solve[0]!=0:
         gradi = -np.real(vfimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
         gradout[0] = gradi
-
+    # dchi2/drho
     if pol_solve[1]!=0:
         gradv = -np.real(iimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
         gradrho = gradv*np.sin(psiimage)
         gradout[1] = gradrho
-
+    # dchi2/dpsi
     if pol_solve[3]!=0:
         gradv = -np.real(iimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
         gradpsi = gradv * (vfimage/np.tan(psiimage))
@@ -620,31 +639,31 @@ def chisqgrad_p_nfft(imarr, A, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
     plan.trafo()
     psamples = plan.f.copy()*pulsefac
 
-
+    # compute gradient
     pdiff_vec = (-1.0/len(p)) * (p - psamples) / (sigmap**2) * pulsefac.conj()
     plan.f = pdiff_vec
     plan.adjoint()
     ppart = (plan.f_hat.copy().T).reshape(nfft_info.xdim*nfft_info.ydim)
 
+    # dchi2/dI
     if pol_solve[0]!=0:
         gradi = np.real(mimage * np.exp(-2j*chiimage) * ppart)
         gradout[0] = gradi
-
+    # dchi2/drho
     if pol_solve[1]!=0:
         gradm = np.real(iimage*np.exp(-2j*chiimage) *ppart)
         gradrho = gradm * np.cos(psiimage)
         gradout[1] = gradrho
-
+    # dchi2/dphi
     if pol_solve[2]!=0:
         gradchi = 2 * np.imag(pimage.conj() * ppart)
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
-
+    # dchi2/dpsi
     if pol_solve[3]!=0:
         gradm = np.real(iimage*np.exp(-2j*chiimage) *ppart)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
         gradout[3] = gradpsi
-
 
     return gradout
 
@@ -702,30 +721,32 @@ def chisqgrad_m_nfft(imarr, A, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
     plan.trafo()
     psamples = plan.f.copy()*pulsefac
 
+    # compute gradient
     msamples = psamples/isamples
     mdiff_vec = (-1./len(m))*(m - msamples) / (isamples.conj() * sigmam**2) * pulsefac.conj()
     plan.f = mdiff_vec
     plan.adjoint()
     mpart = (plan.f_hat.copy().T).reshape(nfft_info.xdim*nfft_info.ydim)
 
-    if pol_solve[0]!=0: #TODO -- check!!
+    # dchi2/dI
+    if pol_solve[0]!=0:
         plan.f = mdiff_vec * msamples.conj()
         plan.adjoint()
         mpart2 = (plan.f_hat.copy().T).reshape(nfft_info.xdim*nfft_info.ydim)
 
         gradi = (np.real(mimage * np.exp(-2j*chiimage) * mpart) - np.real(mpart2))
         gradout[0] = gradi
-
+    # dchi2/drho
     if pol_solve[1]!=0:
         gradm = np.real(iimage*np.exp(-2j*chiimage) * mpart)
         gradrho = gradm * np.cos(psiimage)
         gradout[1] = gradrho
-
+    # dchi2/dphi
     if pol_solve[2]!=0:
         gradchi = 2 * np.imag(pimage.conj() * mpart)
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
-
+    # dchi2/dpsi
     if pol_solve[3]!=0:
         gradm = np.real(iimage*np.exp(-2j*chiimage) * mpart)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
@@ -733,7 +754,6 @@ def chisqgrad_m_nfft(imarr, A, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
 
     return gradout
 
-# stokes v
 def chisq_vvis_nfft(imarr, A, v, sigmav):
     """V visibility chi-squared
     """
@@ -779,21 +799,22 @@ def chisqgrad_vvis_nfft(imarr, A, v, sigmav,pol_solve=POL_SOLVE_DEFAULT):
     plan.trafo()
     vsamples = plan.f.copy()*pulsefac
 
+    # compute gradient
     vdiff_vec = (-1.0/len(v)) * (v - vsamples) / (sigmav**2) * pulsefac.conj()
     plan.f = vdiff_vec
     plan.adjoint()
     vpart = (plan.f_hat.copy().T).reshape(nfft_info.xdim*nfft_info.ydim)
 
-
+    # dchi2/dI
     if pol_solve[0]!=0:
         gradi = np.real(vfimage*vpart)
         gradout[0] = gradi
-
+    # dchi2/drho
     if pol_solve[1]!=0:
         gradv = np.real(iimage*vpart)
         gradrho = gradv*np.sin(psiimage)
         gradout[1] = gradrho
-
+    # dchi2/dpsi
     if pol_solve[3]!=0:
         gradv = np.real(iimage*vpart)
         gradpsi = gradv * (vfimage/np.tan(psiimage))
@@ -807,40 +828,49 @@ def chisqgrad_vvis_nfft(imarr, A, v, sigmav,pol_solve=POL_SOLVE_DEFAULT):
 #
 # Each `reg_X` / `reggrad_X` implements a polarimetric regularizer with the
 # uniform `(imarr, mask, **kwargs)` signature used by the `_REGULARIZER_DISPATCH`
-# table in `imager_backend.py`. Each returns the penalty value (positive; the
-# imager solver minimises it). Spatial regularizers (ptv, vtv, vtv2) use
-# `embed_imarr` (not `embed`) for the pre-step and slice the gradient as
-# `g[:, mask]` since the pol gradient is shaped (4, nimage) — one row per
-# Stokes component, gated on `pol_solve[0..3]`.
+# table in `imager_backend.py`.
+#
+# Each returns the penalty value (defined positive; cf the old entropy style negative regularizers).
+# Spatial regularizers (ptv, vtv, vtv2) use `embed_imarr` (not `embed`) for the pre-step
+# and slice the gradient as `g[:, mask]` since the pol gradient is shaped (4, nimage)
+# — one row per Stokes component, gated on `pol_solve[0..3]`.
 ##################################################################################################
 
-
 def reg_msimple(imarr, mask, **kwargs):
+    """Simple polarimetric entropy regularizer."""
     flux = kwargs['flux']
     norm = flux if kwargs.get('norm_reg', True) else 1
+
     iimage = make_i_image(imarr)
     mimage = make_m_image(imarr)
+
     return np.sum(iimage * np.log(mimage)) / norm
 
 
 def reggrad_msimple(imarr, mask, **kwargs):
-    """Gradient of the 'msimple' polarimetric entropy regularizer.
+    """Gradient of the simple polarimetric entropy regularizer.
 
     pol_solve here flags the required physical gradients (I, rho, phi, psi),
     not the solver variables.
     """
-    flux = kwargs['flux']
     pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT)
+
+    flux = kwargs['flux']
     norm = flux if kwargs.get('norm_reg', True) else 1
+
     iimage = make_i_image(imarr)
     mimage = make_m_image(imarr)
     psiimage = make_psi_image(imarr)
+
     gradout = np.zeros(imarr.shape)
+    # dR/dI
     if pol_solve[0] != 0:
         gradout[0] = np.log(mimage)
+    # dR/drho
     if pol_solve[1] != 0:
         gradm = iimage / mimage
         gradout[1] = gradm * np.cos(psiimage)
+    # dR/dpsi
     if pol_solve[3] != 0:
         gradm = iimage / mimage
         gradout[3] = gradm * (-mimage * np.tan(psiimage))
@@ -848,12 +878,15 @@ def reggrad_msimple(imarr, mask, **kwargs):
 
 
 def reg_hw(imarr, mask, **kwargs):
+    """Holdaway-Wardle polarimetric entropy regularizer."""
     flux = kwargs['flux']
     norm = flux if kwargs.get('norm_reg', True) else 1
+
     iimage = make_i_image(imarr)
     mimage = make_m_image(imarr)
+
     return np.sum(iimage * (((1+mimage)/2) * np.log((1+mimage)/2)
-                            + ((1-mimage)/2) * np.log((1-mimage)/2))) / norm
+                         + ((1-mimage)/2) * np.log((1-mimage)/2))) / norm
 
 
 def reggrad_hw(imarr, mask, **kwargs):
@@ -862,19 +895,25 @@ def reggrad_hw(imarr, mask, **kwargs):
     pol_solve here flags the required physical gradients (I, rho, phi, psi),
     not the solver variables.
     """
-    flux = kwargs['flux']
     pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT)
+
+    flux = kwargs['flux']
     norm = flux if kwargs.get('norm_reg', True) else 1
+
     iimage = make_i_image(imarr)
     mimage = make_m_image(imarr)
     psiimage = make_psi_image(imarr)
+
     gradout = np.zeros(imarr.shape)
+    # dR/dI
     if pol_solve[0] != 0:
         gradout[0] = (((1+mimage)/2) * np.log((1+mimage)/2)
                       + ((1-mimage)/2) * np.log((1-mimage)/2))
+    # dR/drho
     if pol_solve[1] != 0:
         gradm = iimage * np.arctanh(mimage)
         gradout[1] = gradm * np.cos(psiimage)
+    # dR/dpsi
     if pol_solve[3] != 0:
         gradm = iimage * np.arctanh(mimage)
         gradout[3] = gradm * (-mimage * np.tan(psiimage))
@@ -882,14 +921,20 @@ def reggrad_hw(imarr, mask, **kwargs):
 
 
 def reg_ptv(imarr, mask, **kwargs):
+    """Linear polarimetric total-variation regularizer."""
+    # embed image if masked
     from ehtim.imaging.imager_utils import embed_imarr
     if np.any(np.invert(mask)):
         imarr = embed_imarr(imarr, mask, randomfloor=True)
+
+    # parameters and normalization
+    epsilon = kwargs.get('epsilon_tv', 0.)
     flux = kwargs['flux']
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     beam_size = kwargs.get('beam_size', 1) or psize
     norm = flux * psize / beam_size if kwargs.get('norm_reg', True) else 1
-    epsilon = kwargs.get('epsilon_tv', 0.)
+
+    # compute TV
     pimage = make_p_image(imarr)
     im = pimage.reshape(ny, nx)
     impad = np.pad(im, 1, mode='constant', constant_values=0)
@@ -904,20 +949,29 @@ def reggrad_ptv(imarr, mask, **kwargs):
     pol_solve here flags the required physical gradients (I, rho, phi, psi),
     not the solver variables.
     """
+    # embed image if masked
     from ehtim.imaging.imager_utils import embed_imarr
     do_slice = np.any(np.invert(mask))
     if do_slice:
         imarr = embed_imarr(imarr, mask, randomfloor=True)
+
+    # pol_solve output mask
+    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT)
+
+    # parameters and normalization
+    epsilon = kwargs.get('epsilon_tv', 0.)
     flux = kwargs['flux']
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
-    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT)
     beam_size = kwargs.get('beam_size', 1) or psize
     norm = flux * psize / beam_size if kwargs.get('norm_reg', True) else 1
-    epsilon = kwargs.get('epsilon_tv', 0.)
+
+    # compute necessary images
     iimage = make_i_image(imarr)
     pimage = make_p_image(imarr)
     mimage = make_m_image(imarr)
     psiimage = make_psi_image(imarr)
+
+    # shifted 2D images
     im = pimage.reshape(ny, nx)
     impad = np.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
@@ -926,30 +980,32 @@ def reggrad_ptv(imarr, mask, **kwargs):
     im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
     im_r1l2 = np.roll(np.roll(impad,  1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
     im_l1r2 = np.roll(np.roll(impad, -1, axis=0),  1, axis=1)[1:ny+1, 1:nx+1]
+
     # Denominators: |forward-l1|+|forward-l2|, |back-r1|+|cross|, |back-r2|+|cross|.
     d1 = np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2 + epsilon)
     d2 = np.sqrt(np.abs(im_r1 - im)**2 + np.abs(im_r1l2 - im_r1)**2 + epsilon)
     d3 = np.sqrt(np.abs(im_r2 - im)**2 + np.abs(im_l1r2 - im_r2)**2 + epsilon)
-    # Numerators below use cos/sin of the single-angle difference between
-    # neighbors, from d|P_l1 - P|^2/d|P| = 2|P| - 2|P_l1|*cos(angle(P_l1) - angle(P)).
+
     # The back-neighbor (m2/d2, m3/d3) terms reference a pixel that does not
     # exist on the first row/column (it is the zero pad), so they must be zeroed
-    # there -- same masking reggrad_vtv applies. chi (slot 2) self-zeros at the
-    # pad, so it needs no masking.
-    mask1 = np.zeros(im.shape, dtype=bool); mask1[0, :] = True   # no back-neighbor in axis 0
-    mask2 = np.zeros(im.shape, dtype=bool); mask2[:, 0] = True   # no back-neighbor in axis 1
+    mask1 = np.zeros(im.shape, dtype=bool)
+    mask1[0, :] = True   # no back-neighbor in axis 0
+    mask2 = np.zeros(im.shape, dtype=bool)
+    mask2[:, 0] = True   # no back-neighbor in axis 1
+
+    # compute gradient
     gradout = np.zeros(imarr.shape)
+    # dR/dI numerators (chain through |P| = I*m)
     if pol_solve[0] != 0:
-        # dS/dI numerators (chain through |P| = I*m)
         m1 = 2*np.abs(im*im) - np.abs(im*im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im*im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im*im) - np.abs(im*im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im*im) - np.abs(im*im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
         m2[mask1] = 0
         m3[mask2] = 0
         gradout[0] = (1./iimage) * (m1/d1 + m2/d2 + m3/d3).flatten()
+    # dR/drho numerators; m enters via |P| = I*m, so dR/dm = I * dR/d|P|.
+    # Then dm/drho = cos(psi)
     if pol_solve[1] != 0:
-        # dS/dm numerators; m enters via |P| = I*m, so dS/dm = I * dS/d|P|.
-        # Then dm/dprimitive[1] = cos(psi) on the (m, psi) -> (m, v) chart.
         m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
@@ -957,16 +1013,18 @@ def reggrad_ptv(imarr, mask, **kwargs):
         m3[mask2] = 0
         gradm = iimage * (m1/d1 + m2/d2 + m3/d3).flatten()
         gradout[1] = gradm * np.cos(psiimage)
+    # dR/dphi numerators
+    # `gradchi` is dR/dchi; chain through chi = phi/2 gives the *0.5.
     if pol_solve[2] != 0:
-        # dS/dphi numerators (primitive is phi = 2*chi, see PR #240).
-        # `gradchi` is dS/dchi; chain through chi(phi) = phi/2 gives the *0.5.
         c1 = -2*np.abs(im*im_l1)*np.sin(np.angle(im_l1) - np.angle(im)) - 2*np.abs(im*im_l2)*np.sin(np.angle(im_l2) - np.angle(im))
         c2 = 2*np.abs(im*im_r1)*np.sin(np.angle(im) - np.angle(im_r1))
         c3 = 2*np.abs(im*im_r2)*np.sin(np.angle(im) - np.angle(im_r2))
+        c2[mask1] = 0
+        c3[mask2] = 0
         gradchi = (c1/d1 + c2/d2 + c3/d3).flatten()
         gradout[2] = 0.5 * gradchi
+    # dR/dpsi numerators; reuse dR/dm and chain through dm/dpsi = -m*tan(psi).
     if pol_solve[3] != 0:
-        # dS/dpsi numerators; reuse dS/dm and chain through dm/dpsi = -m*tan(psi).
         m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
@@ -977,12 +1035,8 @@ def reggrad_ptv(imarr, mask, **kwargs):
     g = gradout / norm
     return g[:, mask] if do_slice else g
 
-
-# --- circular-polarization (V) regularizers ---------------------------------
-# TODO check!! The V-pol regularizers below were never thoroughly audited; the
-# `gradv * (vfimage / np.tan(psiimage))` chain-rule form (dS/dpsi) is unusual
-# and the test coverage only exercises generic random pol structure.
 def reg_vflux(imarr, mask, **kwargs):
+    """Total circular flux regularizer"""
     vflux = kwargs['vflux']
     norm = np.abs(vflux)**2 if kwargs.get('norm_reg', True) else 1
     vimage = make_v_image(imarr)
@@ -990,34 +1044,42 @@ def reg_vflux(imarr, mask, **kwargs):
 
 
 def reggrad_vflux(imarr, mask, **kwargs):
-    """Gradient of the Stokes V total-flux regularizer.
+    """Gradient of the total circular flux regularizer.
 
     pol_solve here flags the required physical gradients (I, rho, phi, psi),
     not the solver variables.
     """
-    vflux = kwargs['vflux']
     pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
+
+    # normalization
+    vflux = kwargs['vflux']
     norm = np.abs(vflux)**2 if kwargs.get('norm_reg', True) else 1
+
+    # necessary images
     iimage = make_i_image(imarr)
     vimage = make_v_image(imarr)
     vfimage = make_vf_image(imarr)
     psiimage = make_psi_image(imarr)
-    # base = dS/dV via V = I * vf, vf = m*sin(psi); pol_solve branches below
-    # chain through dV/dI = V/I, dV/dm = I*sin(psi), dV/dpsi = I*m*cos(psi).
-    base = 2 * (np.sum(vimage) - vflux) * np.ones(len(vimage))
+
+    # gradients
     gradout = np.zeros(imarr.shape)
+    base = 2 * (np.sum(vimage) - vflux) * np.ones(len(vimage)) #dR/dV
+    # dR/dI
     if pol_solve[0] != 0:
-        gradout[0] = (vimage / iimage) * base  # dS/dI
+        gradout[0] = (vimage / iimage) * base
+    # dR/drho
     if pol_solve[1] != 0:
         gradv = iimage * base
-        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+        gradout[1] = gradv * np.sin(psiimage)
+    # dR/dpsi
     if pol_solve[3] != 0:
         gradv = iimage * base
-        gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi; vf/tan(psi) = m*cos(psi)
+        gradout[3] = gradv * (vfimage / np.tan(psiimage))
     return gradout / norm
 
 
 def reg_l1v(imarr, mask, **kwargs):
+    """Stokes V L1-norm regularizer"""
     vflux = kwargs['vflux']
     norm = np.abs(vflux) if kwargs.get('norm_reg', True) else 1
     vimage = make_v_image(imarr)
@@ -1030,28 +1092,37 @@ def reggrad_l1v(imarr, mask, **kwargs):
     pol_solve here flags the required physical gradients (I, rho, phi, psi),
     not the solver variables.
     """
-    vflux = kwargs['vflux']
     pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
+
+    # normalization
+    vflux = kwargs['vflux']
     norm = np.abs(vflux) if kwargs.get('norm_reg', True) else 1
+
+    # necessary images
     iimage = make_i_image(imarr)
     vimage = make_v_image(imarr)
     vfimage = make_vf_image(imarr)
     psiimage = make_psi_image(imarr)
-    # base = dS/dV via V = I*vf; chain rules per reggrad_vflux.
-    base = np.sign(vimage)
+
+    # gradient
     gradout = np.zeros(imarr.shape)
+    base = np.sign(vimage) # dR/dV
+    # dR/dI
     if pol_solve[0] != 0:
-        gradout[0] = vfimage * base  # dS/dI (vfimage = V/I)
+        gradout[0] = vfimage * base
+    # dR/drho
     if pol_solve[1] != 0:
         gradv = iimage * base
-        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+        gradout[1] = gradv * np.sin(psiimage)
+    # dR/dpsi
     if pol_solve[3] != 0:
         gradv = iimage * base
-        gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi
+        gradout[3] = gradv * (vfimage / np.tan(psiimage))
     return gradout / norm
 
 
 def reg_l2v(imarr, mask, **kwargs):
+    """Stokes V L2-norm regularizer"""
     vflux = kwargs['vflux']
     norm = np.abs(vflux**2) if kwargs.get('norm_reg', True) else 1
     vimage = make_v_image(imarr)
@@ -1064,41 +1135,56 @@ def reggrad_l2v(imarr, mask, **kwargs):
     pol_solve here flags the required physical gradients (I, rho, phi, psi),
     not the solver variables.
     """
-    vflux = kwargs['vflux']
     pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
+
+    # normalization
+    vflux = kwargs['vflux']
     norm = np.abs(vflux**2) if kwargs.get('norm_reg', True) else 1
+
+    # necessary images
     iimage = make_i_image(imarr)
     vimage = make_v_image(imarr)
     vfimage = make_vf_image(imarr)
     psiimage = make_psi_image(imarr)
-    # base = dS/dV via V = I*vf; chain rules per reggrad_vflux.
-    base = 2 * vimage
+
+    # gradient
     gradout = np.zeros(imarr.shape)
+    base = 2 * vimage #dR/dV
+    # dR/dI
     if pol_solve[0] != 0:
-        gradout[0] = vfimage * base  # dS/dI
+        gradout[0] = vfimage * base
+    # dR/drho
     if pol_solve[1] != 0:
         gradv = iimage * base
-        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+        gradout[1] = gradv * np.sin(psiimage)
+    # dR/dpsi
     if pol_solve[3] != 0:
         gradv = iimage * base
-        gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi
+        gradout[3] = gradv * (vfimage / np.tan(psiimage))
     return gradout / norm
 
 
 def reg_vtv(imarr, mask, **kwargs):
+    """Stokes V total-variation regularizer"""
+    # embed image if masked
     from ehtim.imaging.imager_utils import embed_imarr
     if np.any(np.invert(mask)):
         imarr = embed_imarr(imarr, mask, randomfloor=True)
+
+    # parameters and normalization
+    epsilon = kwargs.get('epsilon_tv', 0.)
     vflux = kwargs['vflux']
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     beam_size = kwargs.get('beam_size', 1) or psize
     norm = np.abs(vflux) * psize / beam_size if kwargs.get('norm_reg', True) else 1
+
+    # compute TV
     vimage = make_v_image(imarr)
     im = vimage.reshape(ny, nx)
     impad = np.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
     im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    return np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2)) / norm
+    return np.sum(np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2 + epsilon)) / norm
 
 
 def reggrad_vtv(imarr, mask, **kwargs):
@@ -1107,20 +1193,29 @@ def reggrad_vtv(imarr, mask, **kwargs):
     pol_solve here flags the required physical gradients (I, rho, phi, psi),
     not the solver variables.
     """
+    # embed image if masked
     from ehtim.imaging.imager_utils import embed_imarr
     do_slice = np.any(np.invert(mask))
     if do_slice:
         imarr = embed_imarr(imarr, mask, randomfloor=True)
+
+    # pol_solve output mask
+    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
+
+    # parameters and normalization
+    epsilon = kwargs.get('epsilon_tv', 0.)
     vflux = kwargs['vflux']
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
-    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
     beam_size = kwargs.get('beam_size', 1) or psize
     norm = np.abs(vflux) * psize / beam_size if kwargs.get('norm_reg', True) else 1
-    epsilon = 0.
+
+    # compute necessary images
     iimage = make_i_image(imarr)
     vimage = make_v_image(imarr)
     vfimage = make_vf_image(imarr)
     psiimage = make_psi_image(imarr)
+
+    # shifted 2D images
     im = vimage.reshape(ny, nx)
     impad = np.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
@@ -1129,38 +1224,54 @@ def reggrad_vtv(imarr, mask, **kwargs):
     im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
     im_r1l2 = np.roll(np.roll(impad,  1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
     im_l1r2 = np.roll(np.roll(impad, -1, axis=0),  1, axis=1)[1:ny+1, 1:nx+1]
+
+    # base gradient terms
     g1 = (2*im - im_l1 - im_l2) / np.sqrt((im - im_l1)**2 + (im - im_l2)**2 + epsilon)
     g2 = (im - im_r1) / np.sqrt((im - im_r1)**2 + (im_r1l2 - im_r1)**2 + epsilon)
     g3 = (im - im_r2) / np.sqrt((im - im_r2)**2 + (im_l1r2 - im_r2)**2 + epsilon)
+
+    # The back-neighbor (g2, g3) terms reference a pixel that does not
+    # exist on the first row/column (it is the zero pad), so they must be zeroed
     mask1 = np.zeros(im.shape)
     mask2 = np.zeros(im.shape)
     mask1[0, :] = 1
     mask2[:, 0] = 1
     g2[mask1.astype(bool)] = 0
     g3[mask2.astype(bool)] = 0
-    # base = dS/dV via V = I*vf; chain rules per reggrad_vflux.
-    base = (g1 + g2 + g3).flatten()
+
+    # final gradient
     gradout = np.zeros(imarr.shape)
+    base = (g1 + g2 + g3).flatten() #dR/dV via V = I*vf
+    # dR/dI
     if pol_solve[0] != 0:
-        gradout[0] = vfimage * base  # dS/dI
+        gradout[0] = vfimage * base
+    # dR/drho
     if pol_solve[1] != 0:
         gradv = iimage * base
-        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+        gradout[1] = gradv * np.sin(psiimage)
+    # dR/dpsi
     if pol_solve[3] != 0:
         gradv = iimage * base
-        gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi
+        gradout[3] = gradv * (vfimage / np.tan(psiimage))
+
     g = gradout / norm
     return g[:, mask] if do_slice else g
 
 
 def reg_vtv2(imarr, mask, **kwargs):
+    """Stokes V total-squared-variation regularizer"""
+    # embed image if masked
     from ehtim.imaging.imager_utils import embed_imarr
     if np.any(np.invert(mask)):
         imarr = embed_imarr(imarr, mask, randomfloor=True)
+
+    # parameters and normalization
     vflux = kwargs['vflux']
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
     beam_size = kwargs.get('beam_size', 1) or psize
     norm = psize**4 * np.abs(vflux**2) / beam_size**4 if kwargs.get('norm_reg', True) else 1
+
+    # compute TV2
     vimage = make_v_image(imarr)
     im = vimage.reshape(ny, nx)
     impad = np.pad(im, 1, mode='constant', constant_values=0)
@@ -1175,45 +1286,64 @@ def reggrad_vtv2(imarr, mask, **kwargs):
     pol_solve here flags the required physical gradients (I, rho, phi, psi),
     not the solver variables.
     """
+    # embed image if masked
     from ehtim.imaging.imager_utils import embed_imarr
     do_slice = np.any(np.invert(mask))
     if do_slice:
         imarr = embed_imarr(imarr, mask, randomfloor=True)
+
+    # pol_solve output mask
+    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
+
+    # parameters and normalization
     vflux = kwargs['vflux']
     nx, ny, psize = kwargs['xdim'], kwargs['ydim'], kwargs['psize']
-    pol_solve = kwargs.get('pol_solve', POL_SOLVE_DEFAULT_V)
     beam_size = kwargs.get('beam_size', 1) or psize
     norm = psize**4 * np.abs(vflux**2) / beam_size**4 if kwargs.get('norm_reg', True) else 1
+
+    # necessary images
     iimage = make_i_image(imarr)
     vimage = make_v_image(imarr)
     vfimage = make_vf_image(imarr)
     psiimage = make_psi_image(imarr)
     im = vimage.reshape(ny, nx)
+
+    # shifted 2D images
     impad = np.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = np.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
     im_l2 = np.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
     im_r1 = np.roll(impad, 1, axis=0)[1:ny+1, 1:nx+1]
     im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
+
+    # base gradient terms
     g1 = 2*im - im_l1 - im_l2
     g2 = im - im_r1
     g3 = im - im_r2
+
+    # The back-neighbor (g2, g3) terms reference a pixel that does not
+    # exist on the first row/column (it is the zero pad), so they must be zeroed
     mask1 = np.zeros(im.shape)
     mask2 = np.zeros(im.shape)
     mask1[0, :] = 1
     mask2[:, 0] = 1
     g2[mask1.astype(bool)] = 0
     g3[mask2.astype(bool)] = 0
-    # base = dS/dV via V = I*vf; chain rules per reggrad_vflux.
-    base = 2 * (g1 + g2 + g3).flatten()
+
+    # final gradient
     gradout = np.zeros(imarr.shape)
+    base = 2 * (g1 + g2 + g3).flatten() # base = dR/dV via V = I*vf
+    # dR/dI
     if pol_solve[0] != 0:
-        gradout[0] = vfimage * base  # dS/dI
+        gradout[0] = vfimage * base
+    # dR/drho
     if pol_solve[1] != 0:
         gradv = iimage * base
-        gradout[1] = gradv * np.sin(psiimage)  # dS/dm
+        gradout[1] = gradv * np.sin(psiimage)
+    # dR/dpsi
     if pol_solve[3] != 0:
         gradv = iimage * base
-        gradout[3] = gradv * (vfimage / np.tan(psiimage))  # dS/dpsi
+        gradout[3] = gradv * (vfimage / np.tan(psiimage))
+
     g = gradout / norm
     return g[:, mask] if do_slice else g
 
@@ -1237,7 +1367,7 @@ def chisqdata_pvis(Obsdata, Prior, mask, **kwargs):
     return (vis, sigma, A)
 
 def chisqdata_pvis_nfft(Obsdata, Prior, **kwargs):
-    """Return the visibilities, sigmas, and fourier matrix for an observation."""
+    """Return the visibilities, sigmas, and nfft plan for an observation."""
 
     # unpack keyword args
     fft_pad_factor = kwargs.get('fft_pad_factor',FFT_PAD_DEFAULT)
@@ -1274,7 +1404,7 @@ def chisqdata_m(Obsdata, Prior, mask, **kwargs):
     return (m, sigmam, A)
 
 def chisqdata_m_nfft(Obsdata, Prior, **kwargs):
-    """Return the pol ratios, sigmas, and fourier matrix for an observation."""
+    """Return the pol ratios, sigmas, and nfft plan for an observation."""
 
     # unpack keyword args
     fft_pad_factor = kwargs.get('fft_pad_factor',FFT_PAD_DEFAULT)
@@ -1311,7 +1441,7 @@ def chisqdata_vvis(Obsdata, Prior, mask, **kwargs):
     return (vis, sigma, A)
 
 def chisqdata_vvis_nfft(Obsdata, Prior, **kwargs):
-    """Return the visibilities, sigmas, and fourier matrix for an observation."""
+    """Return the visibilities, sigmas, and nfft plan for an observation."""
 
     # unpack keyword args
     fft_pad_factor = kwargs.get('fft_pad_factor',FFT_PAD_DEFAULT)
@@ -1360,14 +1490,12 @@ def plot_m(polarr, Prior, nit, chi2_dict, **kwargs):
             print('clipping values less than 0')
             imarr[imarr<0.0] = 0.0
         imarr = np.log(imarr + np.max(imarr)/dynamic_range)
-        #unit = 'log(' + cbar_unit[0] + ' per ' + cbar_unit[1] + ')'
 
     if scale=='gamma':
         if (imarr < 0.0).any():
             print('clipping values less than 0')
             imarr[imarr<0.0] = 0.0
         imarr = (imarr + np.max(imarr)/dynamic_range)**(gamma)
-        #unit = '(' + cbar_unit[0] + ' per ' + cbar_unit[1] + ')^gamma'
 
     # Mask for low flux points
     thin = int(round(Prior.xdim/nvec))
@@ -1423,5 +1551,3 @@ def plot_m(polarr, Prior, nit, chi2_dict, **kwargs):
     for key in chi2_dict.keys():
         plotstr += rf"$\chi^2_{{{key}}}$: {chi2_dict[key]:0.2f}  "
     plt.suptitle(plotstr, fontsize=18)
-
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,6 +185,46 @@ def make_rect_image():
 
 
 @pytest.fixture(scope="session")
+def make_asym_image():
+    """Factory: asymmetric offset double-Gaussian of arbitrary (xdim, ydim).
+
+    Two broad, rotated, elongated, offset blobs. Unlike a centered circular
+    Gaussian, this breaks the reflection / rotation / x<->y symmetries and
+    shifts flux toward the edges, so boundary-masking and axis-ordering bugs
+    (which a symmetric image hides) surface in the chisq / regularizer /
+    gradient FD tests. The blobs are kept broad with modest offsets so the field
+    fills the grid (no dead pixels) -- a compact/offset source leaves zero-flux
+    corners where the |.|-kink TV gradients are FD-ill-conditioned at
+    epsilon_tv=0, producing spurious FD outliers unrelated to correctness.
+    Drop-in for make_rect_image (same (xdim, ydim[, psize]) signature, Stokes-I).
+    """
+    import numpy as np
+
+    def _factory(xdim, ydim, psize=None):
+        if psize is None:
+            psize = 200 * eh.RADPERUAS / max(xdim, ydim)
+        yy, xx = np.mgrid[0:ydim, 0:xdim]
+        x = (xx - xdim / 2.0) * psize
+        y = (yy - ydim / 2.0) * psize
+        ua = eh.RADPERUAS
+
+        def blob(flux, fmaj, fmin, pa, x0, y0):
+            smaj, smin = fmaj / 2.355, fmin / 2.355
+            xr = (x - x0) * np.cos(pa) + (y - y0) * np.sin(pa)
+            yr = -(x - x0) * np.sin(pa) + (y - y0) * np.cos(pa)
+            return flux * np.exp(-(xr**2 / (2 * smaj**2) + yr**2 / (2 * smin**2)))
+
+        image_arr = (blob(0.6, 120 * ua, 78 * ua, 0.5, 16 * ua, -11 * ua)
+                     + blob(0.4, 84 * ua, 116 * ua, -0.7, -19 * ua, 17 * ua))
+        image_arr /= image_arr.sum()
+        return eh.image.Image(
+            image_arr, psize, 17.761, -29.0,
+            polrep="stokes", pol_prim="I", rf=230e9,
+        )
+    return _factory
+
+
+@pytest.fixture(scope="session")
 def observe(eht_array):
     """Factory fixture: observation with project-standard defaults.
 

--- a/tests/test_chisquared.py
+++ b/tests/test_chisquared.py
@@ -9,6 +9,13 @@ import numpy as np
 import pytest
 
 from ehtim.imaging.imager_utils import chisq, chisqdata, chisqgrad
+from ehtim.imaging.imager_backend import (
+    ImagerConfig,
+    MfConfig,
+    compute_chisq_term,
+    compute_chisqdata_term,
+    compute_chisqgrad_term,
+)
 
 # Observation parameters (must match conftest.py)
 TINT_SEC = 5
@@ -194,3 +201,127 @@ def _gradient_comparison(chisq_setup, dtype, pair):
     frac_diff = np.abs((grad_a - grad_b) / (np.abs(grad_a) + compare_floor))
     print(f"  {dtype} {ttype_a}-{ttype_b}: grad median={np.median(frac_diff):.6f} max={np.max(frac_diff):.6f}")
     return np.median(frac_diff), np.max(frac_diff)
+
+
+# ---------------------------------------------------------------------------
+# Polarimetric chi-squared (pvis / m / vvis). Pol has no 'fast' ttype.
+# ---------------------------------------------------------------------------
+POL_DATATERMS = ["pvis", "m", "vvis"]
+POL_FD_REL = 1e-6
+POL_FD_FLOOR = 1e-9
+POL_GRAD_FD_TOL = 1e-4      # fractional, FD vs analytic (same ttype, self-consistent)
+POL_CHISQ_FRAC_TOL = 0.01   # direct-vs-nfft value agreement
+
+
+def _pol_config(ttype):
+    return ImagerConfig(
+        pol="IP", transforms=[], ttype=ttype, mf=False,
+        mf_config=MfConfig(mf_order=0, mf_order_pol=0, mf_rm=0, mf_cm=0),
+    )
+
+
+def _pol_data_tuple(obs, prior, mask, dtype, ttype):
+    data, sigma, A = compute_chisqdata_term(obs, prior, mask, dtype, _pol_config(ttype))
+    return A, data, sigma
+
+
+@pytest.fixture(scope="module")
+def chisq_setup_pol(eht_array, make_rect_image):
+    """32x48 polarized Gaussian + a jittered physical-space imcur [I,rho,phi,psi]."""
+    im = make_rect_image(32, 48)
+    im.imvec = im.imvec * 2.0 / im.total_flux()
+    im.add_qu(0.10 * im.imarr(), 0.05 * im.imarr())
+    im.add_v(0.02 * im.imarr())
+    prior = im.copy()
+
+    obs = im.observe(
+        eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
+        ampcal=True, phasecal=True, ttype="direct", add_th_noise=False,
+    )
+    mask = np.ones(im.imvec.size, dtype=bool)
+
+    # Physical-space imcur jittered off the truth so residuals (and grads) are
+    # nonzero; keep rho in (0,1) and psi away from 0 (tan(psi) in vvis grad).
+    rng = np.random.default_rng(RNG_SEED)
+    I = im.imvec
+    Q, U, V = im.qvec, im.uvec, im.vvec
+    P = np.sqrt(Q**2 + U**2 + V**2)
+    n = I.size
+    imcur = np.array([
+        I * (1.0 + 0.05 * (rng.random(n) - 0.5)),
+        np.clip((P / I) * (1.0 + 0.1 * (rng.random(n) - 0.5)), 0.02, 0.95),
+        np.arctan2(U, Q) + 0.1 * (rng.random(n) - 0.5),
+        np.clip(np.arcsin(V / (P + 1e-30)) * (1.0 + 0.1 * (rng.random(n) - 0.5)), 0.02, 1.5),
+    ])
+    return {"obs": obs, "prior": prior, "mask": mask, "imcur": imcur}
+
+
+class TestPolChisqConsistency:
+    """Pol chi-squared values agree between direct and nfft (same obs, different A)."""
+
+    @pytest.mark.parametrize("dtype", POL_DATATERMS)
+    def test_chisq_values(self, chisq_setup_pol, dtype):
+        obs, prior = chisq_setup_pol["obs"], chisq_setup_pol["prior"]
+        mask, imcur = chisq_setup_pol["mask"], chisq_setup_pol["imcur"]
+        vals = {}
+        for tt in ("direct", "nfft"):
+            A, data, sigma = _pol_data_tuple(obs, prior, mask, dtype, tt)
+            vals[tt] = compute_chisq_term(imcur, dtype, A, data, sigma, ttype=tt, mask=mask)
+        frac = abs((vals["direct"] - vals["nfft"]) / abs(vals["direct"]))
+        assert frac < POL_CHISQ_FRAC_TOL, f"{dtype}: chisq frac diff = {frac:.6f}"
+
+
+class TestPolChisqGradConsistency:
+    """Pol chi-squared gradients agree between direct and nfft."""
+
+    @pytest.mark.parametrize("dtype", POL_DATATERMS)
+    def test_grad_values(self, chisq_setup_pol, dtype):
+        obs, prior = chisq_setup_pol["obs"], chisq_setup_pol["prior"]
+        mask, imcur = chisq_setup_pol["mask"], chisq_setup_pol["imcur"]
+        grads = {}
+        for tt in ("direct", "nfft"):
+            A, data, sigma = _pol_data_tuple(obs, prior, mask, dtype, tt)
+            grads[tt] = compute_chisqgrad_term(
+                imcur, dtype, A, data, sigma, ttype=tt, mask=mask,
+                pol_solve=np.array([1, 1, 1, 1]))
+        a, b = grads["direct"], grads["nfft"]
+        floor = np.min(np.abs(a)) * 1e-20 + 1e-100
+        frac = np.abs((a - b) / (np.abs(a) + floor))
+        assert np.median(frac) < GRAD_MEDIAN_TOL
+        assert np.max(frac) < GRAD_MAX_TOL_NFFT
+
+
+class TestPolChisqGradFD:
+    """Pol chisqgrad matches finite differences of the chisq value, in all four
+    physical slots (driven with pol_solve=[1,1,1,1]). vvis slot 2 (EVPA) is
+    asserted identically zero -- Stokes V is independent of EVPA -- and its FD
+    is also zero, so the all-slot loop covers it consistently."""
+
+    @pytest.mark.parametrize("dtype", POL_DATATERMS)
+    @pytest.mark.parametrize("ttype", ["direct", "nfft"])
+    def test_grad_matches_fd(self, chisq_setup_pol, dtype, ttype):
+        obs, prior = chisq_setup_pol["obs"], chisq_setup_pol["prior"]
+        mask, imcur = chisq_setup_pol["mask"], chisq_setup_pol["imcur"]
+        A, data, sigma = _pol_data_tuple(obs, prior, mask, dtype, ttype)
+        grad = compute_chisqgrad_term(
+            imcur, dtype, A, data, sigma, ttype=ttype, mask=mask,
+            pol_solve=np.array([1, 1, 1, 1]))
+
+        if dtype == "vvis":   # V is independent of EVPA
+            np.testing.assert_array_equal(grad[2], 0.0)
+
+        rng = np.random.default_rng(RNG_SEED)
+        n = imcur.shape[1]
+        sample = rng.choice(n, size=min(30, n), replace=False)
+        frac = []
+        for slot in range(4):
+            for j in sample:
+                dx = max(POL_FD_REL * abs(imcur[slot, j]), POL_FD_FLOOR)
+                ip = imcur.copy(); ip[slot, j] += dx
+                im_ = imcur.copy(); im_[slot, j] -= dx
+                fd = (compute_chisq_term(ip, dtype, A, data, sigma, ttype=ttype, mask=mask)
+                      - compute_chisq_term(im_, dtype, A, data, sigma, ttype=ttype, mask=mask)) / (2 * dx)
+                ex = grad[slot, j]
+                denom = max(abs(ex), abs(fd), POL_FD_FLOOR)
+                frac.append(abs(ex - fd) / denom)
+        assert max(frac) < POL_GRAD_FD_TOL, f"{dtype} {ttype}: max frac diff = {max(frac):.4g}"

--- a/tests/test_chisquared.py
+++ b/tests/test_chisquared.py
@@ -8,6 +8,7 @@ exercises the rectangular-image code paths (rect subsumes square).
 import numpy as np
 import pytest
 
+import ehtim as eh
 from ehtim.imaging.imager_utils import chisq, chisqdata, chisqgrad
 from ehtim.imaging.imager_backend import (
     ImagerConfig,
@@ -211,7 +212,12 @@ def _gradient_comparison(chisq_setup, dtype, pair):
 POL_DATATERMS = ["pvis", "m", "vvis"]
 POL_FD_REL = 1e-6
 POL_FD_FLOOR = 1e-9
-POL_GRAD_FD_TOL = 1e-4      # fractional, FD vs analytic (same ttype, self-consistent)
+# fractional FD vs analytic (same ttype, self-consistent). median is tight (any
+# systematic gradient error blows it up); max is looser to tolerate 2nd-order FD
+# truncation outliers at small-gradient pixels of the structured-pol imcur. Real
+# pol-gradient bugs are %-level (e.g. the mcv slot-3 coupling), far above these.
+POL_GRAD_FD_MEDIAN_TOL = 1e-5
+POL_GRAD_FD_MAX_TOL = 1e-3
 POL_CHISQ_FRAC_TOL = 0.01   # direct-vs-nfft value agreement
 
 
@@ -228,12 +234,18 @@ def _pol_data_tuple(obs, prior, mask, dtype, ttype):
 
 
 @pytest.fixture(scope="module")
-def chisq_setup_pol(eht_array, make_rect_image):
-    """32x48 polarized Gaussian + a jittered physical-space imcur [I,rho,phi,psi]."""
-    im = make_rect_image(32, 48)
+def chisq_setup_pol(eht_array, make_asym_image):
+    """Asymmetric 32x48 polarized image + a jittered physical imcur [I,rho,phi,psi].
+
+    add_random_pol gives a spatially-varying EVPA (random screen) and, with
+    ccorr>0, a spatially-varying circular fraction -- so chi, vfrac, rho, and psi
+    all vary across the image. A constant pol fraction would leave the
+    polarization structure spatially uniform and never exercise those gradients.
+    """
+    im = make_asym_image(32, 48)
     im.imvec = im.imvec * 2.0 / im.total_flux()
-    im.add_qu(0.10 * im.imarr(), 0.05 * im.imarr())
-    im.add_v(0.02 * im.imarr())
+    im = im.add_random_pol(0.25, 40 * eh.RADPERUAS,
+                           cmag=0.06, ccorr=40 * eh.RADPERUAS, seed=7)
     prior = im.copy()
 
     obs = im.observe(
@@ -253,7 +265,7 @@ def chisq_setup_pol(eht_array, make_rect_image):
         I * (1.0 + 0.05 * (rng.random(n) - 0.5)),
         np.clip((P / I) * (1.0 + 0.1 * (rng.random(n) - 0.5)), 0.02, 0.95),
         np.arctan2(U, Q) + 0.1 * (rng.random(n) - 0.5),
-        np.clip(np.arcsin(V / (P + 1e-30)) * (1.0 + 0.1 * (rng.random(n) - 0.5)), 0.02, 1.5),
+        np.clip(np.abs(np.arcsin(V / (P + 1e-30))) * (1.0 + 0.1 * (rng.random(n) - 0.5)), 0.02, 1.5),
     ])
     return {"obs": obs, "prior": prior, "mask": mask, "imcur": imcur}
 
@@ -326,4 +338,8 @@ class TestPolChisqGradFD:
                 ex = grad[slot, j]
                 denom = max(abs(ex), abs(fd), POL_FD_FLOOR)
                 frac.append(abs(ex - fd) / denom)
-        assert max(frac) < POL_GRAD_FD_TOL, f"{dtype} {ttype}: max frac diff = {max(frac):.4g}"
+        frac = np.array(frac)
+        assert np.median(frac) < POL_GRAD_FD_MEDIAN_TOL, (
+            f"{dtype} {ttype}: median frac diff = {np.median(frac):.4g}")
+        assert np.max(frac) < POL_GRAD_FD_MAX_TOL, (
+            f"{dtype} {ttype}: max frac diff = {np.max(frac):.4g}")

--- a/tests/test_chisquared.py
+++ b/tests/test_chisquared.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 
 import ehtim as eh
-from ehtim.imaging.imager_utils import chisq, chisqdata, chisqgrad
 from ehtim.imaging.imager_backend import (
     ImagerConfig,
     MfConfig,
@@ -17,6 +16,7 @@ from ehtim.imaging.imager_backend import (
     compute_chisqdata_term,
     compute_chisqgrad_term,
 )
+from ehtim.imaging.imager_utils import chisq, chisqdata, chisqgrad
 
 # Observation parameters (must match conftest.py)
 TINT_SEC = 5
@@ -331,8 +331,10 @@ class TestPolChisqGradFD:
         for slot in range(4):
             for j in sample:
                 dx = max(POL_FD_REL * abs(imcur[slot, j]), POL_FD_FLOOR)
-                ip = imcur.copy(); ip[slot, j] += dx
-                im_ = imcur.copy(); im_[slot, j] -= dx
+                ip = imcur.copy()
+                ip[slot, j] += dx
+                im_ = imcur.copy()
+                im_[slot, j] -= dx
                 fd = (compute_chisq_term(ip, dtype, A, data, sigma, ttype=ttype, mask=mask)
                       - compute_chisq_term(im_, dtype, A, data, sigma, ttype=ttype, mask=mask)) / (2 * dx)
                 ex = grad[slot, j]

--- a/tests/test_chisquared.py
+++ b/tests/test_chisquared.py
@@ -73,15 +73,17 @@ RNG_SEED = 4
 
 
 @pytest.fixture(scope="module")
-def chisq_setup(eht_array, make_rect_image):
+def chisq_setup(eht_array, make_asym_image):
     """Set up observation and test image for chi-squared comparison tests.
 
-    Uses a 32x48 synthetic Gaussian image so xdim != ydim exercises the
-    rectangular-image code paths. A single DFT observation serves as ground
-    truth; chi-squared is then evaluated with different transform matrices
-    (direct, fast, nfft), testing that the transform approximations agree.
+    Uses a 32x48 asymmetric (offset double-Gaussian) image: xdim != ydim
+    exercises the rectangular-image code paths, and the broken symmetry +
+    edge flux surface axis-ordering bugs a centered Gaussian hides. A single
+    DFT observation serves as ground truth; chi-squared is then evaluated with
+    different transform matrices (direct, fast, nfft) to test that the
+    transform approximations agree.
     """
-    im = make_rect_image(32, 48)
+    im = make_asym_image(32, 48)
     im.imvec = im.imvec * 2.0 / im.total_flux()  # normalize to 2 Jy
 
     obs = im.observe(

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -54,12 +54,14 @@ BW_HZ = 4e9
 
 
 @pytest.fixture(scope="module")
-def grad_setup(eht_array, make_rect_image):
-    """Set up observation and test image from 32x48 synthetic Gaussian.
+def grad_setup(eht_array, make_asym_image):
+    """Set up observation and test image from a 32x48 asymmetric image.
 
-    Uses xdim != ydim so the rectangular-image code paths are exercised.
+    Offset double-Gaussian: xdim != ydim exercises the rectangular-image code
+    paths, and the broken symmetry + edge flux surface boundary/axis bugs a
+    centered Gaussian hides.
     """
-    im = make_rect_image(32, 48)
+    im = make_asym_image(32, 48)
     im.imvec = im.imvec * 2.0 / im.total_flux()  # normalize to 2 Jy
 
     obs = im.observe(

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -1813,33 +1813,37 @@ class TestComputeObjectiveGrad:
             rtol=1e-4, atol=1e-8,
         )
 
-    def test_fd_matches_analytic_polarimetric(self, gauss_im_pol, observe,
-                                                initialize_imager):
-        """FD verification under pol='IP' with log+mcv transforms.
-
-        Exercises the chain rule applied through both the log (Stokes I) and
-        mcv (polarization) transform components, on top of the polarimetric
-        forward model. atol=1e-7 covers the FD noise floor: with chisq values
-        ~O(1e6) and eps=1e-6, FD precision floors near 1e-7 in absolute terms.
-        """
-        obs = observe(gauss_im_pol)
-        imgr, _ = initialize_imager(
-            obs, gauss_im_pol, {"vis": 100, "pvis": 100},
-            reg_term={"simple": 1, "hw": 1},
-            pol="IP", transform=["log", "mcv"],
-        )
-        imvec = imgr._init_vec
-
-        rng = np.random.default_rng(7)
-        indices = rng.choice(len(imvec), size=20, replace=False)
-
-        grad_analytic = _call_backend_objective_grad(imgr, imvec)
-        grad_fd = _fd_grad_of_objective(imgr, imvec, indices)
-
-        np.testing.assert_allclose(
-            grad_analytic[indices], grad_fd[indices],
-            rtol=1e-4, atol=1e-7,
-        )
+    # Superseded by TestObjectiveGradPolarimetricFD, which samples the
+    # polarization DOF block. This global-sampling version was insensitive to
+    # the mcv cross-coupling (it missed the slot-3 term entirely). Commented out
+    # rather than deleted pending the PR2 test reorganization.
+    # def test_fd_matches_analytic_polarimetric(self, gauss_im_pol, observe,
+    #                                             initialize_imager):
+    #     """FD verification under pol='IP' with log+mcv transforms.
+    #
+    #     Exercises the chain rule applied through both the log (Stokes I) and
+    #     mcv (polarization) transform components, on top of the polarimetric
+    #     forward model. atol=1e-7 covers the FD noise floor: with chisq values
+    #     ~O(1e6) and eps=1e-6, FD precision floors near 1e-7 in absolute terms.
+    #     """
+    #     obs = observe(gauss_im_pol)
+    #     imgr, _ = initialize_imager(
+    #         obs, gauss_im_pol, {"vis": 100, "pvis": 100},
+    #         reg_term={"simple": 1, "hw": 1},
+    #         pol="IP", transform=["log", "mcv"],
+    #     )
+    #     imvec = imgr._init_vec
+    #
+    #     rng = np.random.default_rng(7)
+    #     indices = rng.choice(len(imvec), size=20, replace=False)
+    #
+    #     grad_analytic = _call_backend_objective_grad(imgr, imvec)
+    #     grad_fd = _fd_grad_of_objective(imgr, imvec, indices)
+    #
+    #     np.testing.assert_allclose(
+    #         grad_analytic[indices], grad_fd[indices],
+    #         rtol=1e-4, atol=1e-7,
+    #     )
 
     @pytest.mark.parametrize("xdim,ydim", IMAGE_SHAPES)
     def test_rect_images(self, make_rect_image, observe, initialize_imager,
@@ -1855,6 +1859,76 @@ class TestComputeObjectiveGrad:
         backend_grad = _call_backend_objective_grad(imgr, imvec)
         method_grad = imgr.objgrad(imvec)
         np.testing.assert_array_equal(backend_grad, method_grad)
+
+
+# Composition objective-FD for the three pol transforms x {direct, nfft}. Each
+# case bundles its applicable pol data terms AND a pol regularizer, so both
+# gradient paths through physical_grad_slots are exercised end-to-end:
+#   chisq: pvis (chisqgrad_p) + m (chisqgrad_m) under mcv/polcv; vvis
+#          (chisqgrad_vvis) under vcv/polcv;
+#   reg:   hw (linear) / l2v (circular) pol reggrad kernels.
+# The test samples the polarization DOF block (everything past the leading
+# Stokes-I block), where the mcv/vcv cross-coupling lives -- the global/top-|g|
+# sampling in the other objective-FD tests is dominated by the large Stokes-I
+# log gradients and misses a dropped pol-coupling term: pre-fix (pol_solve = raw
+# DOF, slot 3 zeroed for IP) the m' gradient is ~4% off FD at V=0.02*I and ~430%
+# off at V=0.2*I. Smooth regs (hw/l2v) avoid the small-denominator FD noise of
+# TV-style pol regs, which are FD-checked at kernel level in test_regularizers.
+POL_OBJFD_CASES = [
+    ("IP",  ["log", "mcv"],   {"vis": 100, "pvis": 100, "m": 100},
+     {"simple": 1, "hw": 1}),
+    ("IV",  ["log", "vcv"],   {"amp": 100, "vvis": 100},
+     {"simple": 1, "l2v": 1}),
+    ("IQUV", ["log", "polcv"], {"vis": 100, "pvis": 100, "m": 100, "vvis": 100},
+     {"simple": 1, "hw": 1, "l2v": 1}),
+]
+
+
+class TestObjectiveGradPolarimetricFD:
+    """objgrad matches FD on the polarization DOF block for IP/IV/IQUV, direct+nfft.
+
+    Composition test: real chisq+reg kernels o transform_gradients o pack/unpack
+    o objgrad, through physical_grad_slots. Sensitive to the mcv/vcv cross-
+    coupling that the Stokes-I-dominated samples in the other FD tests miss,
+    on both the chisq and the regularizer gradient paths. Subsumes the former
+    test_fd_matches_analytic_polarimetric (IP) and the e2e
+    test_iv_gradient_matches_finite_difference (IV).
+    """
+
+    @pytest.mark.parametrize("ttype", ["direct", "nfft"])
+    @pytest.mark.parametrize("pol,transform,data_term,reg_term", POL_OBJFD_CASES,
+                             ids=[c[0] for c in POL_OBJFD_CASES])
+    def test_pol_dof_grad_matches_fd(self, gauss_im_pol, obs_pol_direct,
+                                     gauss_prior, pol, transform, data_term,
+                                     reg_term, ttype):
+        imgr = eh.imager.Imager(
+            obs_pol_direct, gauss_prior, prior_im=gauss_prior,
+            flux=gauss_im_pol.total_flux(),
+            data_term=data_term, reg_term=reg_term,
+            ttype=ttype, pol=pol, transform=transform, maxit=10,
+        )
+        imgr.init_imager()
+        nslots = int(np.sum(imgr._which_solve))
+        x = np.asarray(imgr._init_vec, float)
+        rng = np.random.default_rng(4)
+        x = x + 0.10 * rng.standard_normal(x.size)
+        nimage = x.size // nslots
+
+        g = np.asarray(imgr.objgrad(x))
+        # pol DOF components = everything past the leading Stokes-I block;
+        # take the best-conditioned 30 so the fractional FD check is stable.
+        pol_idx = np.arange(nimage, x.size)
+        idx = pol_idx[np.argsort(np.abs(g[pol_idx]))[-30:]]
+
+        fd = np.empty(len(idx))
+        for k, j in enumerate(idx):
+            a, b = x.copy(), x.copy()
+            a[j] += 1e-6
+            b[j] -= 1e-6
+            fd[k] = (imgr.objfunc(a) - imgr.objfunc(b)) / 2e-6
+        frac = np.abs((fd - g[idx]) / (np.abs(g[idx]) + 1e-100))
+        assert np.median(frac) < 1e-4, f"{pol}/{ttype}: median frac {np.median(frac):.3e}"
+        assert np.max(frac) < 1e-2, f"{pol}/{ttype}: max frac {np.max(frac):.3e}"
 
 
 def test_objective_and_objective_grad_share_consistency(gauss_im, observe,

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -1884,6 +1884,25 @@ POL_OBJFD_CASES = [
 ]
 
 
+@pytest.fixture(scope="module")
+def asym_pol_setup(make_asym_image, observe):
+    """Asymmetric image with spatially-varying linear+circular pol + Stokes-I prior.
+
+    add_random_pol with ccorr>0 gives a spatially-varying EVPA and circular
+    fraction, so chi, vfrac, rho, psi all vary across the (asymmetric) image --
+    the realistic structured-pol case the constant-fraction gauss_im_pol lacks.
+    A Stokes-I prior (the imager random-inits pol) matches the prior the
+    superseded tests used. Returns (truth_image, obs, prior).
+    """
+    im = make_asym_image(32, 48)
+    im.imvec = im.imvec * 2.0 / im.total_flux()
+    prior = im.blur_circ(30 * eh.RADPERUAS)            # Stokes-I prior
+    im_pol = im.add_random_pol(0.25, 40 * eh.RADPERUAS,
+                               cmag=0.06, ccorr=40 * eh.RADPERUAS, seed=7)
+    obs = observe(im_pol, ttype="direct")
+    return im_pol, obs, prior
+
+
 class TestObjectiveGradPolarimetricFD:
     """objgrad matches FD on the polarization DOF block for IP/IV/IQUV, direct+nfft.
 
@@ -1898,12 +1917,12 @@ class TestObjectiveGradPolarimetricFD:
     @pytest.mark.parametrize("ttype", ["direct", "nfft"])
     @pytest.mark.parametrize("pol,transform,data_term,reg_term", POL_OBJFD_CASES,
                              ids=[c[0] for c in POL_OBJFD_CASES])
-    def test_pol_dof_grad_matches_fd(self, gauss_im_pol, obs_pol_direct,
-                                     gauss_prior, pol, transform, data_term,
-                                     reg_term, ttype):
+    def test_pol_dof_grad_matches_fd(self, asym_pol_setup, pol, transform,
+                                     data_term, reg_term, ttype):
+        im_pol, obs, prior = asym_pol_setup
         imgr = eh.imager.Imager(
-            obs_pol_direct, gauss_prior, prior_im=gauss_prior,
-            flux=gauss_im_pol.total_flux(),
+            obs, prior, prior_im=prior,
+            flux=im_pol.total_flux(),
             data_term=data_term, reg_term=reg_term,
             ttype=ttype, pol=pol, transform=transform, maxit=10,
         )

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -363,6 +363,14 @@ class TestPhysicalGradSlots:
         out = physical_grad_slots([1, 0, 0, 0], ["log"])
         np.testing.assert_array_equal(out, [1, 0, 0, 0])
 
+    def test_single_pol_mask_passthrough_despite_mcv(self):
+        # Stokes-I carries 'mcv' in transforms inertly; a sub-4-wide mask has
+        # no rho/psi DOFs to couple and must pass through (no IndexError).
+        np.testing.assert_array_equal(
+            physical_grad_slots([1], ["log", "mcv"]), [1])
+        np.testing.assert_array_equal(
+            physical_grad_slots([1, 1, 1], ["log", "mcv"]), [1, 1, 1])  # mf I
+
     def test_returns_copy_not_alias(self):
         pol_solve = np.array([1, 1, 1, 0])
         out = physical_grad_slots(pol_solve, ["log", "mcv"])

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -35,6 +35,7 @@ from ehtim.imaging.imager_backend import (
     compute_which_solve,
     make_initarr,
     pack_imarr,
+    physical_grad_slots,
     transform_gradients,
     transform_imarr,
     transform_imarr_inverse,
@@ -332,6 +333,41 @@ class TestComputeWhichSolve:
             imgr._which_solve,
             compute_which_solve(imgr._config),
         )
+
+
+class TestPhysicalGradSlots:
+    """physical_grad_slots maps the DOF mask -> physical gradout slots the
+    kernels must fill. Must mirror transform_gradients' Jacobian sparsity."""
+
+    def test_ip_mcv_fills_psi(self):
+        # m' (slot 1) drives both rho and psi via mcv cross-term
+        out = physical_grad_slots([1, 1, 1, 0], ["log", "mcv"])
+        np.testing.assert_array_equal(out, [1, 1, 1, 1])
+
+    def test_iv_vcv_fills_rho(self):
+        # v' (slot 3) drives both rho and psi via vcv cross-term
+        out = physical_grad_slots([1, 0, 0, 1], ["log", "vcv"])
+        np.testing.assert_array_equal(out, [1, 1, 0, 1])
+
+    def test_ipv_polcv_is_diagonal(self):
+        # polcv is diagonal: physical-need == DOF
+        out = physical_grad_slots([1, 1, 1, 1], ["log", "polcv"])
+        np.testing.assert_array_equal(out, [1, 1, 1, 1])
+
+    def test_vcv_inactive_pol_is_diagonal(self):
+        # vcv present but V not solved -> no cross-coupling
+        out = physical_grad_slots([1, 0, 0, 0], ["log", "vcv"])
+        np.testing.assert_array_equal(out, [1, 0, 0, 0])
+
+    def test_no_pol_transform_passthrough(self):
+        out = physical_grad_slots([1, 0, 0, 0], ["log"])
+        np.testing.assert_array_equal(out, [1, 0, 0, 0])
+
+    def test_returns_copy_not_alias(self):
+        pol_solve = np.array([1, 1, 1, 0])
+        out = physical_grad_slots(pol_solve, ["log", "mcv"])
+        assert out is not pol_solve
+        np.testing.assert_array_equal(pol_solve, [1, 1, 1, 0])  # input untouched
 
 
 def _call_compute_data_tuples(imgr):

--- a/tests/test_imager_e2e.py
+++ b/tests/test_imager_e2e.py
@@ -239,33 +239,37 @@ class TestEndToEndReconstruction:
         assert p_total == pytest.approx(p_truth, rel=0.5), (
             f"total polarized flux {p_total:.3e} off from truth {p_truth:.3e}")
 
-    def test_iv_gradient_matches_finite_difference(self, obs_pol_direct, gauss_im_pol, gauss_prior):
-        """IV (circular-pol) analytic gradient must match finite differences.
-
-        Regression for the vcv / chisqgrad_vvis bug: vcv_grad's vprime chain rule
-        uses the physical rho gradient, which chisqgrad_vvis previously skipped for
-        pol='IV' (pol_solve=[1,0,0,1]), making the V-angle gradient badly wrong
-        (~99% off; FD median was ~6e-2 before, ~3e-10 after).
-        """
-        imgr = eh.imager.Imager(
-            obs_pol_direct, gauss_prior, prior_im=gauss_prior, flux=gauss_im_pol.total_flux(),
-            data_term={"amp": 100, "vvis": 100}, reg_term={"simple": 1},
-            ttype="direct", pol="IV", transform=["log", "vcv"], maxit=100,
-        )
-        imgr.init_imager()
-        rng = np.random.default_rng(4)
-        x = np.asarray(imgr._init_vec, float) + 0.10 * rng.standard_normal(imgr._init_vec.size)
-        g = np.asarray(imgr.objgrad(x))
-        idx = np.argsort(np.abs(g))[-40:]  # best-conditioned components
-        fd = np.empty(40)
-        for k, j in enumerate(idx):
-            a, b = x.copy(), x.copy()
-            a[j] += 1e-6
-            b[j] -= 1e-6
-            fd[k] = (imgr.objfunc(a) - imgr.objfunc(b)) / 2e-6
-        frac = np.abs((fd - g[idx]) / (np.abs(g[idx]) + 1e-100))
-        assert np.median(frac) < 1e-3
-        assert np.max(frac) < 1e-2
+    # Superseded by TestObjectiveGradPolarimetricFD (IV case) in
+    # test_imager_backend.py, which samples the polarization DOF block across
+    # IP/IV/IQUV x {direct,nfft}. Commented out rather than deleted pending the
+    # PR2 test reorganization.
+    # def test_iv_gradient_matches_finite_difference(self, obs_pol_direct, gauss_im_pol, gauss_prior):
+    #     """IV (circular-pol) analytic gradient must match finite differences.
+    #
+    #     Regression for the vcv / chisqgrad_vvis bug: vcv_grad's vprime chain rule
+    #     uses the physical rho gradient, which chisqgrad_vvis previously skipped for
+    #     pol='IV' (pol_solve=[1,0,0,1]), making the V-angle gradient badly wrong
+    #     (~99% off; FD median was ~6e-2 before, ~3e-10 after).
+    #     """
+    #     imgr = eh.imager.Imager(
+    #         obs_pol_direct, gauss_prior, prior_im=gauss_prior, flux=gauss_im_pol.total_flux(),
+    #         data_term={"amp": 100, "vvis": 100}, reg_term={"simple": 1},
+    #         ttype="direct", pol="IV", transform=["log", "vcv"], maxit=100,
+    #     )
+    #     imgr.init_imager()
+    #     rng = np.random.default_rng(4)
+    #     x = np.asarray(imgr._init_vec, float) + 0.10 * rng.standard_normal(imgr._init_vec.size)
+    #     g = np.asarray(imgr.objgrad(x))
+    #     idx = np.argsort(np.abs(g))[-40:]  # best-conditioned components
+    #     fd = np.empty(40)
+    #     for k, j in enumerate(idx):
+    #         a, b = x.copy(), x.copy()
+    #         a[j] += 1e-6
+    #         b[j] -= 1e-6
+    #         fd[k] = (imgr.objfunc(a) - imgr.objfunc(b)) / 2e-6
+    #     frac = np.abs((fd - g[idx]) / (np.abs(g[idx]) + 1e-100))
+    #     assert np.median(frac) < 1e-3
+    #     assert np.max(frac) < 1e-2
 
 
 def test_imager_fast_ttype_warns_deprecated(gauss_im, observe):

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -226,15 +226,17 @@ def _pol_tols(rtype):
 
 
 @pytest.fixture(scope="module")
-def polreg_setup(make_rect_image):
-    """32x48 Gaussian Stokes I with jittered pol structure.
+def polreg_setup(make_asym_image):
+    """32x48 asymmetric Stokes I with jittered pol structure.
 
-    Per-pixel jitter on rho / phi / psi is required so TV-style regularizers
-    (ptv, vtv, vtv2) get a non-degenerate denominator in their gradient
-    (which is sqrt of squared spatial differences and goes to 0 on uniform
-    fields).
+    Stokes I is the asymmetric (offset double-Gaussian) image so the pol
+    regularizers see a non-symmetric magnitude field. Per-pixel jitter on
+    rho / phi / psi is kept (rather than a smooth pol field) so TV-style
+    regularizers (ptv, vtv, vtv2) get a non-degenerate denominator in their
+    gradient (sqrt of squared spatial differences, which goes to 0 on uniform
+    fields and is FD-ill-conditioned there).
     """
-    im = make_rect_image(32, 48)
+    im = make_asym_image(32, 48)
     im.pulse = eh.observing.pulses.deltaPulse2D
 
     mask = im.imvec > 0

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -340,6 +340,75 @@ def _pol_gradient_check(polreg_setup, rtype):
     return float(np.median(frac_diffs)), float(np.max(frac_diffs))
 
 
+# reggrad_{ptv,vtv,tv} zero their back-neighbor (m2/m3, g2/g3) terms on the
+# first row/column, where the back-neighbor is the zero pad and does not exist.
+# Without it the entire first row+column of the affected slots is wrong (corner
+# ~4x off vs FD). Full-grid central FD catches it; interior pixels are already
+# correct, so the boundary is the signal.
+_BOUNDARY_POL_TV = {
+    "ptv": (pu.reg_ptv, pu.reggrad_ptv, "flux"),
+    "vtv": (pu.reg_vtv, pu.reggrad_vtv, "vflux"),
+}
+
+
+def _boundary_pol_imarr(nx, ny):
+    rng = np.random.default_rng(11)
+    npix = nx * ny
+    I = 1.0 + 0.3 * rng.random(npix)
+    rho = np.clip(0.3 + 0.10 * rng.standard_normal(npix), 0.05, 0.95)
+    phi = 0.5 + 0.30 * rng.standard_normal(npix)
+    psi = 0.2 + 0.10 * rng.standard_normal(npix)
+    return np.array([I, rho, phi, psi])
+
+
+@pytest.mark.parametrize("rtype", list(_BOUNDARY_POL_TV))
+def test_pol_tv_grad_matches_fd_on_boundary(rtype):
+    """Pol TV reggrad matches full-grid FD, including first-row/col pixels."""
+    regfn, gradfn, fluxkey = _BOUNDARY_POL_TV[rtype]
+    nx, ny = 4, 5
+    npix = nx * ny
+    imarr = _boundary_pol_imarr(nx, ny)
+    mask = np.ones(npix, dtype=bool)
+    kwargs = dict(xdim=nx, ydim=ny, psize=1.0, beam_size=1.0, norm_reg=False)
+    kwargs[fluxkey] = float(np.sum(imarr[0]))
+    grad = gradfn(imarr, mask, pol_solve=np.array([1, 1, 1, 1]), **kwargs)
+
+    eps = 1e-6
+    frac = []
+    for slot in (0, 1, 3):   # chi (slot 2) does not enter |P|/V back-neighbor terms
+        for j in range(npix):
+            ip = imarr.copy(); ip[slot, j] += eps
+            im = imarr.copy(); im[slot, j] -= eps
+            fd = (regfn(ip, mask, **kwargs)
+                  - regfn(im, mask, **kwargs)) / (2 * eps)
+            denom = max(abs(fd), abs(grad[slot, j]), 1e-6)
+            frac.append(abs(grad[slot, j] - fd) / denom)
+    assert max(frac) < 1e-3, f"{rtype}: max fractional grad diff = {max(frac):.4g}"
+
+
+def test_reggrad_tv_matches_fd_on_boundary():
+    """Stokes-I reggrad_tv matches full-grid FD, including first-row/col pixels."""
+    nx, ny = 4, 5
+    npix = nx * ny
+    rng = np.random.default_rng(11)
+    imvec = 1.0 + 0.5 * rng.random(npix)
+    mask = np.ones(npix, dtype=bool)
+    kwargs = dict(xdim=nx, ydim=ny, psize=1.0, flux=float(np.sum(imvec)),
+                  beam_size=1.0, norm_reg=False)
+    grad = iu.reggrad_tv(imvec, mask, **kwargs)
+
+    eps = 1e-6
+    frac = []
+    for j in range(npix):
+        ip = imvec.copy(); ip[j] += eps
+        im = imvec.copy(); im[j] -= eps
+        fd = (iu.reg_tv(ip, mask, **kwargs)
+              - iu.reg_tv(im, mask, **kwargs)) / (2 * eps)
+        denom = max(abs(fd), abs(grad[j]), 1e-6)
+        frac.append(abs(grad[j] - fd) / denom)
+    assert max(frac) < 1e-3, f"tv: max fractional grad diff = {max(frac):.4g}"
+
+
 # regularizer_mf dispatches by string prefix: names starting with 'l2_'
 # compute an L2 distance from the prior; names starting with 'tv_' compute
 # spatial total variation. The 12 names in REGULARIZERS_SPECTRAL only differ

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -383,8 +383,10 @@ def test_pol_tv_grad_matches_fd_on_boundary(rtype):
     frac = []
     for slot in (0, 1, 3):   # chi (slot 2) does not enter |P|/V back-neighbor terms
         for j in range(npix):
-            ip = imarr.copy(); ip[slot, j] += eps
-            im = imarr.copy(); im[slot, j] -= eps
+            ip = imarr.copy()
+            ip[slot, j] += eps
+            im = imarr.copy()
+            im[slot, j] -= eps
             fd = (regfn(ip, mask, **kwargs)
                   - regfn(im, mask, **kwargs)) / (2 * eps)
             denom = max(abs(fd), abs(grad[slot, j]), 1e-6)
@@ -406,8 +408,10 @@ def test_reggrad_tv_matches_fd_on_boundary():
     eps = 1e-6
     frac = []
     for j in range(npix):
-        ip = imvec.copy(); ip[j] += eps
-        im = imvec.copy(); im[j] -= eps
+        ip = imvec.copy()
+        ip[j] += eps
+        im = imvec.copy()
+        im[j] -= eps
         fd = (iu.reg_tv(ip, mask, **kwargs)
               - iu.reg_tv(im, mask, **kwargs)) / (2 * eps)
         denom = max(abs(fd), abs(grad[j]), 1e-6)

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -210,9 +210,11 @@ POL_MAX_FRAC_TOL_TV = 2.0
 
 
 def _pol_solve_for(rtype):
-    if rtype in POL_LIN_REGS:
-        return pu.POL_SOLVE_DEFAULT
-    return pu.POL_SOLVE_DEFAULT_V
+    # Drive every physical slot (I, rho, phi, psi), not just the mode's DOF
+    # slots, so the cross-coupling slots are FD-checked: reggrad_ptv psi (3),
+    # reggrad_vflux/l1v/l2v/vtv rho (1), and slot 0 for every pol reg. Kernels
+    # that do not fill a slot leave it 0, which FD of the value confirms.
+    return np.array([1, 1, 1, 1])
 
 
 def _pol_tols(rtype):

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -40,12 +40,14 @@ GRAD_DX_FLOOR = 1e-12  # absolute minimum step size
 
 
 @pytest.fixture(scope="module")
-def reg_setup(make_rect_image):
-    """Set up regularizer test data from 32x48 synthetic Gaussian.
+def reg_setup(make_asym_image):
+    """Set up regularizer test data from a 32x48 asymmetric image.
 
-    Uses xdim != ydim so the rectangular-image code paths are exercised.
+    Offset double-Gaussian: xdim != ydim exercises the rectangular-image code
+    paths, and the broken symmetry + edge flux surface boundary/axis bugs a
+    centered Gaussian hides.
     """
-    im = make_rect_image(32, 48)
+    im = make_asym_image(32, 48)
     im.pulse = eh.observing.pulses.deltaPulse2D
     mask = im.imvec > 0
     imvec = im.imvec
@@ -419,9 +421,9 @@ def test_reggrad_tv_matches_fd_on_boundary():
 
 
 @pytest.fixture(scope="module")
-def mfreg_setup(make_rect_image):
+def mfreg_setup(make_asym_image):
     """32x48 spectral coefficient vector with a half-amplitude prior."""
-    im = make_rect_image(32, 48)
+    im = make_asym_image(32, 48)
     imvec = im.imvec
     nprior = imvec * 0.5
     mask = imvec > 0


### PR DESCRIPTION
## What & why

Stops overloading `pol_solve`, which conflated two distinct masks: (1) which
solver DOFs are optimized, and (2) which physical gradient slots (I, rho, phi,
psi) the chisq/reg kernels must fill. These differ wherever a value-transform's
Jacobian is non-diagonal (mcv, vcv): one solved pol DOF drives BOTH rho and psi.

Introduces `physical_grad_slots(pol_solve, transforms)` as the single source of
truth, wired into both the chisq and regularizer gradient dicts, and reverts the
kernels to clean diagonal gating.

### Correctness fixes
- **mcv/vcv cross-coupling**, centralized in `physical_grad_slots`. This fixes
  IP imaging when V!=0: `mcv_grad`'s m' gradient needs the psi
  physical gradient, which the old mask zeroed.
- **`reggrad_ptv` first-row/col boundary masking** + `epsilon_tv` in
  `reg_ptv`/`reggrad_ptv` and `reg_vtv`/`reggrad_vtv` (default 0, byte-identical).

### Test coverage
- `physical_grad_slots` unit tests; pol chisq FD all-slots (`pvis`/`m`/`vvis` x
  direct/nfft); pol-reg FD driven with all four slots; boundary FD regressions
  for `ptv`/`vtv`/`tv`; one parametrized objective-FD over {IP/mcv, IV/vcv,
  IQUV/polcv} x {direct,nfft} that samples the **polarization DOF block** (the
  existing global-sampling tests missed the m'-coupling bug).
- FD fixtures switched to an **asymmetric** image (offset double-Gaussian) with
  spatially-varying pol (`add_random_pol`, ccorr>0) so EVPA/vfrac/rho/psi all
  vary -- surfaces boundary/axis bugs a centered constant-fraction Gaussian hides.

### Cosmetic
- Comment/docstring cleanup pass on `imager_utils.py` and `pol_imager_utils.py`
  (no behavior change), ruff-clean.

## Supersedes part of #295
The `reggrad_ptv` boundary + `epsilon_tv` fixes and the reg-grad cross-coupling
land here; #295 should drop those and stay jax-agnostic plumbing (Option B).

## Testing
Full suite: 1776 passed, 2 skipped, 1 xfailed. 
