### PR TITLE
Fast non-averaging uvfits loading (multi-frequency obslist) + speedups default

### DIFF
--- a/ehtim/io/load.py
+++ b/ehtim/io/load.py
@@ -1051,7 +1051,7 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
                     allow_singlepol=True, force_singlepol=None,
                     channel=all, IF=all, remove_nan=False,
                     ignore_pzero_date=True,
-                    trial_speedups=True,
+                    speedups=True,
                     invvar_channel_avg=True):
     """Load observation data from a uvfits file.
 
@@ -1067,9 +1067,9 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
            remove_nan (bool): whether or not to remove entries with nan data
            ignore_pzero_date (bool): if True, ignore the offset parameters in DATE field
                                      TODO: what is the correct behavior per AIPS memo 117?
-           trial_speedups (bool): if True (default), use faster vectorized
-                                  array/telescope handling paths; produces data
-                                  and tarr identical to the legacy paths
+           speedups (bool): if True (default), use faster vectorized
+                            array/telescope handling paths; produces data
+                            and tarr identical to the legacy paths
            invvar_channel_avg (bool): if True, average IFs/channels with inverse-variance
                                       weighting. If False, use the original simple averaging.
        Returns:
@@ -1379,7 +1379,7 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
     t2c = t2c - 1
 
     # TODO make site identificantion faster
-    if trial_speedups and (not np.any(tnums!=np.arange(len(tnums)))):
+    if speedups and (not np.any(tnums!=np.arange(len(tnums)))):
         sites = tarr['site']
         t1 = sites[t1c]
         t2 = sites[t2c]
@@ -1519,7 +1519,7 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
         poldict_out = ehc.POLDICT_STOKES
 
     #TODO new, faster,
-    if trial_speedups:
+    if speedups:
         datatable = np.empty((len(times)),dtype=dtpol_out)
         datatable['time'] = times
         datatable['tint'] = tints
@@ -1553,7 +1553,7 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
 
     obs = ehtim.obsdata.Obsdata(ra, dec, rf, bw, datatable, tarr, polrep=polrep_uvfits,
                                 source=src, mjd=mjd, scantable=scantable,
-                                trial_speedups=trial_speedups)
+                                speedups=speedups)
 
     if remove_nan:
         if polrep_uvfits == 'circ':
@@ -1568,6 +1568,390 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
 
     # TODO get calibration flags from uvfits?
     return obs
+
+
+def load_obs_uvfits_spectral(filename, polrep: str = 'stokes', flipbl: bool = False,
+                             allow_singlepol: bool = True, force_singlepol=None,
+                             channel=all, IF=all, remove_nan: bool = False,
+                             invvar_channel_avg: bool = True, ignore_pzero_date: bool = True,
+                             average_if: bool = False, average_channel: bool = False) -> list:
+    """Load a uvfits file keeping the spectral axis (partly) resolved.
+
+    ``load_obs_uvfits`` collapses every channel and IF into one visibility per
+    baseline-time. This instead treats the (IF, channel) grid as two axes you can
+    independently average or keep: an averaged axis becomes one group over all its
+    indices, a kept axis yields one group per index. Each surviving frequency group
+    is read in one vectorized pass and returned as its own Obsdata, carrying its own
+    reference frequency and its own u,v (the light-second UU/VV scaled by that
+    group's sky frequency, not by a single reference frequency). The list drops
+    straight into ``ehtim.imager.Imager(obslist, ...)`` for multi-frequency imaging.
+    With both flags True everything averages into a one-element list; ``load_uvfits``
+    routes that case to the single-Obsdata path instead.
+
+    Only circular and Stokes uvfits are supported, the same basis coverage as
+    ``load_obs_uvfits``; linear or mixed-feed files raise NotImplementedError
+    (that path is handled by the mixed-polarization loader).
+
+    Args:
+        filename (str or HDUList): path to a uvfits file, or an open HDUList
+        polrep (str): return the Obsdata as 'stokes' or 'circ'
+        flipbl (bool): flip baseline sign (u,v -> -u,-v) if True
+        allow_singlepol (bool): with polrep='stokes', treat single-pol data as Stokes I
+        force_singlepol (str): 'R'/'L'/'RL'/'LR' to keep one hand as Stokes I (circ files only)
+        channel (list): channel indices to load; channel=all loads every channel
+        IF (list): IF indices to load; IF=all loads every IF
+        remove_nan (bool): fill nan sigmas from the surviving hands (circ files)
+        invvar_channel_avg (bool): average within a group by inverse variance if True,
+            else by a simple mean
+        ignore_pzero_date (bool): ignore nonzero PZERO offsets on the DATE params
+        average_if (bool): average over all IFs (one group) if True, else one group per IF
+        average_channel (bool): average the channels within each IF group if True,
+            else one group per channel
+
+    Returns:
+        obslist (list of Obsdata): one Obsdata per surviving (IF-group, channel-group),
+            ordered IF-major then channel. Groups with no unflagged data are skipped.
+            Each carries its own rf and per-group u,v, so ``[o.rf for o in obslist]`` is
+            the frequency list the multi-frequency imager expects.
+    """
+
+    if polrep not in ('stokes', 'circ'):
+        raise Exception("polrep should be 'stokes' or 'circ' in load_uvfits_spectral")
+    if not (force_singlepol is None or force_singlepol is False) and polrep != 'stokes':
+        raise Exception("force_singlepol is incompatible with polrep!='stokes'")
+
+    if isinstance(filename, fits.HDUList):
+        hdulist = filename.copy()
+    else:
+        print("Loading uvfits (spectral, non-averaging): ", filename)
+        hdulist = fits.open(filename)
+    header = hdulist[0].header
+    data = hdulist[0].data
+
+    # --- antenna table -> tarr (circular / Stokes feeds only) ---
+    tnames = hdulist['AIPS AN'].data['ANNAME']
+    tnums = hdulist['AIPS AN'].data['NOSTA'] - 1
+    xyz = np.real(hdulist['AIPS AN'].data['STABXYZ'])
+    try:
+        sefdr = np.real(hdulist['AIPS AN'].data['SEFD'])
+        sefdl = np.real(hdulist['AIPS AN'].data['SEFD'])
+    except KeyError:
+        sefdr = np.zeros(len(tnames))
+        sefdl = np.zeros(len(tnames))
+    fr_par = np.zeros(len(tnames))
+    fr_el = np.zeros(len(tnames))
+    fr_off = np.zeros(len(tnames))
+    dr = np.zeros(len(tnames), dtype=complex)
+    dl = np.zeros(len(tnames), dtype=complex)
+
+    # Linear / mixed feeds are handled by the mixed-pol loader, not here.
+    feeds = set()
+    for col in ('POLTYA', 'POLTYB'):
+        try:
+            poltys = hdulist['AIPS AN'].data[col]
+        except KeyError:
+            continue
+        for p in poltys:
+            s = (p.decode() if isinstance(p, bytes) else str(p)).strip().upper()
+            if s:
+                feeds.add(s)
+    if not feeds <= {'R', 'L'}:
+        raise NotImplementedError(
+            "load_uvfits_spectral supports only circular/Stokes feeds; detected "
+            f"{sorted(feeds)} in POLTYA/POLTYB. Linear/mixed-feed uvfits loading "
+            "is handled by the mixed-polarization loader.")
+
+    tarr = np.array([np.array((
+        str(tnames[i]), xyz[i][0], xyz[i][1], xyz[i][2],
+        sefdr[i], sefdl[i], dr[i], dl[i],
+        fr_par[i], fr_el[i], fr_off[i], 'rl'), dtype=ehc.DTARR)
+        for i in range(len(tnames))])
+
+    # --- source position and name ---
+    try:
+        ra = header['OBSRA'] * 12. / 180.
+        dec = header['OBSDEC']
+    except KeyError:
+        if header.get('CTYPE6') == 'RA':
+            ra = header['CRVAL6'] * 12. / 180.
+        else:
+            raise Exception('Cannot find RA!')
+        if header.get('CTYPE7') == 'DEC':
+            dec = header['CRVAL7']
+        else:
+            raise Exception('Cannot find DEC!')
+    if ra > 24 and ra >= 0:
+        ranew = ra * 12 / 180.
+        if ranew < 24:
+            ra = ranew
+        else:
+            raise Exception(f"Cannot interpret fits file RA {ra:.3f}!")
+    elif ra < 0:
+        raise Exception(f'fits file RA {ra:.3f}<0!')
+    src = header['OBJECT']
+
+    # --- frequency grid: reference freq + per-IF offset + per-channel step ---
+    if header['CTYPE4'] != 'FREQ':
+        raise Exception('Cannot find observing frequencies (CTYPE4 is not FREQ)!')
+    ch1_freq = header['CRVAL4']
+    ch_bw = header['CDELT4']
+    crpix4 = header.get('CRPIX4', 1)
+
+    nvis = data['DATA'].shape[0]
+    nif = data['DATA'].shape[3]
+    nchan = data['DATA'].shape[4]
+    num_corr = data['DATA'].shape[5]
+
+    # Which IFs / channels to load (all by default); validate the requested indices.
+    sel_if = list(range(nif)) if IF is all else [int(i) for i in np.atleast_1d(IF)]
+    sel_ch = list(range(nchan)) if channel is all else [int(c) for c in np.atleast_1d(channel)]
+    if min(sel_if) < 0 or max(sel_if) >= nif:
+        raise Exception(f"requested IF out of range (file has {nif} IFs)")
+    if min(sel_ch) < 0 or max(sel_ch) >= nchan:
+        raise Exception(f"requested channel out of range (file has {nchan} channels)")
+
+    # Per-IF sky-frequency offsets from the AIPS FQ table (0 if the table is absent).
+    if_freqs = np.zeros(nif)
+    fq_ok = False
+    try:
+        fqcol = np.asarray(hdulist['AIPS FQ'].data['IF FREQ'])
+        fqrow = fqcol.reshape(len(hdulist['AIPS FQ'].data), -1)[0]
+        if len(fqrow) == nif:
+            if_freqs = fqrow.astype(float)
+            fq_ok = True
+    except Exception:
+        pass
+    if nif > 1 and not fq_ok:
+        print("Warning! could not read per-IF frequency offsets from the AIPS FQ table; "
+              "the IFs will share a frequency and their u,v scaling may be wrong.")
+
+    try:
+        if header['CTYPE3'] != 'STOKES':
+            raise Exception("STOKES field not in expected header position 'CTYPE3'!")
+        if header['CRVAL3'] == 1:
+            polrep_uvfits = 'stokes'
+        elif header['CRVAL3'] == -1:
+            polrep_uvfits = 'circ'
+        else:
+            raise Exception("header[CRVAL3] not a recognized polarization basis!")
+    except KeyError:
+        raise Exception("STOKES field not in expected header position 'CTYPE3'!")
+    if polrep_uvfits == 'stokes' and force_singlepol is not None:
+        raise Exception("force_singlepol not implemented for native Stokes uvfits files!")
+
+    # --- per-record quantities (identical for every channel) ---
+    # Observation times from the DATE (+ _DATE) random parameters.
+    try:
+        paridx = data.parnames.index("DATE") + 1
+        jd1scal = header.get(f"PSCAL{paridx}", 1.0)
+        jd1zero = header.get(f"PZERO{paridx}", 0.0)
+        jd2scal = header.get(f"PSCAL{paridx + 1}", 1.0)
+        jd2zero = header.get(f"PZERO{paridx + 1}", 0.0)
+    except ValueError:
+        jd1scal = jd2scal = 1.0
+        jd1zero = jd2zero = 0.0
+    if ignore_pzero_date:
+        if jd1zero != 0. or jd2zero != 0.:
+            print("Warning! ignoring nonzero header PZERO values for DATE.")
+        jd1zero = jd2zero = 0.0
+    jds = jd1scal * data['DATE'].astype('d') + jd1zero
+    try:
+        jds = jds + jd2scal * data['_DATE'].astype('d') + jd2zero
+    except KeyError:
+        pass
+    # Reference mjd from records that are unflagged somewhere (as load_obs_uvfits does),
+    # so a fully-flagged early record on an earlier day cannot shift the reference day.
+    ti_corrs = (0, 1) if (polrep_uvfits == 'circ' and num_corr >= 2) else (0,)
+    gmask = np.zeros(nvis, dtype=bool)
+    for i in sel_if:
+        for c in sel_ch:
+            for corr in ti_corrs:
+                w = data['DATA'][:, 0, 0, i, c, corr, 2].astype(float)
+                gmask |= np.isfinite(w) & (w > 0.)
+    if not np.any(gmask):
+        gmask[:] = True
+    mjd = int(np.min(jds[gmask]) - 2400000.5)
+    times_all = (jds - 2400000.5 - mjd) * 24.0
+
+    # Site names from the BASELINE code (256*t1 + t2, 1-based NOSTA).
+    bl = data['BASELINE'].astype(int)
+    t1c = bl // 256 - 1
+    t2c = bl - (bl // 256) * 256 - 1
+    if not np.any(tnums != np.arange(len(tnums))):
+        sites = tarr['site']
+        t1_all = sites[t1c]
+        t2_all = sites[t2c]
+    else:
+        t1_all = np.array([tarr[np.where(tnums == i)[0][0]]['site'] for i in t1c])
+        t2_all = np.array([tarr[np.where(tnums == i)[0][0]]['site'] for i in t2c])
+
+    try:
+        tint_all = data['INTTIM']
+    except KeyError:
+        tint_all = np.zeros(nvis)
+    try:
+        tau1_all = data['TAU1']
+        tau2_all = data['TAU2']
+    except KeyError:
+        tau1_all = np.zeros(nvis)
+        tau2_all = np.zeros(nvis)
+
+    # UU/VV are in light-seconds; each channel scales them by its own frequency.
+    for uname, vname in (('UU---SIN', 'VV---SIN'), ('UU', 'VV'), ('UU--', 'VV--')):
+        try:
+            uu = data[uname].astype('d')
+            vv = data[vname].astype('d')
+            break
+        except KeyError:
+            continue
+    else:
+        raise Exception("Cant figure out column label for UV coords")
+    if flipbl:
+        uu = -uu
+        vv = -vv
+
+    # Scan table (shared across channels).
+    try:
+        scantable = []
+        for scan in hdulist['AIPS NX'].data:
+            scan_start = scan['TIME']
+            scan_dur = scan['TIME INTERVAL']
+            scantable.append([scan_start - 0.5 * scan_dur,
+                              scan_start + 0.5 * scan_dur])
+        scantable = np.array(scantable) * 24
+    except BaseException:
+        scantable = None
+
+    if polrep_uvfits == 'circ':
+        dtpol_out = ehc.DTPOL_CIRC
+        poldict_out = ehc.POLDICT_CIRC
+    else:
+        dtpol_out = ehc.DTPOL_STOKES
+        poldict_out = ehc.POLDICT_STOKES
+
+    # Sky frequency of a single (IF, channel) point.
+    def _point_freq(if_idx, ch_idx):
+        return ch1_freq + if_freqs[if_idx] + (ch_idx + 1 - crpix4) * ch_bw
+
+    # DATA axes are (group, dec, ra, IF, FREQ, corr, [re, im, weight]).
+    def _read_point(if_idx, ch_idx, corr):
+        cube = data['DATA'][:, 0, 0, if_idx, ch_idx, corr, :]
+        return cube[:, 0] + 1j * cube[:, 1], cube[:, 2].astype(float)
+
+    def _zero_acc():
+        z = np.zeros(nvis)
+        return [np.zeros(nvis, dtype=complex), z.copy(),
+                np.zeros(nvis, dtype=complex), z.copy(), z.copy()]
+
+    # Accumulate one correlation over a set of (IF, channel) points. A slot counts only
+    # when its weight is positive AND its visibility is finite, so a NaN visibility with a
+    # stray positive weight cannot poison the average. Returns the sums needed for both
+    # inverse-variance and simple-mean combination.
+    def _accumulate(points, corr):
+        sum_vw = np.zeros(nvis, dtype=complex)   # sum(vis * weight)
+        sum_w = np.zeros(nvis)                   # sum(weight)
+        sum_v = np.zeros(nvis, dtype=complex)    # sum(vis)
+        sum_iv = np.zeros(nvis)                  # sum(1 / weight)
+        count = np.zeros(nvis)                   # number of good slots
+        for if_idx, ch_idx in points:
+            vis, wt = _read_point(if_idx, ch_idx, corr)
+            good = np.isfinite(wt) & (wt > 0.) & np.isfinite(vis)
+            wt = np.where(good, wt, 0.)
+            vis = np.where(good, vis, 0.)
+            sum_vw += vis * wt
+            sum_w += wt
+            sum_v += vis
+            sum_iv += np.where(good, 1., 0.) / np.where(good, wt, 1.)
+            count += good
+        return [sum_vw, sum_w, sum_v, sum_iv, count]
+
+    # Drop a correlation (used by force_singlepol) by zeroing its weight/count.
+    def _mask_out(acc):
+        return [acc[0] * 0., acc[1] * 0., acc[2] * 0., acc[3] * 0., acc[4] * 0.]
+
+    # Combine an accumulator into (visibility, sigma, mask) by the chosen averaging.
+    def _reduce(acc):
+        sum_vw, sum_w, sum_v, sum_iv, count = acc
+        mask = count > 0
+        with np.errstate(divide='ignore', invalid='ignore'):
+            if invvar_channel_avg:
+                vis = np.where(mask, sum_vw / sum_w, np.nan)
+                sig = np.where(mask, 1. / np.sqrt(sum_w), np.nan)
+            else:
+                vis = np.where(mask, sum_v / count, np.nan)
+                sig = np.where(mask, np.sqrt(sum_iv) / count, np.nan)
+        return vis, sig, mask
+
+    # An averaged axis collapses to one group over its selected indices; a kept axis
+    # yields one group per selected index. Output is one Obsdata per (IF-group, ch-group).
+    if_groups = [sel_if] if average_if else [[i] for i in sel_if]
+    ch_groups = [sel_ch] if average_channel else [[c] for c in sel_ch]
+
+    obslist = []
+    for ifg in if_groups:
+        for chg in ch_groups:
+            points = [(i, c) for i in ifg for c in chg]
+            freq = float(np.mean([_point_freq(i, c) for i, c in points]))
+
+            rr_acc = _accumulate(points, 0)
+            ll_acc = _accumulate(points, 1) if num_corr >= 2 else _zero_acc()
+            rl_acc = _accumulate(points, 2) if num_corr >= 3 else _zero_acc()
+            lr_acc = _accumulate(points, 3) if num_corr >= 4 else _zero_acc()
+
+            if polrep_uvfits == 'circ' and force_singlepol is not None:
+                if force_singlepol in ('L', 'LL'):
+                    rr_acc, rl_acc, lr_acc = _mask_out(rr_acc), _mask_out(rl_acc), _mask_out(lr_acc)
+                elif force_singlepol in ('R', 'RR'):
+                    ll_acc, rl_acc, lr_acc = _mask_out(ll_acc), _mask_out(rl_acc), _mask_out(lr_acc)
+                elif force_singlepol == 'LR':
+                    rr_acc, ll_acc, rl_acc, lr_acc = (lr_acc, _mask_out(ll_acc),
+                                                      _mask_out(rl_acc), _mask_out(lr_acc))
+                elif force_singlepol == 'RL':
+                    rr_acc, ll_acc, rl_acc, lr_acc = (rl_acc, _mask_out(ll_acc),
+                                                      _mask_out(rl_acc), _mask_out(lr_acc))
+
+            rr, rrsig, rrm = _reduce(rr_acc)
+            ll, llsig, llm = _reduce(ll_acc)
+            rl, rlsig, rlm = _reduce(rl_acc)
+            lr, lrsig, lrm = _reduce(lr_acc)
+
+            keep = (rrm | llm) if polrep_uvfits == 'circ' else rrm
+            if not np.any(keep):
+                print(f"  no unflagged data in IF group {ifg}, channel group {chg}; skipping")
+                continue
+
+            datatable = np.empty(int(np.sum(keep)), dtype=dtpol_out)
+            datatable['time'] = times_all[keep]
+            datatable['tint'] = tint_all[keep]
+            datatable['t1'] = t1_all[keep]
+            datatable['t2'] = t2_all[keep]
+            datatable['tau1'] = tau1_all[keep]
+            datatable['tau2'] = tau2_all[keep]
+            datatable['u'] = uu[keep] * freq
+            datatable['v'] = vv[keep] * freq
+            datatable[poldict_out['vis1']] = rr[keep]
+            datatable[poldict_out['vis2']] = ll[keep]
+            datatable[poldict_out['vis3']] = rl[keep]
+            datatable[poldict_out['vis4']] = lr[keep]
+            datatable[poldict_out['sigma1']] = rrsig[keep]
+            datatable[poldict_out['sigma2']] = llsig[keep]
+            datatable[poldict_out['sigma3']] = rlsig[keep]
+            datatable[poldict_out['sigma4']] = lrsig[keep]
+
+            # Group bandwidth spans the averaged channels across the averaged IFs.
+            bw = ch_bw * len(chg) * len(ifg)
+            obs = ehtim.obsdata.Obsdata(ra, dec, freq, bw, datatable, tarr,
+                                        polrep=polrep_uvfits, source=src, mjd=mjd,
+                                        scantable=scantable, speedups=True)
+            if remove_nan and polrep_uvfits == 'circ':
+                (obs.data['rrsigma'], obs.data['llsigma'],
+                 obs.data['rlsigma'], obs.data['lrsigma']) = _fill_nan_sigmas(
+                    obs.data['rrsigma'], obs.data['llsigma'],
+                    obs.data['rlsigma'], obs.data['lrsigma'])
+            obs = obs.switch_polrep(polrep, allow_singlepol=allow_singlepol)
+            obslist.append(obs)
+
+    return obslist
 
 
 def load_obs_maps(arrfile, obsspec, ifile, qfile=0, ufile=0, vfile=0,

--- a/ehtim/io/load.py
+++ b/ehtim/io/load.py
@@ -1045,6 +1045,116 @@ def _fill_nan_sigmas(rr, ll, rl, lr):
     return rr_filled, ll_filled, rl_filled, lr_filled
 
 
+# ------------------------------------------------------------------------------------
+# Header readers shared by load_obs_uvfits and load_obs_uvfits_spectral. The two loaders
+# differ in how they read the DATA cube (one averages the spectral axis away, the other
+# keeps it), but everything they take from the header tables is the same, so it lives
+# here and neither copy can drift from the other.
+# ------------------------------------------------------------------------------------
+
+
+def _read_antenna_table(hdulist):
+    """Read the AIPS AN table into a tarr. Returns (tarr, station numbers).
+
+    Circular feeds only. A linear or hybrid station raises instead of being loaded as
+    circular by mistake, since turning POLTYA/POLTYB into per-station feed types is the
+    mixed-pol loader's job.
+    """
+    an = hdulist['AIPS AN'].data
+    tnames = an['ANNAME']
+    tnums = an['NOSTA'] - 1
+    xyz = np.real(an['STABXYZ'])
+    nant = len(tnames)
+    try:
+        sefdr = np.real(an['SEFD'])
+        sefdl = np.real(an['SEFD'])  # TODO add sefdl to uvfits?
+    except KeyError:
+        sefdr = np.zeros(nant)
+        sefdl = np.zeros(nant)
+
+    # TODO - get the *actual* values of these telescope parameters from the uvfits file?
+    fr_par = np.zeros(nant)
+    fr_el = np.zeros(nant)
+    fr_off = np.zeros(nant)
+    dr = np.zeros(nant, dtype=complex)
+    dl = np.zeros(nant, dtype=complex)
+
+    # Check both feed columns, so a hybrid station (say POLTYA='R', POLTYB='X') is caught
+    # rather than quietly loaded as circular.
+    feeds = set()
+    for col in ('POLTYA', 'POLTYB'):
+        try:
+            poltys = an[col]
+        except KeyError:
+            continue
+        for p in poltys:
+            s = (p.decode() if isinstance(p, bytes) else str(p)).strip().upper()
+            if s:
+                feeds.add(s)
+    if not feeds <= {'R', 'L'}:
+        raise NotImplementedError(
+            "mixed-pol / linear-feed uvfits load is not yet supported; "
+            f"detected feed types {sorted(feeds)} in POLTYA/POLTYB. "
+            "See obsdata_mixedpol_plan.md.")
+
+    # TODO (Phase 7 mixed-pol): read POLTYA/POLTYB here to fill in per-station
+    # feed_type. Until then, assume circular feeds.
+    tarr = np.array([np.array((
+        str(tnames[i]), xyz[i][0], xyz[i][1], xyz[i][2],
+        sefdr[i], sefdl[i], dr[i], dl[i],
+        fr_par[i], fr_el[i], fr_off[i], 'rl'), dtype=ehc.DTARR)
+        for i in range(nant)])
+    return tarr, tnums
+
+
+def _read_source_position(header):
+    """Read the source position and name from the header. Returns (ra, dec, source).
+
+    RA comes back in fractional hours. Some files write it in decimal degrees instead,
+    which shows up as a value above 24; we convert those and say so.
+    """
+    try:
+        ra = header['OBSRA'] * 12. / 180.
+        dec = header['OBSDEC']
+    except KeyError:
+        if header.get('CTYPE6') == 'RA':
+            ra = header['CRVAL6'] * 12. / 180.
+        else:
+            raise Exception('Cannot find RA!')
+        if header.get('CTYPE7') == 'DEC':
+            dec = header['CRVAL7']
+        else:
+            raise Exception('Cannot find DEC!')
+
+    if ra > 24 and ra >= 0:
+        ranew = ra * 12 / 180.
+        if ranew < 24:
+            print(f' Warning! file RA>24, interpreting as decimal deg. : '
+                  f'{ra:.3f} deg -> {ranew:.3f} hr')
+            ra = ranew
+        else:
+            raise Exception(f"Cannot interpret fits file RA {ra:.3f}!")
+    elif ra < 0:
+        raise Exception(f'fits file RA {ra:.3f}<0!')
+
+    return ra, dec, header['OBJECT']
+
+
+def _read_scan_table(hdulist):
+    """Read scan start/stop times (in hours) from the AIPS NX table, or None if absent."""
+    try:
+        scantable = []
+        for scan in hdulist['AIPS NX'].data:
+            scan_start = scan['TIME']          # days since the reference date
+            scan_dur = scan['TIME INTERVAL']
+            scantable.append([scan_start - 0.5 * scan_dur,
+                              scan_start + 0.5 * scan_dur])
+        return np.array(scantable) * 24
+    except BaseException:
+        print("No NX table in uvfits!")
+        return None
+
+
 # TODO can we save new telescope array terms and flags to uvfits and load them?
 # TODO uv coordinates, multiply by IF freqs and not header FREQ?
 def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
@@ -1092,79 +1202,10 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
     data = hdulist[0].data
 
     # Load the array data
-    tnames = hdulist['AIPS AN'].data['ANNAME']
-    tnums = hdulist['AIPS AN'].data['NOSTA'] - 1
-    xyz = np.real(hdulist['AIPS AN'].data['STABXYZ'])
-    try:
-        sefdr = np.real(hdulist['AIPS AN'].data['SEFD'])
-        sefdl = np.real(hdulist['AIPS AN'].data['SEFD'])  # TODO add sefdl to uvfits?
-    except KeyError:
-        sefdr = np.zeros(len(tnames))
-        sefdl = np.zeros(len(tnames))
-
-    # TODO - get the *actual* values of these telescope parameters from the uvfits file?
-    fr_par = np.zeros(len(tnames))
-    fr_el = np.zeros(len(tnames))
-    fr_off = np.zeros(len(tnames))
-    dr = np.zeros(len(tnames)) + 1j * np.zeros(len(tnames))
-    dl = np.zeros(len(tnames)) + 1j * np.zeros(len(tnames))
-
-    # Detect antenna feed types and raise if the observation is mixed-polarization
-    # (full POLTYA/POLTYB -> feed_type parsing is not yet implemented). Both feed
-    # columns are checked, so a hybrid station (e.g. POLTYA='R', POLTYB='X') is
-    # caught rather than silently loaded as circular.
-    feeds = set()
-    for col in ('POLTYA', 'POLTYB'):
-        try:
-            poltys = hdulist['AIPS AN'].data[col]
-        except KeyError:
-            continue
-        for p in poltys:
-            s = (p.decode() if isinstance(p, bytes) else str(p)).strip().upper()
-            if s:
-                feeds.add(s)
-    if not feeds <= {'R', 'L'}:
-        raise NotImplementedError(
-            "mixed-pol / linear-feed uvfits load is not yet supported; "
-            f"detected feed types {sorted(feeds)} in POLTYA/POLTYB. "
-            "See obsdata_mixedpol_plan.md.")
-
-    # TODO (Phase 7 mixed-pol): read POLTYA/POLTYB from the AIPS AN table
-    # to populate per-station feed_type. Until then, assume circular feeds.
-    tarr = [np.array((
-            str(tnames[i]), xyz[i][0], xyz[i][1], xyz[i][2],
-            sefdr[i], sefdl[i], dr[i], dl[i],
-            fr_par[i], fr_el[i], fr_off[i], 'rl'),
-        dtype=ehc.DTARR) for i in range(len(tnames))]
-
-    tarr = np.array(tarr)
+    tarr, tnums = _read_antenna_table(hdulist)
 
     # Various header parameters
-    try:
-        ra = header['OBSRA'] * 12. / 180.
-        dec = header['OBSDEC']
-    except KeyError:
-        if header['CTYPE6'] == 'RA':
-            ra = header['CRVAL6'] * 12. / 180.
-        else:
-            raise Exception('Cannot find RA!')
-        if header['CTYPE7'] == 'DEC':
-            dec = header['CRVAL7']
-        else:
-            raise Exception('Cannot find DEC!')
-
-    # catch bug if RA is in decimal degrees and > 24
-    if ra>24 and ra>=0:
-        ranew = ra*12/180.
-        if ranew<24:
-            print(f' Warning! file RA>24, interpreting as decimal deg. : {ra:.3f} deg -> {ranew:.3f} hr')
-            ra = ranew
-        else:
-            raise Exception(f"Cannot interpret fits file RA {ra:.3f}!")
-    elif ra<0:
-        raise Exception(f'fits file RA {ra:.3f}<0!')
-
-    src = header['OBJECT']
+    ra, dec, src = _read_source_position(header)
     rf = hdulist['AIPS AN'].header['FREQ']
 
     if header['CTYPE4'] == 'FREQ':
@@ -1350,21 +1391,7 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
     mjd = int(np.min(jds) - 2400000.5)
     times = (jds - 2400000.5 - mjd) * 24.0
 
-    try:
-        scantable = []
-        nxtable = hdulist['AIPS NX']
-        for scan in nxtable.data:
-            scan_start = scan['TIME']  # in days since reference date
-            scan_dur = scan['TIME INTERVAL']
-            startvis = scan['START VIS'] - 1
-            endvis = scan['END VIS'] - 1
-            scantable.append([scan_start - 0.5 * scan_dur,
-                              scan_start + 0.5 * scan_dur])
-        scantable = np.array(scantable) * 24
-
-    except BaseException:
-        print("No NX table in uvfits!")
-        scantable = None
+    scantable = _read_scan_table(hdulist)
 
     # Integration times
     try:
@@ -1552,8 +1579,7 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
         datatable = np.array(datatable)
 
     obs = ehtim.obsdata.Obsdata(ra, dec, rf, bw, datatable, tarr, polrep=polrep_uvfits,
-                                source=src, mjd=mjd, scantable=scantable,
-                                speedups=speedups)
+                                source=src, mjd=mjd, scantable=scantable)
 
     if remove_nan:
         if polrep_uvfits == 'circ':
@@ -1629,66 +1655,10 @@ def load_obs_uvfits_spectral(filename, polrep: str = 'stokes', flipbl: bool = Fa
     data = hdulist[0].data
 
     # --- antenna table -> tarr (circular / Stokes feeds only) ---
-    tnames = hdulist['AIPS AN'].data['ANNAME']
-    tnums = hdulist['AIPS AN'].data['NOSTA'] - 1
-    xyz = np.real(hdulist['AIPS AN'].data['STABXYZ'])
-    try:
-        sefdr = np.real(hdulist['AIPS AN'].data['SEFD'])
-        sefdl = np.real(hdulist['AIPS AN'].data['SEFD'])
-    except KeyError:
-        sefdr = np.zeros(len(tnames))
-        sefdl = np.zeros(len(tnames))
-    fr_par = np.zeros(len(tnames))
-    fr_el = np.zeros(len(tnames))
-    fr_off = np.zeros(len(tnames))
-    dr = np.zeros(len(tnames), dtype=complex)
-    dl = np.zeros(len(tnames), dtype=complex)
-
-    # Linear / mixed feeds are handled by the mixed-pol loader, not here.
-    feeds = set()
-    for col in ('POLTYA', 'POLTYB'):
-        try:
-            poltys = hdulist['AIPS AN'].data[col]
-        except KeyError:
-            continue
-        for p in poltys:
-            s = (p.decode() if isinstance(p, bytes) else str(p)).strip().upper()
-            if s:
-                feeds.add(s)
-    if not feeds <= {'R', 'L'}:
-        raise NotImplementedError(
-            "load_uvfits_spectral supports only circular/Stokes feeds; detected "
-            f"{sorted(feeds)} in POLTYA/POLTYB. Linear/mixed-feed uvfits loading "
-            "is handled by the mixed-polarization loader.")
-
-    tarr = np.array([np.array((
-        str(tnames[i]), xyz[i][0], xyz[i][1], xyz[i][2],
-        sefdr[i], sefdl[i], dr[i], dl[i],
-        fr_par[i], fr_el[i], fr_off[i], 'rl'), dtype=ehc.DTARR)
-        for i in range(len(tnames))])
+    tarr, tnums = _read_antenna_table(hdulist)
 
     # --- source position and name ---
-    try:
-        ra = header['OBSRA'] * 12. / 180.
-        dec = header['OBSDEC']
-    except KeyError:
-        if header.get('CTYPE6') == 'RA':
-            ra = header['CRVAL6'] * 12. / 180.
-        else:
-            raise Exception('Cannot find RA!')
-        if header.get('CTYPE7') == 'DEC':
-            dec = header['CRVAL7']
-        else:
-            raise Exception('Cannot find DEC!')
-    if ra > 24 and ra >= 0:
-        ranew = ra * 12 / 180.
-        if ranew < 24:
-            ra = ranew
-        else:
-            raise Exception(f"Cannot interpret fits file RA {ra:.3f}!")
-    elif ra < 0:
-        raise Exception(f'fits file RA {ra:.3f}<0!')
-    src = header['OBJECT']
+    ra, dec, src = _read_source_position(header)
 
     # --- frequency grid: reference freq + per-IF offset + per-channel step ---
     if header['CTYPE4'] != 'FREQ':
@@ -1811,16 +1781,7 @@ def load_obs_uvfits_spectral(filename, polrep: str = 'stokes', flipbl: bool = Fa
         vv = -vv
 
     # Scan table (shared across channels).
-    try:
-        scantable = []
-        for scan in hdulist['AIPS NX'].data:
-            scan_start = scan['TIME']
-            scan_dur = scan['TIME INTERVAL']
-            scantable.append([scan_start - 0.5 * scan_dur,
-                              scan_start + 0.5 * scan_dur])
-        scantable = np.array(scantable) * 24
-    except BaseException:
-        scantable = None
+    scantable = _read_scan_table(hdulist)
 
     if polrep_uvfits == 'circ':
         dtpol_out = ehc.DTPOL_CIRC
@@ -1942,7 +1903,7 @@ def load_obs_uvfits_spectral(filename, polrep: str = 'stokes', flipbl: bool = Fa
             bw = ch_bw * len(chg) * len(ifg)
             obs = ehtim.obsdata.Obsdata(ra, dec, freq, bw, datatable, tarr,
                                         polrep=polrep_uvfits, source=src, mjd=mjd,
-                                        scantable=scantable, speedups=True)
+                                        scantable=scantable)
             if remove_nan and polrep_uvfits == 'circ':
                 (obs.data['rrsigma'], obs.data['llsigma'],
                  obs.data['rlsigma'], obs.data['lrsigma']) = _fill_nan_sigmas(

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -123,8 +123,7 @@ class Obsdata:
 
     def __init__(self, ra, dec, rf, bw, datatable, tarr, scantable=None,
                  polrep='stokes', source=ehc.SOURCE_DEFAULT, mjd=ehc.MJD_DEFAULT, timetype='UTC',
-                 ampcal=True, phasecal=True, opacitycal=True, dcal=True, frcal=True,
-                 speedups=False):
+                 ampcal=True, phasecal=True, opacitycal=True, dcal=True, frcal=True):
         """A polarimetric VLBI observation of visibility amplitudes and phases (in Jy).
 
            Args:
@@ -256,7 +255,7 @@ class Obsdata:
             self.reorder_tarr_sefd(reorder_baselines=False)
 
         # reorder baselines to uvfits convention
-        self.reorder_baselines(speedups=speedups)
+        self.reorder_baselines()
 
         # Get tstart, mjd and tstop
         times = self.unpack(['time'])['time']
@@ -511,7 +510,7 @@ class Obsdata:
 
         return newobs
 
-    def reorder_baselines(self, speedups=False):
+    def reorder_baselines(self):
         """Reorder baselines to canonical order (tkey[t1] < tkey[t2]) and handle duplicates.
 
         Within each timestep, any row whose baseline is in reversed order is swapped
@@ -526,10 +525,6 @@ class Obsdata:
             ``UserWarning`` is emitted and only the first row is kept. The
             single-frequency Obsdata schema cannot represent per-channel data,
             so loaders that flatten multi-channel files lose information here.
-
-        Args:
-            speedups (bool): kept for API compatibility; the implementation
-                is now always vectorized and this flag has no effect.
         """
         dat = self.data.copy()
 

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -124,7 +124,7 @@ class Obsdata:
     def __init__(self, ra, dec, rf, bw, datatable, tarr, scantable=None,
                  polrep='stokes', source=ehc.SOURCE_DEFAULT, mjd=ehc.MJD_DEFAULT, timetype='UTC',
                  ampcal=True, phasecal=True, opacitycal=True, dcal=True, frcal=True,
-                 trial_speedups=False):
+                 speedups=False):
         """A polarimetric VLBI observation of visibility amplitudes and phases (in Jy).
 
            Args:
@@ -256,7 +256,7 @@ class Obsdata:
             self.reorder_tarr_sefd(reorder_baselines=False)
 
         # reorder baselines to uvfits convention
-        self.reorder_baselines(trial_speedups=trial_speedups)
+        self.reorder_baselines(speedups=speedups)
 
         # Get tstart, mjd and tstop
         times = self.unpack(['time'])['time']
@@ -511,7 +511,7 @@ class Obsdata:
 
         return newobs
 
-    def reorder_baselines(self, trial_speedups=False):
+    def reorder_baselines(self, speedups=False):
         """Reorder baselines to canonical order (tkey[t1] < tkey[t2]) and handle duplicates.
 
         Within each timestep, any row whose baseline is in reversed order is swapped
@@ -528,7 +528,7 @@ class Obsdata:
             so loaders that flatten multi-channel files lose information here.
 
         Args:
-            trial_speedups (bool): kept for API compatibility; the implementation
+            speedups (bool): kept for API compatibility; the implementation
                 is now always vectorized and this flag has no effect.
         """
         dat = self.data.copy()
@@ -4604,8 +4604,10 @@ def load_txt(fname, polrep='stokes'):
 def load_uvfits(fname, flipbl=False, remove_nan=False, force_singlepol=None,
                 channel=all, IF=all, polrep='stokes', allow_singlepol=True,
                 ignore_pzero_date=True,
-                trial_speedups=False,
-                invvar_channel_avg=True):
+                speedups=True,
+                invvar_channel_avg=True,
+                average_if=True,
+                average_channel=True):
     """Load observation data from a uvfits file.
 
        Args:
@@ -4619,21 +4621,32 @@ def load_uvfits(fname, flipbl=False, remove_nan=False, force_singlepol=None,
            remove_nan (bool): whether or not to remove entries with nan data
            ignore_pzero_date (bool): if True, ignore the offset parameters in DATE field
                                      TODO: what is the correct behavior per AIPS memo 117?
-           trial_speedups (bool): if True, use faster array/telescope handling paths
+           speedups (bool): if True (default), use the faster vectorized read paths
            invvar_channel_avg (bool): if True, average IFs/channels with inverse-variance
                                       weighting. If False, use simple averaging.
+           average_if (bool): if True (default), average over all IFs; if False, keep
+                              each IF/SPW as its own frequency point (returns a list)
+           average_channel (bool): if True (default), average the fine channels within
+                              each IF; if False, keep each channel (returns a list)
        Returns:
-           obs (Obsdata): Obsdata object loaded from file
+           obs (Obsdata): the averaged observation, if average_if and average_channel
+           obslist (list of Obsdata): one per surviving (IF-group, channel-group) otherwise
     """
+
+    if not (average_if and average_channel):
+        return ehtim.io.load.load_obs_uvfits_spectral(
+            fname, polrep=polrep, flipbl=flipbl, allow_singlepol=allow_singlepol,
+            force_singlepol=force_singlepol, channel=channel, IF=IF,
+            remove_nan=remove_nan, invvar_channel_avg=invvar_channel_avg,
+            ignore_pzero_date=ignore_pzero_date,
+            average_if=average_if, average_channel=average_channel)
 
     return ehtim.io.load.load_obs_uvfits(fname, flipbl=flipbl, force_singlepol=force_singlepol,
                                          channel=channel, IF=IF, polrep=polrep,
                                          remove_nan=remove_nan, allow_singlepol=allow_singlepol,
                                          ignore_pzero_date=ignore_pzero_date,
-                                         trial_speedups=trial_speedups,
+                                         speedups=speedups,
                                          invvar_channel_avg=invvar_channel_avg)
-
-
 
 
 def load_maps(arrfile, obsspec, ifile, qfile=0, ufile=0, vfile=0,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -5,6 +5,7 @@ import os
 
 import numpy as np
 import pytest
+from astropy.io import fits
 
 import ehtim as eh
 from ehtim.io import load
@@ -26,15 +27,15 @@ def test_load_obs_uvfits():
 @pytest.mark.parametrize("path", UVFITS_FILES,
                          ids=[os.path.basename(p) for p in UVFITS_FILES])
 @pytest.mark.parametrize("polrep", ["stokes", "circ"])
-def test_load_obs_uvfits_trial_speedups_matches_default(path, polrep):
-    """The trial_speedups paths in load_obs_uvfits (vectorized site lookup,
+def test_load_obs_uvfits_speedups_matches_default(path, polrep):
+    """The vectorized `speedups` paths in load_obs_uvfits (vectorized site lookup,
     alternate datatable assembly) must produce data and tarr identical to the
-    default paths, across every uvfits file in the data directory and both
-    polreps."""
-    obs_default = load.load_obs_uvfits(path, polrep=polrep, trial_speedups=False)
-    obs_trial = load.load_obs_uvfits(path, polrep=polrep, trial_speedups=True)
-    np.testing.assert_array_equal(obs_default.data, obs_trial.data)
-    np.testing.assert_array_equal(obs_default.tarr, obs_trial.tarr)
+    legacy paths, across every uvfits file in the data directory and both
+    polreps. This is the verification the 'speedups' default relies on."""
+    obs_legacy = load.load_obs_uvfits(path, polrep=polrep, speedups=False)
+    obs_fast = load.load_obs_uvfits(path, polrep=polrep, speedups=True)
+    np.testing.assert_array_equal(obs_legacy.data, obs_fast.data)
+    np.testing.assert_array_equal(obs_legacy.tarr, obs_fast.tarr)
 
 
 def test_load_array_txt():
@@ -67,3 +68,196 @@ def test_fill_nan_sigmas_order_dependent():
     np.testing.assert_array_equal(lrf, [9.0, 2.0, 1.0, nan])
     # inputs not mutated
     np.testing.assert_array_equal(rr, [nan, 2.0, 1.0, nan])
+
+
+# ---------------------------------------------------------------------------
+# Non-averaging load path: load_uvfits(average_if=..., average_channel=...)
+#
+# The default averages all channels/IFs into one Obsdata; setting either flag
+# False keeps that axis resolved and returns a list of Obsdata. Real multi-channel
+# data here is synthetic -- a saved single-channel obs with its FREQ axis tiled --
+# so these run in CI; two guarded tests use the real HL Tau files when present.
+# ---------------------------------------------------------------------------
+
+_HLTAU = "/scratch/year/rdahale/jax-ehtim/benchmarks/hltau_example"
+_HLTAU_SINGLE = os.path.join(_HLTAU, "hltau_mf_223.8.uvfits")
+_HLTAU_LINEAR = os.path.join(_HLTAU, "ALMA_data/Band7/HLTau_Band7_spw02_polswap.uvfits")
+
+_FACTORS = [1.0, 2.0, 0.5]
+_CDELT = 2.0e8
+
+
+def _expand_channels(inpath, outpath, factors=_FACTORS, cdelt=_CDELT, flag_channel=None):
+    """Tile a single-channel uvfits's FREQ axis into len(factors) channels.
+
+    Channel c's visibilities (not weights) are scaled by factors[c] so each channel
+    is distinguishable, and CDELT4 is set to `cdelt` to give the channels distinct
+    frequencies. If flag_channel is given, that channel's weights are zeroed.
+    """
+    h = fits.open(inpath)
+    gd = h[0].data
+    dat = np.asarray(gd["DATA"])
+    new = np.repeat(dat, len(factors), axis=4)                 # tile the FREQ axis
+    for c, f in enumerate(factors):
+        new[:, :, :, :, c, :, 0:2] *= f                        # scale re + im only
+    if flag_channel is not None:
+        new[:, :, :, :, flag_channel, :, 2] = 0.0              # zero that channel's weights
+    pars = list(gd.parnames)
+    pardata = [gd.par(i) for i in range(len(pars))]
+    h[0].data = fits.GroupData(new.astype("float32"), parnames=pars, pardata=pardata, bitpix=-32)
+    h[0].header["CDELT4"] = cdelt
+    h.writeto(outpath, overwrite=True)
+    h.close()
+
+
+def _set_linear_feeds(inpath, outpath):
+    """Rewrite the antenna table's POLTYA/POLTYB feed columns to linear (X/Y)."""
+    h = fits.open(inpath)
+    an = h["AIPS AN"]
+    for col, val in (("POLTYA", "X"), ("POLTYB", "Y")):
+        if col in an.data.columns.names:
+            an.data[col] = np.array([val] * len(an.data))
+    h.writeto(outpath, overwrite=True)
+    h.close()
+
+
+def _keyed(obs):
+    """Return obs.data sorted by (time, t1, t2) so two loads line up row-for-row."""
+    d = obs.data
+    return d[np.lexsort((d["t2"], d["t1"], d["time"]))]
+
+
+@pytest.fixture
+def single_uvfits(obs_direct, tmp_path):
+    """A single-channel circular uvfits saved from the noise-free Gaussian obs."""
+    path = str(tmp_path / "single.uvfits")
+    obs_direct.save_uvfits(path)
+    return path
+
+
+@pytest.fixture
+def multichan_uvfits(single_uvfits, tmp_path):
+    """The single-channel file expanded to 3 channels scaled by _FACTORS."""
+    path = str(tmp_path / "multi.uvfits")
+    _expand_channels(single_uvfits, path)
+    return path
+
+
+def test_load_uvfits_default_returns_single_obsdata(single_uvfits):
+    """Default (average everything) still returns one Obsdata, not a list."""
+    assert isinstance(eh.obsdata.load_uvfits(single_uvfits), eh.obsdata.Obsdata)
+
+
+def test_load_uvfits_average_channel_false_returns_list(single_uvfits):
+    """Keeping the channel axis returns a list, even for a single channel."""
+    out = eh.obsdata.load_uvfits(single_uvfits, average_channel=False)
+    assert isinstance(out, list) and len(out) == 1
+    assert isinstance(out[0], eh.obsdata.Obsdata)
+
+
+def test_load_uvfits_single_channel_spectral_matches_average(single_uvfits):
+    """On a single-channel file the resolved and averaged loads read the same data."""
+    ref = eh.obsdata.load_uvfits(single_uvfits, polrep="circ")
+    spec = eh.obsdata.load_uvfits(single_uvfits, polrep="circ", average_channel=False)[0]
+    a, b = _keyed(ref), _keyed(spec)
+    assert len(a) == len(b)
+    np.testing.assert_allclose(a["rrvis"], b["rrvis"], rtol=1e-5, atol=1e-6, equal_nan=True)
+    np.testing.assert_allclose(a["rrsigma"], b["rrsigma"], rtol=1e-5, atol=1e-8, equal_nan=True)
+    # rf and u,v also agree (the FREQ-axis CRVAL4 equals the AN-table FREQ on a well-formed file)
+    assert np.isclose(ref.rf, spec.rf, rtol=1e-12)
+    np.testing.assert_allclose(a["u"], b["u"], rtol=1e-6)
+    np.testing.assert_allclose(a["v"], b["v"], rtol=1e-6)
+
+
+def test_load_uvfits_channel_selection(multichan_uvfits):
+    """channel=[...] with average_channel=False loads only the requested channels."""
+    obslist = eh.obsdata.load_uvfits(multichan_uvfits, polrep="circ",
+                                     channel=[0, 2], average_if=False, average_channel=False)
+    assert len(obslist) == 2
+    crval4 = fits.open(multichan_uvfits)[0].header["CRVAL4"]
+    rfs = sorted(o.rf for o in obslist)
+    np.testing.assert_allclose(rfs, [crval4, crval4 + 2 * _CDELT], rtol=1e-12)
+
+
+def test_load_uvfits_multichannel_split(single_uvfits, multichan_uvfits):
+    """Both axes resolved -> one Obsdata per channel, with per-channel freq and u,v."""
+    obslist = eh.obsdata.load_uvfits(multichan_uvfits, polrep="circ",
+                                     average_if=False, average_channel=False)
+    assert len(obslist) == len(_FACTORS)
+
+    crval4 = fits.open(multichan_uvfits)[0].header["CRVAL4"]
+    rfs = np.array([o.rf for o in obslist])
+    np.testing.assert_allclose(rfs, crval4 + np.arange(len(_FACTORS)) * _CDELT, rtol=1e-12)
+
+    base_obs = eh.obsdata.load_uvfits(single_uvfits, polrep="circ")
+    base = _keyed(base_obs)
+    for c, f in enumerate(_FACTORS):
+        ch = _keyed(obslist[c])
+        # channel c's visibilities are the base scaled by factors[c]
+        np.testing.assert_allclose(ch["rrvis"], f * base["rrvis"], rtol=1e-5, atol=1e-6,
+                                   equal_nan=True)
+        # u,v are scaled by that channel's frequency, so u/rf recovers the shared UU
+        np.testing.assert_allclose(ch["u"] / obslist[c].rf, base["u"] / base_obs.rf, rtol=1e-6)
+
+    # the per-channel u,v really differ (the frequency scaling was applied)
+    assert not np.allclose(_keyed(obslist[0])["u"], _keyed(obslist[-1])["u"])
+
+
+def test_load_uvfits_multichannel_default_averages(single_uvfits, multichan_uvfits):
+    """Default load of the multichannel file is the inverse-variance channel average."""
+    avg = eh.obsdata.load_uvfits(multichan_uvfits, polrep="circ")
+    assert isinstance(avg, eh.obsdata.Obsdata)
+    base = _keyed(eh.obsdata.load_uvfits(single_uvfits, polrep="circ"))
+    # equal per-channel weights, so the average is the mean of the channel scalings
+    expected = (sum(_FACTORS) / len(_FACTORS)) * base["rrvis"]
+    np.testing.assert_allclose(_keyed(avg)["rrvis"], expected, rtol=1e-4, atol=1e-6,
+                               equal_nan=True)
+
+
+def test_load_uvfits_average_if_false_single_if_averages_channels(multichan_uvfits):
+    """With one IF, average_if=False still averages the channels -> a one-element list."""
+    both = eh.obsdata.load_uvfits(multichan_uvfits, polrep="circ")            # both averaged
+    out = eh.obsdata.load_uvfits(multichan_uvfits, polrep="circ", average_if=False)
+    assert isinstance(out, list) and len(out) == 1
+    np.testing.assert_allclose(_keyed(out[0])["rrvis"], _keyed(both)["rrvis"],
+                               rtol=1e-6, equal_nan=True)
+
+
+def test_load_uvfits_empty_channel_skipped(single_uvfits, tmp_path):
+    """A fully-flagged channel is dropped from the returned list."""
+    path = str(tmp_path / "flagged.uvfits")
+    _expand_channels(single_uvfits, path, factors=[1.0, 1.0, 1.0], flag_channel=1)
+    obslist = eh.obsdata.load_uvfits(path, polrep="circ",
+                                     average_if=False, average_channel=False)
+    assert len(obslist) == 2
+
+
+def test_load_uvfits_linear_feed_raises(single_uvfits, tmp_path):
+    """Linear/mixed feeds are out of scope for this loader and must raise."""
+    path = str(tmp_path / "linear.uvfits")
+    _set_linear_feeds(single_uvfits, path)
+    with pytest.raises(NotImplementedError):
+        eh.obsdata.load_uvfits(path, average_channel=False)
+
+
+def test_load_uvfits_trial_speedups_kwarg_removed(single_uvfits):
+    """The old experimental `trial_speedups` name is gone (renamed to `speedups`)."""
+    with pytest.raises(TypeError):
+        eh.obsdata.load_uvfits(single_uvfits, trial_speedups=True)
+
+
+@pytest.mark.skipif(not os.path.exists(_HLTAU_SINGLE), reason="HL Tau data not present")
+def test_load_uvfits_real_hltau_single_channel():
+    """On a real single-channel HL Tau file the resolved load matches the averaged load."""
+    ref = eh.obsdata.load_uvfits(_HLTAU_SINGLE, polrep="circ")
+    spec = eh.obsdata.load_uvfits(_HLTAU_SINGLE, polrep="circ", average_channel=False)
+    assert len(spec) == 1
+    a, b = _keyed(ref), _keyed(spec[0])
+    np.testing.assert_allclose(a["rrvis"], b["rrvis"], rtol=1e-5, atol=1e-6, equal_nan=True)
+
+
+@pytest.mark.skipif(not os.path.exists(_HLTAU_LINEAR), reason="HL Tau linear data not present")
+def test_load_uvfits_real_linear_feed_raises():
+    """The real linear-feed ALMA file raises (confirms the feed guard on genuine data)."""
+    with pytest.raises(NotImplementedError):
+        eh.obsdata.load_uvfits(_HLTAU_LINEAR, average_channel=False)

--- a/tests/test_obsdata.py
+++ b/tests/test_obsdata.py
@@ -235,22 +235,14 @@ def test_reorder_baselines_time_sorted(obs_direct):
     assert np.all(np.diff(obs_direct.data["time"]) >= 0)
 
 
-def test_speedups_matches_default(obs_direct):
-    # The speedups flag in reorder_baselines is now a no-op; both
-    # invocations must produce byte-identical output, including when the
-    # input contains conjugate pairs and true duplicates.
-    extra = obs_direct.data[0].copy()
-    extra["t1"], extra["t2"] = obs_direct.data[0]["t2"], obs_direct.data[0]["t1"]
-    extra["u"], extra["v"] = -obs_direct.data[0]["u"], -obs_direct.data[0]["v"]
-    extra["vis"] = np.conj(obs_direct.data[0]["vis"])
-    seeded = obs_direct.copy()
-    seeded.data = np.concatenate([obs_direct.data, np.array([extra], dtype=obs_direct.data.dtype)])
+def test_reorder_baselines_speedups_kwarg_removed(obs_direct):
+    """reorder_baselines is always vectorized now, so the old flag is gone.
 
-    obs_legacy = seeded.copy()
-    obs_legacy.reorder_baselines(speedups=False)
-    obs_fast = seeded.copy()
-    obs_fast.reorder_baselines(speedups=True)
-    np.testing.assert_array_equal(obs_legacy.data, obs_fast.data)
+    The behaviour it used to guard is covered by the conjugate-pair and duplicate
+    tests below.
+    """
+    with pytest.raises(TypeError):
+        obs_direct.reorder_baselines(speedups=True)
 
 
 def _seed_extra_row(obs, **overrides):

--- a/tests/test_obsdata.py
+++ b/tests/test_obsdata.py
@@ -235,8 +235,8 @@ def test_reorder_baselines_time_sorted(obs_direct):
     assert np.all(np.diff(obs_direct.data["time"]) >= 0)
 
 
-def test_trial_speedups_matches_default(obs_direct):
-    # The trial_speedups flag in reorder_baselines is now a no-op; both
+def test_speedups_matches_default(obs_direct):
+    # The speedups flag in reorder_baselines is now a no-op; both
     # invocations must produce byte-identical output, including when the
     # input contains conjugate pairs and true duplicates.
     extra = obs_direct.data[0].copy()
@@ -246,11 +246,11 @@ def test_trial_speedups_matches_default(obs_direct):
     seeded = obs_direct.copy()
     seeded.data = np.concatenate([obs_direct.data, np.array([extra], dtype=obs_direct.data.dtype)])
 
-    obs_default = seeded.copy()
-    obs_default.reorder_baselines(trial_speedups=False)
-    obs_trial = seeded.copy()
-    obs_trial.reorder_baselines(trial_speedups=True)
-    np.testing.assert_array_equal(obs_default.data, obs_trial.data)
+    obs_legacy = seeded.copy()
+    obs_legacy.reorder_baselines(speedups=False)
+    obs_fast = seeded.copy()
+    obs_fast.reorder_baselines(speedups=True)
+    np.testing.assert_array_equal(obs_legacy.data, obs_fast.data)
 
 
 def _seed_extra_row(obs, **overrides):


### PR DESCRIPTION
Multi-frequency ALMA/VLA imaging needs each channel/IF kept as its own frequency point, loaded without the per-record loops that don't finish on large unaveraged files. The averaging default is unchanged, so existing scripts are unaffected.

1. `load_uvfits` now has `average_if` and `average_channel` (both default True). Left at the default it behaves exactly as before, one averaged `Obsdata`. Set either to False and it keeps that spectral axis resolved and returns a `list[Obsdata]`, one per surviving frequency group, each with its own reference frequency and its own u,v. That list is exactly what the multi-frequency imager takes as its obslist, so you can go straight from one native multi-channel / multi-IF uvfits to an mf obslist instead of pre-splitting per-SPW by hand in CASA.

2. **`trial_speedups` → `speedups`, default True.** The vectorized read paths added in 2022 are now verified identical to the legacy, so `load_uvfits` uses them by default and the flag drops the "trial". This makes the default load fast.

## How it works

New internal `load_obs_uvfits_spectral` reads the DATA one (IF, channel) slice at a time and groups the (IF, channel) grid — an averaged axis collapses to a single inverse-variance group, a kept axis yields one group per index. `load_obs_uvfits` (the averaged path) is unchanged apart from the rename.

## Backward-compatibility

- **`trial_speedups` renamed.** It was an experimental opt-in (default False), so external use should be near nil, but a script passing `trial_speedups=...` now gets a `TypeError`
- `Obsdata` when both flags are True (the default), `list[Obsdata]` otherwise.
