### PR TITLE
NaN-safe Stokes-I and pol TV regularizers on flat maps

### DIFF
--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -1759,6 +1759,17 @@ def reggrad_cm(imvec, mask, **kwargs):
     return g[mask]
 
 
+def _safe_sqrt(xp, sq):
+    """sqrt(sq) with a finite autodiff gradient at sq == 0 (0 rather than inf).
+
+    Forward equals xp.sqrt for sq >= 0, so values are unchanged for any epsilon_tv > 0 -- only
+    the backward pass differs. Keeps autodiff of the TV regularizers from producing NaNs at flat
+    pixels when epsilon_tv == 0.
+    """
+    safe = xp.where(sq > 0, sq, 1.0)
+    return xp.where(sq > 0, xp.sqrt(safe), 0.0)
+
+
 def reg_tv(imvec, mask, **kwargs):
     """Total Variation regularizer"""
     # embed image
@@ -1776,7 +1787,10 @@ def reg_tv(imvec, mask, **kwargs):
     impad = xp.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = xp.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
     im_l2 = xp.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    return xp.sum(xp.sqrt(xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2 + epsilon)) / norm
+    # _safe_sqrt keeps the value and its autodiff gradient finite at a flat pixel (sq == 0) when
+    # epsilon_tv == 0; identical to xp.sqrt for any epsilon_tv > 0.
+    sq = xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2 + epsilon
+    return xp.sum(_safe_sqrt(xp, sq)) / norm
 
 
 def reggrad_tv(imvec, mask, **kwargs):
@@ -1799,10 +1813,15 @@ def reggrad_tv(imvec, mask, **kwargs):
     im_r2 = np.roll(impad, 1, axis=1)[1:ny+1, 1:nx+1]
     im_r1l2 = np.roll(np.roll(impad,  1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
     im_l1r2 = np.roll(np.roll(impad, -1, axis=0),  1, axis=1)[1:ny+1, 1:nx+1]
-    # gradient terms
-    g1 = (2*im - im_l1 - im_l2) / np.sqrt((im - im_l1)**2 + (im - im_l2)**2 + epsilon)
-    g2 = (im - im_r1) / np.sqrt((im - im_r1)**2 + (im_r1l2 - im_r1)**2 + epsilon)
-    g3 = (im - im_r2) / np.sqrt((im - im_r2)**2 + (im_l1r2 - im_r2)**2 + epsilon)
+    # gradient terms. Guarded division (mirrors reggrad_tv_spec): at a flat pixel the denominator
+    # is 0 when epsilon_tv == 0, so the gradient is 0 rather than 0/0 = NaN. Identical to the plain
+    # division wherever the denominator is > 0, so non-flat results are unchanged.
+    d1 = np.sqrt((im - im_l1)**2 + (im - im_l2)**2 + epsilon)
+    d2 = np.sqrt((im - im_r1)**2 + (im_r1l2 - im_r1)**2 + epsilon)
+    d3 = np.sqrt((im - im_r2)**2 + (im_l1r2 - im_r2)**2 + epsilon)
+    g1 = np.where(d1 > 0, (2*im - im_l1 - im_l2) / np.where(d1 > 0, d1, 1.0), 0.0)
+    g2 = np.where(d2 > 0, (im - im_r1) / np.where(d2 > 0, d2, 1.0), 0.0)
+    g3 = np.where(d3 > 0, (im - im_r2) / np.where(d3 > 0, d3, 1.0), 0.0)
     # The back-neighbor (g2, g3) terms reference a pixel that does not
     # exist on the first row/column (it is the zero pad), so they must be zeroed
     mask1 = np.zeros(im.shape)

--- a/ehtim/imaging/multifreq_imager_utils.py
+++ b/ehtim/imaging/multifreq_imager_utils.py
@@ -242,7 +242,7 @@ def reggrad_l2_spec(imvec, mask, **kwargs):
 
 
 def reg_tv_spec(imvec, mask, **kwargs):
-    from ehtim.imaging.imager_utils import embed
+    from ehtim.imaging.imager_utils import _safe_sqrt, embed
     xp = array_namespace(imvec)
     if np.any(np.invert(mask)):
         imvec = embed(imvec, mask, clipfloor=0, randomfloor=False)
@@ -254,11 +254,10 @@ def reg_tv_spec(imvec, mask, **kwargs):
     impad = xp.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = xp.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
     im_l2 = xp.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    # autodiff-safe sqrt: a flat map gives sq == 0 when epsilon_tv == 0, where the
-    # gradient of sqrt is undefined; the double-where keeps both value and grad finite.
+    # _safe_sqrt keeps the value and its autodiff gradient finite at a flat pixel (sq == 0) when
+    # epsilon_tv == 0; identical to xp.sqrt for any epsilon_tv > 0.
     sq = xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2 + epsilon
-    safe = xp.where(sq > 0, sq, 1.0)
-    return xp.sum(xp.where(sq > 0, xp.sqrt(safe), 0.0)) / norm
+    return xp.sum(_safe_sqrt(xp, sq)) / norm
 
 
 def reggrad_tv_spec(imvec, mask, **kwargs):

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -925,10 +925,12 @@ def reg_ptv(imarr, mask, **kwargs):
     impad = xp.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = xp.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
     im_l2 = xp.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
-    # epsilon_tv (default 0, matching reg_tv) regularizes the sqrt so the gradient
-    # is finite at near-zero-|P|-difference pixels; epsilon=0 is byte-identical.
+    # _safe_sqrt keeps the value and its autodiff gradient finite at a flat-|P| pixel (sq == 0) when
+    # epsilon_tv == 0; identical to xp.sqrt for any epsilon_tv > 0.
+    from ehtim.imaging.imager_utils import _safe_sqrt
     epsilon = kwargs.get('epsilon_tv', 0.)
-    return xp.sum(xp.sqrt(xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2 + epsilon)) / norm
+    sq = xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2 + epsilon
+    return xp.sum(_safe_sqrt(xp, sq)) / norm
 
 
 def reggrad_ptv(imarr, mask, **kwargs):
@@ -975,6 +977,12 @@ def reggrad_ptv(imarr, mask, **kwargs):
     d1 = np.sqrt(np.abs(im_l1 - im)**2 + np.abs(im_l2 - im)**2 + epsilon)
     d2 = np.sqrt(np.abs(im_r1 - im)**2 + np.abs(im_r1l2 - im_r1)**2 + epsilon)
     d3 = np.sqrt(np.abs(im_r2 - im)**2 + np.abs(im_l1r2 - im_r2)**2 + epsilon)
+    # Guarded denominators (mirror reggrad_tv_spec): at a flat-|P| pixel d == 0 when epsilon_tv == 0,
+    # and the numerators below are 0 there too (cos terms cancel, sin -> 0), so each m/d term is 0
+    # rather than 0/0 = NaN. Unchanged wherever d > 0, so non-flat results are identical.
+    d1 = np.where(d1 > 0, d1, 1.0)
+    d2 = np.where(d2 > 0, d2, 1.0)
+    d3 = np.where(d3 > 0, d3, 1.0)
     # Numerators below use cos/sin of the single-angle difference between
     # neighbors, from d|P_l1 - P|^2/d|P| = 2|P| - 2|P_l1|*cos(angle(P_l1) - angle(P)).
     # mask first-row/col back-neighbor terms that don't exist (as reggrad_tv does)
@@ -1176,8 +1184,12 @@ def reg_vtv(imarr, mask, **kwargs):
     impad = xp.pad(im, 1, mode='constant', constant_values=0)
     im_l1 = xp.roll(impad, -1, axis=0)[1:ny+1, 1:nx+1]
     im_l2 = xp.roll(impad, -1, axis=1)[1:ny+1, 1:nx+1]
+    # _safe_sqrt keeps the value and its autodiff gradient finite at a flat-V pixel (sq == 0) when
+    # epsilon_tv == 0; identical to xp.sqrt for any epsilon_tv > 0.
+    from ehtim.imaging.imager_utils import _safe_sqrt
     epsilon = kwargs.get('epsilon_tv', 0.)
-    return xp.sum(xp.sqrt(xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2 + epsilon)) / norm
+    sq = xp.abs(im_l1 - im)**2 + xp.abs(im_l2 - im)**2 + epsilon
+    return xp.sum(_safe_sqrt(xp, sq)) / norm
 
 
 def reggrad_vtv(imarr, mask, **kwargs):
@@ -1219,10 +1231,15 @@ def reggrad_vtv(imarr, mask, **kwargs):
     im_r1l2 = np.roll(np.roll(impad,  1, axis=0), -1, axis=1)[1:ny+1, 1:nx+1]
     im_l1r2 = np.roll(np.roll(impad, -1, axis=0),  1, axis=1)[1:ny+1, 1:nx+1]
 
-    # base gradient terms
-    g1 = (2*im - im_l1 - im_l2) / np.sqrt((im - im_l1)**2 + (im - im_l2)**2 + epsilon)
-    g2 = (im - im_r1) / np.sqrt((im - im_r1)**2 + (im_r1l2 - im_r1)**2 + epsilon)
-    g3 = (im - im_r2) / np.sqrt((im - im_r2)**2 + (im_l1r2 - im_r2)**2 + epsilon)
+    # base gradient terms. Guarded division (mirrors reggrad_tv_spec): at a flat pixel the denominator
+    # is 0 when epsilon_tv == 0, so the gradient is 0 rather than 0/0 = NaN. Identical to the plain
+    # division wherever the denominator is > 0, so non-flat results are unchanged.
+    d1 = np.sqrt((im - im_l1)**2 + (im - im_l2)**2 + epsilon)
+    d2 = np.sqrt((im - im_r1)**2 + (im_r1l2 - im_r1)**2 + epsilon)
+    d3 = np.sqrt((im - im_r2)**2 + (im_l1r2 - im_r2)**2 + epsilon)
+    g1 = np.where(d1 > 0, (2*im - im_l1 - im_l2) / np.where(d1 > 0, d1, 1.0), 0.0)
+    g2 = np.where(d2 > 0, (im - im_r1) / np.where(d2 > 0, d2, 1.0), 0.0)
+    g3 = np.where(d3 > 0, (im - im_r2) / np.where(d3 > 0, d3, 1.0), 0.0)
 
     # The back-neighbor (g2, g3) terms reference a pixel that does not
     # exist on the first row/column (it is the zero pad), so they must be zeroed

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -392,6 +392,60 @@ class TestSpectralTVFlatMapFinite:
         assert np.all(np.isfinite(np.asarray(grad))), f"{rtype}: NaN in jax.grad on flat map"
 
 
+# The same flat-map 0/0 lives in the Stokes-I (reg_tv) and pol (reg_ptv / reg_vtv) TV terms: a flat
+# region (e.g. a uniform init) makes every neighbour difference 0, so the naive sqrt(0) leaves a 0/0
+# in both the value (autodiff) and the analytic gradient. The S3/S4 fixtures use a structured map
+# with epsilon_tv != 0, so they never exercised it. tv2 / tv2log are curvature-based (no sqrt) -- safe.
+STOKESI_TV = ["tv", "tvlog"]
+POL_TV = ["ptv", "vtv"]
+
+
+class TestStokesIPolTVFlatMapFinite:
+    @pytest.mark.parametrize("rtype", STOKESI_TV)
+    def test_stokesI_analytic_finite_on_flat(self, reg_si_setup, rtype):
+        imvec, mask, kw = reg_si_setup
+        kw = {**kw, "epsilon_tv": 0.0}
+        flat = np.full(imvec.shape, 0.5)
+        grad = compute_regularizergrad_term(flat, rtype, mask, **kw)
+        val = compute_regularizer_term(flat, rtype, mask, **kw)
+        assert np.all(np.isfinite(grad)), f"{rtype}: NaN/inf in analytic grad on flat map"
+        assert np.isfinite(val), f"{rtype}: NaN/inf in value on flat map"
+
+    @pytest.mark.parametrize("rtype", POL_TV)
+    def test_pol_analytic_finite_on_flat(self, reg_pol_setup, rtype):
+        imarr, mask, kw = reg_pol_setup
+        kw = {**kw, "epsilon_tv": 0.0}
+        flat = np.stack([np.full(mask.size, c) for c in (0.5, 0.3, 1.0, 0.5)])
+        grad = compute_regularizergrad_term(flat, rtype, mask, **kw)
+        val = compute_regularizer_term(flat, rtype, mask, **kw)
+        assert np.all(np.isfinite(grad)), f"{rtype}: NaN/inf in analytic grad on flat map"
+        assert np.isfinite(val), f"{rtype}: NaN/inf in value on flat map"
+
+    @pytest.mark.jax
+    @pytest.mark.parametrize("rtype", STOKESI_TV)
+    def test_stokesI_autodiff_finite_on_flat(self, reg_si_setup, rtype):
+        import jax
+        import jax.numpy as jnp
+        jax.config.update("jax_enable_x64", True)
+        _, mask, kw = reg_si_setup
+        kw = {**kw, "epsilon_tv": 0.0}
+        flat = jnp.full(mask.size, 0.5)
+        grad = jax.grad(lambda v: compute_regularizer_term(v, rtype, mask, **kw))(flat)
+        assert np.all(np.isfinite(np.asarray(grad))), f"{rtype}: NaN in jax.grad on flat map"
+
+    @pytest.mark.jax
+    @pytest.mark.parametrize("rtype", POL_TV)
+    def test_pol_autodiff_finite_on_flat(self, reg_pol_setup, rtype):
+        import jax
+        import jax.numpy as jnp
+        jax.config.update("jax_enable_x64", True)
+        _, mask, kw = reg_pol_setup
+        kw = {**kw, "epsilon_tv": 0.0}
+        flat = jnp.stack([jnp.full(mask.size, c) for c in (0.5, 0.3, 1.0, 0.5)])
+        grad = jax.grad(lambda v: compute_regularizer_term(v, rtype, mask, **kw))(flat)
+        assert np.all(np.isfinite(np.asarray(grad))), f"{rtype}: NaN in jax.grad on flat map"
+
+
 # ============================== S6: transforms ===============================
 # Each change-of-variables maps a solver image to a physical one. We finite-difference an
 # arbitrary DENSE linear objective sum(grad_phys * fwd(solver)) w.r.t. the solver slots and


### PR DESCRIPTION
## What

The flat-map `0/0` NaN that #311 fixed in the **spectral** TV regularizer (`reg_tv_spec`/`reggrad_tv_spec`) exists identically in the **Stokes-I** and **polarimetric** TV regularizers, and was never fixed. A flat region (e.g. a uniform init or an unconstrained patch) makes every neighbour difference zero, so the naive `sqrt(0)` / `num/sqrt(0)` leaves a `0/0` in both the **value** (under autodiff) and the **analytic gradient**:

| Family | value (autodiff) | analytic gradient |
|---|---|---|
| Stokes-I (`tv`, `tvlog`) | `reg_tv` | `reggrad_tv` |
| pol P (`ptv`) | `reg_ptv` | `stv_pol_grad` |
| pol V (`vtv`) | `reg_vtv` | `reggrad_vtv` |

(`tvlog`/`reggrad_tvlog` route through `reg_tv`/`reggrad_tv`; `tv2`, `tv2log`, `vtv2`, `l2_spec` are curvature/L2 with no `sqrt` and are already finite.)

## Fix

- Promote `_safe_sqrt` to a shared helper in `imager_utils.py` and use it in every TV **value** (`reg_tv`, `reg_ptv`, `reg_vtv`, and `reg_tv_spec` — unifying #311's inline double-where to the same helper). It is `xp.sqrt` for any `epsilon_tv > 0`, and gives a finite (zero) gradient at flat pixels when `epsilon_tv == 0`.
- Guard the divisions in the **analytic gradients** (`reggrad_tv`, `reggrad_vtv`, `stv_pol_grad`): at a flat pixel the denominator and numerators are both zero, so the term is `0` rather than `0/0`. Identical to the plain division wherever the denominator is `> 0`, so non-flat results are unchanged.

## Test

`TestStokesIPolTVFlatMapFinite` in `test_gradients.py` (mirrors #311's spectral test): every Stokes-I and pol TV regularizer stays finite on a flat map at `epsilon_tv == 0`, on both the NumPy analytic gradient and `jax.grad` of the value. The existing S3/S4 FD-parity suites use a structured map with `epsilon_tv != 0`, which is why they never caught this.

Verified: 56 regularizer tests pass (FD-parity on structured maps unchanged → non-flat gradients are bit-for-bit identical; flat-map tests finite). ruff clean.

## Notes

Companion to #311; backend-touching. The default numpy `make_image` path is unchanged for any non-flat image.
