### PR TITLE
pol gradient fixes + tests to main (v1.3.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,24 @@ on:
     branches: [main]
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - run: pip install -e ".[dev]"
+      # Interim gradient suite only. pynfft (NFFT C library) is not installed
+      # here, so the nfft cases skip and the direct-FT cases run.
+      - run: pytest tests/test_gradients_main_tmp.py
+
   package:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ vex_files/*
 docs/_build/*
 docs/build/
 local/*
-*test*
+.pytest_cache/
 imagingChallenge*
 tmp/*
 *.uvfits

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -2063,10 +2063,10 @@ def transform_gradients(gradarr, imarr, transforms, which_solve):
             outarr[0:4] = polutils.polcv_chain(imarr[0:4]) * gradarr[0:4]
         elif (pol_which_solve[1]==1) and ('mcv' in transforms):
 #            outarr[0:4] = polutils.mcv_chain(imarr[0:4]) * gradarr[0:4]
-            outarr[0:4] = polutils.mcv_grad(imarr[0:4], gradarr[0:4])
+            outarr[1:4] = polutils.mcv_grad(imarr[0:4], gradarr[0:4])
         elif (pol_which_solve[3]==1) and ('vcv' in transforms):
 #            outarr[0:4] = polutils.vcv_chain(imarr[0:4]) * gradarr[0:4]
-            outarr[0:4] = polutils.vcv_grad(imarr[0:4], gradarr[0:4])
+            outarr[1:4] = polutils.vcv_grad(imarr[0:4], gradarr[0:4])
              
              
     return outarr

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -1260,9 +1260,12 @@ class Imager(object):
                         pol_solve = self._which_solve[0:4]
                     else:
                         pol_solve = self._which_solve
+                    # which gradient terms we need depends of the current pol transform
+                    pol_grad_slots = physical_grad_slots(pol_solve, self.transform_next)
+                    # compute the gradient
                     chi2grad = polutils.polchisqgrad(imcur_nu, A, data, sigma, dname,
                                                      ttype=self._ttype, mask=self._embed_mask,
-                                                     pol_solve=pol_solve)
+                                                     pol_solve=pol_grad_slots)
                                                      
                 # Single polarization chi^2 gradients
                 elif dname in DATATERMS:
@@ -1434,12 +1437,15 @@ class Imager(object):
                     imcur_pol = imcur[0:4]
                     prior_pol = self._xprior[0:4] 
                     pol_solve = self._which_solve[0:4]
+                    # which gradient terms we need depends of the current pol transform
+                    pol_grad_slots = physical_grad_slots(pol_solve, self.transform_next)
+                    # compute the gradient
                     regp = polutils.polregularizergrad(imcur_pol, prior_pol, self._embed_mask, 
                                                       self.flux_next, self.pflux_next, self.vflux_next,
                                                       self.prior_next.xdim, self.prior_next.ydim, self.prior_next.psize, 
                                                       regname,
                                                       norm_reg=self.norm_reg, beam_size=self.beam_size,
-                                                      pol_solve=pol_solve,
+                                                      pol_solve=pol_grad_slots,
                                                       **self.regparams) 
                     reggrad = np.zeros((len(imcur), self._nimage))
                     reggrad[0:4] = regp
@@ -1520,12 +1526,16 @@ class Imager(object):
             else:        
                 # Single-frequency polarimetric regularizer
                 if regname in REGULARIZERS_POL:
+                    pol_solve = self._which_solve
+                    # which gradient terms we need depends of the current pol transform
+                    pol_grad_slots = physical_grad_slots(pol_solve, self.transform_next)
+                    # compute the gradient
                     reggrad = polutils.polregularizergrad(imcur, self._xprior, self._embed_mask, 
                                                       self.flux_next, self.pflux_next, self.vflux_next,
                                                       self.prior_next.xdim, self.prior_next.ydim,
                                                       self.prior_next.psize, regname,
                                                       norm_reg=self.norm_reg, beam_size=self.beam_size,
-                                                      pol_solve=self._which_solve,
+                                                      pol_solve=pol_grad_slots,
                                                       **self.regparams)
 
 
@@ -2061,6 +2071,23 @@ def transform_gradients(gradarr, imarr, transforms, which_solve):
              
     return outarr
 
+def physical_grad_slots(pol_solve, transforms):
+    """Physical gradout slots the gradient kernels must fill, given the DOF mask.
+    """
+    mask = np.array(pol_solve, dtype=int).copy()
+    # Cross-coupling only exists for the full 4-wide Stokes block. Single-pol
+    # (Stokes-I, possibly mf with [I, alpha, beta]) has no rho/psi DOFs to
+    # couple -- and may carry 'mcv' in transforms inertly, so the transform
+    # check alone is not enough. Mirror transform_gradients' shape gating.
+    if len(mask) < 4:
+        return mask
+    if 'mcv' in transforms and pol_solve[1]:     # m' (slot 1) -> rho AND psi
+        mask[1] = 1
+        mask[3] = 1
+    elif 'vcv' in transforms and pol_solve[3]:   # v' (slot 3) -> rho AND psi
+        mask[1] = 1
+        mask[3] = 1
+    return mask
 
 def make_initarr(image, mask, norm_init=False, flux=1, 
                  mf=False, pol=False, 

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -2052,9 +2052,11 @@ def transform_gradients(gradarr, imarr, transforms, which_solve):
         if (pol_which_solve[1]==1 and pol_which_solve[3]==1 and ('polcv' in transforms)):
             outarr[0:4] = polutils.polcv_chain(imarr[0:4]) * gradarr[0:4]
         elif (pol_which_solve[1]==1) and ('mcv' in transforms):
-            outarr[0:4] = polutils.mcv_chain(imarr[0:4]) * gradarr[0:4]
+#            outarr[0:4] = polutils.mcv_chain(imarr[0:4]) * gradarr[0:4]
+            outarr[0:4] = polutils.mcv_grad(imarr[0:4], gradarr[0:4])
         elif (pol_which_solve[3]==1) and ('vcv' in transforms):
-            outarr[0:4] = polutils.vcv_chain(imarr[0:4]) * gradarr[0:4]
+#            outarr[0:4] = polutils.vcv_chain(imarr[0:4]) * gradarr[0:4]
+            outarr[0:4] = polutils.vcv_grad(imarr[0:4], gradarr[0:4])
              
              
     return outarr

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -1217,11 +1217,11 @@ class Imager(object):
 
                 # Single Polarization chi^2 terms
                 elif dname in DATATERMS:
-                    if self.pol_next in POLARIZATION_MODES: 
-                        imcur_nu_I = imcur_nu[0] 
+                    if self.pol_next in POLARIZATION_MODES:
+                        imcur_nu_I = imcur_nu[0]
                     else:
                         imcur_nu_I = imcur_nu
-                    chi2 = imutils.chisq(imcur_nu, A, data, sigma, dname,
+                    chi2 = imutils.chisq(imcur_nu_I, A, data, sigma, dname,
                                          ttype=self._ttype, mask=self._embed_mask)
 
                 else:

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -2060,7 +2060,7 @@ def transform_gradients(gradarr, imarr, transforms, which_solve):
             outarr[0] = np.exp(imarr[0]) * gradarr[0]
             
         if (pol_which_solve[1]==1 and pol_which_solve[3]==1 and ('polcv' in transforms)):
-            outarr[0:4] = polutils.polcv_chain(imarr[0:4]) * gradarr[0:4]
+            outarr[1:4] = (polutils.polcv_chain(imarr[0:4]) * gradarr[0:4])[1:4]
         elif (pol_which_solve[1]==1) and ('mcv' in transforms):
 #            outarr[0:4] = polutils.mcv_chain(imarr[0:4]) * gradarr[0:4]
             outarr[1:4] = polutils.mcv_grad(imarr[0:4], gradarr[0:4])

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -592,7 +592,7 @@ def chisqgrad_cphase_diag(imvec, Amatrices, clphase_diag, sigma):
                                (clphase_diag_sigma**2.0)), (tform_mats[iA]/i3)), A3[2])
         deriv += -2.0*np.imag(term1 + term2 + term3)
 
-    deriv *= 1.0/np.float(len(np.concatenate(clphase_diag)))
+    deriv *= 1.0/float(len(np.concatenate(clphase_diag)))
 
     return deriv
 
@@ -729,7 +729,7 @@ def chisqgrad_logcamp_diag(imvec, Amatrices, log_clamp_diag, sigma):
                                (log_clamp_diag_sigma**2.0)), (tform_mats[iA]/i4)), A4[3])
         deriv += -2.0*np.real(term1 + term2 - term3 - term4)
 
-    deriv *= 1.0/np.float(len(np.concatenate(log_clamp_diag)))
+    deriv *= 1.0/float(len(np.concatenate(log_clamp_diag)))
 
     return deriv
 
@@ -993,7 +993,7 @@ def chisqgrad_cphase_diag_fft(imvec, A, clphase_diag, sigma):
     # extract relevant cells and flatten
     deriv = np.imag(grad_arr[im_info.padvalx1:-im_info.padvalx2,
                              im_info.padvaly1:-im_info.padvaly2].flatten())
-    deriv *= 1.0/np.float(len(clphase_diag))
+    deriv *= 1.0/float(len(clphase_diag))
 
     return deriv
 
@@ -1163,7 +1163,7 @@ def chisqgrad_logcamp_diag_fft(imvec, A, log_clamp_diag, sigma):
     # extract relevant cells and flatten
     deriv = np.real(grad_arr[im_info.padvalx1:-im_info.padvalx2,
                              im_info.padvaly1:-im_info.padvaly2].flatten())
-    deriv *= 1.0/np.float(len(log_clamp_diag))
+    deriv *= 1.0/float(len(log_clamp_diag))
 
     return deriv
 
@@ -1611,7 +1611,7 @@ def chisqgrad_cphase_diag_nfft(imvec, A, clphase_diag, sigma):
     out3 = np.imag((plan3.f_hat.copy().T).reshape(nfft_info3.xdim*nfft_info3.ydim))
 
     deriv = out1 + out2 + out3
-    deriv *= 1.0/np.float(len(clphase_diag))
+    deriv *= 1.0/float(len(clphase_diag))
 
     return deriv
 
@@ -1989,7 +1989,7 @@ def chisqgrad_logcamp_diag_nfft(imvec, A, log_clamp_diag, sigma):
     out4 = np.real((plan4.f_hat.copy().T).reshape(nfft_info4.xdim*nfft_info4.ydim))
 
     deriv = out1 + out2 + out3 + out4
-    deriv *= 1.0/np.float(len(log_clamp_diag))
+    deriv *= 1.0/float(len(log_clamp_diag))
 
     return deriv
 
@@ -2885,9 +2885,9 @@ def chisqdata_cphase_diag(Obsdata, Prior, mask, pol='I', **kwargs):
         tform_mats.append(cl[4].astype('float'))
 
     # combine Fourier and transformation matrices into tuple for outputting
-    Amatrices = (np.array(A3_diag), np.array(tform_mats))
+    Amatrices = (np.array(A3_diag, dtype=object), np.array(tform_mats, dtype=object))
 
-    return (np.array(clphase_diag), np.array(sigma_diag), Amatrices)
+    return (np.array(clphase_diag, dtype=object), np.array(sigma_diag, dtype=object), Amatrices)
 
 
 def chisqdata_camp(Obsdata, Prior, mask, pol='I', **kwargs):
@@ -3045,9 +3045,9 @@ def chisqdata_logcamp_diag(Obsdata, Prior, mask, pol='I', **kwargs):
         tform_mats.append(cl[4].astype('float'))
 
     # combine Fourier and transformation matrices into tuple for outputting
-    Amatrices = (np.array(A4_diag), np.array(tform_mats))
+    Amatrices = (np.array(A4_diag, dtype=object), np.array(tform_mats, dtype=object))
 
-    return (np.array(clamp_diag), np.array(sigma_diag), Amatrices)
+    return (np.array(clamp_diag, dtype=object), np.array(sigma_diag, dtype=object), Amatrices)
 
 ##################################################################################################
 # FFT Chi^2 Data functions
@@ -3339,9 +3339,9 @@ def chisqdata_cphase_diag_fft(Obsdata, Prior, pol='I', **kwargs):
     A3 = (im_info, sampler_info_list, gridder_info_list)
 
     # combine Fourier and transformation matrices into tuple for outputting
-    Amatrices = (A3, np.array(tform_mats))
+    Amatrices = (A3, np.array(tform_mats, dtype=object))
 
-    return (np.array(clphase_diag), np.array(sigma_diag), Amatrices)
+    return (np.array(clphase_diag, dtype=object), np.array(sigma_diag, dtype=object), Amatrices)
 
 
 def chisqdata_camp_fft(Obsdata, Prior, pol='I', **kwargs):
@@ -3555,9 +3555,9 @@ def chisqdata_logcamp_diag_fft(Obsdata, Prior, pol='I', **kwargs):
     A = (im_info, sampler_info_list, gridder_info_list)
 
     # combine Fourier and transformation matrices into tuple for outputting
-    Amatrices = (A, np.array(tform_mats))
+    Amatrices = (A, np.array(tform_mats, dtype=object))
 
-    return (np.array(clamp_diag), np.array(sigma_diag), Amatrices)
+    return (np.array(clamp_diag, dtype=object), np.array(sigma_diag, dtype=object), Amatrices)
 
 ##################################################################################################
 # NFFT Chi^2 Data functions
@@ -3820,9 +3820,9 @@ def chisqdata_cphase_diag_nfft(Obsdata, Prior, pol='I', **kwargs):
     A = [A1, A2, A3]
 
     # combine Fourier and transformation matrices into tuple for outputting
-    Amatrices = (A, np.array(tform_mats))
+    Amatrices = (A, np.array(tform_mats, dtype=object))
 
-    return (np.array(clphase_diag), np.array(sigma_diag), Amatrices)
+    return (np.array(clphase_diag, dtype=object), np.array(sigma_diag, dtype=object), Amatrices)
 
 
 def chisqdata_camp_nfft(Obsdata, Prior, pol='I', **kwargs):
@@ -4013,9 +4013,9 @@ def chisqdata_logcamp_diag_nfft(Obsdata, Prior, pol='I', **kwargs):
     A = [A1, A2, A3, A4]
 
     # combine Fourier and transformation matrices into tuple for outputting
-    Amatrices = (A, np.array(tform_mats))
+    Amatrices = (A, np.array(tform_mats, dtype=object))
 
-    return (np.array(clamp_diag), np.array(sigma_diag), Amatrices)
+    return (np.array(clamp_diag, dtype=object), np.array(sigma_diag, dtype=object), Amatrices)
 
 ##################################################################################################
 # Plotting Functions

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -648,7 +648,7 @@ def chisqgrad_m(imarr, Amatrix, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
     mdiff = (m - msamples) / (isamples.conj() * sigmam**2)
 
     if pol_solve[0]!=0:
-        gradi = (-np.real(   * np.dot(Amatrix.conj().T, mdiff)) / len(m) + 
+        gradi = (-np.real(mimage * np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, mdiff)) / len(m) +
                   np.real(np.dot(Amatrix.conj().T, msamples.conj() * mdiff)) / len(m))
         gradout[0] = gradi
 
@@ -959,7 +959,7 @@ def smgrad(imarr, flux, pol_solve=POL_SOLVE_DEFAULT,
 
     if pol_solve[0]!=0:
         gradi = -np.log(mimage)
-        outgrad[0] = gradi
+        gradout[0] = gradi
         
     if pol_solve[1]!=0:
         gradm = -iimage / mimage
@@ -1160,7 +1160,7 @@ def svfluxgrad(imarr, vflux,  pol_solve=POL_SOLVE_DEFAULT_V, norm_reg=NORM_REGUL
         gradpsi = gradv * (vfimage/np.tan(psiimage))
         gradout[3] = gradpsi
 
-    return gradoutout/norm
+    return gradout/norm
     
 def sl1v(imarr, vflux, norm_reg=NORM_REGULARIZER):
     """L1 norm regularizer on V

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -308,11 +308,25 @@ def vcv_r(imarr):
     return out
 
 # TODO WE ARE GOING TO HAVE TO CHECK ALL OF THESE NUMERICALLY
-def vcv_chain(imarr):
-    """chain rule terms drho/dv' and dpsi/dv' for vcv
-       input is solver values
+def vcv_grad(imarr, gradarr):
+    """Apply gradient transformation for vcv
+
+    phys[1]=rho and phys[3]=psi both depend on vprime via vfrac,
+    so the Jacobian has off-diagonal terms.
+    Slot 1 of the result is zero because mfrac is held constant.
+
+    Parameters
+    ----------
+    imarr : np.ndarray, shape (4, ...)
+        Solver-space image array.
+    gradarr : np.ndarray, shape (4, ...)
+        Gradient w.r.t. physical components phys[0:4]. gradarr[0] is unused.
+
+    Returns
+    -------
+    out : np.ndarray, shape (4, ...)
+        Transformed gradient
     """
-    out = np.ones(imarr.shape)
     
     mfrac = imarr[1] # when using this transform, we interpret transformed imarr[1] as mfrac=\rho cos(\psi)
     vfrac_max = 1-np.abs(mfrac)
@@ -326,15 +340,21 @@ def vcv_chain(imarr):
     
     dv_dvprime = 2. * vfrac_max / (TANWIDTH_V*np.pi*(1 + (vfrac_prime/TANWIDTH_V)**2))
 
-    # we only use mcv when holding v constant, so dF/imarr[1]=0      
-    #drho_dv = rhofrac / v                # drho/dv holding m constant
-    #drho_dvprime = drho_dv * dv_dvprime
-    #out[1] = drho_dvprime
-    out[1] = np.zeros(out[3].shape)  
-        
-    dpsi_dv = mfrac / (rho*rho)          # dpsi/dv holding m constant # TODO CHECK
+    # Avoid 0/0 when total polarization is zero; in that limit both terms vanish.
+    safe_rho = np.where(rho > 0, rho, 1.0)
+
+    drho_dv = vfrac/safe_rho
+    drho_dvprime = drho_dv * dv_dvprime
+
+    dpsi_dv = np.abs(mfrac) / (safe_rho*safe_rho)
     dpsi_dvprime = dpsi_dv * dv_dvprime
-    out[3] = dpsi_dvprime       
+
+    # package result
+    out = np.empty((4,) + gradarr.shape[1:])
+    out[0] = gradarr[0]
+    out[1] = 0.0
+    out[2] = gradarr[2]
+    out[3] = drho_dvprime * gradarr[1] + dpsi_dvprime * gradarr[3]
     return out
 
 

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -237,8 +237,8 @@ def mcv_grad(imarr, gradarr):
 
     Returns
     -------
-    outarr : np.ndarray, shape (4, ...)
-        Transformed gradient
+    outarr : np.ndarray, shape (3, ...)
+        Transformed gradient (pol parts only, stokes I unaffected)
     """
     
     vfrac = imarr[3] # when using this transform, we interpret transformed imarr[3] as mfrac=\rho sin(\psi)
@@ -264,11 +264,10 @@ def mcv_grad(imarr, gradarr):
     dpsi_dmprime = dpsi_dm * dm_dmprime
 
     # package result
-    out = np.empty((4,) + gradarr.shape[1:])
-    out[0] = gradarr[0]
-    out[1] = drho_dmprime * gradarr[1] + dpsi_dmprime * gradarr[3]
-    out[2] = gradarr[2]
-    out[3] = 0.0
+    out = np.empty((3,) + gradarr.shape[1:])
+    out[0] = drho_dmprime * gradarr[1] + dpsi_dmprime * gradarr[3]
+    out[1] = gradarr[2]
+    out[2] = 0.0
 
     return out
            
@@ -322,8 +321,8 @@ def vcv_grad(imarr, gradarr):
 
     Returns
     -------
-    out : np.ndarray, shape (4, ...)
-        Transformed gradient
+    out : np.ndarray, shape (3, ...)
+        Transformed gradient (pol parts only, Stokes I unaffected)
     """
     
     mfrac = imarr[1] # when using this transform, we interpret transformed imarr[1] as mfrac=\rho cos(\psi)
@@ -348,11 +347,10 @@ def vcv_grad(imarr, gradarr):
     dpsi_dvprime = dpsi_dv * dv_dvprime
 
     # package result
-    out = np.empty((4,) + gradarr.shape[1:])
-    out[0] = gradarr[0]
-    out[1] = 0.0
-    out[2] = gradarr[2]
-    out[3] = drho_dvprime * gradarr[1] + dpsi_dvprime * gradarr[3]
+    out = np.empty((3,) + gradarr.shape[1:])
+    out[0] = 0.0
+    out[1] = gradarr[2]
+    out[2] = drho_dvprime * gradarr[1] + dpsi_dvprime * gradarr[3]
     return out
 
 

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -221,11 +221,25 @@ def mcv_r(imarr):
     return out
     
 # TODO WE ARE GOING TO HAVE TO CHECK ALL OF THESE NUMERICALLY
-def mcv_chain(imarr):
-    """chain rule terms drho/dm' and dpsi/dv' for mcv
-       input is solver values
+def mcv_grad(imarr, gradarr):
+    """Apply gradient transformation for mcv
+
+    phys[1]=rho and phys[3]=psi both depend on mprime
+    so the Jacobian has off-diagonal terms.
+    Slot 3 of the result is zero because vfrac is held constant.
+
+    Parameters
+    ----------
+    imarr : np.ndarray, shape (4, ...)
+        Solver-space image array.
+    gradarr : np.ndarray, shape (4, ...)
+        Gradient w.r.t. physical components phys[0:4].
+
+    Returns
+    -------
+    outarr : np.ndarray, shape (4, ...)
+        Transformed gradient
     """
-    out = np.ones(imarr.shape)
     
     vfrac = imarr[3] # when using this transform, we interpret transformed imarr[3] as mfrac=\rho sin(\psi)
     mfrac_max = 1-np.abs(vfrac)
@@ -239,17 +253,25 @@ def mcv_chain(imarr):
     psi = np.arcsin(vfrac/rho)
 
     dm_dmprime = mfrac_max / (TANWIDTH_M*np.pi*(1 + (mfrac_prime/TANWIDTH_M)**2))
-        
-    drho_dm = mfrac / rho                # drho/dm holding v constant
-    drho_dmprime = drho_dm * dm_dmprime
-    out[1] = drho_dmprime
 
-    # we only use mcv when holding v constant, so dF/imarr[3]=0  
-    #dpsi_dm = -vfrac/ (rho*rho)         # dpsi/dm holding v constant # TODO CHECK
-    #dpsi_dmprime = dpsi_dm * dm_dmprime
-    #out[3] = dpsi_dmprime   
-    out[3] = np.zeros(out[3].shape)  
-        
+    # Avoid 0/0 when total polarization is zero; in that limit both terms vanish.
+    safe_rho = np.where(rho > 0, rho, 1.0)
+
+    drho_dm = mfrac / safe_rho                # drho/dm holding v constant
+    drho_dmprime = drho_dm * dm_dmprime
+
+    dpsi_dm = -(vfrac*np.sign(mfrac)) / (safe_rho*safe_rho)
+    dpsi_dmprime = dpsi_dm * dm_dmprime
+
+    out[1] = drho_dmprime # TODO need to refactor this to 
+
+    # package result
+    out = np.empty((4,) + gradarr.shape[1:])
+    out[0] = gradarr[0]
+    out[1] = drho_dmprime * gradarr[1] + dpsi_dmprime * gradarr[3]
+    out[2] = gradarr[2]
+    out[3] = 0.0
+
     return out
            
 def vcv(imarr):

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -263,8 +263,6 @@ def mcv_grad(imarr, gradarr):
     dpsi_dm = -(vfrac*np.sign(mfrac)) / (safe_rho*safe_rho)
     dpsi_dmprime = dpsi_dm * dm_dmprime
 
-    out[1] = drho_dmprime # TODO need to refactor this to 
-
     # package result
     out = np.empty((4,) + gradarr.shape[1:])
     out[0] = gradarr[0]

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -1063,6 +1063,13 @@ def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT,
     d2 = np.sqrt(np.abs(im_r1 - im)**2 + np.abs(im_r1l2 - im_r1)**2)
     d3 = np.sqrt(np.abs(im_r2 - im)**2 + np.abs(im_l1r2 - im_r2)**2)
 
+    # The back-neighbor (m2/d2, m3/d3) terms reference a pixel that does not
+    # exist on the first row/column (it is the zero pad), so they must be zeroed
+    mask1 = np.zeros(im.shape, dtype=bool)
+    mask1[0, :] = True   # no back-neighbor in axis 0
+    mask2 = np.zeros(im.shape, dtype=bool)
+    mask2[:, 0] = True   # no back-neighbor in axis 1
+
     # Numerators use cos/sin of the single-angle difference between neighbors,
     # from d|P_l1 - P|^2 / d|P| = 2|P| - 2|P_l1|*cos(angle(P_l1) - angle(P)).
 
@@ -1071,6 +1078,8 @@ def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT,
         m1 = 2*np.abs(im*im) - np.abs(im*im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im*im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im*im) - np.abs(im*im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im*im) - np.abs(im*im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        m2[mask1] = 0
+        m3[mask2] = 0
         gradi = -(1./iimage)*(m1/d1 + m2/d2 + m3/d3).flatten()
         gradout[0] = gradi
 
@@ -1079,6 +1088,8 @@ def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT,
         m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        m2[mask1] = 0
+        m3[mask2] = 0
         gradm = -iimage*(m1/d1 + m2/d2 + m3/d3).flatten()
         gradrho = gradm * np.cos(psiimage)        
         gradout[1] = gradrho
@@ -1088,6 +1099,8 @@ def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT,
         c1 = -2*np.abs(im*im_l1)*np.sin(np.angle(im_l1) - np.angle(im)) - 2*np.abs(im*im_l2)*np.sin(np.angle(im_l2) - np.angle(im))
         c2 = 2*np.abs(im*im_r1)*np.sin(np.angle(im) - np.angle(im_r1))
         c3 = 2*np.abs(im*im_r2)*np.sin(np.angle(im) - np.angle(im_r2))
+        c2[mask1] = 0
+        c3[mask2] = 0
         gradchi = -(c1/d1 + c2/d2 + c3/d3).flatten()
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
@@ -1097,6 +1110,8 @@ def stv_pol_grad(imarr, flux, nx, ny, psize, pol_solve=POL_SOLVE_DEFAULT,
         m1 = 2*np.abs(im) - np.abs(im_l1)*np.cos(np.angle(im_l1) - np.angle(im)) - np.abs(im_l2)*np.cos(np.angle(im_l2) - np.angle(im))
         m2 = np.abs(im) - np.abs(im_r1)*np.cos(np.angle(im) - np.angle(im_r1))
         m3 = np.abs(im) - np.abs(im_r2)*np.cos(np.angle(im) - np.angle(im_r2))
+        m2[mask1] = 0
+        m3[mask2] = 0
         gradm = -iimage*(m1/d1 + m2/d2 + m3/d3).flatten()
         gradpsi = gradm * (-mimage*np.tan(psiimage))
         gradout[3] = gradpsi     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ehtim"
-version = "1.3.1"
+version = "1.3.2"
 description = "Imaging, analysis, and simulation software for radio interferometry"
 readme = "README.rst"
 license = { text = "GPLv3" }
@@ -50,7 +50,7 @@ docs = [
 
 [project.urls]
 Homepage = "https://github.com/achael/eht-imaging"
-Download = "https://github.com/achael/eht-imaging/archive/v1.3.1.tar.gz"
+Download = "https://github.com/achael/eht-imaging/archive/v1.3.2.tar.gz"
 
 # --- setuptools-specific config ---
 

--- a/tests/test_gradients_main_tmp.py
+++ b/tests/test_gradients_main_tmp.py
@@ -71,8 +71,12 @@ POL_REGS = list(pu.REGULARIZERS_POL)  # msimple, hw, ptv, l1v, l2v, vtv, vtv2, v
 CHISQ_FD_MEDIAN, CHISQ_FD_MAX = 1e-3, 1e-2
 REG_FD_MEDIAN, REG_FD_MAX = 0.05, 0.6
 POL_CHISQ_FD_MEDIAN, POL_CHISQ_FD_MAX = 1e-5, 1e-3
-POL_REG_FD_MEDIAN, POL_REG_FD_MAX, POL_REG_FD_MAX_TV = 0.05, 0.6, 2.0
-NFFT_VALUE_FRAC, NFFT_GRAD_MEDIAN, NFFT_GRAD_MAX = 1e-2, 0.05, 10.0
+POL_REG_FD_MEDIAN, POL_REG_FD_MAX = 1e-4, 1e-2
+# nfft-vs-direct: median of per-pixel frac diff + relative L2 norm of the
+# whole gradient. (A per-pixel MAX is meaningless here -- it blows up on
+# near-zero-gradient pixels where a tiny absolute Fourier diff is a huge
+# relative one; the L2 norm is the robust "do these vectors agree" metric.)
+NFFT_VALUE_FRAC, NFFT_GRAD_MEDIAN, NFFT_GRAD_REL_L2 = 1e-2, 0.05, 0.05
 
 POL_FD_REL, POL_FD_FLOOR = 1e-6, 1e-9
 FD_REL, FD_FLOOR = 1e-8, 1e-12
@@ -132,8 +136,12 @@ def intensity_setup(array):
 def pol_setup(array):
     """Asymmetric polarized image (spatially-varying EVPA + circular fraction)
     + noise-free obs + a jittered physical imcur [I, rho, phi=2chi, psi].
+
+    Square grid: add_random_pol -> MakePhaseScreen has a rectangular-image bug
+    on main (deferred scattering rect fix), so pol fixtures use a square image.
+    The offset/rotated double-Gaussian still breaks the symmetries.
     """
-    im = make_asym_image(32, 48)
+    im = make_asym_image(32, 32)
     im.imvec = im.imvec * 2.0 / im.total_flux()
     im = im.add_random_pol(0.25, 40 * UA, cmag=0.06, ccorr=40 * UA, seed=7)
     obs = im.observe(array, TINT, TADV, TSTART, TSTOP, BW,
@@ -193,3 +201,171 @@ class TestIntensityChisqGradFD:
         med, mx = _intensity_chisq_fd(intensity_setup, dtype, ttype)
         assert med < CHISQ_FD_MEDIAN, f"{dtype}/{ttype}: median frac {med:.2e}"
         assert mx < CHISQ_FD_MAX, f"{dtype}/{ttype}: max frac {mx:.2e}"
+
+
+# ===========================================================================
+# (1) Intensity chi^2: nfft vs direct (value + gradient)
+# ===========================================================================
+@requires_nfft
+class TestIntensityChisqNFFTvsDirect:
+    """nfft and direct chi^2 (value + gradient) agree to Fourier accuracy.
+
+    Independent of the FD checks: FD validates each transform against itself,
+    so it cannot catch a self-consistent-but-wrong Fourier operator.
+    """
+
+    @pytest.mark.parametrize("dtype", INTENSITY_DATATERMS)
+    def test_value_and_grad(self, intensity_setup, dtype):
+        obs, prior, mask, imvec = (intensity_setup["obs"], intensity_setup["prior"],
+                                   intensity_setup["mask"], intensity_setup["imvec"])
+        vals, grads = {}, {}
+        for tt in ("direct", "nfft"):
+            data, sigma, A = iu.chisqdata(obs, prior, mask, dtype, ttype=tt, debias=False)
+            vals[tt] = iu.chisq(imvec, A, data, sigma, dtype, ttype=tt, mask=mask)
+            grads[tt] = iu.chisqgrad(imvec, A, data, sigma, dtype, ttype=tt, mask=mask)
+        vfrac = abs((vals["direct"] - vals["nfft"]) / abs(vals["direct"]))
+        assert vfrac < NFFT_VALUE_FRAC, f"{dtype}: value frac {vfrac:.2e}"
+        gmed, _ = _frac_stats(grads["nfft"], grads["direct"])
+        rel_l2 = np.linalg.norm(grads["nfft"] - grads["direct"]) / np.linalg.norm(grads["direct"])
+        assert gmed < NFFT_GRAD_MEDIAN, f"{dtype}: grad median frac {gmed:.2e}"
+        assert rel_l2 < NFFT_GRAD_REL_L2, f"{dtype}: grad rel L2 {rel_l2:.2e}"
+
+
+# ===========================================================================
+# (2) Intensity regularizer gradients vs finite differences
+# ===========================================================================
+def _intensity_reg_fd(setup, rtype):
+    im, imvec, mask = setup["im"], setup["imvec"], setup["mask"]
+    nprior = np.ones_like(imvec)
+    nprior = nprior * np.sum(imvec) / np.sum(nprior)
+    flux = float(np.sum(imvec))
+    kwargs = dict(beam_size=20 * UA, alpha_A=5000.0, epsilon_tv=0.0, norm_reg=True)
+
+    y0 = iu.regularizer(imvec, nprior, mask, flux, im.xdim, im.ydim, im.psize, rtype, **kwargs)
+    grad = iu.regularizergrad(imvec, nprior, mask, flux, im.xdim, im.ydim, im.psize, rtype, **kwargs)
+
+    rng = np.random.default_rng(RNG_SEED)
+    samp = rng.choice(imvec.size, size=min(N_SAMPLES, imvec.size), replace=False)
+    numeric = np.empty(samp.size)
+    for i, j in enumerate(samp):
+        dx = max(FD_REL * abs(imvec[j]), FD_FLOOR)
+        v2 = imvec.copy()
+        v2[j] += dx
+        y1 = iu.regularizer(v2, nprior, mask, flux, im.xdim, im.ydim, im.psize, rtype, **kwargs)
+        numeric[i] = (y1 - y0) / dx
+    return _frac_stats(numeric, grad[samp])
+
+
+class TestIntensityRegGradFD:
+    """Analytic regularizergrad matches forward FD of regularizer."""
+
+    @pytest.mark.parametrize("rtype", INTENSITY_REGS)
+    def test_fd(self, intensity_setup, rtype):
+        med, mx = _intensity_reg_fd(intensity_setup, rtype)
+        assert med < REG_FD_MEDIAN, f"{rtype}: median frac {med:.2e}"
+        assert mx < REG_FD_MAX, f"{rtype}: max frac {mx:.2e}"
+
+
+# ===========================================================================
+# (2) Pol chi^2 gradients vs finite differences  [direct + nfft, all 4 slots]
+# ===========================================================================
+def _pol_data(setup, dtype, ttype):
+    data, sigma, A = pu.polchisqdata(setup["obs"], setup["prior"], setup["mask"], dtype, ttype=ttype)
+    return A, data, sigma
+
+
+class TestPolChisqGradFD:
+    """polchisqgrad matches central FD of polchisq in all four physical slots
+    (driven with pol_solve=[1,1,1,1] so the cross-coupling slots are exercised);
+    the vvis EVPA slot (2) must be identically zero -- V is independent of EVPA.
+    """
+
+    @pytest.mark.parametrize("dtype", POL_DATATERMS)
+    @pytest.mark.parametrize("ttype", TTYPES)
+    def test_fd(self, pol_setup, dtype, ttype):
+        mask, imcur = pol_setup["mask"], pol_setup["imcur"]
+        A, data, sigma = _pol_data(pol_setup, dtype, ttype)
+        grad = pu.polchisqgrad(imcur, A, data, sigma, dtype, ttype=ttype, mask=mask,
+                               pol_solve=np.array([1, 1, 1, 1]))
+        if dtype == "vvis":
+            np.testing.assert_array_equal(grad[2], 0.0)
+
+        rng = np.random.default_rng(RNG_SEED)
+        n = imcur.shape[1]
+        samp = rng.choice(n, size=min(30, n), replace=False)
+        frac = []
+        for slot in range(4):
+            for j in samp:
+                dx = max(POL_FD_REL * abs(imcur[slot, j]), POL_FD_FLOOR)
+                ip, im_ = imcur.copy(), imcur.copy()
+                ip[slot, j] += dx
+                im_[slot, j] -= dx
+                fd = (pu.polchisq(ip, A, data, sigma, dtype, ttype=ttype, mask=mask)
+                      - pu.polchisq(im_, A, data, sigma, dtype, ttype=ttype, mask=mask)) / (2 * dx)
+                ex = grad[slot, j]
+                frac.append(abs(ex - fd) / max(abs(ex), abs(fd), POL_FD_FLOOR))
+        frac = np.array(frac)
+        assert np.median(frac) < POL_CHISQ_FD_MEDIAN, f"{dtype}/{ttype}: median {np.median(frac):.2e}"
+        assert np.max(frac) < POL_CHISQ_FD_MAX, f"{dtype}/{ttype}: max {np.max(frac):.2e}"
+
+
+# ===========================================================================
+# (1) Pol chi^2: nfft vs direct (value + gradient)
+# ===========================================================================
+@requires_nfft
+class TestPolChisqNFFTvsDirect:
+    """nfft and direct pol chi^2 (value + gradient) agree to Fourier accuracy."""
+
+    @pytest.mark.parametrize("dtype", POL_DATATERMS)
+    def test_value_and_grad(self, pol_setup, dtype):
+        mask, imcur = pol_setup["mask"], pol_setup["imcur"]
+        vals, grads = {}, {}
+        for tt in ("direct", "nfft"):
+            A, data, sigma = _pol_data(pol_setup, dtype, tt)
+            vals[tt] = pu.polchisq(imcur, A, data, sigma, dtype, ttype=tt, mask=mask)
+            grads[tt] = pu.polchisqgrad(imcur, A, data, sigma, dtype, ttype=tt, mask=mask,
+                                        pol_solve=np.array([1, 1, 1, 1]))
+        vfrac = abs((vals["direct"] - vals["nfft"]) / abs(vals["direct"]))
+        assert vfrac < NFFT_VALUE_FRAC, f"{dtype}: value frac {vfrac:.2e}"
+        gmed, _ = _frac_stats(grads["nfft"], grads["direct"])
+        rel_l2 = np.linalg.norm(grads["nfft"] - grads["direct"]) / np.linalg.norm(grads["direct"])
+        assert gmed < NFFT_GRAD_MEDIAN, f"{dtype}: grad median frac {gmed:.2e}"
+        assert rel_l2 < NFFT_GRAD_REL_L2, f"{dtype}: grad rel L2 {rel_l2:.2e}"
+
+
+# ===========================================================================
+# (2) Pol regularizer gradients vs finite differences  [all four slots]
+# ===========================================================================
+class TestPolRegGradFD:
+    """polregularizergrad matches central FD of polregularizer in all four
+    physical slots (pol_solve=[1,1,1,1] so the cross-coupling slots are checked);
+    reuses the chisq pol image, whose per-pixel jitter keeps the TV denominators
+    non-degenerate. Central differences keep the tan(psi)-steep entropy slots
+    well-conditioned even at the realistic (large-psi) circular-pol pixels."""
+
+    @pytest.mark.parametrize("rtype", POL_REGS)
+    def test_fd(self, pol_setup, rtype):
+        im, imarr, mask = pol_setup["im"], pol_setup["imcur"], pol_setup["mask"]
+        priorarr = np.zeros_like(imarr)
+        flux = im.total_flux()
+        kwargs = dict(beam_size=20 * UA, norm_reg=True)
+        args = (priorarr, mask, flux, flux, flux, im.xdim, im.ydim, im.psize, rtype)
+        grad = pu.polregularizergrad(imarr, *args, pol_solve=np.array([1, 1, 1, 1]), **kwargs)
+
+        rng = np.random.default_rng(RNG_SEED)
+        nimage = imarr.shape[1]
+        samp = rng.choice(nimage, size=min(N_SAMPLES, nimage), replace=False)
+        frac = []
+        for slot in range(4):
+            for j in samp:
+                dx = max(POL_FD_REL * abs(imarr[slot, j]), POL_FD_FLOOR)
+                a, b = imarr.copy(), imarr.copy()
+                a[slot, j] += dx
+                b[slot, j] -= dx
+                num = (pu.polregularizer(a, *args, **kwargs)
+                       - pu.polregularizer(b, *args, **kwargs)) / (2 * dx)
+                ex = grad[slot, j]
+                frac.append(abs(num - ex) / max(abs(ex), abs(num), POL_FD_FLOOR))
+        frac = np.array(frac)
+        assert np.median(frac) < POL_REG_FD_MEDIAN, f"{rtype}: median frac {np.median(frac):.2e}"
+        assert np.max(frac) < POL_REG_FD_MAX, f"{rtype}: max frac {np.max(frac):.2e}"

--- a/tests/test_gradients_main_tmp.py
+++ b/tests/test_gradients_main_tmp.py
@@ -369,3 +369,217 @@ class TestPolRegGradFD:
         frac = np.array(frac)
         assert np.median(frac) < POL_REG_FD_MEDIAN, f"{rtype}: median frac {np.median(frac):.2e}"
         assert np.max(frac) < POL_REG_FD_MAX, f"{rtype}: max frac {np.max(frac):.2e}"
+
+
+# ===========================================================================
+# (2) Boundary FD: first-row/col back-neighbor masking in the TV gradients
+#     Pins the #306 stv_pol_grad boundary-mask fix (tv/vtv already had it).
+#     Full 4x5 grid, central FD on EVERY pixel, so the first row/col -- where
+#     the back-neighbor is the zero pad and the masking lives -- are checked.
+# ===========================================================================
+def _boundary_pol_imarr(nx, ny):
+    rng = np.random.default_rng(11)
+    npix = nx * ny
+    I = 1.0 + 0.3 * rng.random(npix)
+    rho = np.clip(0.3 + 0.10 * rng.standard_normal(npix), 0.05, 0.95)
+    phi = 0.5 + 0.30 * rng.standard_normal(npix)
+    psi = 0.2 + 0.10 * rng.standard_normal(npix)
+    return np.array([I, rho, phi, psi])
+
+
+@pytest.mark.parametrize("rtype", ["ptv", "vtv"])
+def test_pol_tv_grad_matches_fd_on_boundary(rtype):
+    nx, ny = 4, 5
+    npix = nx * ny
+    imarr = _boundary_pol_imarr(nx, ny)
+    mask = np.ones(npix, dtype=bool)
+    flux = float(np.sum(imarr[0]))
+    kwargs = dict(norm_reg=False, beam_size=1.0)
+    args = (np.zeros_like(imarr), mask, flux, flux, flux, nx, ny, 1.0, rtype)
+    grad = pu.polregularizergrad(imarr, *args, pol_solve=np.array([1, 1, 1, 1]), **kwargs)
+
+    eps = 1e-6
+    frac = []
+    for slot in (0, 1, 3):  # chi (slot 2) is absent from the |P|/V back-neighbor terms
+        for j in range(npix):
+            a, b = imarr.copy(), imarr.copy()
+            a[slot, j] += eps
+            b[slot, j] -= eps
+            fd = (pu.polregularizer(a, *args, **kwargs)
+                  - pu.polregularizer(b, *args, **kwargs)) / (2 * eps)
+            frac.append(abs(grad[slot, j] - fd) / max(abs(fd), abs(grad[slot, j]), 1e-6))
+    assert max(frac) < 1e-3, f"{rtype}: max boundary frac diff = {max(frac):.4g}"
+
+
+def test_intensity_tv_grad_matches_fd_on_boundary():
+    nx, ny = 4, 5
+    npix = nx * ny
+    rng = np.random.default_rng(11)
+    imvec = 1.0 + 0.5 * rng.random(npix)
+    mask = np.ones(npix, dtype=bool)
+    flux = float(np.sum(imvec))
+    kwargs = dict(norm_reg=False, beam_size=1.0, epsilon_tv=0.0)
+    args = (np.zeros_like(imvec), mask, flux, nx, ny, 1.0, "tv")
+    grad = iu.regularizergrad(imvec, *args, **kwargs)
+
+    eps = 1e-6
+    frac = []
+    for j in range(npix):
+        a, b = imvec.copy(), imvec.copy()
+        a[j] += eps
+        b[j] -= eps
+        fd = (iu.regularizer(a, *args, **kwargs) - iu.regularizer(b, *args, **kwargs)) / (2 * eps)
+        frac.append(abs(grad[j] - fd) / max(abs(fd), abs(grad[j]), 1e-6))
+    assert max(frac) < 1e-3, f"tv: max boundary frac diff = {max(frac):.4g}"
+
+
+# ===========================================================================
+# (3) Transforms modify the gradient correctly -- chain rule vs FD, isolated
+#     transform_gradients(grad_phys, ...) must equal d/dimarr [f(transform(imarr))]
+#     for the mcv / vcv / polcv image transforms. Covers the off-diagonal
+#     cross-terms the #306 fix added and the log-I-slot preservation.
+# ===========================================================================
+def _scalar_obj(phys):
+    """Arbitrary smooth scalar f(phys) = sum(weights * phys**2)."""
+    weights = np.array([0.7, 1.3, -0.5, 0.9])[:, None]
+    return float(np.sum(weights * phys**2))
+
+
+def _fd_grad_of_transform(imarr, transforms, which_solve):
+    """Centered FD gradient of (scalar_obj o transform_imarr) in solver space."""
+    eps = 1e-6
+    grad = np.zeros_like(imarr)
+    for k in range(imarr.shape[0]):
+        for i in range(imarr.shape[1]):
+            ip, im_ = imarr.copy(), imarr.copy()
+            ip[k, i] += eps
+            im_[k, i] -= eps
+            grad[k, i] = (_scalar_obj(transform_imarr(ip, transforms, which_solve))
+                          - _scalar_obj(transform_imarr(im_, transforms, which_solve))) / (2 * eps)
+    return grad
+
+
+def _solver_imarr(seed=0, n=8, v_pre=None, m_pre=None):
+    """Build a (4, n) solver-space image array; pin a row to set up the
+    diagonal-Jacobian operating points (mcv vfrac=0, vcv mfrac=0)."""
+    rng = np.random.default_rng(seed)
+    log_I = rng.uniform(-1.0, 1.0, size=n)
+    m_arr = rng.uniform(-2.0, 2.0, size=n) if m_pre is None else np.full(n, m_pre)
+    chi_arr = rng.uniform(-0.5, 0.5, size=n)
+    v_arr = rng.uniform(-0.3, 0.3, size=n) if v_pre is None else np.full(n, v_pre)
+    return np.array([log_I, m_arr, chi_arr, v_arr])
+
+
+class TestTransformGradientsChainRule:
+    """transform_gradients(grad_phys, ...) == FD of (f o transform_imarr)."""
+
+    @pytest.mark.parametrize(
+        "transforms,which_solve,imarr_kwargs,check_rows",
+        [
+            # real-usage diagonal operating points
+            (["log", "mcv"], np.array([1, 1, 1, 0]), {"v_pre": 0.0}, [0, 1, 2]),
+            (["log", "vcv"], np.array([1, 0, 0, 1]), {"m_pre": 0.0}, [0, 3]),
+            (["log", "polcv"], np.array([1, 1, 0, 1]), {}, [0, 1, 3]),
+            # general regimes -> nonzero off-diagonal cross-terms (the #306 fix)
+            (["log", "mcv"], np.array([1, 1, 0, 0]), {}, [0, 1]),
+            (["log", "vcv"], np.array([1, 0, 0, 1]), {}, [0, 3]),
+            # sanity: log only, and pure pol-cv with no log
+            (["log"], np.array([1, 0, 0, 0]), {}, [0]),
+            (["mcv"], np.array([0, 1, 0, 0]), {"v_pre": 0.0}, [1]),
+            (["vcv"], np.array([0, 0, 0, 1]), {"m_pre": 0.0}, [3]),
+            (["polcv"], np.array([0, 1, 0, 1]), {}, [1, 3]),
+        ],
+        ids=["IP_vfrac0", "IV_mfrac0", "IPV", "IP_general", "IV_general",
+             "log_only", "mcv_only", "vcv_only", "polcv_only"],
+    )
+    def test_chain_rule_matches_fd(self, transforms, which_solve, imarr_kwargs, check_rows):
+        imarr = _solver_imarr(seed=0, **imarr_kwargs)
+        phys = transform_imarr(imarr, transforms, which_solve)
+        weights = np.array([0.7, 1.3, -0.5, 0.9])[:, None]
+        grad_phys = 2.0 * weights * phys  # = d(_scalar_obj)/dphys
+
+        grad_solver = transform_gradients(grad_phys, imarr, transforms, which_solve)
+        grad_fd = _fd_grad_of_transform(imarr, transforms, which_solve)
+        for k in check_rows:
+            np.testing.assert_allclose(
+                grad_solver[k], grad_fd[k], rtol=1e-5, atol=1e-8,
+                err_msg=f"chain rule mismatch row {k} for transforms={transforms}")
+
+    def test_log_chain_preserved_under_mcv(self):
+        """log+mcv: outarr[0] = exp(imarr[0]); mcv must not clobber the I slot."""
+        imarr = _solver_imarr(seed=1, v_pre=0.0)
+        out = transform_gradients(np.ones_like(imarr), imarr, ["log", "mcv"], np.array([1, 1, 0, 0]))
+        np.testing.assert_allclose(out[0], np.exp(imarr[0]), rtol=1e-12)
+
+    def test_log_chain_preserved_under_polcv(self):
+        """log+polcv: outarr[0] = exp(imarr[0]); polcv must not clobber the I slot."""
+        imarr = _solver_imarr(seed=2)
+        out = transform_gradients(np.ones_like(imarr), imarr, ["log", "polcv"], np.array([1, 1, 0, 1]))
+        np.testing.assert_allclose(out[0], np.exp(imarr[0]), rtol=1e-12)
+
+
+# ===========================================================================
+# (3) Transforms modify the gradient correctly -- end-to-end through Imager
+#     Builds a real Imager and compares objgrad to FD of objfunc, sampling the
+#     POLARIZATION DOF block (past the leading Stokes-I block) where the mcv/vcv
+#     cross-coupling lives -- the Stokes-I-dominated global sampling misses it.
+#     This is the test that exposes the mcv/vcv cross-coupling bug end-to-end.
+# ===========================================================================
+# (pol, transform, data_term, reg_term)
+POL_OBJFD_CASES = [
+    ("IP", ["log", "mcv"], {"vis": 100, "pvis": 100, "m": 100}, {"simple": 1, "hw": 1}),
+    ("IV", ["log", "vcv"], {"amp": 100, "vvis": 100}, {"simple": 1, "l2v": 1}),
+    ("IQUV", ["log", "polcv"], {"vis": 100, "pvis": 100, "m": 100, "vvis": 100},
+     {"simple": 1, "hw": 1, "l2v": 1}),
+]
+
+
+@pytest.fixture(scope="module")
+def asym_pol_setup(array):
+    """Asymmetric image, spatially-varying lin+circ pol, Stokes-I prior.
+    Square grid (add_random_pol scattering rect bug on main)."""
+    im = make_asym_image(32, 32)
+    im.imvec = im.imvec * 2.0 / im.total_flux()
+    prior = im.blur_circ(30 * UA)
+    im_pol = im.add_random_pol(0.25, 40 * UA, cmag=0.06, ccorr=40 * UA, seed=7)
+    obs = im_pol.observe(array, TINT, TADV, TSTART, TSTOP, BW,
+                         ampcal=True, phasecal=True, ttype="direct", add_th_noise=False)
+    return im_pol, obs, prior
+
+
+class TestObjectiveGradPolarimetricFD:
+    """imgr.objgrad matches central FD of imgr.objfunc on the polarization DOF
+    block, for IP/mcv, IV/vcv, IQUV/polcv x {direct, nfft}."""
+
+    @pytest.mark.parametrize("ttype", TTYPES)
+    @pytest.mark.parametrize("pol,transform,data_term,reg_term", POL_OBJFD_CASES,
+                             ids=[c[0] for c in POL_OBJFD_CASES])
+    def test_pol_dof_grad_matches_fd(self, asym_pol_setup, pol, transform,
+                                     data_term, reg_term, ttype):
+        im_pol, obs, prior = asym_pol_setup
+        imgr = eh.imager.Imager(
+            obs, prior, prior_im=prior, flux=im_pol.total_flux(),
+            data_term=data_term, reg_term=reg_term,
+            ttype=ttype, pol=pol, transform=transform, maxit=10,
+        )
+        imgr.init_imager()
+        nslots = int(np.sum(imgr._which_solve))
+        x = np.asarray(imgr._xinit, float)
+        rng = np.random.default_rng(4)
+        x = x + 0.10 * rng.standard_normal(x.size)
+        nimage = x.size // nslots
+
+        g = np.asarray(imgr.objgrad(x))
+        # pol DOF block = everything past the leading Stokes-I block (slot-major
+        # packing); take the best-conditioned 30 for a stable fractional check.
+        pol_idx = np.arange(nimage, x.size)
+        idx = pol_idx[np.argsort(np.abs(g[pol_idx]))[-30:]]
+        fd = np.empty(idx.size)
+        for k, j in enumerate(idx):
+            a, b = x.copy(), x.copy()
+            a[j] += 1e-6
+            b[j] -= 1e-6
+            fd[k] = (imgr.objfunc(a) - imgr.objfunc(b)) / 2e-6
+        frac = np.abs((fd - g[idx]) / (np.abs(g[idx]) + 1e-100))
+        assert np.median(frac) < 1e-4, f"{pol}/{ttype}: median frac {np.median(frac):.3e}"
+        assert np.max(frac) < 1e-2, f"{pol}/{ttype}: max frac {np.max(frac):.3e}"

--- a/tests/test_gradients_main_tmp.py
+++ b/tests/test_gradients_main_tmp.py
@@ -15,9 +15,10 @@ Scope (only gradients; everything else is inherited from dev later):
      checked against finite differences both in isolation (chain rule) and
      end-to-end through the Imager objective.
 
-RUN WITH THE SYSTEM PYTHON (it has the legacy `nfft` backend):
+RUN WITH THE SYSTEM PYTHON (it has pynfft, the NFFT C-library backend):
     python3 -m pytest tests/test_gradients_main_tmp.py
-The `jax-ehtim` micromamba env lacks legacy `nfft`; the nfft cases skip there.
+Where pynfft is absent (CI, the jax-ehtim env), the nfft cases skip and only
+the direct-FT cases run.
 
 Delete this file once dev lands on main.
 """
@@ -33,17 +34,19 @@ import ehtim.imaging.pol_imager_utils as pu
 from ehtim.imager import transform_gradients, transform_imarr
 
 # ---------------------------------------------------------------------------
-# nfft availability (legacy backend; present only in the system env)
+# nfft availability. main's nfft ttype uses pynfft (needs the NFFT C library),
+# so gate on that -- not the unrelated `nfft` PyPI package. Absent (e.g. CI,
+# or the jax-ehtim env) -> the nfft cases skip and only direct runs.
 # ---------------------------------------------------------------------------
 try:
-    import nfft as _nfft_mod  # noqa: F401
+    from pynfft.nfft import NFFT as _NFFT  # noqa: F401
     HAS_NFFT = True
 except Exception:
     HAS_NFFT = False
 
 TTYPES = ["direct"] + (["nfft"] if HAS_NFFT else [])
 requires_nfft = pytest.mark.skipif(
-    not HAS_NFFT, reason="legacy 'nfft' backend not installed (use system python)"
+    not HAS_NFFT, reason="pynfft (NFFT C library) not installed"
 )
 
 # ---------------------------------------------------------------------------
@@ -114,6 +117,34 @@ def make_asym_image(xdim, ydim, psize=None):
                           polrep="stokes", pol_prim="I", rf=230e9)
 
 
+def make_pol_image(im, seed=7):
+    """Add smooth + per-pixel-jittered spatially-varying Q/U/V to a Stokes-I
+    image, so EVPA, linear fraction, and circular fraction all vary across the
+    field. Replaces add_random_pol, whose scattering phase screen calls
+    scipy.integrate.quad in a way that breaks on newer scipy and fails on
+    rectangular grids -- neither is relevant to gradient correctness.
+    """
+    ny, nx = im.ydim, im.xdim
+    yy, xx = np.mgrid[0:ny, 0:nx]
+    xn = (xx - nx / 2.0) / nx
+    yn = (yy - ny / 2.0) / ny
+    rng = np.random.default_rng(seed)
+    n = im.imvec.size
+
+    mfrac = (0.18 + 0.10 * np.sin(3.0 * xn) * np.cos(2.0 * yn)).flatten()
+    mfrac = np.clip(mfrac + 0.02 * rng.standard_normal(n), 0.03, 0.7)
+    evpa = (0.5 * np.pi * xn + 0.9 * yn**2).flatten() + 0.05 * rng.standard_normal(n)
+    vfrac = (0.04 + 0.02 * np.cos(2.0 * xn + yn)).flatten() + 0.01 * rng.standard_normal(n)
+
+    Q = (im.imvec * mfrac * np.cos(2.0 * evpa)).reshape(ny, nx)
+    U = (im.imvec * mfrac * np.sin(2.0 * evpa)).reshape(ny, nx)
+    V = (im.imvec * vfrac).reshape(ny, nx)
+    out = im.copy()
+    out.add_qu(Q, U)
+    out.add_v(V)
+    return out
+
+
 @pytest.fixture(scope="module")
 def array():
     return eh.array.load_txt(ARRAY_PATH)
@@ -137,13 +168,10 @@ def pol_setup(array):
     """Asymmetric polarized image (spatially-varying EVPA + circular fraction)
     + noise-free obs + a jittered physical imcur [I, rho, phi=2chi, psi].
 
-    Square grid: add_random_pol -> MakePhaseScreen has a rectangular-image bug
-    on main (deferred scattering rect fix), so pol fixtures use a square image.
-    The offset/rotated double-Gaussian still breaks the symmetries.
     """
-    im = make_asym_image(32, 32)
+    im = make_asym_image(32, 48)
     im.imvec = im.imvec * 2.0 / im.total_flux()
-    im = im.add_random_pol(0.25, 40 * UA, cmag=0.06, ccorr=40 * UA, seed=7)
+    im = make_pol_image(im, seed=7)
     obs = im.observe(array, TINT, TADV, TSTART, TSTOP, BW,
                      ampcal=True, phasecal=True, ttype="direct", add_th_noise=False)
     mask = np.ones(im.imvec.size, dtype=bool)
@@ -536,12 +564,11 @@ POL_OBJFD_CASES = [
 
 @pytest.fixture(scope="module")
 def asym_pol_setup(array):
-    """Asymmetric image, spatially-varying lin+circ pol, Stokes-I prior.
-    Square grid (add_random_pol scattering rect bug on main)."""
-    im = make_asym_image(32, 32)
+    """Asymmetric image, spatially-varying lin+circ pol, Stokes-I prior."""
+    im = make_asym_image(32, 48)
     im.imvec = im.imvec * 2.0 / im.total_flux()
     prior = im.blur_circ(30 * UA)
-    im_pol = im.add_random_pol(0.25, 40 * UA, cmag=0.06, ccorr=40 * UA, seed=7)
+    im_pol = make_pol_image(im, seed=7)
     obs = im_pol.observe(array, TINT, TADV, TSTART, TSTOP, BW,
                          ampcal=True, phasecal=True, ttype="direct", add_th_noise=False)
     return im_pol, obs, prior

--- a/tests/test_gradients_main_tmp.py
+++ b/tests/test_gradients_main_tmp.py
@@ -1,0 +1,195 @@
+"""Temporary gradient-validation suite for the `main` (v1.3.x) branch.
+
+This is a *minimal, interim* suite whose sole purpose is to validate that the
+analytic gradients on `main` are correct before `dev` (which carries the full
+test suite) replaces `main`. It mirrors the gradient tests in PR #306
+(branch fix/pol-grad-mask -> dev), re-expressed against main's API
+(`imager_utils` / `pol_imager_utils` / `imager`), since main lacks the
+backend (`imager_backend`) those dev tests call.
+
+Scope (only gradients; everything else is inherited from dev later):
+  1. nfft vs direct (dft) agreement for every intensity and pol chi^2 term.
+  2. analytic gradients vs finite differences for every intensity / pol chi^2
+     term and regularizer.
+  3. the polcv / vcv / mcv image transforms correctly modify the gradient,
+     checked against finite differences both in isolation (chain rule) and
+     end-to-end through the Imager objective.
+
+RUN WITH THE SYSTEM PYTHON (it has the legacy `nfft` backend):
+    python3 -m pytest tests/test_gradients_main_tmp.py
+The `jax-ehtim` micromamba env lacks legacy `nfft`; the nfft cases skip there.
+
+Delete this file once dev lands on main.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+import ehtim as eh
+import ehtim.imaging.imager_utils as iu
+import ehtim.imaging.pol_imager_utils as pu
+from ehtim.imager import transform_gradients, transform_imarr
+
+# ---------------------------------------------------------------------------
+# nfft availability (legacy backend; present only in the system env)
+# ---------------------------------------------------------------------------
+try:
+    import nfft as _nfft_mod  # noqa: F401
+    HAS_NFFT = True
+except Exception:
+    HAS_NFFT = False
+
+TTYPES = ["direct"] + (["nfft"] if HAS_NFFT else [])
+requires_nfft = pytest.mark.skipif(
+    not HAS_NFFT, reason="legacy 'nfft' backend not installed (use system python)"
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+ARRAY_PATH = os.path.join(os.path.dirname(__file__), "..", "arrays", "EHT2017.txt")
+TINT, TADV, TSTART, TSTOP, BW = 5, 600, 0, 24, 4e9
+RNG_SEED = 4
+UA = eh.RADPERUAS
+
+# Intensity chi^2 terms under test (every entry of imager_utils.DATATERMS).
+INTENSITY_DATATERMS = ["vis", "bs", "amp", "logamp", "cphase", "camp", "logcamp",
+                       "cphase_diag", "logcamp_diag"]
+
+# Intensity regularizers under test (the well-conditioned set + the log-TV
+# variants, which share the boundary-masking path the #306 patch touched).
+# Omitted from this interim suite (special params / FD-ill-conditioned;
+# inherited from dev's full suite later): lA, patch, compact, compact2, rgauss.
+INTENSITY_REGS = ["simple", "gs", "l1w", "tv", "tv2", "tvlog", "tv2log"]
+
+POL_DATATERMS = ["pvis", "m", "vvis"]
+POL_REGS = list(pu.REGULARIZERS_POL)  # msimple, hw, ptv, l1v, l2v, vtv, vtv2, vflux
+
+# Tolerances (mirrored from the dev #306 suite, calibrated on a 32x48 image)
+CHISQ_FD_MEDIAN, CHISQ_FD_MAX = 1e-3, 1e-2
+REG_FD_MEDIAN, REG_FD_MAX = 0.05, 0.6
+POL_CHISQ_FD_MEDIAN, POL_CHISQ_FD_MAX = 1e-5, 1e-3
+POL_REG_FD_MEDIAN, POL_REG_FD_MAX, POL_REG_FD_MAX_TV = 0.05, 0.6, 2.0
+NFFT_VALUE_FRAC, NFFT_GRAD_MEDIAN, NFFT_GRAD_MAX = 1e-2, 0.05, 10.0
+
+POL_FD_REL, POL_FD_FLOOR = 1e-6, 1e-9
+FD_REL, FD_FLOOR = 1e-8, 1e-12
+N_SAMPLES = 100
+
+
+# ---------------------------------------------------------------------------
+# Image helpers / fixtures (self-contained; main has no tests/conftest.py)
+# ---------------------------------------------------------------------------
+def make_asym_image(xdim, ydim, psize=None):
+    """Asymmetric offset double-Gaussian Stokes-I image of size (xdim, ydim).
+
+    Breaks reflection/rotation/x<->y symmetry and pushes flux toward the edges
+    so boundary-masking / axis-ordering bugs (which a centered Gaussian hides)
+    surface in the chisq / regularizer / gradient FD checks. Blobs are broad so
+    the grid is filled (no dead pixels that make TV gradients FD-ill-conditioned
+    at epsilon=0). xdim != ydim exercises rectangular-image code paths.
+    """
+    if psize is None:
+        psize = 200 * UA / max(xdim, ydim)
+    yy, xx = np.mgrid[0:ydim, 0:xdim]
+    x = (xx - xdim / 2.0) * psize
+    y = (yy - ydim / 2.0) * psize
+
+    def blob(flux, fmaj, fmin, pa, x0, y0):
+        smaj, smin = fmaj / 2.355, fmin / 2.355
+        xr = (x - x0) * np.cos(pa) + (y - y0) * np.sin(pa)
+        yr = -(x - x0) * np.sin(pa) + (y - y0) * np.cos(pa)
+        return flux * np.exp(-(xr**2 / (2 * smaj**2) + yr**2 / (2 * smin**2)))
+
+    image_arr = (blob(0.6, 120 * UA, 78 * UA, 0.5, 16 * UA, -11 * UA)
+                 + blob(0.4, 84 * UA, 116 * UA, -0.7, -19 * UA, 17 * UA))
+    image_arr /= image_arr.sum()
+    return eh.image.Image(image_arr, psize, 17.761, -29.0,
+                          polrep="stokes", pol_prim="I", rf=230e9)
+
+
+@pytest.fixture(scope="module")
+def array():
+    return eh.array.load_txt(ARRAY_PATH)
+
+
+@pytest.fixture(scope="module")
+def intensity_setup(array):
+    """Asymmetric Stokes-I image + noise-free obs + a jittered test image."""
+    im = make_asym_image(32, 48)
+    im.imvec = im.imvec * 2.0 / im.total_flux()
+    obs = im.observe(array, TINT, TADV, TSTART, TSTOP, BW,
+                     ampcal=True, phasecal=True, ttype="direct", add_th_noise=False)
+    mask = np.ones(im.imvec.size, dtype=bool)
+    rng = np.random.default_rng(RNG_SEED)
+    test_imvec = im.imvec * (1.0 + 0.1 * (rng.random(im.imvec.size) - 0.5))
+    return dict(obs=obs, prior=im.copy(), mask=mask, imvec=test_imvec, im=im)
+
+
+@pytest.fixture(scope="module")
+def pol_setup(array):
+    """Asymmetric polarized image (spatially-varying EVPA + circular fraction)
+    + noise-free obs + a jittered physical imcur [I, rho, phi=2chi, psi].
+    """
+    im = make_asym_image(32, 48)
+    im.imvec = im.imvec * 2.0 / im.total_flux()
+    im = im.add_random_pol(0.25, 40 * UA, cmag=0.06, ccorr=40 * UA, seed=7)
+    obs = im.observe(array, TINT, TADV, TSTART, TSTOP, BW,
+                     ampcal=True, phasecal=True, ttype="direct", add_th_noise=False)
+    mask = np.ones(im.imvec.size, dtype=bool)
+
+    rng = np.random.default_rng(RNG_SEED)
+    I = im.imvec
+    Q, U, V = im.qvec, im.uvec, im.vvec
+    P = np.sqrt(Q**2 + U**2 + V**2)
+    n = I.size
+    imcur = np.array([
+        I * (1.0 + 0.05 * (rng.random(n) - 0.5)),
+        np.clip((P / I) * (1.0 + 0.1 * (rng.random(n) - 0.5)), 0.02, 0.95),
+        np.arctan2(U, Q) + 0.1 * (rng.random(n) - 0.5),
+        np.clip(np.abs(np.arcsin(V / (P + 1e-30))) * (1.0 + 0.1 * (rng.random(n) - 0.5)),
+                0.02, 1.5),
+    ])
+    return dict(obs=obs, prior=im.copy(), mask=mask, imcur=imcur, im=im)
+
+
+def _frac_stats(numeric, exact):
+    """Median and max of the elementwise fractional difference |num-ex|/|ex|."""
+    floor = np.min(np.abs(exact)) * 1e-20 + 1e-100
+    frac = np.abs((numeric - exact) / (np.abs(exact) + floor))
+    return float(np.median(frac)), float(np.max(frac))
+
+
+# ===========================================================================
+# (2) Intensity chi^2 gradients vs finite differences  [direct + nfft]
+# ===========================================================================
+def _intensity_chisq_fd(setup, dtype, ttype):
+    obs, prior, mask, imvec = setup["obs"], setup["prior"], setup["mask"], setup["imvec"]
+    # debias=False: the obs is noise-free, so amplitude debiasing would subtract
+    # sigma^2 from clean sub-noise amplitudes and drive log-amp data to NaN.
+    data, sigma, A = iu.chisqdata(obs, prior, mask, dtype, ttype=ttype, debias=False)
+    grad = iu.chisqgrad(imvec, A, data, sigma, dtype, ttype=ttype, mask=mask)
+    y0 = iu.chisq(imvec, A, data, sigma, dtype, ttype=ttype, mask=mask)
+
+    rng = np.random.default_rng(RNG_SEED)
+    samp = rng.choice(imvec.size, size=min(N_SAMPLES, imvec.size), replace=False)
+    numeric = np.empty(samp.size)
+    for i, j in enumerate(samp):
+        dx = max(FD_REL * abs(imvec[j]), FD_FLOOR)
+        v2 = imvec.copy()
+        v2[j] += dx
+        numeric[i] = (iu.chisq(v2, A, data, sigma, dtype, ttype=ttype, mask=mask) - y0) / dx
+    return _frac_stats(numeric, grad[samp])
+
+
+class TestIntensityChisqGradFD:
+    """Analytic chisqgrad matches forward FD of chisq for every DATATERM."""
+
+    @pytest.mark.parametrize("dtype", INTENSITY_DATATERMS)
+    @pytest.mark.parametrize("ttype", TTYPES)
+    def test_fd(self, intensity_setup, dtype, ttype):
+        med, mx = _intensity_chisq_fd(intensity_setup, dtype, ttype)
+        assert med < CHISQ_FD_MEDIAN, f"{dtype}/{ttype}: median frac {med:.2e}"
+        assert mx < CHISQ_FD_MAX, f"{dtype}/{ttype}: max frac {mx:.2e}"


### PR DESCRIPTION
## What & why
Patches a latent bug in the polarimetric imager gradients on `main`,
mirroring the dev fix in #306, and fixes several further latent
pol-gradient bugs uncovered while adding test coverage. Ships an interim
gradient-validation suite and wires it into CI.

### Core fix (mirrors #306)
- `physical_grad_slots` separates the physical-gradient mask from the
  solve mask, centralizing the mcv/vcv cross-coupling (one solved pol DOF
  drives BOTH rho and psi). Fixes IP imaging when V!=0 (and the IV analog).
- `mcv_grad`/`vcv_grad`: add the off-diagonal Jacobian terms (dpsi/dm',
  drho/dv'); return 3-wide and assign to outarr[1:4] so the Stokes-I log
  Jacobian survives. Same preservation for the polcv path.
- `stv_pol_grad` (ptv): first-row/col back-neighbor masking (corner was
  ~4x off vs finite differences).

### Further latent bugs fixed (found via the new tests; all pre-existing, all in never-exercised Stokes-I / V-flux slots)
These paths are already correct on dev -- its gradient test coverage caught
them; this PR backports the equivalent fixes to main.
- `chisqgrad_m`: restore dropped `mimage*exp(-2i*chi)` factor (was a
  TypeError from `np.real(  * ...)`).
- `smgrad` / `svfluxgrad`: `outgrad` / `gradoutout` -> `gradout` (NameError).
- `make_chisq_dict`: pass the Stokes-I row to chisq for standard data
  terms in pol mode (the gradient path was already correct).

### #233 port
- NumPy >= 1.24 fixes (`dtype=object` on ragged diag arrays, `np.float` ->
  `float`) so the diagonalized closures build.

### Tests + CI
- `tests/test_gradients_main_tmp.py`: interim gradient suite (71 tests) --
  nfft-vs-direct, analytic-vs-FD for all intensity/pol chi^2 terms and
  regularizers, and the mcv/vcv/polcv transforms vs FD (isolated +
  end-to-end through the Imager objective). Temporary; delete when dev
  lands on main.
- CI `test` job on py3.8 + py3.11 running the suite (pynfft absent in CI
  -> nfft cases skip, direct-FT cases run).
- Drop the `*test*` gitignore rule (it hid top-level tests/).

### Version
- Bump to 1.3.2.

## How to test
`python3 -m pytest tests/test_gradients_main_tmp.py`
System python (has pynfft): 71 pass. Without pynfft: 44 pass + 12 nfft-skip.

## Design decisions
- Interim suite is intentionally gradient-only; broader coverage comes
  from dev.
- Pol fixtures build Q/U/V manually instead of add_random_pol, avoiding a
  scipy-version-fragile scattering path (and the rect-image scattering bug).
- nfft gated on pynfft (what main's nfft ttype actually uses).