### PR TITLE
obs_helpers: seed noise from crc32 instead of builtin hash

### DIFF
--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -28,6 +28,7 @@ import copy
 import itertools as it
 import sys
 import warnings
+import zlib
 
 import astropy.time as at
 import finufft
@@ -1276,18 +1277,33 @@ def cerror(sigma):
     return noise
 
 
+def _stable_seed(*args):
+    """Deterministic 32-bit seed derived from the repr of *args.
+
+    Used to seed numpy from a collection of arguments (station names, time,
+    polarization, ...) so that a given quantity always draws the same random
+    value regardless of data ordering. Uses zlib.crc32 rather than the builtin
+    hash(): CPython salts str/bytes hashing per process (PYTHONHASHSEED), so
+    hash() gives a different seed -- and different noise -- every run, whereas
+    crc32 of the same text is identical across processes, machines, and Python
+    versions. crc32 already returns a value in [0, 2**32 - 1], the valid range
+    for np.random.seed.
+    """
+    return zlib.crc32(",".join(map(repr, args)).encode())
+
+
 def cerror_hash(sigma, *args):
     """Return a complex number drawn from a circular complex Gaussian of zero mean
     """
 
     reargs = list(args)
     reargs.append('re')
-    np.random.seed(hash(",".join(map(repr, reargs))) % 4294967295)
+    np.random.seed(_stable_seed(*reargs))
     re = np.random.randn()
 
     imargs = list(args)
     imargs.append('im')
-    np.random.seed(hash(",".join(map(repr, imargs))) % 4294967295)
+    np.random.seed(_stable_seed(*imargs))
     im = np.random.randn()
 
     err = sigma * (re + 1j*im)
@@ -1298,7 +1314,7 @@ def cerror_hash(sigma, *args):
 def hashmultivariaterandn(size, cov, *args):
     """set the seed according to a collection of arguments and return random multivariate gaussian var
     """
-    np.random.seed(hash(",".join(map(repr, args))) % 4294967295)
+    np.random.seed(_stable_seed(*args))
     mean = np.zeros(size)
     noise = np.random.multivariate_normal(mean, cov, check_valid='ignore')
     return noise
@@ -1308,7 +1324,7 @@ def hashrandn(*args):
     """set the seed according to a collection of arguments and return random gaussian var
     """
 
-    np.random.seed(hash(",".join(map(repr, args))) % 4294967295)
+    np.random.seed(_stable_seed(*args))
     noise = np.random.randn()
     return noise
 
@@ -1317,7 +1333,7 @@ def hashrand(*args):
     """set the seed according to a collection of arguments and return random number in 0,1
     """
 
-    np.random.seed(hash(",".join(map(repr, args))) % 4294967295)
+    np.random.seed(_stable_seed(*args))
     noise = np.random.rand()
     return noise
 

--- a/tests/test_obs_helpers.py
+++ b/tests/test_obs_helpers.py
@@ -1,16 +1,20 @@
-"""Tests for ehtim.observing.obs_helpers.
-
-Focus: the hash-seeded random helpers must be reproducible across Python
-processes. CPython salts str hashing per process (PYTHONHASHSEED), so seeding
-numpy from the builtin hash() produced different simulated noise every run;
-_stable_seed (zlib.crc32) makes the draws identical across processes.
-"""
+"""Tests for ehtim.observing.obs_helpers."""
 import os
 import subprocess
 import sys
 import zlib
 
 from ehtim.observing import obs_helpers as obsh
+
+
+# ---------------------------------------------------------------------------
+# Hash-seeded random helpers: reproducibility across processes
+#
+# The hash-seeded random helpers must be reproducible across Python processes.
+# CPython salts str hashing per process (PYTHONHASHSEED), so seeding numpy from
+# the builtin hash() produced different simulated noise every run; _stable_seed
+# (zlib.crc32) makes the draws identical across processes.
+# ---------------------------------------------------------------------------
 
 
 def test_stable_seed_matches_crc32():

--- a/tests/test_obs_helpers.py
+++ b/tests/test_obs_helpers.py
@@ -1,0 +1,53 @@
+"""Tests for ehtim.observing.obs_helpers.
+
+Focus: the hash-seeded random helpers must be reproducible across Python
+processes. CPython salts str hashing per process (PYTHONHASHSEED), so seeding
+numpy from the builtin hash() produced different simulated noise every run;
+_stable_seed (zlib.crc32) makes the draws identical across processes.
+"""
+import os
+import subprocess
+import sys
+import zlib
+
+from ehtim.observing import obs_helpers as obsh
+
+
+def test_stable_seed_matches_crc32():
+    # Pins the implementation to crc32 (process-independent), guarding against a
+    # regression back to the per-process-salted builtin hash().
+    assert obsh._stable_seed("ALMA", "APEX", 12.5, "rr") == \
+        zlib.crc32(b"'ALMA','APEX',12.5,'rr'")
+
+
+def test_stable_seed_in_numpy_seed_range():
+    # np.random.seed requires 0 <= seed < 2**32.
+    seed = obsh._stable_seed("x", 1, 2.0, "im")
+    assert 0 <= seed < 2**32
+
+
+# --- cross-process reproducibility ---------
+
+# Draw one thermal-noise value (cerror_hash) and one gain value (hashrandn) and
+# print them; the values must not depend on PYTHONHASHSEED.
+_SNIPPET = (
+    "from ehtim.observing import obs_helpers as obsh;"
+    "print('RESULT',"
+    " repr(obsh.cerror_hash(2.0, 'ALMA', 'APEX', 12.5, 'rr', 42)),"
+    " repr(obsh.hashrandn('SMT', 3.0, 'gain')))"
+)
+
+
+def _run_with_hashseed(hashseed):
+    env = {**os.environ, "PYTHONHASHSEED": hashseed}
+    out = subprocess.check_output([sys.executable, "-c", _SNIPPET], env=env, text=True)
+    lines = [ln for ln in out.splitlines() if ln.startswith("RESULT")]
+    assert lines, f"subprocess produced no RESULT line; output was:\n{out}"
+    return lines[-1]
+
+
+def test_hash_helpers_reproducible_across_processes():
+    # With the old builtin hash() these would differ per PYTHONHASHSEED but with
+    # crc32 the drawn values are byte-identical across salts.
+    results = {_run_with_hashseed(hs) for hs in ("0", "1", "999999")}
+    assert len(results) == 1, f"noise varied across PYTHONHASHSEED: {results}"

--- a/tests/test_obs_helpers.py
+++ b/tests/test_obs_helpers.py
@@ -6,7 +6,6 @@ import zlib
 
 from ehtim.observing import obs_helpers as obsh
 
-
 # ---------------------------------------------------------------------------
 # Hash-seeded random helpers: reproducibility across processes
 #


### PR DESCRIPTION
## What
The hash-seeded random helpers in `obs_helpers.py` (`cerror_hash`, `hashrandn`, `hashrand`, `hashmultivariaterandn`) seeded numpy from the builtin `hash()` of a repr string built from each quantity's identity (sites/time/pol/seed). They now route through a single new `_stable_seed()` helper that uses `zlib.crc32`.



## Why
CPython salts `str` hashing per process (`PYTHONHASHSEED`), so the seed and all simulated thermal noise and gain/D-term errors changed on every run, even with the same `seed` argument. `zlib.crc32` of the same text is identical across processes, machines, and Python versions, so simulated noise is now reproducible while preserving the per-quantity independence the helpers were designed for (draws keyed to a visibility's identity, independent of data ordering).

Surfaced while regression-testing simulated observations: clean (noise-free) obs were bit-identical across processes but noisy obs were not; pinning `PYTHONHASHSEED=0` made them identical, which pointed at the salted `hash()`.



## How to test
- `pytest tests/test_obs_helpers.py`  pins the crc32 implementation and asserts drawn noise/gain values are byte-identical across `PYTHONHASHSEED` ∈ {0, 1, 999999} via subprocesses (fails on the old `hash()`).
- Full calibration/noise sweep (`test_obs_simulate`, `test_self_cal`, `test_network_cal`, `test_pol_cal`, `test_polgains_cal`, `test_caltable`, `test_obsdata`): 340 passed.

## Notes
- Seed *values* change vs. the old code (crc32 ≠ hash), so noise realizations differ from previous runs but the old ones were never reproducible anyway.
- Kept separate from the mixed-pol work.