### PR TITLE
Fix NaN in spectral TV regularizer on flat maps (epsilon_tv=0)

### DIFF
--- a/ehtim/imaging/multifreq_imager_utils.py
+++ b/ehtim/imaging/multifreq_imager_utils.py
@@ -254,7 +254,11 @@ def reg_tv_spec(imvec, mask, **kwargs):
     impad = xp.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = xp.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
     im_l2 = xp.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    return xp.sum(xp.sqrt(xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2 + epsilon)) / norm
+    # autodiff-safe sqrt: a flat map gives sq == 0 when epsilon_tv == 0, where the
+    # gradient of sqrt is undefined; the double-where keeps both value and grad finite.
+    sq = xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2 + epsilon
+    safe = xp.where(sq > 0, sq, 1.0)
+    return xp.sum(xp.where(sq > 0, xp.sqrt(safe), 0.0)) / norm
 
 
 def reggrad_tv_spec(imvec, mask, **kwargs):
@@ -273,9 +277,13 @@ def reggrad_tv_spec(imvec, mask, **kwargs):
     im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
     im_r1l2 = np.roll(np.roll(impad,  1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
     im_l1r2 = np.roll(np.roll(impad, -1, axis=0),  1, axis=1)[1:ny+1, 1:nx+1]
-    g1 = (2*im - im_l1 - im_l2) / np.sqrt((im - im_l1)**2 + (im - im_l2)**2 + epsilon)
-    g2 = (im - im_r1) / np.sqrt((im - im_r1)**2 + (im_r1l2 - im_r1)**2 + epsilon)
-    g3 = (im - im_r2) / np.sqrt((im - im_r2)**2 + (im_l1r2 - im_r2)**2 + epsilon)
+    d1 = np.sqrt((im - im_l1)**2 + (im - im_l2)**2 + epsilon)
+    d2 = np.sqrt((im - im_r1)**2 + (im_r1l2 - im_r1)**2 + epsilon)
+    d3 = np.sqrt((im - im_r2)**2 + (im_l1r2 - im_r2)**2 + epsilon)
+    # guarded division: at a flat pixel (d == 0 when epsilon_tv == 0) the gradient is 0, not 0/0=NaN
+    g1 = np.where(d1 > 0, (2*im - im_l1 - im_l2) / np.where(d1 > 0, d1, 1.0), 0.0)
+    g2 = np.where(d2 > 0, (im - im_r1) / np.where(d2 > 0, d2, 1.0), 0.0)
+    g3 = np.where(d3 > 0, (im - im_r2) / np.where(d3 > 0, d3, 1.0), 0.0)
     mask1 = np.zeros(im.shape)
     mask2 = np.zeros(im.shape)
     mask1[0, :] = 1

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -361,6 +361,37 @@ class TestRegularizerGradientSpectral:
         assert_grad_close(analytic, fd, label=rtype)
 
 
+# Flat spectral map at epsilon_tv == 0 is the multifreq imaging start (add_const_mf gives a
+# constant alpha): every neighbour difference is 0, so the naive sqrt(0) leaves a 0/0 in both
+# the value (autodiff) and the analytic gradient. The S5 fixture above uses a structured map
+# with epsilon_tv != 0, so it never exercised this; reg_tv_spec must stay finite here.
+SPECTRAL_TV = [r for r in REGULARIZERS_SPECTRAL if r.startswith("tv_")]
+
+
+class TestSpectralTVFlatMapFinite:
+    @pytest.mark.parametrize("rtype", SPECTRAL_TV)
+    def test_analytic_finite_on_flat(self, reg_spectral_setup, rtype):
+        _, mask, kw = reg_spectral_setup
+        kw = {**kw, "epsilon_tv": 0.0}
+        flat = np.ones(mask.size)
+        grad = compute_regularizergrad_term(flat, rtype, mask, **kw)
+        val = compute_regularizer_term(flat, rtype, mask, **kw)
+        assert np.all(np.isfinite(grad)), f"{rtype}: NaN/inf in analytic grad on flat map"
+        assert np.isfinite(val), f"{rtype}: NaN/inf in value on flat map"
+
+    @pytest.mark.jax
+    @pytest.mark.parametrize("rtype", SPECTRAL_TV)
+    def test_autodiff_finite_on_flat(self, reg_spectral_setup, rtype):
+        import jax
+        import jax.numpy as jnp
+        jax.config.update("jax_enable_x64", True)
+        _, mask, kw = reg_spectral_setup
+        kw = {**kw, "epsilon_tv": 0.0}
+        flat = jnp.ones(mask.size)
+        grad = jax.grad(lambda v: compute_regularizer_term(v, rtype, mask, **kw))(flat)
+        assert np.all(np.isfinite(np.asarray(grad))), f"{rtype}: NaN in jax.grad on flat map"
+
+
 # ============================== S6: transforms ===============================
 # Each change-of-variables maps a solver image to a physical one. We finite-difference an
 # arbitrary DENSE linear objective sum(grad_phys * fwd(solver)) w.r.t. the solver slots and


### PR DESCRIPTION
## What

`reg_tv_spec` / `reggrad_tv_spec` produced `NaN` on a **flat spectral map** when `epsilon_tv == 0` (the default since #310). A flat coefficient map is exactly the multifrequency imaging start — `add_const_mf` initialises a constant spectral index, so every neighbour difference is zero and the naive `sqrt(0)` leaves a `0/0`:

- in the **value** (the autodiff path under JAX), and
- in the **analytic gradient** (the NumPy path).

Downstream this killed the optimizer: an HL Tau `mf_order=1` run gave `J: nan` and reconstructed a flat blob instead of the disk. With the fix it converges to `chi2_vis ~ 1` and nxcorr 0.999 vs the exact v1.2.5 result.

## Fix

Double-`where` guard in both functions (autodiff-safe; a flat pixel gets gradient 0, not `0/0`). Minimal and self-contained — only `multifreq_imager_utils.py` is touched, no new shared helper.

## Test

New `TestSpectralTVFlatMapFinite` in `test_gradients.py`: every `tv_*` spectral regularizer stays finite on a flat map at `epsilon_tv=0`, checked on **both** the NumPy analytic gradient and `jax.grad` of the value. The existing S5 FD-parity suite uses a structured map with `epsilon_tv != 0`, which is why it never caught this.

## Origin

Regression from #310, which flipped the `epsilon_tv` default from `1e-12` to `0`. Backend-touching. May warrant a release cherry-pick like the #240 `stv_pol_grad` fix.