### PR TITLE
Mixed/linear-feed polarimetry: simulator + Jones + uvfits round-trip (Phase 6 & 7)

### DIFF
--- a/docs/polarization_conventions.md
+++ b/docs/polarization_conventions.md
@@ -434,3 +434,62 @@ Implemented at: `obs_simulate.add_jones_and_noise` (forward) and
 correlation basis; `Obsdata.switch_polrep` handles `stokes`↔`circ`/`lin`
 (a `mixed` obs must be built natively — switching *to* `'mixed'` is not
 yet supported).
+
+---
+
+## §13. uvfits encoding: the STOKES axis and AIPS feed tags
+
+Polarization enters a uvfits file in two independent places, and ehtim
+reads both.
+
+**(a) The STOKES axis (`CTYPE3 = 'STOKES'`).** AIPS Memo 117 defines this
+axis by its reference value `CRVAL3`, with the axis running in unit steps
+away from that reference (`CDELT3 = +1` for the Stokes block, `-1` for the
+two feed-product blocks). There are three blocks:
+
+| `CRVAL3` | slots | plane order | ehtim polrep |
+|---|---|---|---|
+| $+1$ | $1 \ldots 4$ | $I$, $Q$, $U$, $V$ | `'stokes'` |
+| $-1$ | $-1 \ldots -4$ | $RR$, $LL$, $RL$, $LR$ | `'circ'` |
+| $-5$ | $-5 \ldots -8$ | $XX$, $YY$, $XY$, $YX$ | `'lin'` |
+
+ehtim reads the four correlation planes **positionally** (slot 0 … slot 3),
+which is valid only for that standard unit step, so a `CDELT3` other than
+$+1$ / $-1$ is rejected rather than silently mis-slotted.
+
+**(b) The per-station feed tags (`POLTYA`/`POLTYB` in the `AIPS AN` table).**
+`POLTYA` is the station's first feed and `POLTYB` its second, giving the
+two-character `tarr['feed_type']` code (`'rl'`, `'xy'`, …).
+
+The two can disagree, and for mixed-feed arrays they *must*: a mixed array
+has no single global product block, so its STOKES axis is only a nominal
+4-slot grid and each baseline's four slots are the products of the two
+stations' own feeds. ehtim therefore treats the **station feed tags as
+authoritative** and uses `CRVAL3` only as a fallback (both POLTY columns
+absent) and as a consistency check:
+
+* homogeneous feeds contradicting the axis (linear planes at $-5$ tagged
+  $R$/$L$, or circular planes at $-1$ tagged $X$/$Y$) → raise;
+* mixed feeds under a $-1$ or $-5$ axis → warn (`FeedTagWarning`), load as
+  `'mixed'`;
+* both POLTY columns absent → infer `'xy'` from $-5$, else `'rl'`, and warn;
+* one POLTY column absent → complete each pair from the tag present
+  ($R \leftrightarrow L$, $X \leftrightarrow Y$), and warn;
+* a blank tag on a column that exists → raise. A writer that emits POLTY
+  and leaves it empty conveys nothing about the basis, and assuming circular
+  is exactly wrong for a mixed-pol observation.
+
+### Feed-character naming: X/Y vs V/H
+
+The latest revision of AIPS Memo 117 renames the linear feed characters
+**X and Y to V and H** (vertical and horizontal). **ehtim keeps X and Y**
+— in `POLTYA`/`POLTYB` parsing, in `feed_type` codes (`'xy'`), in the
+`DTPOL_LIN` column names (`xxvis`/`yyvis`/`xyvis`/`yxvis`) and throughout
+this document. The renaming is nomenclature only: the $-5$ slot block is
+the same physical set of linear products under either naming, and $X, Y$
+are the field components of §1. Files written with V/H feed tags are not
+currently recognized and will fail the feed-vocabulary check.
+
+Implemented at: `ehtim/io/load.py:load_obs_uvfits` (POLTY parsing, CRVAL3
+fallback and consistency checks) and `ehtim/io/save.py:save_obs_uvfits`
+(POLTY emission from `feed_type`, `CRVAL3` per `polrep_out`).

--- a/docs/polarization_conventions.md
+++ b/docs/polarization_conventions.md
@@ -300,45 +300,81 @@ For a baseline $(i, j)$ the observed coherency matrix is
 
 $$C^{ij}_{\text{obs}} = J_i \, C^{ij}_{\text{true}} \, J_j^\dagger,$$
 
-where $J_i, J_j$ are the per-station Jones matrices. Inverting gives
-the calibration formula in §11.
+where $J_i, J_j$ are the per-station Jones matrices. This **forward**
+direction is what simulation applies to corrupt clean visibilities; the
+**inverse** (§11) is what a-priori calibration applies. Both use the same
+per-station $J$, assembled in §10.
 
-(The full mixed-pol Jones treatment lives in Alex's mixed-pol imaging
-work. This module ships the per-station algebra so that downstream
-calibration code has a single home to call into.)
-
-Implemented at: scaffolding in
-`ehtim/observing/pol_conventions.py:310-330` (`jones_matrix`),
-`:332-337` (`invert_jones`), `:340-357`
-(`apply_inverse_jones_to_coherency`).
+Implemented at (`ehtim/observing/pol_conventions.py`): `assemble_jones`
+builds $J$; `apply_jones_to_coherency` applies the forward
+$J_1 C J_2^\dagger$; `apply_inverse_jones_to_coherency` / `invert_jones`
+apply the inverse. These are driven from `ehtim/observing/obs_simulate.py`:
+`make_jones` (random corruption) and `make_jones_inverse` (estimated
+inverse) build the per-station matrices; `add_jones_and_noise` and
+`apply_jones_inverse` apply them per baseline.
 
 ---
 
-## §10. Jones factoring: $J = G \cdot (I + D)$
+## §10. Jones factoring: $J = G \cdot (I + D) \cdot \Phi$
 
-ehtim factors a station's Jones matrix into a diagonal complex gain and
-a D-term cross-coupling matrix:
+ehtim factors a station's Jones matrix into a complex gain, a D-term
+cross-coupling, and a field-rotation factor (EHT Paper VII,
+[arXiv:2105.01169](https://arxiv.org/pdf/2105.01169), Eq. 4):
 
-$$J = G \cdot (I + D), \quad
-  G = \begin{pmatrix} g_{p_1} & 0 \\ 0 & g_{p_2} \end{pmatrix}, \quad
+$$J = G \cdot (I + D) \cdot \Phi.$$
+
+Here $D$ denotes the off-diagonal leakage matrix so that $I+D$ is the full leakage operator.
+
+### Gain and leakage ($G$, $I + D$)
+
+$$G = \begin{pmatrix} g_{p_1} & 0 \\ 0 & g_{p_2} \end{pmatrix}, \qquad
   I + D = \begin{pmatrix} 1 & d_{p_1} \\ d_{p_2} & 1 \end{pmatrix}.$$
-
-Equivalently,
-
-$$J = \begin{pmatrix} g_{p_1} & g_{p_1} d_{p_1} \\
-                       g_{p_2} d_{p_2} & g_{p_2} \end{pmatrix}.$$
 
 The $d_{p_1}, d_{p_2}$ entries are the per-feed leakage of the
 *other* feed into this one (so $d_{p_1}$ is the leakage of $p_2$ into
-$p_1$).
+$p_1$). This matches the convention used in CASA's polcal and in the
+EHT calibration pipeline. When the first full-Jones `applycal` lands,
+verify against existing `pol_cal*` code — flip here if a sign mismatch
+is found.
 
-This factoring matches the convention used in CASA's polcal and in the
-EHT calibration pipeline. When the first consumer (full-Jones
-`applycal`) lands, verify against existing `pol_cal*` code in this
-repo — flip here if a sign mismatch is found.
+### Field rotation ($\Phi$) — basis dependent
 
-Implemented at: `ehtim/observing/pol_conventions.py:310-330`
-(`jones_matrix`).
+Field rotation by angle $\varphi$ (from the station mount geometry,
+$\varphi = \texttt{fr\_elev}\cdot\text{el} + \texttt{fr\_par}\cdot\text{par}
++ \texttt{fr\_off}$) acts *differently in each feed basis*:
+
+- **Circular feeds** ($p_1,p_2 = R,L$): a diagonal phase,
+  $$\Phi_{\text{circ}} = \begin{pmatrix} e^{-i\varphi} & 0 \\ 0 & e^{+i\varphi}\end{pmatrix}.$$
+- **Linear feeds** ($p_1,p_2 = X,Y$): a real rotation of the feed axes,
+  $$\Phi_{\text{lin}} = \begin{pmatrix} \cos\varphi & \sin\varphi \\ -\sin\varphi & \cos\varphi \end{pmatrix}.$$
+
+These are the *same physical operator* in two bases: with $F = $
+`BASIS_LIN_TO_CIRC` (§2), $\Phi_{\text{lin}} = F^{-1}\,\Phi_{\text{circ}}\,F$
+(verified for all $\varphi$). So the linear form is **not** a free
+choice once the circular convention is fixed.
+
+> **Convention assumption (to verify):** the circular
+> $\Phi_{\text{circ}} = \mathrm{diag}(e^{-i\varphi}, e^{+i\varphi})$
+> (with $R = p_1$) is taken as the reference, matching the existing
+> `obs_simulate.make_jones` behavior; the derived $\Phi_{\text{lin}}$ and
+> the sign of $\varphi$ (from `fr_elev`/`fr_par`) are assumed to match
+> Paper VII's field-rotation Jones. Hybrid feeds (e.g. `'rx'`, one
+> circular + one linear channel) have no agreed field-rotation
+> convention and are not yet supported.
+
+### Field-rotation-corrected residual
+
+When field rotation has already been removed from the data but leakage
+has not, the leakage must "double-rotate." The assembly carries a
+second angle `fr_angle_D` and applies $J = G\,(I + \Phi_D^{-1} D)\,\Phi$,
+where $\Phi_D^{-1} = \Phi(-\texttt{fr\_angle\_D})$. For circular
+(diagonal) $\Phi$ this reproduces the $e^{\pm i\,\texttt{fr\_angle\_D}}$
+leakage rotation in the legacy circular code. This one-sided form is only
+correct for diagonal $\Phi$, so a nonzero `fr_angle_D` with linear/mixed
+feeds currently raises (pending the linear conjugation form).
+
+Implemented at: `pol_conventions.assemble_jones` (assembly),
+`field_rotation_matrix` ($\Phi$, circular and linear).
 
 ---
 
@@ -349,12 +385,15 @@ matrix $C^{ij}_{\text{obs}}$, the calibrated coherency is
 
 $$C^{ij}_{\text{corr}} = J_i^{-1} \, C^{ij}_{\text{obs}} \, (J_j^\dagger)^{-1}.$$
 
-When gains and D-terms are well-determined and the feed model is
-correct, $C^{ij}_{\text{corr}}$ recovers the true sky-domain coherency
-matrix up to noise.
+This is the exact inverse of the §9 forward corruption: applying the
+forward Jones and then this correction recovers the clean coherency to
+machine precision (checked by a corrupt→invert round-trip for circular,
+linear, and mixed feeds).
 
-Implemented at: `ehtim/observing/pol_conventions.py:340-357`
-(`apply_inverse_jones_to_coherency`).
+Implemented at: `pol_conventions.apply_inverse_jones_to_coherency`.
+`obs_simulate.make_jones_inverse` builds each estimated $J$ (via
+`assemble_jones`) and inverts it with `invert_jones`;
+`obs_simulate.apply_jones_inverse` applies the result per baseline.
 
 ---
 
@@ -370,16 +409,28 @@ quantities depending on the feed types of the two stations:
 | circ–linear (i.e. station $i$ has circular feed, $j$ has linear) | $V_{RX}$ | $V_{RY}$ | $V_{LX}$ | $V_{LY}$ | `'mixed'` (per-baseline) |
 | stokes (sky-frame; only meaningful at calibrated-image level) | $I$ | $Q + iU$ | $Q - iU$ | $V$ | `'stokes'` |
 
-The Jones machinery in §9-§11 operates on the coherency matrix and is
-**polrep-agnostic** — it does not know which physical quantities are
-in each slot. The polrep is used only to label the slots when packing
-results back into ehtim's column-storage layout (`rrvis`/`xxvis`/etc.).
+Each station's $J$ is assembled **in that station's own feed basis**,
+selected by its `tarr['feed_type']`: circular stations get the
+diagonal-phase $\Phi$, linear stations the rotation $\Phi$. On a
+baseline the two matrices $J_i, J_j$ may therefore be in different bases;
+the congruence $J_i C J_j^\dagger$ is still well-defined because $C$'s
+rows are indexed by station $i$'s feeds and its columns by station $j$'s.
 
-For `'mixed'` polrep the slot interpretation varies per baseline, so
-the per-baseline `polbasis` field on the DTPOL_MIXED dtype carries the
-feed-pair label needed to route results correctly. This is set up in
-the schema layer (DTPOL_MIXED definition in `ehtim/const_def.py`)
-and consumed by Obsdata polrep-dispatching code.
+The Jones machinery in §9–§11 operates on the coherency matrix and is
+otherwise **polrep-agnostic** — it does not care which physical
+quantities sit in each slot. The polrep only labels the slots when
+packing results back into ehtim's column storage: the generic
+`p1p1/p2p2/p1p2/p2p1` slots map to `rrvis/llvis/rlvis/lrvis` (circ),
+`xxvis/yyvis/xyvis/yxvis` (lin), or stay generic (mixed).
 
-Implemented at: dispatch logic in `Obsdata.switch_polrep` and friends
-(forthcoming).
+`obs_simulate` corrupts/corrects in the observation's correlation basis:
+a `circ`/`lin`/`mixed` obs is used in place; a `stokes` obs is first
+switched to the array's feed basis (`circ` or `lin`). For `'mixed'` the
+per-baseline `polbasis` field on the DTPOL_MIXED dtype carries the
+feed-pair label, so noise/thermal sigmas are built per feed pairing.
+
+Implemented at: `obs_simulate.add_jones_and_noise` (forward) and
+`apply_jones_inverse` (inverse), applying $J$ per baseline in the
+correlation basis; `Obsdata.switch_polrep` handles `stokes`↔`circ`/`lin`
+(a `mixed` obs must be built natively — switching *to* `'mixed'` is not
+yet supported).

--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -391,9 +391,7 @@ class Array:
                polrep (str): polarization representation, one of
                              {'stokes', 'circ', 'lin', 'mixed'}. 'circ' requires
                              all-RL feeds; 'lin' requires all-XY feeds; 'mixed'
-                             requires at least two distinct feed types. 'lin'
-                             and 'mixed' are not yet wired through the
-                             simulation backend.
+                             requires at least two distinct feed types.
                elevmin (float): station minimum elevation in degrees
                elevmax (float): station maximum elevation in degrees
                no_elevcut_space (bool): if True, do not apply elevation cut to orbiters
@@ -422,10 +420,6 @@ class Array:
             raise ValueError(
                 f"polrep='mixed' requires at least two distinct feed types; "
                 f"array has feed_types={sorted(feeds)}")
-        if polrep in ('lin', 'mixed'):
-            raise NotImplementedError(
-                f"Array.obsdata(polrep={polrep!r}) is not yet supported by "
-                f"the simulation backend")
 
         obsarr = simobs.make_uvpoints(self, ra, dec, rf, bw,
                                       tint, tadv, tstart, tstop,

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -86,6 +86,32 @@ VALID_FEED_TYPES = frozenset({
     'xr', 'xl', 'yr', 'yl',
 })
 
+# Canonical ordering of the two feeds of a station: R before L before X before
+# Y. In memory a station's feed_type is ordered ('lr' means p1 = L, p2 = R and
+# so p1p1vis is the LL product), but on disk a uvfits STOKES axis labels its
+# planes absolutely (CRVAL3 = -1 -> RR, LL, RL, LR). The two agree only when
+# every station's feeds are in canonical order, so uvfits I/O canonicalizes.
+FEED_CHAR_ORDER = 'rlxy'
+
+
+def canonical_feed_type(feed_type):
+    """Return (canonical_feed_type, was_reversed) for a two-character feed code.
+
+       Args:
+           feed_type (str): a member of VALID_FEED_TYPES, e.g. 'rl', 'lr', 'xr'
+
+       Returns:
+           (str, bool): the pair reordered to FEED_CHAR_ORDER, and whether that
+           reordering swapped the two feeds ('lr' -> ('rl', True)).
+    """
+    ft = str(feed_type).lower()
+    if ft not in VALID_FEED_TYPES:
+        raise ValueError(f"canonical_feed_type: {feed_type!r} is not one of "
+                         f"{sorted(VALID_FEED_TYPES)}")
+    if FEED_CHAR_ORDER.index(ft[0]) <= FEED_CHAR_ORDER.index(ft[1]):
+        return ft, False
+    return ft[1] + ft[0], True
+
 # Observation recarray datatypes
 # DTARR uses generic names primary because it is a single shared dtype across
 # all stations; legacy names are title aliases. Per-Obsdata/Caltable dtypes
@@ -169,8 +195,8 @@ DTSCANS = [('time', 'f8'), ('interval', 'f8'), ('startvis', 'f8'), ('endvis', 'f
 
 
 # TODO: the feed_dtype_for_polrep / feed_poldict / upgrade_* helpers below
-# should migrate to ehtim/observing/pol_conventions.py (created in
-# MixPol Phase 3) when Obsdata.switch_polrep is wired up to it.
+# should migrate to ehtim/observing/pol_conventions.py when
+# Obsdata.switch_polrep is wired up to it.
 
 def feed_dtype_for_polrep(polrep):
     """Return the DTPOL_* field-spec list for a given polrep."""

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -194,10 +194,6 @@ DTCAL = DTCAL_CIRC  # legacy alias
 DTSCANS = [('time', 'f8'), ('interval', 'f8'), ('startvis', 'f8'), ('endvis', 'f8')]
 
 
-# TODO: the feed_dtype_for_polrep / feed_poldict / upgrade_* helpers below
-# should migrate to ehtim/observing/pol_conventions.py when
-# Obsdata.switch_polrep is wired up to it.
-
 def feed_dtype_for_polrep(polrep):
     """Return the DTPOL_* field-spec list for a given polrep."""
     try:

--- a/ehtim/image.py
+++ b/ehtim/image.py
@@ -2633,8 +2633,10 @@ class Image:
                (list): a list of [I,Q,U,V] visibilities
         """
 
-        if polrep_obs not in ['stokes', 'circ']:
-            raise Exception("polrep_obs must be either 'stokes' or 'circ'")
+        if polrep_obs not in ['stokes', 'circ', 'lin']:
+            # 'mixed' is excluded: the per-baseline Stokes->coherency conversion
+            # needs feed-pairing info that this bare-uv helper does not have.
+            raise Exception("polrep_obs must be 'stokes', 'circ', or 'lin'")
 
         data = simobs.sample_vis(self, uv, polrep_obs=polrep_obs, sgrscat=sgrscat,
                                  ttype=ttype, cache=cache, fft_pad_factor=fft_pad_factor,
@@ -2682,21 +2684,9 @@ class Image:
                                  ttype=ttype, cache=cache, fft_pad_factor=fft_pad_factor,
                                  zero_empty_pol=zero_empty_pol, verbose=verbose)
 
-        # put visibilities into the obsdata
-        if obs.polrep == 'stokes':
-            obsdata['vis'] = data[0]
-            if data[1] is not None:
-                obsdata['qvis'] = data[1]
-                obsdata['uvis'] = data[2]
-                obsdata['vvis'] = data[3]
-
-        elif obs.polrep == 'circ':
-            obsdata['rrvis'] = data[0]
-            if data[1] is not None:
-                obsdata['llvis'] = data[1]
-            if data[2] is not None:
-                obsdata['rlvis'] = data[2]
-                obsdata['lrvis'] = data[3]
+        # put visibilities into the obsdata (mixed: converts Stokes -> per-baseline
+        # correlations using each row's polbasis)
+        obsdata = simobs.pack_sampled_visibilities(obsdata, data, obs.polrep)
 
         obs_no_noise = ehtim.obsdata.Obsdata(self.ra, self.dec, obs.rf, obs.bw, obsdata, obs.tarr,
                                              source=self.source, mjd=self.mjd, polrep=obs.polrep,

--- a/ehtim/io/load.py
+++ b/ehtim/io/load.py
@@ -33,6 +33,7 @@ import ehtim.movie
 import ehtim.obsdata
 import ehtim.observing
 import ehtim.vex
+import ehtim.warnings as ehw
 
 warnings.filterwarnings("ignore", message="Mean of empty slice")
 warnings.filterwarnings("ignore", message="invalid value encountered in true_divide")
@@ -1143,23 +1144,91 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
         poltyb = hdulist['AIPS AN'].data['POLTYB']
     except KeyError:
         pass
-    if poltya is None and poltyb is None:
-        print(f"Warning: no POLTYA/POLTYB in AIPS AN table; assuming {default_feed!r} "
-              f"feeds inferred from CRVAL3={stokes_crval3}")
+    columns_absent = poltya is None and poltyb is None
+    if columns_absent:
+        warnings.warn(
+            f"no POLTYA/POLTYB columns in the AIPS AN table; inferring "
+            f"{default_feed!r} feeds from CRVAL3={stokes_crval3}.",
+            ehw.FeedTagWarning)
 
-    feed_types = []
+    # 1. Parse each station's raw feed_type from its POLTY tags. Blanks are
+    #    errors (a possibly-mixed file must not have a feed basis assumed);
+    #    absent columns fall back to the CRVAL3-inferred default.
+    raw_feeds = []
     for i in range(len(tnames)):
         a = _feedchar(poltya, i)
         b = _feedchar(poltyb, i)
+        station = str(tnames[i])
+        if a == '' and b == '':
+            if columns_absent:
+                # No POLTY columns at all: fall back to the CRVAL3-inferred feed.
+                raw_feeds.append(default_feed)
+                continue
+            # Columns exist but this station's tags are blank. A feed basis
+            # cannot be assumed for a possibly-mixed file -- silently defaulting
+            # to circular is exactly wrong for a mixed-pol observation -- so
+            # fail loudly rather than guess.
+            raise Exception(
+                f"station {station!r} has empty POLTYA and POLTYB feed tags; "
+                f"its feed basis cannot be determined. Populate the AIPS AN "
+                f"POLTYA/POLTYB columns, or remove them entirely to fall back "
+                f"to the CRVAL3-inferred default.")
+        if a == '' or b == '':
+            # Exactly one feed tag present. Do not complete the pair from the
+            # known feed (that would silently assume, e.g., 'R' -> 'rl').
+            raise Exception(
+                f"station {station!r} has an incomplete feed tag "
+                f"(POLTYA={a!r}, POLTYB={b!r}); exactly one feed is blank. "
+                f"Provide both feed characters (e.g. POLTYA='R', POLTYB='L') "
+                f"or omit both columns.")
         ft = (a + b).lower()
-        if ft == '':
-            ft = default_feed   # no POLTY tags recorded; inferred from CRVAL3
-        elif ft not in ehc.VALID_FEED_TYPES:
+        if ft not in ehc.VALID_FEED_TYPES:
             raise NotImplementedError(
                 f"unsupported feed pair POLTYA={a!r}/POLTYB={b!r} for station "
-                f"{str(tnames[i])!r}; valid feed types are "
-                f"{sorted(ehc.VALID_FEED_TYPES)}. See obsdata_mixedpol_plan.md.")
-        feed_types.append(ft)
+                f"{station!r}; valid feed types are "
+                f"{sorted(ehc.VALID_FEED_TYPES)}.")
+        raw_feeds.append(ft)
+
+    # 2. Reject hybrid feeds -- a single station mixing a circular and a linear
+    #    feed (e.g. POLTYA='R'/POLTYB='X' -> 'rx'). Their convention is undecided
+    #    across the stack (pol_conventions.field_rotation_matrix raises on them),
+    #    so fail here rather than load data the rest of the pipeline cannot read.
+    hybrid_stations = sorted({
+        f"{str(tnames[i])}={raw_feeds[i]!r}"
+        for i in range(len(tnames))
+        if (raw_feeds[i][0] in 'rl') != (raw_feeds[i][1] in 'rl')})
+    if hybrid_stations:
+        raise NotImplementedError(
+            "hybrid feeds (a station with one circular and one linear feed, "
+            "e.g. POLTYA='R'/POLTYB='X') are not yet supported by the uvfits "
+            f"loader: {hybrid_stations}.")
+
+    # 3. Canonicalize feed order ONLY when the file's feed basis is homogeneous.
+    #    The uvfits STOKES axis labels its four correlation planes absolutely, so
+    #    for an all-circular or all-linear file a station whose POLTY tags are in
+    #    reversed order ('lr') describes the same physical feeds as canonical
+    #    'rl' and its planes are read identically -- canonicalize so reversed
+    #    tags are not misclassified as a distinct (mixed) basis. For a genuinely
+    #    MIXED file the STOKES axis is only nominal and each baseline's four
+    #    correlation slots are written in feed order, so per-station order is
+    #    meaningful and is preserved as-is (canonicalizing without permuting the
+    #    slots would silently mislabel correlations).
+    canon = [ehc.canonical_feed_type(ft) for ft in raw_feeds]
+    canon_set = {c[0] for c in canon}
+    if canon_set <= {'rl'} or canon_set <= {'xy'}:
+        feed_types = [c[0] for c in canon]
+        n_reversed = sum(c[1] for c in canon)
+        if n_reversed:
+            warnings.warn(
+                f"{n_reversed} station(s) had POLTYA/POLTYB feed tags in "
+                f"reversed order (e.g. POLTYA='L', POLTYB='R'); canonicalized "
+                f"to standard feed order. The uvfits STOKES axis fixes the "
+                f"correlation-plane meanings, so reversed tags would otherwise "
+                f"misclassify a homogeneous file as mixed.",
+                ehw.FeedTagWarning)
+    else:
+        # Genuinely mixed feed basis: preserve the recorded per-station order.
+        feed_types = raw_feeds
 
     tarr = [np.array((
             str(tnames[i]), xyz[i][0], xyz[i][1], xyz[i][2],
@@ -1233,7 +1302,6 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
                 raise Exception("header[CRVAL3] not a recognized polarization basis!")
     except BaseException:
         raise Exception("STOKES field not in expected header position 'CTYPE3'!")
-    print('POLREP_UVFITS:', polrep_uvfits)
 
     if polrep_uvfits == 'stokes' and force_singlepol is not None:
         raise Exception("force_singlepole not implemented on native Stokes uvfits files!")
@@ -1274,7 +1342,7 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
     # force_singlepol selects a single circular hand (R/L) and is only defined
     # for circular-feed data. The enforcement block below is gated on 'circ', so
     # on a linear/mixed file the request would otherwise be silently dropped.
-    # X/Y single-pol selection is deferred to Phase 4.
+    # X/Y single-pol selection is not yet implemented.
     if (not (force_singlepol is None or force_singlepol is False)
             and polrep_uvfits != 'circ'):
         raise NotImplementedError(
@@ -1342,11 +1410,11 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
 
     # If necessary, enforce single polarization
     if polrep_uvfits == 'circ':
-        if force_singlepol in ['L' or 'LL']:
+        if force_singlepol in ('L', 'LL'):
             rrweight = rrweight * 0.0
             rlweight = rlweight * 0.0
             lrweight = lrweight * 0.0
-        elif force_singlepol in ['R' or 'RR']:
+        elif force_singlepol in ('R', 'RR'):
             llweight = llweight * 0.0
             rlweight = rlweight * 0.0
             lrweight = lrweight * 0.0
@@ -1651,8 +1719,10 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
     # cannot be synthesized from a homogeneous-feed file.
     if polrep_uvfits == 'mixed':
         if polrep != 'mixed':
-            print(f"Warning: mixed-feed uvfits loads only as polrep='mixed' "
-                  f"(requested {polrep!r}); returning a mixed-basis Obsdata.")
+            warnings.warn(
+                f"mixed-feed uvfits loads only as polrep='mixed' "
+                f"(requested {polrep!r}); returning a mixed-basis Obsdata.",
+                ehw.PolrepOverrideWarning)
     elif polrep == 'mixed':
         raise Exception("polrep='mixed' was requested but the uvfits array has "
                         "homogeneous feeds; load as 'stokes', 'circ', or 'lin'.")

--- a/ehtim/io/load.py
+++ b/ehtim/io/load.py
@@ -38,6 +38,12 @@ import ehtim.warnings as ehw
 warnings.filterwarnings("ignore", message="Mean of empty slice")
 warnings.filterwarnings("ignore", message="invalid value encountered in true_divide")
 
+# The other feed of a dual-feed station, by AIPS POLTY feed character. Used to
+# complete a station's feed pair when a uvfits file carries only one of the
+# POLTYA/POLTYB columns. Hybrid (circular + linear) stations are rejected
+# separately, so within a basis the partner is unambiguous.
+FEED_PARTNER_CHAR = {'R': 'L', 'L': 'R', 'X': 'Y', 'Y': 'X'}
+
 ##################################################################################################
 # Vex IO
 ##################################################################################################
@@ -1060,9 +1066,13 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
            filename (str or HDUList): path to either an input text file or an HDUList object
            polrep (str): output representation: 'stokes', 'circ', 'lin', or 'mixed'.
                          Feed types are read per-station from the AIPS AN table
-                         POLTYA/POLTYB tags (defaulting to circular 'rl' when
-                         absent). A mixed-feed file loads only as 'mixed'; a
-                         homogeneous file cannot be loaded as 'mixed'.
+                         POLTYA/POLTYB tags. When both columns are absent the
+                         feed basis falls back to the STOKES axis reference
+                         value, which AIPS Memo 117 defines as CRVAL3=+1 for
+                         I/Q/U/V, -1 for the circular products RR/LL/RL/LR and
+                         -5 for the linear products XX/YY/XY/YX. A mixed-feed
+                         file loads only as 'mixed'; a homogeneous file cannot
+                         be loaded as 'mixed'.
            flipbl (bool): flip baseline phases if True.
            allow_singlepol (bool): If True and polrep='stokes',
                                    treat single-polarization data as Stokes I
@@ -1125,10 +1135,24 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
         return (p.decode() if isinstance(p, bytes) else str(p)).strip().upper()
 
     # When POLTY tags are absent, infer the default feed basis from the STOKES
-    # axis (CRVAL3) rather than blindly assuming circular: -5 (linear XX/YY/...)
-    # -> 'xy', anything else (circular -1 or Stokes +1) -> 'rl'. This stops a
-    # POLTY-less pure-linear file from being silently mislabeled circular and its
-    # XX/YY/XY/YX read as RR/LL/RL/LR.
+    # axis (CRVAL3) rather than blindly assuming circular.
+    #
+    # AIPS Memo 117 defines the STOKES axis by its reference value CRVAL3, with
+    # the axis running in unit steps away from it (CDELT3 = +1 for the Stokes
+    # block, -1 for the feed-product blocks). The three blocks are
+    #
+    #     CRVAL3 = +1, slots  1 ..  4  ->  I,  Q,  U,  V      (Stokes)
+    #     CRVAL3 = -1, slots -1 .. -4  ->  RR, LL, RL, LR     (circular products)
+    #     CRVAL3 = -5, slots -5 .. -8  ->  XX, YY, XY, YX     (linear products)
+    #
+    # so CRVAL3 = -5 -> 'xy' feeds and anything else (circular -1, Stokes +1) ->
+    # 'rl'. This stops a POLTY-less pure-linear file from being silently
+    # mislabeled circular and its XX/YY/XY/YX read as RR/LL/RL/LR.
+    #
+    # Feed-character naming: the latest revision of AIPS Memo 117 renames the
+    # linear feed characters X and Y to V and H. ehtim keeps X and Y throughout
+    # (see docs/polarization_conventions.md sec 13); the -5 slot block is the
+    # same physical set of linear products under either naming.
     try:
         stokes_crval3 = header['CRVAL3']
     except KeyError:
@@ -1145,20 +1169,53 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
     except KeyError:
         pass
     columns_absent = poltya is None and poltyb is None
+    # Exactly one POLTY column present. The station's feed basis is still known
+    # from the tag that *is* there, so complete the pair with that feed's
+    # partner (R <-> L, X <-> Y) instead of failing. This covers only a wholly
+    # missing column: a present-but-blank tag on an existing column is still an
+    # error below, because a writer that emits POLTY and leaves it empty tells
+    # us nothing about the basis, and assuming circular there is exactly wrong
+    # for a mixed-pol observation.
+    partial_column = (poltya is None) != (poltyb is None)
+    # which column survived (only meaningful when partial_column)
+    present, missing = ('POLTYA', 'POLTYB') if poltyb is None else ('POLTYB', 'POLTYA')
     if columns_absent:
         warnings.warn(
             f"no POLTYA/POLTYB columns in the AIPS AN table; inferring "
             f"{default_feed!r} feeds from CRVAL3={stokes_crval3}.",
             ehw.FeedTagWarning)
+    elif partial_column:
+        warnings.warn(
+            f"the AIPS AN table has a {present} column but no {missing} column; "
+            f"completing each station's feed pair from the tag that is present "
+            f"(R <-> L, X <-> Y).",
+            ehw.FeedTagWarning)
 
     # 1. Parse each station's raw feed_type from its POLTY tags. Blanks are
     #    errors (a possibly-mixed file must not have a feed basis assumed);
-    #    absent columns fall back to the CRVAL3-inferred default.
+    #    absent columns fall back to the CRVAL3-inferred default, and a single
+    #    absent column to the present tag's partner feed.
     raw_feeds = []
     for i in range(len(tnames)):
         a = _feedchar(poltya, i)
         b = _feedchar(poltyb, i)
         station = str(tnames[i])
+        if partial_column and (a == '') != (b == ''):
+            # One column is missing entirely; fill in the partner feed. (If the
+            # present column is also blank for this station both tags are '' and
+            # we fall through to the empty-tag error below.)
+            known = a if b == '' else b
+            partner = FEED_PARTNER_CHAR.get(known)
+            if partner is None:
+                raise NotImplementedError(
+                    f"station {station!r} has feed tag {known!r} in the only "
+                    f"POLTY column present ({present}); its partner feed cannot "
+                    f"be determined. Recognized feed characters are "
+                    f"{sorted(FEED_PARTNER_CHAR)}.")
+            if b == '':
+                b = partner
+            else:
+                a = partner
         if a == '' and b == '':
             if columns_absent:
                 # No POLTY columns at all: fall back to the CRVAL3-inferred feed.
@@ -1326,6 +1383,16 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
     if crval3 == -1 and polrep_uvfits == 'lin':
         raise Exception("uvfits STOKES axis is circular (CRVAL3=-1) but station feeds "
                         "are linear (POLTYA/POLTYB=X/Y) -- inconsistent file")
+    if polrep_uvfits == 'mixed' and crval3 in (-1, -5):
+        nominal = 'circular (RR/LL/RL/LR)' if crval3 == -1 else 'linear (XX/YY/XY/YX)'
+        warnings.warn(
+            f"a MIXED feed basis was inferred from the AIPS AN station table "
+            f"(POLTYA/POLTYB), but the uvfits STOKES axis CRVAL3={crval3} would "
+            f"otherwise imply a homogeneous {nominal} file. For a mixed-feed "
+            f"array the STOKES axis is only a nominal 4-slot grid, so the "
+            f"station feed tags are taken as authoritative and each baseline's "
+            f"four correlation slots are read in per-station feed order.",
+            ehw.FeedTagWarning)
     if num_corr > 1:
         expected_cdelt3 = 1 if polrep_uvfits == 'stokes' else -1
         cdelt3 = header.get('CDELT3', expected_cdelt3)

--- a/ehtim/io/load.py
+++ b/ehtim/io/load.py
@@ -1057,7 +1057,11 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
 
        Args:
            filename (str or HDUList): path to either an input text file or an HDUList object
-           polrep (str): load data as either 'stokes' or 'circ'
+           polrep (str): output representation: 'stokes', 'circ', 'lin', or 'mixed'.
+                         Feed types are read per-station from the AIPS AN table
+                         POLTYA/POLTYB tags (defaulting to circular 'rl' when
+                         absent). A mixed-feed file loads only as 'mixed'; a
+                         homogeneous file cannot be loaded as 'mixed'.
            flipbl (bool): flip baseline phases if True.
            allow_singlepol (bool): If True and polrep='stokes',
                                    treat single-polarization data as Stokes I
@@ -1076,8 +1080,8 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
            obs (Obsdata): Obsdata object loaded from file
     """
 
-    if polrep not in ['stokes', 'circ']:
-        raise Exception("polrep should be 'stokes' or 'circ' in load_uvfits")
+    if polrep not in ['stokes', 'circ', 'lin', 'mixed']:
+        raise Exception("polrep should be 'stokes', 'circ', 'lin', or 'mixed' in load_uvfits")
     if not(force_singlepol is None or force_singlepol is False) and polrep != 'stokes':
         raise Exception(
             "force_singlepol is incompatible with polrep!='stokes' in load_uvfits")
@@ -1109,32 +1113,58 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
     dr = np.zeros(len(tnames)) + 1j * np.zeros(len(tnames))
     dl = np.zeros(len(tnames)) + 1j * np.zeros(len(tnames))
 
-    # Detect antenna feed types and raise if the observation is mixed-polarization
-    # (full POLTYA/POLTYB -> feed_type parsing is not yet implemented). Both feed
-    # columns are checked, so a hybrid station (e.g. POLTYA='R', POLTYB='X') is
-    # caught rather than silently loaded as circular.
-    feeds = set()
-    for col in ('POLTYA', 'POLTYB'):
-        try:
-            poltys = hdulist['AIPS AN'].data[col]
-        except KeyError:
-            continue
-        for p in poltys:
-            s = (p.decode() if isinstance(p, bytes) else str(p)).strip().upper()
-            if s:
-                feeds.add(s)
-    if not feeds <= {'R', 'L'}:
-        raise NotImplementedError(
-            "mixed-pol / linear-feed uvfits load is not yet supported; "
-            f"detected feed types {sorted(feeds)} in POLTYA/POLTYB. "
-            "See obsdata_mixedpol_plan.md.")
+    # Parse per-station feed types from the AIPS AN table POLTYA/POLTYB columns.
+    # POLTYA is the station's first feed, POLTYB the second, so (POLTYA, POLTYB)
+    # maps to a 2-char feed_type code ('rl' circular, 'xy' linear, 'rx' hybrid,
+    # etc.).
+    def _feedchar(col, i):
+        if col is None:
+            return ''
+        p = col[i]
+        return (p.decode() if isinstance(p, bytes) else str(p)).strip().upper()
 
-    # TODO (Phase 7 mixed-pol): read POLTYA/POLTYB from the AIPS AN table
-    # to populate per-station feed_type. Until then, assume circular feeds.
+    # When POLTY tags are absent, infer the default feed basis from the STOKES
+    # axis (CRVAL3) rather than blindly assuming circular: -5 (linear XX/YY/...)
+    # -> 'xy', anything else (circular -1 or Stokes +1) -> 'rl'. This stops a
+    # POLTY-less pure-linear file from being silently mislabeled circular and its
+    # XX/YY/XY/YX read as RR/LL/RL/LR.
+    try:
+        stokes_crval3 = header['CRVAL3']
+    except KeyError:
+        stokes_crval3 = -1
+    default_feed = 'xy' if stokes_crval3 == -5 else 'rl'
+
+    poltya = poltyb = None
+    try:
+        poltya = hdulist['AIPS AN'].data['POLTYA']
+    except KeyError:
+        pass
+    try:
+        poltyb = hdulist['AIPS AN'].data['POLTYB']
+    except KeyError:
+        pass
+    if poltya is None and poltyb is None:
+        print(f"Warning: no POLTYA/POLTYB in AIPS AN table; assuming {default_feed!r} "
+              f"feeds inferred from CRVAL3={stokes_crval3}")
+
+    feed_types = []
+    for i in range(len(tnames)):
+        a = _feedchar(poltya, i)
+        b = _feedchar(poltyb, i)
+        ft = (a + b).lower()
+        if ft == '':
+            ft = default_feed   # no POLTY tags recorded; inferred from CRVAL3
+        elif ft not in ehc.VALID_FEED_TYPES:
+            raise NotImplementedError(
+                f"unsupported feed pair POLTYA={a!r}/POLTYB={b!r} for station "
+                f"{str(tnames[i])!r}; valid feed types are "
+                f"{sorted(ehc.VALID_FEED_TYPES)}. See obsdata_mixedpol_plan.md.")
+        feed_types.append(ft)
+
     tarr = [np.array((
             str(tnames[i]), xyz[i][0], xyz[i][1], xyz[i][2],
             sefdr[i], sefdl[i], dr[i], dl[i],
-            fr_par[i], fr_el[i], fr_off[i], 'rl'),
+            fr_par[i], fr_el[i], fr_off[i], feed_types[i]),
         dtype=ehc.DTARR) for i in range(len(tnames))]
 
     tarr = np.array(tarr)
@@ -1186,8 +1216,19 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
         if header['CTYPE3'] == 'STOKES':
             if header['CRVAL3'] == 1:
                 polrep_uvfits = 'stokes'
-            elif header['CRVAL3'] == -1:
-                polrep_uvfits = 'circ'
+            elif header['CRVAL3'] in (-1, -5):
+                # Feed-basis storage. The native polrep is decided by the
+                # per-station feed types (circular / linear / mixed) read from
+                # POLTYA/POLTYB, not by CRVAL3: for a mixed-feed array each
+                # baseline's four products differ, so the STOKES axis is only a
+                # nominal 4-slot grid (CRVAL3=-1 circular / -5 linear naming).
+                feedset = set(str(ft) for ft in tarr['feed_type'])
+                if feedset <= {'rl'}:
+                    polrep_uvfits = 'circ'
+                elif feedset <= {'xy'}:
+                    polrep_uvfits = 'lin'
+                else:
+                    polrep_uvfits = 'mixed'
             else:
                 raise Exception("header[CRVAL3] not a recognized polarization basis!")
     except BaseException:
@@ -1203,9 +1244,43 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
     # Determine the number of correlation products in the data
     num_corr = data['DATA'].shape[5]
     print("Number of uvfits Correlation Products:", num_corr)
+
+    # Consistency between the STOKES axis and the parsed feed types. (a) The
+    # axis naming (CRVAL3) must not contradict the feeds -- e.g. linear planes
+    # (-5) tagged with circular feeds. (b) The four correlation planes are read
+    # positionally (slot0..3, below); this is only valid for the standard
+    # unit-step axis, so reject a non-(-1)/(+1) CDELT3 rather than silently
+    # mis-slotting a reordered/rescaled STOKES axis.
+    crval3 = header['CRVAL3']
+    if crval3 == -5 and polrep_uvfits == 'circ':
+        raise Exception("uvfits STOKES axis is linear (CRVAL3=-5) but station feeds "
+                        "are circular (POLTYA/POLTYB=R/L) -- inconsistent file")
+    if crval3 == -1 and polrep_uvfits == 'lin':
+        raise Exception("uvfits STOKES axis is circular (CRVAL3=-1) but station feeds "
+                        "are linear (POLTYA/POLTYB=X/Y) -- inconsistent file")
+    if num_corr > 1:
+        expected_cdelt3 = 1 if polrep_uvfits == 'stokes' else -1
+        cdelt3 = header.get('CDELT3', expected_cdelt3)
+        if cdelt3 != expected_cdelt3:
+            raise Exception(
+                f"uvfits STOKES axis CDELT3={cdelt3} is not the supported unit step "
+                f"{expected_cdelt3}; the four correlation planes are read by position "
+                "(slot0..3) and a reordered/rescaled STOKES axis would be mis-slotted.")
+
     if num_corr == 1 and force_singlepol is not None:
         print("Cannot force single polarization when file is not full polarization.")
         force_singlepol = None
+
+    # force_singlepol selects a single circular hand (R/L) and is only defined
+    # for circular-feed data. The enforcement block below is gated on 'circ', so
+    # on a linear/mixed file the request would otherwise be silently dropped.
+    # X/Y single-pol selection is deferred to Phase 4.
+    if (not (force_singlepol is None or force_singlepol is False)
+            and polrep_uvfits != 'circ'):
+        raise NotImplementedError(
+            "force_singlepol is only supported for circular-feed uvfits files "
+            f"(native feed basis is {polrep_uvfits!r}); "
+            "load without force_singlepol.")
 
     # If the user selects force_singlepol, then we must allow_singlepol for stokes conversion
     if force_singlepol is not None and polrep == 'stokes':
@@ -1245,8 +1320,11 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
     if (np.max(IF) >= full_nifs) or (np.min(IF) < 0):
         raise Exception('The specified IF does not exist')
 
-    # NOTE: here we are assuming data is in RR, LL, RL, LR basis with the variable names
-    # BUT: polrep_uvfits will correctly interpret these data as IQUV if necessary
+    # NOTE: the rr/ll/rl/lr variable names are historical. They hold the four
+    # data-cube correlation slots in order (slot0, slot1, slot2, slot3), which
+    # map to the generic DTPOL slots (p1p1, p2p2, p1p2, p2p1). The physical
+    # meaning depends on polrep_uvfits: RR/LL/RL/LR (circ), XX/YY/XY/YX (lin),
+    # I/Q/U/V (stokes), or per-baseline feed products (mixed).
     # TODO: change the variable names!
     rrweight = data['DATA'][:, 0, 0, IF, channel, 0, 2].reshape(nvis, nifs, nchannels)
     if num_corr >= 2:
@@ -1309,13 +1387,15 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
     lrmask = np.any(np.any(lrmask_2d, axis=2), axis=1)
 
     # Total intensity mask
-    if polrep_uvfits == 'circ':
-        mask = rrmask + llmask
-    elif polrep_uvfits == 'stokes':
+    if polrep_uvfits == 'stokes':
         mask = rrmask  # remember rr is really I when polrep_uvfits=='stokes'!
+    else:
+        # circ / lin / mixed: the two parallel-hand slots (p1p1, p2p2 = slot0,
+        # slot1) carry the total-intensity information.
+        mask = rrmask + llmask
 
     if not np.any(mask):
-        raise Exception("No unflagged RR or LL data in uvfits file!")
+        raise Exception("No unflagged parallel-hand (slot0/slot1) data in uvfits file!")
     if np.any(~(rrmask * llmask)):
         print("Warning: removing flagged data present!")
 
@@ -1509,14 +1589,12 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
         u = -u
         v = -v
 
-    # determine correct data type:
-    # TODO add linear!
-    if polrep_uvfits == 'circ':
-        dtpol_out = ehc.DTPOL_CIRC
-        poldict_out = ehc.POLDICT_CIRC
-    elif polrep_uvfits == 'stokes':
-        dtpol_out = ehc.DTPOL_STOKES
-        poldict_out = ehc.POLDICT_STOKES
+    # determine correct data type (stokes / circ / lin / mixed)
+    dtpol_out = ehc.feed_dtype_for_polrep(polrep_uvfits)
+    poldict_out = ehc.polrep_to_poldict[polrep_uvfits]
+
+    # NOTE: for 'mixed' the DTPOL_MIXED 'polbasis' field is left blank here --
+    # Obsdata.__init__ populates it from tarr (t1_feed + t2_feed) on construction.
 
     #TODO new, faster,
     if trial_speedups:
@@ -1537,18 +1615,19 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
         datatable[poldict_out['sigma2']] = llsig
         datatable[poldict_out['sigma3']] = rlsig
         datatable[poldict_out['sigma4']] = lrsig
+        if polrep_uvfits == 'mixed':
+            datatable['polbasis'] = ''  # placeholder; filled by Obsdata.__init__
     else: # original, slower code
         datatable = []
         for i in range(len(times)):
-            datatable.append(np.array
-                             ((
-                                 times[i], tints[i],
-                                 t1[i], t2[i], tau1[i], tau2[i],
-                                 u[i], v[i],
-                                 rr[i], ll[i], rl[i], lr[i],
-                                 rrsig[i], llsig[i], rlsig[i], lrsig[i]
-                             ), dtype=dtpol_out
-                             ))
+            row = (times[i], tints[i],
+                   t1[i], t2[i], tau1[i], tau2[i],
+                   u[i], v[i],
+                   rr[i], ll[i], rl[i], lr[i],
+                   rrsig[i], llsig[i], rlsig[i], lrsig[i])
+            if polrep_uvfits == 'mixed':
+                row = row + ('',)   # polbasis placeholder; filled by Obsdata.__init__
+            datatable.append(np.array(row, dtype=dtpol_out))
         datatable = np.array(datatable)
 
     obs = ehtim.obsdata.Obsdata(ra, dec, rf, bw, datatable, tarr, polrep=polrep_uvfits,
@@ -1556,15 +1635,29 @@ def load_obs_uvfits(filename, polrep='stokes', flipbl=False,
                                 trial_speedups=trial_speedups)
 
     if remove_nan:
-        if polrep_uvfits == 'circ':
-            (obs.data['rrsigma'], obs.data['llsigma'],
-             obs.data['rlsigma'], obs.data['lrsigma']) = _fill_nan_sigmas(
-                obs.data['rrsigma'], obs.data['llsigma'],
-                obs.data['rlsigma'], obs.data['lrsigma'])
+        if polrep_uvfits in ('circ', 'lin', 'mixed'):
+            # Generic slot names work for all feed-basis dtypes: they are the
+            # primary names on DTPOL_MIXED and title aliases on DTPOL_CIRC/LIN.
+            (obs.data['p1p1sigma'], obs.data['p2p2sigma'],
+             obs.data['p1p2sigma'], obs.data['p2p1sigma']) = _fill_nan_sigmas(
+                obs.data['p1p1sigma'], obs.data['p2p2sigma'],
+                obs.data['p1p2sigma'], obs.data['p2p1sigma'])
         else:
             print("WARNING: remove_nan not implemented with stokes uvfits files!")
 
-    obs = obs.switch_polrep(polrep, allow_singlepol=allow_singlepol)
+    # Convert to the requested output polrep. A mixed-feed observation cannot be
+    # converted out of 'mixed' at the data layer (per-baseline interpretation
+    # needs Jones-level D-terms), so it is returned as-is; conversely 'mixed'
+    # cannot be synthesized from a homogeneous-feed file.
+    if polrep_uvfits == 'mixed':
+        if polrep != 'mixed':
+            print(f"Warning: mixed-feed uvfits loads only as polrep='mixed' "
+                  f"(requested {polrep!r}); returning a mixed-basis Obsdata.")
+    elif polrep == 'mixed':
+        raise Exception("polrep='mixed' was requested but the uvfits array has "
+                        "homogeneous feeds; load as 'stokes', 'circ', or 'lin'.")
+    else:
+        obs = obs.switch_polrep(polrep, allow_singlepol=allow_singlepol)
 
     # TODO get calibration flags from uvfits?
     return obs

--- a/ehtim/io/save.py
+++ b/ehtim/io/save.py
@@ -411,7 +411,9 @@ def save_obs_uvfits(obs, fname=None, force_singlepol=None, polrep_out='circ'):
             obs (Obsdata): obsdata object
             fname (str): path to output fits file, or None to return HDUList only
             force_singlepol (str): if 'R' or 'L', will interpret stokes I field as 'RR' or 'LL'
-            polrep_out (str): 'circ' or 'stokes': how data should be stored in the uvfits file
+            polrep_out (str): how data is stored in the uvfits file: 'circ',
+                'stokes', 'lin', or 'mixed'. 'mixed' requires (and preserves) a
+                mixed-feed Obsdata; feed types are written to POLTYA/POLTYB.
        Returns:
             hdulist (astropy.io.fits.HDUList)
 
@@ -420,12 +422,20 @@ def save_obs_uvfits(obs, fname=None, force_singlepol=None, polrep_out='circ'):
     # output times must be in utc
     obs = obs.switch_timetype(timetype_out='UTC')
 
-    if polrep_out == 'circ':
-        obs = obs.switch_polrep('circ')
-    elif polrep_out == 'stokes':
-        obs = obs.switch_polrep('stokes')
+    if polrep_out not in ('circ', 'stokes', 'lin', 'mixed'):
+        raise Exception("'polrep_out' in 'save_obs_uvfits' must be "
+                        "'circ', 'stokes', 'lin', or 'mixed'!")
+    if obs.polrep == 'mixed' or polrep_out == 'mixed':
+        # A mixed-feed observation is stored as-is; it cannot be converted to or
+        # from any homogeneous basis at the data layer.
+        if obs.polrep != 'mixed':
+            raise Exception("polrep_out='mixed' requires a mixed-feed Obsdata "
+                            f"(obs.polrep is {obs.polrep!r}).")
+        if polrep_out != 'mixed':
+            raise Exception("a mixed-feed Obsdata can only be saved with "
+                            f"polrep_out='mixed' (got {polrep_out!r}).")
     else:
-        raise Exception("'polrep_out' in 'save_obs_uvfits' must be 'circ' or 'stokes'!")
+        obs = obs.switch_polrep(polrep_out)
 
     hdulist_new = fits.HDUList()
     hdulist_new.append(fits.GroupsHDU())
@@ -460,11 +470,19 @@ def save_obs_uvfits(obs, fname=None, force_singlepol=None, polrep_out='circ'):
     header['CROTA2'] = 0.e0
     header['CTYPE3'] = 'STOKES'
     if polrep_out == 'circ':
-        header['CRVAL3'] = -1.e0
+        header['CRVAL3'] = -1.e0   # RR, LL, RL, LR = -1, -2, -3, -4
         header['CDELT3'] = -1.e0
     elif polrep_out == 'stokes':
-        header['CRVAL3'] = 1.e0
+        header['CRVAL3'] = 1.e0    # I, Q, U, V = 1, 2, 3, 4
         header['CDELT3'] = 1.e0
+    elif polrep_out == 'lin':
+        header['CRVAL3'] = -5.e0   # XX, YY, XY, YX = -5, -6, -7, -8
+        header['CDELT3'] = -1.e0
+    elif polrep_out == 'mixed':
+        # Nominal circular naming; the per-baseline physical meaning is carried
+        # by the POLTYA/POLTYB feed tags in the AIPS AN table, not this axis.
+        header['CRVAL3'] = -1.e0
+        header['CDELT3'] = -1.e0
     header['CRPIX3'] = 1.e0
     header['CROTA3'] = 0.e0
     header['CTYPE4'] = 'FREQ'
@@ -521,6 +539,16 @@ def save_obs_uvfits(obs, fname=None, force_singlepol=None, polrep_out='circ'):
     elif polrep_out == 'stokes':
         obsdata = obs.unpack(['time', 'tint', 'u', 'v', 'vis', 'qvis', 'uvis', 'vvis',
                               'sigma', 'qsigma', 'usigma', 'vsigma', 't1', 't2', 'tau1', 'tau2'])
+    elif polrep_out == 'lin':
+        obsdata = obs.unpack(['time', 'tint', 'u', 'v',
+                              'xxvis', 'yyvis', 'xyvis', 'yxvis',
+                              'xxsigma', 'yysigma', 'xysigma', 'yxsigma',
+                              't1', 't2', 'tau1', 'tau2'])
+    elif polrep_out == 'mixed':
+        obsdata = obs.unpack(['time', 'tint', 'u', 'v',
+                              'p1p1vis', 'p2p2vis', 'p1p2vis', 'p2p1vis',
+                              'p1p1sigma', 'p2p2sigma', 'p1p2sigma', 'p2p1sigma',
+                              't1', 't2', 'tau1', 'tau2'])
 
     ndat = len(obsdata['time'])
 
@@ -597,6 +625,26 @@ def save_obs_uvfits(obs, fname=None, force_singlepol=None, polrep_out='circ'):
         weight3 = 1.0/(obsdata['usigma']**2)
         weight4 = 1.0/(obsdata['vsigma']**2)
 
+    elif polrep_out == 'lin':
+        dat1 = obsdata['xxvis']
+        dat2 = obsdata['yyvis']
+        dat3 = obsdata['xyvis']
+        dat4 = obsdata['yxvis']
+        weight1 = 1.0/(obsdata['xxsigma']**2)
+        weight2 = 1.0/(obsdata['yysigma']**2)
+        weight3 = 1.0/(obsdata['xysigma']**2)
+        weight4 = 1.0/(obsdata['yxsigma']**2)
+
+    elif polrep_out == 'mixed':
+        dat1 = obsdata['p1p1vis']
+        dat2 = obsdata['p2p2vis']
+        dat3 = obsdata['p1p2vis']
+        dat4 = obsdata['p2p1vis']
+        weight1 = 1.0/(obsdata['p1p1sigma']**2)
+        weight2 = 1.0/(obsdata['p2p2sigma']**2)
+        weight3 = 1.0/(obsdata['p1p2sigma']**2)
+        weight4 = 1.0/(obsdata['p2p1sigma']**2)
+
     # Replace nans by zeros (including zero weights)
     dat1 = np.nan_to_num(dat1)
     dat2 = np.nan_to_num(dat2)
@@ -641,7 +689,7 @@ def save_obs_uvfits(obs, fname=None, force_singlepol=None, polrep_out='circ'):
     tnames = tarr['site']
     tnums = np.arange(1, len(tarr)+1)
     xyz = np.array([[tarr[i]['x'], tarr[i]['y'], tarr[i]['z']] for i in np.arange(len(tarr))])
-    sefd = tarr['sefdr']
+    sefd = tarr['sefd_p1']  # generic name works for any feed type (alias of sefdr on rl arrays)
 
     nsta = len(tnames)
     col1 = fits.Column(name='ANNAME', format='8A', array=tnames)
@@ -654,14 +702,18 @@ def save_obs_uvfits(obs, fname=None, force_singlepol=None, polrep_out='circ'):
                        array=np.zeros(nsta))
     col5 = fits.Column(name='STAXOF', format='1E', unit='METERS',
                        array=np.zeros(nsta))
-    col6 = fits.Column(name='POLTYA', format='1A',
-                       array=np.array(['R' for i in range(nsta)], dtype='|S1'))
+    # Per-station feed labels from feed_type: POLTYA = first feed, POLTYB =
+    # second (e.g. 'rl' -> R/L, 'xy' -> X/Y, 'rx' -> R/X). For a purely circular
+    # array this reproduces the legacy hardcoded R/L bytes exactly.
+    feedtypes = [str(ft) for ft in tarr['feed_type']]
+    poltya_arr = np.array([ft[0].upper() for ft in feedtypes], dtype='|S1')
+    poltyb_arr = np.array([ft[1].upper() for ft in feedtypes], dtype='|S1')
+    col6 = fits.Column(name='POLTYA', format='1A', array=poltya_arr)
     col7 = fits.Column(name='POLAA', format='1E', unit='DEGREES',
                        array=np.zeros(nsta))
     col8 = fits.Column(name='POLCALA', format='3E',
                        array=np.zeros((nsta, 3)))
-    col9 = fits.Column(name='POLTYB', format='1A',
-                       array=np.array(['L' for i in range(nsta)], dtype='|S1'))
+    col9 = fits.Column(name='POLTYB', format='1A', array=poltyb_arr)
     col10 = fits.Column(name='POLAB', format='1E', unit='DEGREES',
                         array=(90.*np.ones(nsta)))
     col11 = fits.Column(name='POLCALB', format='3E',

--- a/ehtim/movie.py
+++ b/ehtim/movie.py
@@ -1221,21 +1221,9 @@ class Movie:
                                      zero_empty_pol=zero_empty_pol, verbose=verbose)
             verbose = False # only print for one frame
 
-            # Put visibilities into the obsdata
-            if obs.polrep == 'stokes':
-                obsdata['vis'] = data[0]
-                if data[1] is not None:
-                    obsdata['qvis'] = data[1]
-                    obsdata['uvis'] = data[2]
-                    obsdata['vvis'] = data[3]
-
-            elif obs.polrep == 'circ':
-                obsdata['rrvis'] = data[0]
-                if data[1] is not None:
-                    obsdata['llvis'] = data[1]
-                if data[2] is not None:
-                    obsdata['rlvis'] = data[2]
-                    obsdata['lrvis'] = data[3]
+            # Put visibilities into the obsdata (mixed: converts Stokes -> per-baseline
+            # correlations using each row's polbasis)
+            obsdata = simobs.pack_sampled_visibilities(obsdata, data, obs.polrep)
 
             if len(obsdata_out):
                 obsdata_out = np.hstack((obsdata_out, obsdata))

--- a/ehtim/movie.py
+++ b/ehtim/movie.py
@@ -429,32 +429,32 @@ class Movie:
                                          bounds_error=self.bounds_error, fill_value=fill_value)
         self._fundict['LR'] = fun
 
-    # Pre-Phase-3 names rlvec / lrvec were inconsistent with the rest of
-    # Movie's "frames" naming and the rest of the codebase did not call them.
-    # Phase 3 renamed them to rlframes / lrframes; these shims raise so any
-    # surviving caller fails loudly with a migration message.
+    # The old names rlvec / lrvec were inconsistent with the rest of Movie's
+    # "frames" naming and the rest of the codebase did not call them. They were
+    # renamed to rlframes / lrframes; these shims raise so any surviving caller
+    # fails loudly with a migration message.
     @property
     def rlvec(self):
         raise AttributeError(
-            "Movie.rlvec was renamed to Movie.rlframes in Phase 3 mixed-pol; "
+            "Movie.rlvec was renamed to Movie.rlframes; "
             "update the caller.")
 
     @rlvec.setter
     def rlvec(self, frames):
         raise AttributeError(
-            "Movie.rlvec was renamed to Movie.rlframes in Phase 3 mixed-pol; "
+            "Movie.rlvec was renamed to Movie.rlframes; "
             "update the caller.")
 
     @property
     def lrvec(self):
         raise AttributeError(
-            "Movie.lrvec was renamed to Movie.lrframes in Phase 3 mixed-pol; "
+            "Movie.lrvec was renamed to Movie.lrframes; "
             "update the caller.")
 
     @lrvec.setter
     def lrvec(self, frames):
         raise AttributeError(
-            "Movie.lrvec was renamed to Movie.lrframes in Phase 3 mixed-pol; "
+            "Movie.lrvec was renamed to Movie.lrframes; "
             "update the caller.")
 
     @property
@@ -841,7 +841,7 @@ class Movie:
         if polrep_out == self.polrep and pol_prim_out == self.pol_prim:
             return self.copy()
 
-        # circ <-> lin goes through stokes (no direct path; plan Decision 7).
+        # circ <-> lin goes through stokes (no direct path).
         if (polrep_out, self.polrep) in [('circ', 'lin'), ('lin', 'circ')]:
             return self.switch_polrep('stokes').switch_polrep(polrep_out, pol_prim_out)
 

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -252,7 +252,7 @@ class Obsdata:
             ft_arr = self.tarr['feed_type']
             self.data['polbasis'] = np.char.add(ft_arr[t1_idx], ft_arr[t2_idx])
 
-        if np.any(self.tarr['sefdr'] != 0) or np.any(self.tarr['sefdl'] != 0):
+        if np.any(self.tarr['sefd_p1'] != 0) or np.any(self.tarr['sefd_p2'] != 0):
             self.reorder_tarr_sefd(reorder_baselines=False)
 
         # reorder baselines to uvfits convention

--- a/ehtim/obsdata.py
+++ b/ehtim/obsdata.py
@@ -443,7 +443,10 @@ class Obsdata:
                 self.data['sigma'], self.data['qsigma'],
                 self.data['usigma'], self.data['vsigma'])
 
-            if allow_singlepol:
+            # singlepol substitution only applies to rows with no circular-hand
+            # info (vvis missing); when there are none, skip it entirely so the
+            # default singlepol_hand does not gate a fully-polarized conversion.
+            if allow_singlepol and np.any(Vmask):
                 hand = singlepol_hand.upper() if isinstance(singlepol_hand, str) else None
                 if hand not in ('R', 'L'):
                     raise Exception(
@@ -471,7 +474,10 @@ class Obsdata:
                 self.data['sigma'], self.data['qsigma'],
                 self.data['usigma'], self.data['vsigma'])
 
-            if allow_singlepol:
+            # singlepol substitution only applies to rows with no linear-hand
+            # info (vvis missing); when there are none, skip it entirely so the
+            # default singlepol_hand does not gate a fully-polarized conversion.
+            if allow_singlepol and np.any(Vmask):
                 hand = singlepol_hand.upper() if isinstance(singlepol_hand, str) else None
                 if hand not in ('X', 'Y'):
                     raise Exception(

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -28,6 +28,7 @@ from scipy.interpolate import interp1d
 import ehtim.const_def as ehc
 
 from . import obs_helpers as obsh
+from . import pol_conventions
 
 ##################################################################################################
 # Generate U-V Points
@@ -63,13 +64,8 @@ def make_uvpoints(array, ra, dec, rf, bw, tint, tadv, tstart, tstop,
        Returns:
            (Obsdata): an observation object with all visibilities zeroed
     """
-
-    if polrep == 'stokes':
-        poltype = ehc.DTPOL_STOKES
-    elif polrep == 'circ':
-        poltype = ehc.DTPOL_CIRC
-    else:
-        raise Exception("only 'stokes' and 'circ' are supported polreps!")
+    # Define the dtype for the output array
+    poltype = ehc.feed_dtype_for_polrep(polrep)
 
     # Set up time start and steps
     tstep = tadv/3600.0
@@ -116,25 +112,25 @@ def make_uvpoints(array, ra, dec, rf, bw, tint, tadv, tstart, tstop,
                     tau2 = 0.
 
                 # Noise on the correlations
-                if np.any(array.tarr['sefdr'] <= 0) or np.any(array.tarr['sefdl'] <= 0):
+                if np.any(array.tarr['sefd_p1'] <= 0) or np.any(array.tarr['sefd_p2'] <= 0):
                     print("Warning!: in make_uvpoints, some SEFDs are <= 0!")
 
-                sig_rr = obsh.blnoise(array.tarr[i1]['sefdr'], array.tarr[i2]['sefdr'], tint, bw)
-                sig_ll = obsh.blnoise(array.tarr[i1]['sefdl'], array.tarr[i2]['sefdl'], tint, bw)
-                sig_rl = obsh.blnoise(array.tarr[i1]['sefdr'], array.tarr[i2]['sefdl'], tint, bw)
-                sig_lr = obsh.blnoise(array.tarr[i1]['sefdl'], array.tarr[i2]['sefdr'], tint, bw)
+                ft1 = str(array.tarr[i1]['feed_type'])   # e.g. 'rl' or 'xy'
+                ft2 = str(array.tarr[i2]['feed_type'])
+
+                # Slot order matches DTPOL_*: p1p1, p2p2, p1p2, p2p1.
+                # feed1 = first char of feed_type, feed2 = second char.
+                sig_p1p1 = obsh.blnoise(array.sefd_for_feed(site1, ft1[0]), array.sefd_for_feed(site2, ft2[0]), tint, bw)
+                sig_p2p2 = obsh.blnoise(array.sefd_for_feed(site1, ft1[1]), array.sefd_for_feed(site2, ft2[1]), tint, bw)
+                sig_p1p2 = obsh.blnoise(array.sefd_for_feed(site1, ft1[0]), array.sefd_for_feed(site2, ft2[1]), tint, bw)
+                sig_p2p1 = obsh.blnoise(array.sefd_for_feed(site1, ft1[1]), array.sefd_for_feed(site2, ft2[0]), tint, bw)
+
                 if polrep == 'stokes':
-                    sig_iv = 0.5*np.sqrt(sig_rr**2 + sig_ll**2)
-                    sig_qu = 0.5*np.sqrt(sig_rl**2 + sig_lr**2)
-                    sig1 = sig_iv
-                    sig2 = sig_qu
-                    sig3 = sig_qu
-                    sig4 = sig_iv
-                elif polrep == 'circ':
-                    sig1 = sig_rr
-                    sig2 = sig_ll
-                    sig3 = sig_rl
-                    sig4 = sig_lr
+                    sig_iv = 0.5*np.sqrt(sig_p1p1**2 + sig_p2p2**2)
+                    sig_qu = 0.5*np.sqrt(sig_p1p2**2 + sig_p2p1**2)
+                    sig1, sig2, sig3, sig4 = sig_iv, sig_qu, sig_qu, sig_iv
+                else:  # circ, lin, mixed all carry the four correlations directly
+                    sig1, sig2, sig3, sig4 = sig_p1p1, sig_p2p2, sig_p1p2, sig_p2p1
 
                 uvdat = obsh.compute_uv_coordinates(array, site1, site2, times, mjd,
                                                     ra, dec, rf, timetype=timetype,
@@ -144,13 +140,13 @@ def make_uvpoints(array, ra, dec, rf, bw, tint, tadv, tstart, tstop,
 
                 (timesout, uout, vout) = uvdat
                 for k in range(len(timesout)):
-                    outlist.append(np.array((
+                    row = (
                         timesout[k],
                         tint,     # Integration
                         site1,    # Station 1
                         site2,    # Station 2
                         tau1,     # Station 1 zenith optical depth
-                        tau2,     # Station 1 zenith optical depth
+                        tau2,     # Station 2 zenith optical depth
                         uout[k],  # u (lambda)
                         vout[k],  # v (lambda)
                         0.0,      # 1st Visibility (Jy)
@@ -160,9 +156,11 @@ def make_uvpoints(array, ra, dec, rf, bw, tint, tadv, tstart, tstop,
                         sig1,     # 1st Sigma (Jy)
                         sig2,     # 2nd Sigma
                         sig3,     # 3rd Sigma
-                        sig4      # 4th Sigma
-                    ), dtype=poltype
-                    ))
+                        sig4,     # 4th Sigma
+                    )
+                    if polrep == 'mixed':
+                        row = row + (ft1 + ft2,)   # polbasis, e.g. 'rlxy'
+                    outlist.append(np.array(row, dtype=poltype))
 
     obsarr = np.array(outlist)
 
@@ -201,8 +199,18 @@ def sample_vis(im_org, uv, sgrscat=False, polrep_obs='stokes',
     elif polrep_obs == 'circ':
         im = im_org.switch_polrep('circ', 'RR')
         pollist = ['RR', 'LL', 'RL', 'LR']  # TODO what if we have to RR image?
+    elif polrep_obs == 'lin':
+        im = im_org.switch_polrep('lin', 'XX')
+        pollist = ['XX', 'YY', 'XY', 'YX']
+    elif polrep_obs == 'mixed':
+        # There is no single image basis for a mixed-feed observation (the
+        # correlation basis varies per baseline). Sample in Stokes here; the
+        # caller converts each baseline to its polbasis via
+        # pack_sampled_visibilities -> pol_conventions.stokes_to_coherency.
+        im = im_org.switch_polrep('stokes', 'I')
+        pollist = ['I', 'Q', 'U', 'V']
     else:
-        raise Exception("only 'stokes' and 'circ' are supported polreps!")
+        raise Exception("polrep_obs must be 'stokes', 'circ', 'lin', or 'mixed'!")
 
     uv = np.array(uv)
     if uv.shape[1] != 2:
@@ -344,6 +352,71 @@ def sample_vis(im_org, uv, sgrscat=False, polrep_obs='stokes',
             data *= ker
 
     return obsdata
+
+def pack_sampled_visibilities(obsdata, data, polrep):
+    """Write the four sampled visibility vectors from sample_vis into the
+    correct fields of an obsdata recarray.
+
+       Args:
+           obsdata (np.recarray): the data table to fill, in representation
+               `polrep`. For 'mixed' it must carry a populated 'polbasis' column.
+           data (list): the four visibility vectors returned by sample_vis. For
+               'stokes'/'circ'/'lin' these are the four basis correlations; for
+               'mixed' they are Stokes (I, Q, U, V).
+           polrep (str): one of 'stokes', 'circ', 'lin', 'mixed'.
+
+       Returns:
+           (np.recarray): the same obsdata, mutated in place and returned.
+    """
+    if polrep == 'stokes':
+        obsdata['vis'] = data[0]
+        if data[1] is not None:
+            obsdata['qvis'] = data[1]
+            obsdata['uvis'] = data[2]
+            obsdata['vvis'] = data[3]
+
+    elif polrep == 'circ':
+        obsdata['rrvis'] = data[0]
+        if data[1] is not None:
+            obsdata['llvis'] = data[1]
+        if data[2] is not None:
+            obsdata['rlvis'] = data[2]
+            obsdata['lrvis'] = data[3]
+
+    elif polrep == 'lin':
+        obsdata['xxvis'] = data[0]
+        if data[1] is not None:
+            obsdata['yyvis'] = data[1]
+        if data[2] is not None:
+            obsdata['xyvis'] = data[2]
+            obsdata['yxvis'] = data[3]
+
+    elif polrep == 'mixed':
+        # data is Stokes (I, Q, U, V). Convert to the four generic correlation
+        # slots per baseline; rows sharing a polbasis share one feed pairing,
+        # so we group by polbasis and convert each group with one operator.
+        I, Q, U, V = (np.asarray(d) for d in data)
+        p1p1 = np.empty(len(obsdata), dtype=complex)
+        p2p2 = np.empty(len(obsdata), dtype=complex)
+        p1p2 = np.empty(len(obsdata), dtype=complex)
+        p2p1 = np.empty(len(obsdata), dtype=complex)
+        for basis in np.unique(obsdata['polbasis']):
+            mask = obsdata['polbasis'] == basis
+            t1_feed, t2_feed = str(basis)[:2], str(basis)[2:]
+            corr = pol_conventions.stokes_to_coherency(
+                I[mask], Q[mask], U[mask], V[mask], t1_feed, t2_feed)
+            p1p1[mask], p2p2[mask], p1p2[mask], p2p1[mask] = corr
+        obsdata['p1p1vis'] = p1p1
+        obsdata['p2p2vis'] = p2p2
+        obsdata['p1p2vis'] = p1p2
+        obsdata['p2p1vis'] = p2p1
+
+    else:
+        raise ValueError(
+            f"polrep must be one of 'stokes', 'circ', 'lin', 'mixed'; got {polrep!r}")
+
+    return obsdata
+
 
 ##################################################################################################
 # Noise + miscalibration funcitons

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -427,6 +427,47 @@ def pack_sampled_visibilities(obsdata, data, polrep):
 ##################################################################################################
 
 
+def _baseline_correlation_sigmas(obs, t1, t2, tints):
+    """Thermal noise sigmas for the four generic correlations of each baseline.
+
+    Returns ``(sig_p1p1, sig_p2p2, sig_p1p2, sig_p2p1)`` -- one array per generic
+    DTPOL slot -- from the stations' per-feed SEFDs (``sefd_p1``/``sefd_p2``) via
+    :func:`obs_helpers.blnoise`. Each slot pairs the two stations' feeds
+    (p1p1 = t1-feed1 x t2-feed1, p1p2 = t1-feed1 x t2-feed2, etc.). Reduces
+    exactly to the legacy circular ``sig_rr/sig_ll/sig_rl/sig_lr`` pairing
+    (``sefd_p1`` == ``sefdr``, ``sefd_p2`` == ``sefdl``).
+
+    Parameters
+    ----------
+    obs : Obsdata
+        Provides ``tarr``/``tkey`` (SEFDs) and ``bw``.
+    t1, t2 : sequence of str
+        Per-row station names for the two ends of each baseline.
+    tints : sequence of float
+        Per-row integration times.
+
+    Returns
+    -------
+    tuple of four np.ndarray
+        ``(sig_p1p1, sig_p2p2, sig_p1p2, sig_p2p1)``.
+    """
+    n = len(t1)
+    tarr, tkey, bw = obs.tarr, obs.tkey, obs.bw
+
+    def _sefd(site, slot):
+        return tarr[tkey[site]]['sefd_p1' if slot == 0 else 'sefd_p2']
+
+    sig_p1p1 = np.fromiter((obsh.blnoise(_sefd(t1[i], 0), _sefd(t2[i], 0), tints[i], bw)
+                            for i in range(n)), float)
+    sig_p2p2 = np.fromiter((obsh.blnoise(_sefd(t1[i], 1), _sefd(t2[i], 1), tints[i], bw)
+                            for i in range(n)), float)
+    sig_p1p2 = np.fromiter((obsh.blnoise(_sefd(t1[i], 0), _sefd(t2[i], 1), tints[i], bw)
+                            for i in range(n)), float)
+    sig_p2p1 = np.fromiter((obsh.blnoise(_sefd(t1[i], 1), _sefd(t2[i], 0), tints[i], bw)
+                            for i in range(n)), float)
+    return sig_p1p1, sig_p2p2, sig_p1p2, sig_p2p1
+
+
 def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
                frcal=True, rlgaincal=True,
                stabilize_scan_phase=False, stabilize_scan_amp=False, neggains=False,
@@ -802,15 +843,14 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
             fr_angle_D = 2.0*(tarr[i]['fr_elev']*el_angles + tarr[i]
                               ['fr_par']*par_angles + tarr[i]['fr_off']*ehc.DEGREE)
 
-        # Assemble the Jones Matrices and save to dictionary
-        j_matrices = {times[j]: np.array([
-            [np.exp(-1j*fr_angle[j])*gainR[j],
-             np.exp(1j*(fr_angle[j]+fr_angle_D[j]))*dR*gainR[j]],
-            [np.exp(-1j*(fr_angle[j]+fr_angle_D[j]))*dL*gainL[j],
-             np.exp(1j*fr_angle[j])*gainL[j]]
-        ])
-            for j in range(len(times))
-        }
+        # Assemble the Jones matrices (J = G (I + D_rot) Phi) and save to dict.
+        # gainR/gainL are the p1/p2 complex gains, dR/dL the p1/p2 D-terms, built
+        # per station in that station's own feed basis. feed_type selects the
+        # field-rotation form (diagonal phase for 'rl', real rotation for 'xy').
+        feed_type = str(tarr[i]['feed_type'])
+        J = pol_conventions.assemble_jones(gainR, gainL, dR, dL, feed_type,
+                                           fr_angle, fr_angle_D)
+        j_matrices = {times[j]: J[j] for j in range(len(times))}
 
         out[site] = j_matrices
 
@@ -936,15 +976,15 @@ def make_jones_inverse(obs, opacitycal=True, dcal=True, frcal=True):
             fr_angle_D = 2.0*(tarr[i]['fr_elev']*el_angles + tarr[i]
                               ['fr_par']*par_angles + tarr[i]['fr_off']*ehc.DEGREE)
 
-        # Assemble the inverse Jones Matrices and save to dictionary
-        pref = 1.0/(gainL*gainR*(1.0 - dL*dR))
-        j_matrices_inv = {times[j]: pref[j]*np.array([
-            [np.exp(1j*fr_angle[j])*gainL[j],
-             -np.exp(1j*(fr_angle[j] + fr_angle_D[j]))*dR*gainR[j]],
-            [-np.exp(-1j*(fr_angle[j] + fr_angle_D[j]))*dL*gainL[j],
-             np.exp(-1j*fr_angle[j])*gainR[j]]
-        ]) for j in range(len(times))
-        }
+        # Assemble the forward Jones matrices (J = G (I + D_rot) Phi) in this
+        # station's feed basis, then invert. This reproduces the analytic
+        # circular inverse (inv of the make_jones matrix) and generalizes to
+        # linear/mixed feeds. gainR/gainL are p1/p2 gains, dR/dL are p1/p2 D-terms.
+        feed_type = str(tarr[i]['feed_type'])
+        J = pol_conventions.assemble_jones(gainR, gainL, dR, dL, feed_type,
+                                           fr_angle, fr_angle_D)
+        J_inv = pol_conventions.invert_jones(J)
+        j_matrices_inv = {times[j]: J_inv[j] for j in range(len(times))}
 
         out[site] = j_matrices_inv
 
@@ -1031,45 +1071,68 @@ def add_jones_and_noise(obs, add_th_noise=True,
                          rlgsigmat=rlgsigmat,rlpsigmat=rlpsigmat,
                          caltable_path=caltable_path, seed=seed)
 
-    # Change pol rep:
-    obs_circ = obs.switch_polrep('circ')
-    obsdata = copy.copy(obs_circ.data)
+    # Choose the correlation basis to corrupt in. A Jones matrix acts on a
+    # station's feed-basis coherency, so we need the four feed correlations.
+    # If the obs is already in a correlation basis (circ/lin/mixed) we corrupt
+    # in place; a Stokes obs is switched to the array's feed basis first.
+    # Homogeneous-circular reduces exactly to the legacy path (feed-letter noise
+    # tags below reproduce the 'rr'/'rl'/... keys).
+    feed_of = {str(r['site']): str(r['feed_type']) for r in obs.tarr}
+    feeds = set(feed_of.values())
+
+    if obs.polrep in ('circ', 'lin', 'mixed'):
+        obs_work = obs
+        switch_back = False
+    else:  # 'stokes' -> switch to the array's feed correlation basis
+        if feeds <= {'rl'}:
+            target, hand = 'circ', 'R'
+        elif feeds <= {'xy'}:
+            target, hand = 'lin', 'X'
+        else:
+            raise NotImplementedError(
+                "add_jones_and_noise: corrupting a Stokes observation of a "
+                "heterogeneous (mixed-feed) array is not supported because "
+                "switch_polrep cannot yet target 'mixed'. Build the observation "
+                "directly in polrep='mixed' (e.g. observe(..., polrep_obs='mixed')) "
+                "before adding Jones corruption. See docs/polarization_conventions.md sec 12.")
+        obs_work = obs.switch_polrep(target, singlepol_hand=hand)
+        switch_back = True
+
+    obsdata = copy.copy(obs_work.data)
+    pd = obs_work.poldict
 
     times = obsdata['time']
     t1 = obsdata['t1']
     t2 = obsdata['t2']
     tints = obsdata['tint']
-    rr = obsdata['rrvis']
-    ll = obsdata['llvis']
-    rl = obsdata['rlvis']
-    lr = obsdata['lrvis']
+    n = len(times)
 
-    # Recompute the noise std. deviations from the SEFDs
-    if np.any(obs.tarr['sefdr'] <= 0) or np.any(obs.tarr['sefdl'] <= 0):
+    # Generic correlation slots: vis1=p1p1, vis2=p2p2, vis3=p1p2, vis4=p2p1.
+    v_p1p1 = obsdata[pd['vis1']]
+    v_p2p2 = obsdata[pd['vis2']]
+    v_p1p2 = obsdata[pd['vis3']]
+    v_p2p1 = obsdata[pd['vis4']]
+
+    # Per-row feed types (for the noise correlation labels). t1f[0]/t1f[1] are
+    # the station's p1/p2 feed letters, so t1f[0]+t2f[0] is the p1p1 label etc.
+    t1f = [feed_of[t1[i]] for i in range(n)]
+    t2f = [feed_of[t2[i]] for i in range(n)]
+
+    # Recompute the four per-correlation noise sigmas from SEFDs. Each slot
+    # pairs the two stations' feeds; sefd_p1/sefd_p2 are the p1/p2 feed SEFDs
+    # (== sefdr/sefdl for circular), so this reduces exactly to the legacy
+    # sig_rr/sig_ll/sig_rl/sig_lr computation.
+    if np.any(obs.tarr['sefd_p1'] <= 0) or np.any(obs.tarr['sefd_p2'] <= 0):
         if verbose:
             print("Warning!: in add_jones_and_noise, some SEFDs are <= 0!")
             print("Resorting to data point sigmas, which may add too much systematic noise!")
-        sig_rr = obsdata['rrsigma']
-        sig_ll = obsdata['llsigma']
-        sig_rl = obsdata['rlsigma']
-        sig_lr = obsdata['lrsigma']
+        sig_p1p1 = obsdata[pd['sigma1']]
+        sig_p2p2 = obsdata[pd['sigma2']]
+        sig_p1p2 = obsdata[pd['sigma3']]
+        sig_p2p1 = obsdata[pd['sigma4']]
     else:
-        sig_rr = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[t1[i]]]['sefdr'],
-                                           obs.tarr[obs.tkey[t2[i]]]['sefdr'],
-                                           tints[i], obs.bw)
-                              for i in range(len(rr))), float)
-        sig_ll = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[t1[i]]]['sefdl'],
-                                           obs.tarr[obs.tkey[t2[i]]]['sefdl'],
-                                           tints[i], obs.bw)
-                              for i in range(len(ll))), float)
-        sig_rl = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[t1[i]]]['sefdr'],
-                                           obs.tarr[obs.tkey[t2[i]]]['sefdl'],
-                                           tints[i], obs.bw)
-                              for i in range(len(rl))), float)
-        sig_lr = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[t1[i]]]['sefdl'],
-                                           obs.tarr[obs.tkey[t2[i]]]['sefdr'],
-                                           tints[i], obs.bw)
-                              for i in range(len(lr))), float)
+        sig_p1p1, sig_p2p2, sig_p1p2, sig_p2p1 = _baseline_correlation_sigmas(
+            obs, t1, t2, tints)
 
     if verbose and not opacitycal:
         print("   Applying opacity attenuation: opacitycal-->False")
@@ -1084,43 +1147,44 @@ def add_jones_and_noise(obs, add_th_noise=True,
     if verbose and add_th_noise:
         print("Adding thermal noise to data . . . ")
 
-    # Corrupt each IQUV visibility set with the jones matrices and add noise
-    for i in range(len(times)):
-        # Form the visibility correlation matrix
-        corr_matrix = np.array([[rr[i], rl[i]], [lr[i], ll[i]]])
+    # Corrupt each baseline's coherency matrix with the Jones matrices + noise.
+    for i in range(n):
+        # Coherency matrix in generic-slot order [[p1p1, p1p2], [p2p1, p2p2]].
+        corr_matrix = np.array([[v_p1p1[i], v_p1p2[i]], [v_p2p1[i], v_p2p2[i]]])
 
-        # Get the jones matrices and corrupt the corr_matrix
         j1 = jm_dict[t1[i]][times[i]]
         j2 = jm_dict[t2[i]][times[i]]
+        corr_matrix_corrupt = pol_conventions.apply_jones_to_coherency(corr_matrix, j1, j2)
 
-        corr_matrix_corrupt = np.dot(j1, np.dot(corr_matrix, np.conjugate(j2.T)))
-
-        # Add noise
+        # Add noise. Labels are the feed-letter correlation names (p1p1 -> e.g.
+        # 'rr'/'xx'/'rx'), which reproduce the legacy circular keys exactly.
         if add_th_noise:
             noise_matrix = np.array([
-                [obsh.cerror_hash(sig_rr[i], t1[i], t2[i], times[i], 'rr', seed),
-                 obsh.cerror_hash(sig_rl[i], t1[i], t2[i], times[i], 'rl', seed)],
-                [obsh.cerror_hash(sig_lr[i], t1[i], t2[i], times[i], 'lr', seed),
-                 obsh.cerror_hash(sig_ll[i], t1[i], t2[i], times[i], 'll', seed)],
+                [obsh.cerror_hash(sig_p1p1[i], t1[i], t2[i], times[i], t1f[i][0] + t2f[i][0], seed),
+                 obsh.cerror_hash(sig_p1p2[i], t1[i], t2[i], times[i], t1f[i][0] + t2f[i][1], seed)],
+                [obsh.cerror_hash(sig_p2p1[i], t1[i], t2[i], times[i], t1f[i][1] + t2f[i][0], seed),
+                 obsh.cerror_hash(sig_p2p2[i], t1[i], t2[i], times[i], t1f[i][1] + t2f[i][1], seed)],
             ])
-            corr_matrix_corrupt += noise_matrix
+            corr_matrix_corrupt = corr_matrix_corrupt + noise_matrix
 
-        # Put the corrupted data back into the data table
-        obsdata['rrvis'][i] = corr_matrix_corrupt[0][0]
-        obsdata['llvis'][i] = corr_matrix_corrupt[1][1]
-        obsdata['rlvis'][i] = corr_matrix_corrupt[0][1]
-        obsdata['lrvis'][i] = corr_matrix_corrupt[1][0]
+        # Put the corrupted correlations back into the generic slots.
+        obsdata[pd['vis1']][i] = corr_matrix_corrupt[0][0]  # p1p1
+        obsdata[pd['vis2']][i] = corr_matrix_corrupt[1][1]  # p2p2
+        obsdata[pd['vis3']][i] = corr_matrix_corrupt[0][1]  # p1p2
+        obsdata[pd['vis4']][i] = corr_matrix_corrupt[1][0]  # p2p1
 
-        # Put the recomputed sigmas back into the data table
-        obsdata['rrsigma'][i] = sig_rr[i]
-        obsdata['llsigma'][i] = sig_ll[i]
-        obsdata['rlsigma'][i] = sig_rl[i]
-        obsdata['lrsigma'][i] = sig_lr[i]
+        obsdata[pd['sigma1']][i] = sig_p1p1[i]
+        obsdata[pd['sigma2']][i] = sig_p2p2[i]
+        obsdata[pd['sigma3']][i] = sig_p1p2[i]
+        obsdata[pd['sigma4']][i] = sig_p2p1[i]
 
     # put back into input polvec
-    obs_circ.data = obsdata
-    obs_back = obs_circ.switch_polrep(obs.polrep)
-    obsdata_back = obs_back.data
+    if switch_back:
+        obs_work.data = obsdata
+        obs_back = obs_work.switch_polrep(obs.polrep)
+        obsdata_back = obs_back.data
+    else:
+        obsdata_back = obsdata
 
     # Return observation data
     return obsdata_back
@@ -1145,105 +1209,110 @@ def apply_jones_inverse(obs, opacitycal=True, dcal=True, frcal=True, verbose=Tru
     # Build Inverse Jones Matrices
     jm_dict = make_jones_inverse(obs, opacitycal=opacitycal, dcal=dcal, frcal=frcal)
 
-    # Change pol rep:
-    obs_circ = obs.switch_polrep('circ')
+    # Choose the correlation basis to correct in (same logic as
+    # add_jones_and_noise): in place for circ/lin/mixed, switch a Stokes obs to
+    # the array's feed basis first. Homogeneous-circular reduces to the legacy path.
+    feed_of = {str(r['site']): str(r['feed_type']) for r in obs.tarr}
+    feeds = set(feed_of.values())
 
-    # Get data
-    obsdata = copy.deepcopy(obs_circ.data)
+    if obs.polrep in ('circ', 'lin', 'mixed'):
+        obs_work = obs
+        switch_back = False
+    else:  # 'stokes' -> switch to the array's feed correlation basis
+        if feeds <= {'rl'}:
+            target, hand = 'circ', 'R'
+        elif feeds <= {'xy'}:
+            target, hand = 'lin', 'X'
+        else:
+            raise NotImplementedError(
+                "apply_jones_inverse: a Stokes observation of a heterogeneous "
+                "(mixed-feed) array is not supported because switch_polrep cannot "
+                "yet target 'mixed'. Provide the observation in polrep='mixed'. "
+                "See docs/polarization_conventions.md sec 12.")
+        obs_work = obs.switch_polrep(target, singlepol_hand=hand)
+        switch_back = True
+
+    obsdata = copy.deepcopy(obs_work.data)
+    pd = obs_work.poldict
     times = obsdata['time']
     t1 = obsdata['t1']
     t2 = obsdata['t2']
     tints = obsdata['tint']
-    rr = obsdata['rrvis']
-    ll = obsdata['llvis']
-    rl = obsdata['rlvis']
-    lr = obsdata['lrvis']
+    n = len(times)
 
-    # Recompute the noise std. deviations from the SEFDs
-    if np.any(obs.tarr['sefdr'] <= 0) or np.any(obs.tarr['sefdl'] <= 0):
+    # Generic correlation slots: vis1=p1p1, vis2=p2p2, vis3=p1p2, vis4=p2p1.
+    v_p1p1 = obsdata[pd['vis1']]
+    v_p2p2 = obsdata[pd['vis2']]
+    v_p1p2 = obsdata[pd['vis3']]
+    v_p2p1 = obsdata[pd['vis4']]
+
+    # Recompute the four per-correlation sigmas from SEFDs (feed-aware; reduces
+    # to the legacy sig_rr/ll/rl/lr computation for circular).
+    if np.any(obs.tarr['sefd_p1'] <= 0) or np.any(obs.tarr['sefd_p2'] <= 0):
         if verbose:
-            print("Warning!: in add_jones_and_noise, some SEFDs are <= 0!")
+            print("Warning!: in apply_jones_inverse, some SEFDs are <= 0!")
             print("resorting to data point sigmas, which may add too much systematic noise!")
-        sig_rr = obsdata['rrsigma']
-        sig_ll = obsdata['llsigma']
-        sig_rl = obsdata['rlsigma']
-        sig_lr = obsdata['lrsigma']
+        sig_p1p1 = obsdata[pd['sigma1']]
+        sig_p2p2 = obsdata[pd['sigma2']]
+        sig_p1p2 = obsdata[pd['sigma3']]
+        sig_p2p1 = obsdata[pd['sigma4']]
     else:
-        # TODO why are there sqrt(2)s here and not below?
-        sig_rr = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[t1[i]]]['sefdr'],
-                                           obs.tarr[obs.tkey[t2[i]]]['sefdr'],
-                                           tints[i], obs.bw)
-                              for i in range(len(rr))), float)
-        sig_ll = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[t1[i]]]['sefdl'],
-                                           obs.tarr[obs.tkey[t2[i]]]['sefdl'],
-                                           tints[i], obs.bw)
-                              for i in range(len(ll))), float)
-        sig_rl = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[t1[i]]]['sefdr'],
-                                           obs.tarr[obs.tkey[t2[i]]]['sefdl'],
-                                           tints[i], obs.bw)
-                              for i in range(len(rl))), float)
-        sig_lr = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[t1[i]]]['sefdl'],
-                                           obs.tarr[obs.tkey[t2[i]]]['sefdr'],
-                                           tints[i], obs.bw)
-                              for i in range(len(lr))), float)
+        sig_p1p1, sig_p2p2, sig_p1p2, sig_p2p1 = _baseline_correlation_sigmas(
+            obs, t1, t2, tints)
 
-    if not opacitycal:
-        if verbose:
-            print("   Applying opacity corrections: opacitycal-->True")
-        opacitycal = True
-    if not dcal:
-        if verbose:
-            print("   Applying D Term corrections: dcal-->True")
-        dcal = True
-    if not frcal:
-        if verbose:
-            print("   Applying Field Rotation corrections: frcal-->True")
-        frcal = True
+    if verbose and not opacitycal:
+        print("   Applying opacity corrections: opacitycal-->True")
+    if verbose and not dcal:
+        print("   Applying D Term corrections: dcal-->True")
+    if verbose and not frcal:
+        print("   Applying Field Rotation corrections: frcal-->True")
 
-    # Apply the inverse Jones matrices to each visibility
-    for i in range(len(times)):
-
-        # Get the inverse jones matrices
+    # Apply the (already-inverse) Jones matrices to each baseline's coherency
+    # matrix and propagate the four per-slot sigmas.
+    for i in range(n):
         inv_j1 = jm_dict[t1[i]][times[i]]
         inv_j2 = jm_dict[t2[i]][times[i]]
 
-        # Form the visibility correlation matrix
-        corr_matrix = np.array([[rr[i], rl[i]], [lr[i], ll[i]]])
+        # Coherency matrix in generic-slot order [[p1p1, p1p2], [p2p1, p2p2]].
+        corr_matrix = np.array([[v_p1p1[i], v_p1p2[i]], [v_p2p1[i], v_p2p2[i]]])
 
-        # Form the sigma matrices
-        sig_rr_matrix = np.array([[sig_rr[i], 0.0], [0.0, 0.0]])
-        sig_ll_matrix = np.array([[0.0, 0.0], [0.0, sig_ll[i]]])
-        sig_rl_matrix = np.array([[0.0, sig_rl[i]], [0.0, 0.0]])
-        sig_lr_matrix = np.array([[0.0, 0.0], [sig_lr[i], 0.0]])
+        # Per-slot sigma matrices (same generic-slot layout).
+        sig_p1p1_matrix = np.array([[sig_p1p1[i], 0.0], [0.0, 0.0]])
+        sig_p2p2_matrix = np.array([[0.0, 0.0], [0.0, sig_p2p2[i]]])
+        sig_p1p2_matrix = np.array([[0.0, sig_p1p2[i]], [0.0, 0.0]])
+        sig_p2p1_matrix = np.array([[0.0, 0.0], [sig_p2p1[i], 0.0]])
 
-        # Apply the inverse Jones Matrices to the visibility correlation matrix and sigma matrices
-        corr_matrix_new = np.dot(inv_j1, np.dot(corr_matrix, np.conjugate(inv_j2.T)))
+        # inv_j is already the inverse Jones, so applying it forward-style
+        # (J_inv V J_inv^dag) is the a-priori correction.
+        corr_matrix_new = pol_conventions.apply_jones_to_coherency(corr_matrix, inv_j1, inv_j2)
 
-        sig_rr_matrix_new = np.dot(inv_j1, np.dot(sig_rr_matrix, np.conjugate(inv_j2.T)))
-        sig_ll_matrix_new = np.dot(inv_j1, np.dot(sig_ll_matrix, np.conjugate(inv_j2.T)))
-        sig_rl_matrix_new = np.dot(inv_j1, np.dot(sig_rl_matrix, np.conjugate(inv_j2.T)))
-        sig_lr_matrix_new = np.dot(inv_j1, np.dot(sig_lr_matrix, np.conjugate(inv_j2.T)))
+        sig_p1p1_new = pol_conventions.apply_jones_to_coherency(sig_p1p1_matrix, inv_j1, inv_j2)
+        sig_p2p2_new = pol_conventions.apply_jones_to_coherency(sig_p2p2_matrix, inv_j1, inv_j2)
+        sig_p1p2_new = pol_conventions.apply_jones_to_coherency(sig_p1p2_matrix, inv_j1, inv_j2)
+        sig_p2p1_new = pol_conventions.apply_jones_to_coherency(sig_p2p1_matrix, inv_j1, inv_j2)
 
-        # Get the final sigma matrix as a quadrature sum
-        sig_matrix_new = np.sqrt(np.abs(sig_rr_matrix_new)**2 + np.abs(sig_ll_matrix_new)**2 +
-                                 np.abs(sig_rl_matrix_new)**2 + np.abs(sig_lr_matrix_new)**2)
+        # Final sigma matrix as a quadrature sum (independence assumption).
+        sig_matrix_new = np.sqrt(np.abs(sig_p1p1_new)**2 + np.abs(sig_p2p2_new)**2 +
+                                 np.abs(sig_p1p2_new)**2 + np.abs(sig_p2p1_new)**2)
 
-        # Put the corrupted data back into the data table
-        obsdata['rrvis'][i] = corr_matrix_new[0][0]
-        obsdata['llvis'][i] = corr_matrix_new[1][1]
-        obsdata['rlvis'][i] = corr_matrix_new[0][1]
-        obsdata['lrvis'][i] = corr_matrix_new[1][0]
+        # Put the corrected correlations back into the generic slots.
+        obsdata[pd['vis1']][i] = corr_matrix_new[0][0]  # p1p1
+        obsdata[pd['vis2']][i] = corr_matrix_new[1][1]  # p2p2
+        obsdata[pd['vis3']][i] = corr_matrix_new[0][1]  # p1p2
+        obsdata[pd['vis4']][i] = corr_matrix_new[1][0]  # p2p1
 
-        # Put the recomputed sigmas back into the data table
-        obsdata['rrsigma'][i] = sig_matrix_new[0][0]
-        obsdata['llsigma'][i] = sig_matrix_new[1][1]
-        obsdata['rlsigma'][i] = sig_matrix_new[0][1]
-        obsdata['lrsigma'][i] = sig_matrix_new[1][0]
+        obsdata[pd['sigma1']][i] = sig_matrix_new[0][0]  # p1p1
+        obsdata[pd['sigma2']][i] = sig_matrix_new[1][1]  # p2p2
+        obsdata[pd['sigma3']][i] = sig_matrix_new[0][1]  # p1p2
+        obsdata[pd['sigma4']][i] = sig_matrix_new[1][0]  # p2p1
 
     # put back into input polvec
-    obs_circ.data = obsdata
-    obs_back = obs_circ.switch_polrep(obs.polrep)
-    obsdata_back = obs_back.data
+    if switch_back:
+        obs_work.data = obsdata
+        obs_back = obs_work.switch_polrep(obs.polrep)
+        obsdata_back = obs_back.data
+    else:
+        obsdata_back = obsdata
 
     # Return observation data
     return obsdata_back
@@ -1336,8 +1405,7 @@ def add_noise(obs, add_th_noise=True, opacitycal=True, ampcal=True, phasecal=Tru
         times_stable_amp = times_stable.copy()
 
     # Recompute perfect sigmas from SEFDs
-    bw = obs.bw
-    if np.any(obs.tarr['sefdr'] <= 0):
+    if np.any(obs.tarr['sefd_p1'] <= 0) or np.any(obs.tarr['sefd_p2'] <= 0):
         if verbose:
             print("Warning!: in add_noise, some SEFDs are <= 0!")
             print("NOT recomputing sigmas, which may result in double systematic noise")
@@ -1346,30 +1414,33 @@ def add_noise(obs, add_th_noise=True, opacitycal=True, ampcal=True, phasecal=Tru
         sigma_perf3 = obsdata[obs.poldict['sigma3']]
         sigma_perf4 = obsdata[obs.poldict['sigma4']]
     else:
-        sig_rr = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[sites[i][0]]]['sefdr'],
-                                           obs.tarr[obs.tkey[sites[i][1]]]['sefdr'], tint[i], bw)
-                              for i in range(len(tint))), float)
-        sig_ll = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[sites[i][0]]]['sefdl'],
-                                           obs.tarr[obs.tkey[sites[i][1]]]['sefdl'], tint[i], bw)
-                              for i in range(len(tint))), float)
-        sig_rl = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[sites[i][0]]]['sefdr'],
-                                           obs.tarr[obs.tkey[sites[i][1]]]['sefdl'], tint[i], bw)
-                              for i in range(len(tint))), float)
-        sig_lr = np.fromiter((obsh.blnoise(obs.tarr[obs.tkey[sites[i][0]]]['sefdl'],
-                                           obs.tarr[obs.tkey[sites[i][1]]]['sefdr'], tint[i], bw)
-                              for i in range(len(tint))), float)
+        # Four feed-correlation sigmas (p1p1, p2p2, p1p2, p2p1); shared with
+        # add_jones_and_noise / apply_jones_inverse.
+        sig_p1p1, sig_p2p2, sig_p1p2, sig_p2p1 = _baseline_correlation_sigmas(
+            obs, sites[:, 0], sites[:, 1], tint)
         if obs.polrep == 'stokes':
-            sig_iv = 0.5*np.sqrt(sig_rr**2 + sig_ll**2)
-            sig_qu = 0.5*np.sqrt(sig_rl**2 + sig_lr**2)
-            sigma_perf1 = sig_iv
-            sigma_perf2 = sig_qu
-            sigma_perf3 = sig_qu
-            sigma_perf4 = sig_iv
-        elif obs.polrep == 'circ':
-            sigma_perf1 = sig_rr
-            sigma_perf2 = sig_ll
-            sigma_perf3 = sig_rl
-            sigma_perf4 = sig_lr
+            # Propagate to Stokes using the array's feed convention. Reduces to
+            # the legacy circular sig_iv/sig_qu (circ_to_stokes_sigma).
+            feeds = set(str(ft) for ft in obs.tarr['feed_type'])
+            if feeds <= {'rl'}:
+                (sigma_perf1, sigma_perf2, sigma_perf3, sigma_perf4) = \
+                    pol_conventions.circ_to_stokes_sigma(
+                        sig_p1p1, sig_p2p2, sig_p1p2, sig_p2p1)
+            elif feeds <= {'xy'}:
+                (sigma_perf1, sigma_perf2, sigma_perf3, sigma_perf4) = \
+                    pol_conventions.lin_to_stokes_sigma(
+                        sig_p1p1, sig_p2p2, sig_p1p2, sig_p2p1)
+            else:
+                raise NotImplementedError(
+                    "add_noise: Stokes noise for a heterogeneous (mixed-feed) "
+                    "array is not supported (Stokes sigma is per-baseline for "
+                    "mixed feeds). Use polrep='mixed', 'circ', or 'lin'. "
+                    "See docs/polarization_conventions.md sec 12.")
+        else:  # 'circ' / 'lin' / 'mixed': the four correlation sigmas directly
+            sigma_perf1 = sig_p1p1
+            sigma_perf2 = sig_p2p2
+            sigma_perf3 = sig_p1p2
+            sigma_perf4 = sig_p2p1
 
     # Seed for random number generators
     if seed is False:

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -361,8 +361,8 @@ def pack_sampled_visibilities(obsdata, data, polrep):
            obsdata (np.recarray): the data table to fill, in representation
                `polrep`. For 'mixed' it must carry a populated 'polbasis' column.
            data (list): the four visibility vectors returned by sample_vis. For
-               'stokes'/'circ'/'lin' these are the four basis correlations; for
-               'mixed' they are Stokes (I, Q, U, V).
+               'circ'/'lin' these are the four basis correlations; for
+               'stokes'/'mixed' they are the I, Q, U, V visibilities.
            polrep (str): one of 'stokes', 'circ', 'lin', 'mixed'.
 
        Returns:

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -532,6 +532,15 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
     dec = obs_tmp.dec
     sourcevec = np.array([np.cos(dec*ehc.DEGREE), 0, np.sin(dec*ehc.DEGREE)])
 
+    # Up-front guard: the frcal-but-not-dcal leakage double-rotation is only
+    # derived for circular feeds (see pol_conventions.assemble_jones). Fail
+    # clearly here rather than deep inside the per-station assembly.
+    if frcal and not dcal and not set(str(ft) for ft in tarr['feed_type']) <= {'rl'}:
+        raise NotImplementedError(
+            "make_jones: frcal=True with dcal=False (field rotation corrected, "
+            "leakage not) is only supported for circular feeds. For linear/mixed "
+            "feeds use dcal=True or frcal=False. See jones_mixedpol_plan.md.")
+
     # Create a dictionary of taus and a list of unique times
     nsites = len(obs_tmp.tarr['site'])
     taudict = {site: np.array([]) for site in obs_tmp.tarr['site']}
@@ -895,6 +904,15 @@ def make_jones_inverse(obs, opacitycal=True, dcal=True, frcal=True):
     ra = obs.ra
     dec = obs.dec
     sourcevec = np.array([np.cos(dec*ehc.DEGREE), 0, np.sin(dec*ehc.DEGREE)])
+
+    # Up-front guard: the frcal-but-not-dcal leakage double-rotation is only
+    # derived for circular feeds (see pol_conventions.assemble_jones). Fail
+    # clearly here rather than deep inside the per-station assembly.
+    if frcal and not dcal and not set(str(ft) for ft in tarr['feed_type']) <= {'rl'}:
+        raise NotImplementedError(
+            "make_jones_inverse: frcal=True with dcal=False (field rotation "
+            "corrected, leakage not) is only supported for circular feeds. For "
+            "linear/mixed feeds use dcal=True or frcal=False. See jones_mixedpol_plan.md.")
 
     # Create a dictionary of taus and a list of unique times
     nsites = len(obs.tarr['site'])

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -539,7 +539,7 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
         raise NotImplementedError(
             "make_jones: frcal=True with dcal=False (field rotation corrected, "
             "leakage not) is only supported for circular feeds. For linear/mixed "
-            "feeds use dcal=True or frcal=False. See jones_mixedpol_plan.md.")
+            "feeds use dcal=True or frcal=False.")
 
     # Create a dictionary of taus and a list of unique times
     nsites = len(obs_tmp.tarr['site'])
@@ -912,7 +912,7 @@ def make_jones_inverse(obs, opacitycal=True, dcal=True, frcal=True):
         raise NotImplementedError(
             "make_jones_inverse: frcal=True with dcal=False (field rotation "
             "corrected, leakage not) is only supported for circular feeds. For "
-            "linear/mixed feeds use dcal=True or frcal=False. See jones_mixedpol_plan.md.")
+            "linear/mixed feeds use dcal=True or frcal=False.")
 
     # Create a dictionary of taus and a list of unique times
     nsites = len(obs.tarr['site'])

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -395,11 +395,15 @@ def pack_sampled_visibilities(obsdata, data, polrep):
         # data is Stokes (I, Q, U, V). Convert to the four generic correlation
         # slots per baseline; rows sharing a polbasis share one feed pairing,
         # so we group by polbasis and convert each group with one operator.
-        I, Q, U, V = (np.asarray(d) for d in data)
-        p1p1 = np.empty(len(obsdata), dtype=complex)
-        p2p2 = np.empty(len(obsdata), dtype=complex)
-        p1p2 = np.empty(len(obsdata), dtype=complex)
-        p2p1 = np.empty(len(obsdata), dtype=complex)
+        # sample_vis returns None for absent Stokes (e.g. an unpolarized source),
+        # so fill those with zeros before converting.
+        n = len(obsdata)
+        I, Q, U, V = (np.asarray(d) if d is not None else np.zeros(n, complex)
+                      for d in data)
+        p1p1 = np.empty(n, dtype=complex)
+        p2p2 = np.empty(n, dtype=complex)
+        p1p2 = np.empty(n, dtype=complex)
+        p2p1 = np.empty(n, dtype=complex)
         for basis in np.unique(obsdata['polbasis']):
             mask = obsdata['polbasis'] == basis
             t1_feed, t2_feed = str(basis)[:2], str(basis)[2:]

--- a/ehtim/observing/pol_conventions.py
+++ b/ehtim/observing/pol_conventions.py
@@ -488,3 +488,171 @@ def apply_inverse_jones_to_coherency(V_obs, J1, J2):
     J1_inv = np.linalg.inv(J1)
     J2_dagger_inv = np.linalg.inv(np.conjugate(np.swapaxes(J2, -1, -2)))
     return J1_inv @ V_obs @ J2_dagger_inv
+
+
+def apply_jones_to_coherency(V_true, J1, J2):
+    """Apply the forward Jones corruption to a true coherency matrix.
+
+    Computes ``V_obs = J1 @ V_true @ J2^dagger`` (EHT Paper VII / docs sec 9).
+    This is the exact inverse operation of
+    :func:`apply_inverse_jones_to_coherency` and is what simulation uses to
+    corrupt clean visibilities. Broadcasts over leading axes; pure (no in-place
+    mutation).
+
+    Parameters
+    ----------
+    V_true : (..., 2, 2) complex ndarray
+        True (clean) coherency matrix. Leading axes broadcast.
+    J1, J2 : (..., 2, 2) complex ndarray
+        Jones matrices at stations 1 and 2.
+
+    Returns
+    -------
+    V_obs : (..., 2, 2) complex ndarray
+    """
+    _maybe_warn_convention()
+    return J1 @ V_true @ np.conjugate(np.swapaxes(J2, -1, -2))
+
+
+# ---------------------------------------------------------------------------
+# Forward Jones assembly (feeds obs_simulate corruption; calibration reuses it)
+# ---------------------------------------------------------------------------
+#
+# The observing code (obs_simulate) generates the physical corruption
+# parameters -- complex gains, D-terms, and the field-rotation angle from
+# array geometry -- and this module assembles them into the 2x2 Jones matrix.
+# Keeping assembly here (rather than inline in obs_simulate) gives calibration
+# a single home to reuse and keeps the kernel pure/traceable for the JAX track.
+
+
+def field_rotation_matrix(feed_type, fr_angle):
+    """Field-rotation Jones factor ``Phi`` for a station's feeds.
+
+    For circular feeds (``'rl'``) field rotation is a diagonal phase,
+    ``Phi = diag(exp(-i*fr_angle), exp(+i*fr_angle))`` with R = p1 leading.
+    This reproduces the field-rotation convention baked into
+    ``obs_simulate.make_jones`` (cf. docs/polarization_conventions.md sec 8/12).
+
+    For linear feeds (``'xy'``) field rotation is a real rotation of the feed
+    axes, ``Phi = [[cos, sin], [-sin, cos]]``. This form is NOT a free choice:
+    it is FIXED by consistency with the circular convention via
+    ``Phi_lin = F^{-1} Phi_circ F`` where ``F = BASIS_LIN_TO_CIRC``.
+
+    ASSUMPTION (to verify; see docs/polarization_conventions.md sec 10): the
+    derived linear form and the sign of ``fr_angle`` (from tarr ``fr_elev``/
+    ``fr_par``) match EHT Paper VII's field-rotation Jones. Hybrid feeds
+    (e.g. ``'rx'``) have an undecided convention and raise.
+
+    Parameters
+    ----------
+    feed_type : str
+        Two-character station feed type. ``'rl'`` (circular) and ``'xy'``
+        (linear) are supported; hybrid feeds raise ``NotImplementedError``.
+    fr_angle : float or ndarray
+        Field-rotation angle(s) in radians. Broadcasts over leading axes.
+
+    Returns
+    -------
+    Phi : ndarray
+        Complex array of shape ``np.shape(fr_angle) + (2, 2)``.
+    """
+    fr_angle = np.asarray(fr_angle, dtype=float)
+    if feed_type == 'rl':
+        # Circular feeds: field rotation is a diagonal phase.
+        z = np.exp(1j * fr_angle)
+        zc = np.exp(-1j * fr_angle)
+        zeros = np.zeros_like(z)
+        row0 = np.stack([zc, zeros], axis=-1)
+        row1 = np.stack([zeros, z], axis=-1)
+        return np.stack([row0, row1], axis=-2)
+    elif feed_type == 'xy':
+        # Linear feeds: real rotation of the feed axes. Form fixed by
+        # consistency with the circular convention (F^{-1} Phi_circ F).
+        c = np.cos(fr_angle)
+        s = np.sin(fr_angle)
+        zeros = np.zeros_like(c)
+        row0 = np.stack([c, s], axis=-1)
+        row1 = np.stack([-s, c], axis=-1)
+        return np.stack([row0, row1], axis=-2).astype(complex)
+    else:
+        raise NotImplementedError(
+            f"field_rotation_matrix: feed_type {feed_type!r} not supported. Only "
+            "orthogonal same-basis feeds 'rl' (circular) and 'xy' (linear) are "
+            "implemented; hybrid feeds (e.g. 'rx') have an undecided field-"
+            "rotation convention (see docs/polarization_conventions.md sec 10).")
+
+
+def assemble_jones(g_p1, g_p2, d_p1, d_p2, feed_type, fr_angle, fr_angle_D=0.0):
+    """Assemble per-station Jones matrices ``J = G (I + D_rot) Phi``.
+
+    Factoring (EHT Paper VII Eq. 7; docs/polarization_conventions.md sec 10):
+
+        G     = diag(g_p1, g_p2)          complex per-feed gains
+        I + D = [[1, d_p1], [d_p2, 1]]    leakage / D-terms
+        Phi                              field rotation (see
+                                         :func:`field_rotation_matrix`)
+
+    ``fr_angle_D`` is the residual field-rotation angle applied to the leakage
+    when field rotation has been corrected but leakage has not (the
+    ``fr_angle_D`` term in ``obs_simulate.make_jones``); it rotates the D-terms
+    by ``Phi_D^{-1}``. With ``fr_angle_D = 0`` this is the plain
+    ``J = G (I + D) Phi``.
+
+    Reproduces ``obs_simulate.make_jones``'s circular assembly exactly for
+    ``feed_type='rl'``, and extends to linear feeds (``'xy'``) via the linear
+    ``Phi`` in :func:`field_rotation_matrix`. Pure and broadcasting (no in-place
+    mutation), so it is safe for the JAX backend.
+
+    LIMITATION (ASSUMPTION, to verify; see docs/polarization_conventions.md sec 10):
+    for non-circular feeds the one-sided ``Phi_D^{-1} @ D`` leakage rotation is
+    only correct when ``Phi`` is diagonal (circular). For linear ``Phi`` the
+    frcal-but-not-dcal case needs the full conjugation, so a nonzero
+    ``fr_angle_D`` with a non-circular feed raises ``NotImplementedError``.
+
+    Parameters
+    ----------
+    g_p1, g_p2 : complex or ndarray
+        Per-feed complex gains (diagonal of G). Broadcast over leading axes
+        (e.g. one entry per time).
+    d_p1, d_p2 : complex or ndarray
+        Per-feed D-terms (off-diagonal leakage).
+    feed_type : str
+        Station feed type; ``'rl'`` and ``'xy'`` supported.
+    fr_angle : float or ndarray
+        Field-rotation angle(s) in radians.
+    fr_angle_D : float or ndarray, optional
+        Residual leakage-rotation angle(s) in radians. Default 0. Must be 0 for
+        non-circular feeds (see LIMITATION above).
+
+    Returns
+    -------
+    J : ndarray
+        Complex array of shape ``broadcast(inputs) + (2, 2)``.
+    """
+    fr_angle_D = np.asarray(fr_angle_D, dtype=float)
+    if feed_type != 'rl' and np.any(fr_angle_D != 0.0):
+        raise NotImplementedError(
+            "assemble_jones: nonzero fr_angle_D (leakage double-rotation for the "
+            "frcal-but-not-dcal case) is only implemented for circular feeds; "
+            "the linear conjugation form is pending confirmation "
+            "(see docs/polarization_conventions.md sec 10).")
+    g_p1 = np.asarray(g_p1, dtype=complex)
+    g_p2 = np.asarray(g_p2, dtype=complex)
+    gshape = np.broadcast(g_p1, g_p2).shape
+    gzeros = np.zeros(gshape, dtype=complex)
+    G = np.stack([np.stack([np.broadcast_to(g_p1, gshape), gzeros], axis=-1),
+                  np.stack([gzeros, np.broadcast_to(g_p2, gshape)], axis=-1)],
+                 axis=-2)
+
+    d_p1 = np.asarray(d_p1, dtype=complex)
+    d_p2 = np.asarray(d_p2, dtype=complex)
+    dshape = np.broadcast(d_p1, d_p2).shape
+    dzeros = np.zeros(dshape, dtype=complex)
+    D = np.stack([np.stack([dzeros, np.broadcast_to(d_p1, dshape)], axis=-1),
+                  np.stack([np.broadcast_to(d_p2, dshape), dzeros], axis=-1)],
+                 axis=-2)
+
+    Phi = field_rotation_matrix(feed_type, fr_angle)
+    Phi_D_inv = field_rotation_matrix(feed_type, -fr_angle_D)
+    IpD = np.eye(2, dtype=complex) + Phi_D_inv @ D
+    return G @ IpD @ Phi

--- a/ehtim/plotting/interactive.py
+++ b/ehtim/plotting/interactive.py
@@ -2114,8 +2114,8 @@ def dashboard(
             gain_indices[mode].append(len(fig.data) - 1)
 
     # --- Panel 4: D-terms (R and L) in complex plane ---
-    # TODO: schema-coupled - tarr['dr'] / tarr['dl'] move to caltable.dterms
-    # in MixPol Phase 1; this lookup needs to follow.
+    # TODO: schema-coupled - tarr['dr'] / tarr['dl'] move to caltable.dterms;
+    # this lookup needs to follow.
     # Two legends: legend4 = per-site (toggle hides both R and L for that
     # site via legendgroup); legend5 = R/L type (two dummy markers showing
     # the symbol convention).

--- a/ehtim/warnings.py
+++ b/ehtim/warnings.py
@@ -53,16 +53,22 @@ class FeedTagWarning(UserWarning):
     missing, incomplete, or not in canonical feed order.
 
     Feed types are read per station from POLTYA (first feed) and POLTYB
-    (second feed). Three situations are reported:
+    (second feed). Four situations are reported:
 
-    * neither tag is present -- the feed basis is inferred from the STOKES
+    * neither column is present -- the feed basis is inferred from the STOKES
       axis (CRVAL3) instead;
-    * one tag is present and the other is blank -- the partner feed is
-      completed from the known one (``R`` -> ``rl``, ``X`` -> ``xy``);
+    * only one of the two columns is present -- each station's pair is
+      completed from the tag that is there (``POLTYA='R'`` -> ``rl``,
+      ``POLTYB='Y'`` -> ``xy``). A tag that is *blank* on a column that does
+      exist is an error, not a warning: a writer that emits POLTY and leaves
+      it empty says nothing about the basis;
     * the tags are in reversed order (``POLTYA='L'``, ``POLTYB='R'``) --
       the pair is canonicalized to ``rl`` on read, and canonicalized (with
       the four correlation slots permuted to match) on write, because the
-      uvfits STOKES axis labels its planes absolutely.
+      uvfits STOKES axis labels its planes absolutely;
+    * the station tags imply a mixed feed basis while CRVAL3 names a
+      homogeneous circular (-1) or linear (-5) product block -- the station
+      tags win, since for a mixed array the STOKES axis is only nominal.
     """
 
 

--- a/ehtim/warnings.py
+++ b/ehtim/warnings.py
@@ -46,3 +46,32 @@ class MixedPolUnpackNaNWarning(UserWarning):
     The warning reports, per field, how many rows were NaN-filled. It is
     deliberately verbose; suppress with the standard machinery if needed.
     """
+
+
+class FeedTagWarning(UserWarning):
+    """Emitted when the AIPS AN POLTYA/POLTYB feed tags of a uvfits file are
+    missing, incomplete, or not in canonical feed order.
+
+    Feed types are read per station from POLTYA (first feed) and POLTYB
+    (second feed). Three situations are reported:
+
+    * neither tag is present -- the feed basis is inferred from the STOKES
+      axis (CRVAL3) instead;
+    * one tag is present and the other is blank -- the partner feed is
+      completed from the known one (``R`` -> ``rl``, ``X`` -> ``xy``);
+    * the tags are in reversed order (``POLTYA='L'``, ``POLTYB='R'``) --
+      the pair is canonicalized to ``rl`` on read, and canonicalized (with
+      the four correlation slots permuted to match) on write, because the
+      uvfits STOKES axis labels its planes absolutely.
+    """
+
+
+class PolrepOverrideWarning(UserWarning):
+    """Emitted when a loader returns a different polrep than was requested.
+
+    A mixed-feed uvfits file can only be represented as ``polrep='mixed'``:
+    converting out of the mixed basis needs Jones-level D-terms and is not
+    available at the data layer. Requesting any other polrep for such a file
+    returns a mixed-basis Obsdata and raises this warning rather than
+    silently handing back something other than what was asked for.
+    """

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -883,8 +883,10 @@ def test_sample_uv_zero_baseline_is_total_flux(gauss_im, ttype):
 
 
 def test_sample_uv_rejects_bad_polrep(gauss_im):
+    # 'lin' is now accepted; 'mixed' is intentionally rejected here because
+    # sample_uv has no station/feed context for the per-baseline conversion.
     with pytest.raises(Exception, match="polrep_obs"):
-        gauss_im.sample_uv(np.array([[0.0, 0.0]]), polrep_obs="lin",
+        gauss_im.sample_uv(np.array([[0.0, 0.0]]), polrep_obs="mixed",
                            verbose=False)
 
 

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -790,12 +790,13 @@ def test_obsdata_polrep_lin_on_rl_array_raises():
         arr.obsdata(polrep='lin', **_obs_kwargs())
 
 
-def test_obsdata_polrep_lin_on_xy_array_raises_not_implemented():
-    # Validation passes (all xy) but simulation backend doesn't support
-    # 'lin' yet — should raise NotImplementedError pointing to Phase 5.
+def test_obsdata_polrep_lin_on_xy_array():
+    # 'lin' simulation on an all-xy array is supported (Phase 6).
     arr = ea.Array(_eht_like_xy_array())
-    with pytest.raises(NotImplementedError, match="is not yet supported"):
-        arr.obsdata(polrep='lin', **_obs_kwargs())
+    obs = arr.obsdata(polrep='lin', **_obs_kwargs())
+    assert obs.polrep == 'lin'
+    assert len(obs.data) > 0
+    assert 'xxvis' in obs.data.dtype.names
 
 
 def test_obsdata_polrep_mixed_on_homogeneous_array_raises():
@@ -805,10 +806,14 @@ def test_obsdata_polrep_mixed_on_homogeneous_array_raises():
         arr.obsdata(polrep='mixed', **_obs_kwargs())
 
 
-def test_obsdata_polrep_mixed_on_mixed_array_raises_not_implemented():
+def test_obsdata_polrep_mixed_on_mixed_array():
+    # 'mixed' simulation on a heterogeneous-feed array is supported (Phase 6).
     arr = ea.Array(_eht_like_mixed_array())
-    with pytest.raises(NotImplementedError, match="is not yet supported"):
-        arr.obsdata(polrep='mixed', **_obs_kwargs())
+    obs = arr.obsdata(polrep='mixed', **_obs_kwargs())
+    assert obs.polrep == 'mixed'
+    assert len(obs.data) > 0
+    # every row's polbasis is two 2-char feed_types concatenated
+    assert {len(str(b)) for b in obs.data['polbasis']} == {4}
 
 
 # ----- save_array_txt v2 + load_array_txt round-trip ------------------------

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -1981,31 +1981,187 @@ def test_unpack_mixed_recovers_known_stokes():
 
 
 # ============================================================================
-#  load_uvfits mixed-pol detection stop-gap
+#  load_uvfits / save_uvfits mixed-pol support (Phase 3c / 6)
 # ============================================================================
 
-def test_load_uvfits_rejects_noncircular_poltya():
-    from astropy.io import fits
-    path = os.path.join(os.path.dirname(__file__), '..', 'data', 'sample.uvfits')
-    hdul = fits.open(path)
-    hdul['AIPS AN'].data['POLTYA'][:] = 'X'   # pretend the AN table flags linear feeds
-    with pytest.raises(NotImplementedError, match="mixed-pol"):
-        eo.load_uvfits(hdul)
-
-
-def test_load_uvfits_rejects_hybrid_poltyb():
-    # POLTYA stays circular but POLTYB is linear (a hybrid R/X feed) -> caught
-    from astropy.io import fits
-    path = os.path.join(os.path.dirname(__file__), '..', 'data', 'sample.uvfits')
-    hdul = fits.open(path)
-    hdul['AIPS AN'].data['POLTYB'][:] = 'X'
-    with pytest.raises(NotImplementedError, match="mixed-pol"):
-        eo.load_uvfits(hdul)
+_SAMPLE = os.path.join(os.path.dirname(__file__), '..', 'data', 'sample.uvfits')
 
 
 def test_load_uvfits_circular_unaffected():
-    # all-'R' POLTYA (the sample file) loads normally through the new check
-    path = os.path.join(os.path.dirname(__file__), '..', 'data', 'sample.uvfits')
-    obs = eo.load_uvfits(path)
+    # all-'R'/'L' POLTYA/POLTYB (the sample file) loads as a circular Obsdata
+    obs = eo.load_uvfits(_SAMPLE)
     assert obs.polrep in ('stokes', 'circ')
     assert set(obs.tarr['feed_type']) == {'rl'}
+
+
+def test_load_uvfits_parses_linear_poltype():
+    # POLTYA='X'/POLTYB='Y' on a linear STOKES axis (CRVAL3=-5) -> per-station
+    # 'xy' feed_type, detected as a linear-feed observation
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    hdul[0].header['CRVAL3'] = -5.0   # linear XX/YY/XY/YX naming
+    hdul['AIPS AN'].data['POLTYA'][:] = 'X'
+    hdul['AIPS AN'].data['POLTYB'][:] = 'Y'
+    obs = eo.load_uvfits(hdul, polrep='lin')
+    assert obs.polrep == 'lin'
+    assert set(obs.tarr['feed_type']) == {'xy'}
+
+
+def test_load_uvfits_no_poltype_infers_feed_from_crval3_linear():
+    # POLTY tags blanked + linear STOKES axis (CRVAL3=-5): feeds are inferred
+    # 'xy' from CRVAL3, NOT silently mislabeled circular
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    hdul[0].header['CRVAL3'] = -5.0
+    hdul['AIPS AN'].data['POLTYA'][:] = ' '
+    hdul['AIPS AN'].data['POLTYB'][:] = ' '
+    obs = eo.load_uvfits(hdul, polrep='lin')
+    assert obs.polrep == 'lin'
+    assert set(obs.tarr['feed_type']) == {'xy'}
+
+
+def test_load_uvfits_crval3_feed_mismatch_raises():
+    # linear STOKES axis (CRVAL3=-5) but circular POLTY tags (R/L) -> inconsistent
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    hdul[0].header['CRVAL3'] = -5.0   # POLTYA/POLTYB stay R/L from the file
+    with pytest.raises(Exception, match="inconsistent"):
+        eo.load_uvfits(hdul)
+
+
+def test_load_uvfits_nonstandard_cdelt3_raises():
+    # planes are read positionally; a non-unit-step STOKES axis would mis-slot
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    hdul[0].header['CDELT3'] = 1.0   # a circular file must have CDELT3 = -1
+    with pytest.raises(Exception, match="CDELT3"):
+        eo.load_uvfits(hdul)
+
+
+def test_load_uvfits_parses_mixed_poltype():
+    # alternate stations linear, the rest circular -> mixed-feed Obsdata whose
+    # per-baseline polbasis is reconstructed from the station feed types
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    hdul['AIPS AN'].data['POLTYA'][::2] = 'X'
+    hdul['AIPS AN'].data['POLTYB'][::2] = 'Y'
+    obs = eo.load_uvfits(hdul, polrep='mixed')
+    assert obs.polrep == 'mixed'
+    assert set(obs.tarr['feed_type']) == {'rl', 'xy'}
+    assert 'polbasis' in obs.data.dtype.names
+    feed_of = {str(r['site']): str(r['feed_type']) for r in obs.tarr}
+    for row in obs.data:
+        assert str(row['polbasis']) == feed_of[str(row['t1'])] + feed_of[str(row['t2'])]
+
+
+def test_load_uvfits_mixed_defaults_to_mixed_with_warning(capsys):
+    # requesting the default polrep on a mixed file returns a mixed Obsdata and warns
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    hdul['AIPS AN'].data['POLTYA'][::2] = 'X'
+    hdul['AIPS AN'].data['POLTYB'][::2] = 'Y'
+    obs = eo.load_uvfits(hdul)  # default polrep='stokes'
+    assert obs.polrep == 'mixed'
+    assert 'mixed-feed uvfits loads only as' in capsys.readouterr().out
+
+
+def test_load_uvfits_requesting_mixed_on_homogeneous_raises():
+    with pytest.raises(Exception, match="homogeneous feeds"):
+        eo.load_uvfits(_SAMPLE, polrep='mixed')
+
+
+def test_load_uvfits_unsupported_feed_raises():
+    # a feed letter outside the recognized vocabulary fails loudly
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    hdul['AIPS AN'].data['POLTYA'][:] = 'Q'
+    with pytest.raises(NotImplementedError, match="unsupported feed pair"):
+        eo.load_uvfits(hdul)
+
+
+def test_load_uvfits_force_singlepol_on_linear_raises():
+    # force_singlepol is circular-only; on a linear file it must fail loudly
+    # rather than be silently ignored (the enforcement block is gated on 'circ')
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    hdul[0].header['CRVAL3'] = -5.0   # consistent linear file
+    hdul['AIPS AN'].data['POLTYA'][:] = 'X'
+    hdul['AIPS AN'].data['POLTYB'][:] = 'Y'
+    with pytest.raises(NotImplementedError, match="force_singlepol is only supported"):
+        eo.load_uvfits(hdul, polrep='stokes', force_singlepol='R')
+
+
+# ----- save -> load round trips (Checkpoint 3c/6) ---------------------------
+
+def _roundtrip(obs, polrep_out, tmp_path):
+    """save -> load -> save -> load; return the two loaded copies."""
+    p1, p2 = str(tmp_path / 'rt1.uvfits'), str(tmp_path / 'rt2.uvfits')
+    obs.save_uvfits(p1, polrep_out=polrep_out)
+    o1 = eo.load_uvfits(p1, polrep=polrep_out)
+    o1.save_uvfits(p2, polrep_out=polrep_out)
+    o2 = eo.load_uvfits(p2, polrep=polrep_out)
+    return o1, o2
+
+
+def _sort_key(obs):
+    return np.lexsort((obs.data['t2'], obs.data['t1'], obs.data['time']))
+
+
+def test_save_load_uvfits_lin_roundtrip(tmp_path):
+    obs = eo.Obsdata(0., 0., 230e9, 1e9,
+                     _lin_data(['S0', 'S0', 'S1'], ['S1', 'S2', 'S2'], [0.1, 0.2, 0.3]),
+                     _tarr(['xy', 'xy', 'xy']), polrep='lin')
+    o1, o2 = _roundtrip(obs, 'lin', tmp_path)
+    assert o1.polrep == 'lin'
+    assert set(o1.tarr['feed_type']) == {'xy'}
+
+    # input visibilities survive the round trip (uvfits stores float32)
+    ki, ko = _sort_key(obs), _sort_key(o1)
+    for f in ['xxvis', 'yyvis', 'xyvis', 'yxvis']:
+        np.testing.assert_allclose(o1.data[f][ko], obs.data[f][ki], rtol=1e-5, atol=1e-5)
+    # second load is idempotent (both files are float32-sourced)
+    for f in ['xxvis', 'yyvis', 'xyvis', 'yxvis']:
+        np.testing.assert_allclose(o2.data[f][_sort_key(o2)], o1.data[f][ko],
+                                   rtol=1e-6, atol=1e-6)
+    # linear <-> stokes physics preserved through the round trip
+    s_in = obs.switch_polrep('stokes')
+    s_out = o1.switch_polrep('stokes')
+    ksi, kso = _sort_key(s_in), _sort_key(s_out)
+    for f in ['vis', 'qvis', 'uvis', 'vvis']:
+        np.testing.assert_allclose(s_out.data[f][kso], s_in.data[f][ksi],
+                                   rtol=1e-5, atol=1e-5)
+
+
+def test_save_load_uvfits_mixed_roundtrip(tmp_path):
+    obs = eo.Obsdata(0., 0., 230e9, 1e9,
+                     _mixed_data(['S0', 'S0', 'S1'], ['S1', 'S2', 'S2'], [0.1, 0.2, 0.3]),
+                     _tarr(['rl', 'rl', 'xy']), polrep='mixed')
+    o1, o2 = _roundtrip(obs, 'mixed', tmp_path)
+    assert o1.polrep == 'mixed'
+    assert set(o1.tarr['feed_type']) == {'rl', 'xy'}
+    # feed types + polbasis survive
+    assert set(o1.data['polbasis']) == set(obs.data['polbasis'])
+    ki, ko = _sort_key(obs), _sort_key(o1)
+    np.testing.assert_array_equal(o1.data['polbasis'][ko], obs.data['polbasis'][ki])
+    for f in ['p1p1vis', 'p2p2vis', 'p1p2vis', 'p2p1vis']:
+        np.testing.assert_allclose(o1.data[f][ko], obs.data[f][ki], rtol=1e-5, atol=1e-5)
+    # idempotent second load
+    for f in ['p1p1vis', 'p2p2vis', 'p1p2vis', 'p2p1vis']:
+        np.testing.assert_allclose(o2.data[f][_sort_key(o2)], o1.data[f][ko],
+                                   rtol=1e-6, atol=1e-6)
+
+
+def test_save_uvfits_mixed_requires_mixed_polrep_out(tmp_path):
+    obs = eo.Obsdata(0., 0., 230e9, 1e9,
+                     _mixed_data(['S0', 'S0', 'S1'], ['S1', 'S2', 'S2'], [0.1, 0.2, 0.3]),
+                     _tarr(['rl', 'rl', 'xy']), polrep='mixed')
+    with pytest.raises(Exception, match="mixed"):
+        obs.save_uvfits(str(tmp_path / 'x.uvfits'), polrep_out='circ')
+
+
+def test_save_load_uvfits_circ_roundtrip_unaffected(tmp_path):
+    # a circular observation still writes POLTYA/POLTYB = R/L and reloads as circ
+    obs = eo.load_uvfits(_SAMPLE, polrep='circ')
+    o1, _ = _roundtrip(obs, 'circ', tmp_path)
+    assert o1.polrep == 'circ'
+    assert set(o1.tarr['feed_type']) == {'rl'}

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -2007,17 +2007,93 @@ def test_load_uvfits_parses_linear_poltype():
     assert set(obs.tarr['feed_type']) == {'xy'}
 
 
+def _drop_poltype_columns(hdul):
+    """Return an HDUList copy whose AIPS AN table has no POLTYA/POLTYB columns
+    (simulating a legacy / non-AIPS file that never wrote feed tags)."""
+    from astropy.io import fits
+    i_an = hdul.index_of('AIPS AN')
+    an = hdul[i_an]
+    kept = fits.ColDefs([c for c in an.columns
+                         if c.name not in ('POLTYA', 'POLTYB')])
+    hdul[i_an] = fits.BinTableHDU.from_columns(kept, header=an.header)
+    return hdul
+
+
 def test_load_uvfits_no_poltype_infers_feed_from_crval3_linear():
-    # POLTY tags blanked + linear STOKES axis (CRVAL3=-5): feeds are inferred
-    # 'xy' from CRVAL3, NOT silently mislabeled circular
+    # POLTY columns absent + linear STOKES axis (CRVAL3=-5): feeds are inferred
+    # 'xy' from CRVAL3, NOT silently mislabeled circular. (Absent columns are the
+    # legacy fallback; a *present-but-blank* tag raises instead -- see below.)
     from astropy.io import fits
     hdul = fits.open(_SAMPLE)
     hdul[0].header['CRVAL3'] = -5.0
-    hdul['AIPS AN'].data['POLTYA'][:] = ' '
-    hdul['AIPS AN'].data['POLTYB'][:] = ' '
-    obs = eo.load_uvfits(hdul, polrep='lin')
+    hdul = _drop_poltype_columns(hdul)
+    with pytest.warns(ehw.FeedTagWarning):
+        obs = eo.load_uvfits(hdul, polrep='lin')
     assert obs.polrep == 'lin'
     assert set(obs.tarr['feed_type']) == {'xy'}
+
+
+def test_load_uvfits_blank_poltype_raises():
+    # POLTY columns present but a station's tags are blank -> a feed basis
+    # cannot be assumed for a possibly-mixed file; require it be filled.
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    hdul['AIPS AN'].data['POLTYA'][:] = ' '
+    hdul['AIPS AN'].data['POLTYB'][:] = ' '
+    with pytest.raises(Exception, match="empty POLTYA and POLTYB"):
+        eo.load_uvfits(hdul)
+
+
+def test_load_uvfits_partial_poltype_raises():
+    # exactly one feed tag present (POLTYA='R', POLTYB blank) -> incomplete;
+    # do not silently complete the pair, require the missing tag be filled.
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    hdul['AIPS AN'].data['POLTYB'][:] = ' '   # POLTYA stays 'R'
+    with pytest.raises(Exception, match="incomplete feed tag"):
+        eo.load_uvfits(hdul)
+
+
+def test_load_uvfits_reversed_poltype_canonicalized_to_circular():
+    # A genuinely circular file with per-station POLTY order permuted
+    # (alternating L/R) must NOT be reclassified as mixed: the STOKES axis fixes
+    # the plane meanings, so reversed tags are canonicalized to 'rl' and the
+    # visibilities are read identically.
+    from astropy.io import fits
+    ref = eo.load_uvfits(_SAMPLE, polrep='circ')          # normal R/L tags
+    hdul = fits.open(_SAMPLE)
+    hdul['AIPS AN'].data['POLTYA'][::2] = 'L'             # reverse even stations
+    hdul['AIPS AN'].data['POLTYB'][::2] = 'R'
+    with pytest.warns(ehw.FeedTagWarning, match="reversed"):
+        obs = eo.load_uvfits(hdul, polrep='circ')
+    assert obs.polrep == 'circ'
+    assert set(obs.tarr['feed_type']) == {'rl'}           # not mixed
+    ki, ko = _sort_key(ref), _sort_key(obs)
+    for f in ['rrvis', 'llvis', 'rlvis', 'lrvis']:
+        np.testing.assert_array_equal(obs.data[f][ko], ref.data[f][ki])
+
+
+def test_load_uvfits_force_singlepol_ll_matches_l():
+    # regression for `force_singlepol in ['L' or 'LL']`, which Python collapsed
+    # to ['L'] so 'LL'/'RR' were silently ignored.
+    obs_l = eo.load_uvfits(_SAMPLE, polrep='stokes', force_singlepol='L')
+    obs_ll = eo.load_uvfits(_SAMPLE, polrep='stokes', force_singlepol='LL')
+    obs_r = eo.load_uvfits(_SAMPLE, polrep='stokes', force_singlepol='R')
+    obs_rr = eo.load_uvfits(_SAMPLE, polrep='stokes', force_singlepol='RR')
+    np.testing.assert_array_equal(obs_ll.data['vis'][_sort_key(obs_ll)],
+                                  obs_l.data['vis'][_sort_key(obs_l)])
+    np.testing.assert_array_equal(obs_rr.data['vis'][_sort_key(obs_rr)],
+                                  obs_r.data['vis'][_sort_key(obs_r)])
+
+
+def test_load_uvfits_hybrid_feed_raises():
+    # a station with one circular + one linear feed (POLTYA='R', POLTYB='X' ->
+    # 'rx') has an undecided convention across the stack -> the loader rejects it
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    hdul['AIPS AN'].data['POLTYB'][::2] = 'X'   # POLTYA stays 'R' -> 'rx' hybrid
+    with pytest.raises(NotImplementedError, match="hybrid"):
+        eo.load_uvfits(hdul)
 
 
 def test_load_uvfits_crval3_feed_mismatch_raises():
@@ -2054,15 +2130,15 @@ def test_load_uvfits_parses_mixed_poltype():
         assert str(row['polbasis']) == feed_of[str(row['t1'])] + feed_of[str(row['t2'])]
 
 
-def test_load_uvfits_mixed_defaults_to_mixed_with_warning(capsys):
+def test_load_uvfits_mixed_defaults_to_mixed_with_warning():
     # requesting the default polrep on a mixed file returns a mixed Obsdata and warns
     from astropy.io import fits
     hdul = fits.open(_SAMPLE)
     hdul['AIPS AN'].data['POLTYA'][::2] = 'X'
     hdul['AIPS AN'].data['POLTYB'][::2] = 'Y'
-    obs = eo.load_uvfits(hdul)  # default polrep='stokes'
+    with pytest.warns(ehw.PolrepOverrideWarning, match="loads only as"):
+        obs = eo.load_uvfits(hdul)  # default polrep='stokes'
     assert obs.polrep == 'mixed'
-    assert 'mixed-feed uvfits loads only as' in capsys.readouterr().out
 
 
 def test_load_uvfits_requesting_mixed_on_homogeneous_raises():
@@ -2115,12 +2191,14 @@ def test_save_load_uvfits_lin_roundtrip(tmp_path):
     assert o1.polrep == 'lin'
     assert set(o1.tarr['feed_type']) == {'xy'}
 
-    # input visibilities survive the round trip (uvfits stores float32)
+    # input visibilities AND sigmas survive the round trip (uvfits stores float32)
     ki, ko = _sort_key(obs), _sort_key(o1)
-    for f in ['xxvis', 'yyvis', 'xyvis', 'yxvis']:
+    for f in ['xxvis', 'yyvis', 'xyvis', 'yxvis',
+              'xxsigma', 'yysigma', 'xysigma', 'yxsigma']:
         np.testing.assert_allclose(o1.data[f][ko], obs.data[f][ki], rtol=1e-5, atol=1e-5)
     # second load is idempotent (both files are float32-sourced)
-    for f in ['xxvis', 'yyvis', 'xyvis', 'yxvis']:
+    for f in ['xxvis', 'yyvis', 'xyvis', 'yxvis',
+              'xxsigma', 'yysigma', 'xysigma', 'yxsigma']:
         np.testing.assert_allclose(o2.data[f][_sort_key(o2)], o1.data[f][ko],
                                    rtol=1e-6, atol=1e-6)
     # linear <-> stokes physics preserved through the round trip
@@ -2143,12 +2221,65 @@ def test_save_load_uvfits_mixed_roundtrip(tmp_path):
     assert set(o1.data['polbasis']) == set(obs.data['polbasis'])
     ki, ko = _sort_key(obs), _sort_key(o1)
     np.testing.assert_array_equal(o1.data['polbasis'][ko], obs.data['polbasis'][ki])
-    for f in ['p1p1vis', 'p2p2vis', 'p1p2vis', 'p2p1vis']:
+    for f in ['p1p1vis', 'p2p2vis', 'p1p2vis', 'p2p1vis',
+              'p1p1sigma', 'p2p2sigma', 'p1p2sigma', 'p2p1sigma']:
         np.testing.assert_allclose(o1.data[f][ko], obs.data[f][ki], rtol=1e-5, atol=1e-5)
     # idempotent second load
-    for f in ['p1p1vis', 'p2p2vis', 'p1p2vis', 'p2p1vis']:
+    for f in ['p1p1vis', 'p2p2vis', 'p1p2vis', 'p2p1vis',
+              'p1p1sigma', 'p2p2sigma', 'p1p2sigma', 'p2p1sigma']:
         np.testing.assert_allclose(o2.data[f][_sort_key(o2)], o1.data[f][ko],
                                    rtol=1e-6, atol=1e-6)
+
+
+def test_save_load_uvfits_mixed_xyrl_first_baseline(tmp_path):
+    # first baseline is xy x rl (polbasis 'xyrl'): exercises a non-trivial
+    # per-baseline polbasis (not the all-'rlxy' case) through the uvfits IO path
+    obs = eo.Obsdata(0., 0., 230e9, 1e9,
+                     _mixed_data(['S0', 'S0', 'S1'], ['S1', 'S2', 'S2'], [0.1, 0.2, 0.3]),
+                     _tarr(['xy', 'rl', 'rl']), polrep='mixed')
+    ki0 = _sort_key(obs)
+    assert obs.data['polbasis'][ki0][0] == 'xyrl'
+    o1, _ = _roundtrip(obs, 'mixed', tmp_path)
+    ko = _sort_key(o1)
+    np.testing.assert_array_equal(o1.data['polbasis'][ko], obs.data['polbasis'][ki0])
+    for f in ['p1p1vis', 'p2p2vis', 'p1p2vis', 'p2p1vis',
+              'p1p1sigma', 'p2p2sigma', 'p1p2sigma', 'p2p1sigma']:
+        np.testing.assert_allclose(o1.data[f][ko], obs.data[f][ki0], rtol=1e-5, atol=1e-5)
+
+
+def test_save_load_uvfits_mixed_noncanonical_feed_preserved(tmp_path):
+    # a mixed obs with a non-canonical feed order ('lr') must round-trip with its
+    # feed order and polbasis intact. Canonicalizing it on load (as homogeneous
+    # files are) would mislabel correlations, since a mixed file's four slots are
+    # written in feed order, not by the (nominal) STOKES axis.
+    obs = eo.Obsdata(0., 0., 230e9, 1e9,
+                     _mixed_data(['S0', 'S0', 'S1'], ['S1', 'S2', 'S2'], [0.1, 0.2, 0.3]),
+                     _tarr(['lr', 'lr', 'xy']), polrep='mixed')
+    assert set(obs.tarr['feed_type']) == {'lr', 'xy'}
+    o1, _ = _roundtrip(obs, 'mixed', tmp_path)
+    assert set(o1.tarr['feed_type']) == {'lr', 'xy'}     # preserved, NOT canonicalized
+    ki, ko = _sort_key(obs), _sort_key(o1)
+    np.testing.assert_array_equal(o1.data['polbasis'][ko], obs.data['polbasis'][ki])
+    for f in ['p1p1vis', 'p2p2vis', 'p1p2vis', 'p2p1vis',
+              'p1p1sigma', 'p2p2sigma', 'p1p2sigma', 'p2p1sigma']:
+        np.testing.assert_allclose(o1.data[f][ko], obs.data[f][ki], rtol=1e-5, atol=1e-5)
+
+
+def test_save_load_uvfits_lin_from_stokes_source(tmp_path):
+    # regression for the stokes -> lin switch_polrep default-hand crash: a
+    # fully-polarized stokes obs on an xy array must save/load as 'lin'.
+    obs = _stokes_obs(tarr_feeds=('xy', 'xy'))
+    lin = obs.switch_polrep('lin')                 # previously raised (hand='R')
+    assert lin.polrep == 'lin'
+    p = str(tmp_path / 'sl.uvfits')
+    obs.save_uvfits(p, polrep_out='lin')           # save from a stokes source
+    o1 = eo.load_uvfits(p, polrep='lin')
+    assert o1.polrep == 'lin'
+    # linear <-> stokes physics preserved
+    s_out = o1.switch_polrep('stokes')
+    ki, ko = _sort_key(obs), _sort_key(s_out)
+    for f in ['vis', 'qvis', 'uvis', 'vvis']:
+        np.testing.assert_allclose(s_out.data[f][ko], obs.data[f][ki], rtol=1e-4, atol=1e-4)
 
 
 def test_save_uvfits_mixed_requires_mixed_polrep_out(tmp_path):

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -2054,6 +2054,87 @@ def test_load_uvfits_partial_poltype_raises():
         eo.load_uvfits(hdul)
 
 
+def _drop_poltype_column(hdul, name, tag_col=None, tag=None):
+    """Return an HDUList copy whose AIPS AN table has only one POLTY column.
+
+    Rebuilding the table from its ColDefs re-reads the on-disk values, so any
+    tag to write must be applied afterwards -- hence tag_col/tag here rather
+    than editing the HDUList before the call (which would be silently undone).
+    """
+    from astropy.io import fits
+    i_an = hdul.index_of('AIPS AN')
+    an = hdul[i_an]
+    kept = fits.ColDefs([c for c in an.columns if c.name != name])
+    hdul[i_an] = fits.BinTableHDU.from_columns(kept, header=an.header)
+    assert name not in hdul[i_an].data.dtype.names
+    if tag_col is not None:
+        hdul[i_an].data[tag_col][:] = tag
+        # astropy strips padding, so compare stripped (a blank tag reads as '')
+        assert set(hdul[i_an].data[tag_col]) == {tag.strip()}
+    return hdul
+
+
+@pytest.mark.parametrize('dropped,tag_col,tag,crval3,polrep,expect_feeds', [
+    # linear tags on a circular sample file: 'xy' can only come from reading the
+    # single present tag and completing its partner
+    ('POLTYB', 'POLTYA', 'X', -5.0, 'lin', {'xy'}),   # 'X' first  -> 'Y' second
+    ('POLTYA', 'POLTYB', 'Y', -5.0, 'lin', {'xy'}),   # 'Y' second -> 'X' first
+    ('POLTYB', 'POLTYA', 'R', -1.0, 'circ', {'rl'}),  # circular stays circular
+])
+def test_load_uvfits_one_poltype_column_absent_completes_partner(
+        dropped, tag_col, tag, crval3, polrep, expect_feeds):
+    # A whole missing POLTY column is a file-level defect, but the tag that IS
+    # present still fixes the station's basis -> complete the pair from its
+    # partner feed (R <-> L, X <-> Y) and warn, rather than failing.
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    hdul[0].header['CRVAL3'] = crval3
+    hdul = _drop_poltype_column(hdul, dropped, tag_col, tag)
+    with pytest.warns(ehw.FeedTagWarning, match=f"no {dropped} column"):
+        obs = eo.load_uvfits(hdul, polrep=polrep)
+    assert obs.polrep == polrep
+    assert set(obs.tarr['feed_type']) == expect_feeds
+
+
+def test_load_uvfits_one_poltype_column_absent_unknown_feed_raises():
+    # the single present tag must still be a recognized feed character
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    hdul = _drop_poltype_column(hdul, 'POLTYB', 'POLTYA', 'Q')
+    with pytest.raises(NotImplementedError, match="partner feed cannot"):
+        eo.load_uvfits(hdul)
+
+
+def test_load_uvfits_one_poltype_column_absent_blank_tag_raises():
+    # one column absent AND the present column blank -> nothing to infer from
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    hdul = _drop_poltype_column(hdul, 'POLTYB', 'POLTYA', ' ')
+    with pytest.raises(Exception, match="empty POLTYA and POLTYB"):
+        eo.load_uvfits(hdul)
+
+
+def test_load_uvfits_mixed_from_station_table_warns_against_crval3():
+    # mixed inferred from POLTYA/POLTYB while CRVAL3=-1 names the circular
+    # product block: the station tags win, but the disagreement is reported.
+    from astropy.io import fits
+    hdul = fits.open(_SAMPLE)
+    assert hdul[0].header['CRVAL3'] == -1
+    hdul['AIPS AN'].data['POLTYA'][::2] = 'X'
+    hdul['AIPS AN'].data['POLTYB'][::2] = 'Y'
+    with pytest.warns(ehw.FeedTagWarning, match="MIXED feed basis was inferred"):
+        obs = eo.load_uvfits(hdul, polrep='mixed')
+    assert obs.polrep == 'mixed'
+
+
+def test_load_uvfits_homogeneous_does_not_warn_mixed_vs_crval3():
+    # the mixed/CRVAL3 warning must not fire on a consistent homogeneous file
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', ehw.FeedTagWarning)
+        obs = eo.load_uvfits(_SAMPLE, polrep='circ')
+    assert obs.polrep == 'circ'
+
+
 def test_load_uvfits_reversed_poltype_canonicalized_to_circular():
     # A genuinely circular file with per-station POLTY order permuted
     # (alternating L/R) must NOT be reclassified as mixed: the STOKES axis fixes

--- a/tests/test_obs_simulate.py
+++ b/tests/test_obs_simulate.py
@@ -43,6 +43,26 @@ def asymmetric_array(array):
     arr.tarr = tarr
     return arr
 
+@pytest.fixture(scope="module")
+def lin_array(asymmetric_array):
+    """All-'xy' (linear) array; sefd_p1 != sefd_p2 so the four sigmas differ."""
+    arr = asymmetric_array.copy()
+    tarr = np.asarray(arr.tarr).copy()
+    tarr["feed_type"] = "xy"
+    arr.tarr = tarr
+    return arr
+
+
+@pytest.fixture(scope="module")
+def mixed_array(asymmetric_array):
+    """Heterogeneous feeds: first half 'rl', second half 'xy'."""
+    arr = asymmetric_array.copy()
+    tarr = np.asarray(arr.tarr).copy()
+    half = len(tarr) // 2
+    tarr["feed_type"][half:] = "xy"
+    arr.tarr = tarr
+    return arr
+
 
 @pytest.fixture(scope="module")
 def asymmetric_image():
@@ -107,10 +127,14 @@ class TestMakeUvpoints:
         assert set(out.dtype.names) >= {"rrvis", "llvis", "rlvis", "lrvis",
                                         "rrsigma", "llsigma", "rlsigma", "lrsigma"}
 
+    # def test_invalid_polrep_raises(self, array):
+    #     with pytest.raises(Exception, match="only 'stokes' and 'circ'"):
+    #         os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
+    #                              TINT, TADV, TSTART, TSTOP, polrep="linear")
     def test_invalid_polrep_raises(self, array):
-        with pytest.raises(Exception, match="only 'stokes' and 'circ'"):
+        with pytest.raises(ValueError, match="must be one of"):
             os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
-                                 TINT, TADV, TSTART, TSTOP, polrep="linear")
+                                TINT, TADV, TSTART, TSTOP, polrep="linear")
 
     def test_baseline_ordering(self, array):
         out = os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
@@ -157,6 +181,31 @@ class TestMakeUvpoints:
         np.testing.assert_allclose(row["llsigma"], obsh.blnoise(sefdl1, sefdl2, TINT, BW))
         np.testing.assert_allclose(row["rlsigma"], obsh.blnoise(sefdr1, sefdl2, TINT, BW))
         np.testing.assert_allclose(row["lrsigma"], obsh.blnoise(sefdl1, sefdr2, TINT, BW))
+
+    def test_mixed_sigma_layout(self, mixed_array):
+        """rl x xy baseline: slots p1p1,p2p2,p1p2,p2p1 = R.X, L.Y, R.Y, L.X."""
+        out = os_sim.make_uvpoints(mixed_array, 17.761, -29.0, 230e9, BW,
+                                   TINT, TADV, TSTART, TSTOP, polrep="mixed")
+        row = out[0]
+        t1, t2 = row["t1"], row["t2"]
+        ft1 = str(mixed_array.tarr[list(mixed_array.tarr["site"]).index(t1)]["feed_type"])
+        ft2 = str(mixed_array.tarr[list(mixed_array.tarr["site"]).index(t2)]["feed_type"])
+
+        # each slot pairs one feed of t1 with one feed of t2: (slot, t1 feed, t2 feed)
+        slot_pairings = [
+            ("p1p1sigma", ft1[0], ft2[0]),
+            ("p2p2sigma", ft1[1], ft2[1]),
+            ("p1p2sigma", ft1[0], ft2[1]),
+            ("p2p1sigma", ft1[1], ft2[0]),
+        ]
+        for slot, fa, fb in slot_pairings:
+            expected = obsh.blnoise(mixed_array.sefd_for_feed(t1, fa),
+                                    mixed_array.sefd_for_feed(t2, fb), TINT, BW)
+            np.testing.assert_allclose(row[slot], expected)
+
+        # make_uvpoints fills polbasis directly; Obsdata.__init__ would recompute it
+        assert row["polbasis"] == ft1 + ft2
+
 
     def test_scalar_tau_applied(self, array):
         out = os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
@@ -293,7 +342,7 @@ class TestSampleVisBranches:
 
     def test_invalid_polrep_raises(self, asymmetric_image, obs):
         uv = np.column_stack([obs.data["u"], obs.data["v"]])
-        with pytest.raises(Exception, match="only 'stokes' and 'circ'"):
+        with pytest.raises(Exception, match="must be 'stokes', 'circ', 'lin', or 'mixed'"):
             os_sim.sample_vis(asymmetric_image, uv, polrep_obs="linear", ttype="direct")
 
     def test_nfft_rejects_odd_dims(self, array):

--- a/tests/test_obs_simulate.py
+++ b/tests/test_obs_simulate.py
@@ -65,6 +65,20 @@ def mixed_array(asymmetric_array):
 
 
 @pytest.fixture(scope="module")
+def xy_first_array(asymmetric_array):
+    """Heterogeneous feeds with the FIRST station linear ('xy') and the rest
+    circular ('rl'). Because make_uvpoints emits baselines with i1 < i2, this
+    yields xy x rl baselines (t1 linear, t2 circular) -- the reversed pairing
+    that mixed_array (rl first) never produces."""
+    arr = asymmetric_array.copy()
+    tarr = np.asarray(arr.tarr).copy()
+    tarr["feed_type"] = "rl"
+    tarr["feed_type"][0] = "xy"
+    arr.tarr = tarr
+    return arr
+
+
+@pytest.fixture(scope="module")
 def asymmetric_image():
     """Off-centre elongated Gaussian: distinguishes axes and tests centering."""
     im = eh.image.make_empty(64, 200 * eh.RADPERUAS, 17.761, -29.0, rf=230e9)
@@ -213,28 +227,43 @@ class TestMakeUvpoints:
         np.testing.assert_allclose(row["lrsigma"], obsh.blnoise(sefdl1, sefdr2, TINT, BW))
 
     def test_mixed_sigma_layout(self, mixed_array):
-        """rl x xy baseline: slots p1p1,p2p2,p1p2,p2p1 = R.X, L.Y, R.Y, L.X."""
+        """A genuine rl x xy baseline: slots p1p1,p2p2,p1p2,p2p1 pair
+        (R,X), (L,Y), (R,Y), (L,X). Feeds are spelled out explicitly so the test
+        cannot silently pass on the rl x rl baseline that sorts first."""
         out = os_sim.make_uvpoints(mixed_array, 17.761, -29.0, 230e9, BW,
                                    TINT, TADV, TSTART, TSTOP, polrep="mixed")
-        row = out[0]
-        t1, t2 = row["t1"], row["t2"]
-        ft1 = str(mixed_array.tarr[list(mixed_array.tarr["site"]).index(t1)]["feed_type"])
-        ft2 = str(mixed_array.tarr[list(mixed_array.tarr["site"]).index(t2)]["feed_type"])
+        feed_of = {str(r["site"]): str(r["feed_type"]) for r in mixed_array.tarr}
+        rows = [r for r in out if feed_of[r["t1"]] == "rl" and feed_of[r["t2"]] == "xy"]
+        assert rows, "fixture produced no rl x xy baseline"
+        row = rows[0]
+        assert row["polbasis"] == "rlxy"
 
-        # each slot pairs one feed of t1 with one feed of t2: (slot, t1 feed, t2 feed)
-        slot_pairings = [
-            ("p1p1sigma", ft1[0], ft2[0]),
-            ("p2p2sigma", ft1[1], ft2[1]),
-            ("p1p2sigma", ft1[0], ft2[1]),
-            ("p2p1sigma", ft1[1], ft2[0]),
-        ]
-        for slot, fa, fb in slot_pairings:
+        t1, t2 = row["t1"], row["t2"]
+        # (slot, t1 feed letter, t2 feed letter) -- explicit, not read back from tarr
+        for slot, fa, fb in [("p1p1sigma", "r", "x"), ("p2p2sigma", "l", "y"),
+                             ("p1p2sigma", "r", "y"), ("p2p1sigma", "l", "x")]:
             expected = obsh.blnoise(mixed_array.sefd_for_feed(t1, fa),
                                     mixed_array.sefd_for_feed(t2, fb), TINT, BW)
             np.testing.assert_allclose(row[slot], expected)
 
-        # make_uvpoints fills polbasis directly; Obsdata.__init__ would recompute it
-        assert row["polbasis"] == ft1 + ft2
+    def test_mixed_sigma_layout_reversed(self, xy_first_array):
+        """The reversed xy x rl baseline (t1 linear, t2 circular): slots pair
+        (X,R), (Y,L), (X,L), (Y,R). Guards the feed-ordering that the rl-first
+        fixture never exercises."""
+        out = os_sim.make_uvpoints(xy_first_array, 17.761, -29.0, 230e9, BW,
+                                   TINT, TADV, TSTART, TSTOP, polrep="mixed")
+        feed_of = {str(r["site"]): str(r["feed_type"]) for r in xy_first_array.tarr}
+        rows = [r for r in out if feed_of[r["t1"]] == "xy" and feed_of[r["t2"]] == "rl"]
+        assert rows, "fixture produced no xy x rl baseline"
+        row = rows[0]
+        assert row["polbasis"] == "xyrl"
+
+        t1, t2 = row["t1"], row["t2"]
+        for slot, fa, fb in [("p1p1sigma", "x", "r"), ("p2p2sigma", "y", "l"),
+                             ("p1p2sigma", "x", "l"), ("p2p1sigma", "y", "r")]:
+            expected = obsh.blnoise(xy_first_array.sefd_for_feed(t1, fa),
+                                    xy_first_array.sefd_for_feed(t2, fb), TINT, BW)
+            np.testing.assert_allclose(row[slot], expected)
 
 
     def test_scalar_tau_applied(self, array):
@@ -841,6 +870,36 @@ class TestAddJonesAndNoise:
         out = os_sim.add_jones_and_noise(obs_mixed, add_th_noise=False, frcal=False,
                                          verbose=False, seed=42)
         assert not np.allclose(out["p1p1vis"], obs_mixed.data["p1p1vis"])
+
+    def test_field_rotation_stokes_consistent_across_bases(self, obs_pol_asym, obs_lin_pol):
+        """Physical cross-check of the linear field-rotation Phi: the SAME
+        polarized source observed on the SAME geometry with a circular array vs a
+        linear array, corrupted with field rotation only, must recover the SAME
+        Stokes. A wrong-sign Phi_lin would rotate the EVPA the opposite way and
+        this would fail. (obs_pol_asym and obs_lin_pol share asymmetric_image_pol
+        and asymmetric_array geometry; only the feed basis differs.)"""
+        obs_c = obs_pol_asym.switch_polrep("circ")
+        corr_c = obs_c.copy()
+        corr_c.data = os_sim.add_jones_and_noise(obs_c, add_th_noise=False,
+                                                 frcal=False, verbose=False, seed=1)
+        corr_l = obs_lin_pol.copy()
+        corr_l.data = os_sim.add_jones_and_noise(obs_lin_pol, add_th_noise=False,
+                                                 frcal=False, verbose=False, seed=1)
+        sc = corr_c.switch_polrep("stokes").data
+        sl = corr_l.switch_polrep("stokes").data
+        for col in ("vis", "qvis", "uvis", "vvis"):
+            np.testing.assert_allclose(
+                sc[col], sl[col], atol=1e-9,
+                err_msg=f"{col} differs between circular and linear "
+                        "field-rotation corruption")
+
+    def test_frcal_true_dcal_false_noncircular_raises(self, obs_lin_pol):
+        """frcal=True with dcal=False (field rotation corrected, leakage not) is a
+        normal cal mode but the linear leakage double-rotation is not derived, so
+        it must fail up front with a clear error on a non-circular array."""
+        with pytest.raises(NotImplementedError, match="frcal.*dcal|circular feeds"):
+            os_sim.add_jones_and_noise(obs_lin_pol, add_th_noise=False, dcal=False,
+                                       verbose=False, seed=1)
 
     def test_seed_reproducible_no_noise(self, obs):
         """Without thermal noise, same seed -> identical output."""

--- a/tests/test_obs_simulate.py
+++ b/tests/test_obs_simulate.py
@@ -105,6 +105,40 @@ def obs_asym(asymmetric_image, asymmetric_array):
     return _observe(asymmetric_image, asymmetric_array)
 
 
+@pytest.fixture(scope="module")
+def obs_pol_asym(asymmetric_image_pol, asymmetric_array):
+    """Polarized observation against the asymmetric array (nonzero cross-hands,
+    sefdr != sefdl, nonzero D-terms) -- exercises all four correlations."""
+    return _observe(asymmetric_image_pol, asymmetric_array)
+
+
+@pytest.fixture(scope="module")
+def obs_lin(asymmetric_image, lin_array):
+    """Observation against an all-linear ('xy') array."""
+    return _observe(asymmetric_image, lin_array)
+
+
+@pytest.fixture(scope="module")
+def obs_mixed(asymmetric_image_pol, mixed_array):
+    """Polarized clean observation of a heterogeneous ('rl' + 'xy') array in the
+    native 'mixed' polrep. Built via observe_same_nonoise (stokes cannot be
+    switched to 'mixed', and the legacy add_noise path is still stokes/circ-only)."""
+    im = asymmetric_image_pol
+    empty = mixed_array.obsdata(im.ra, im.dec, im.rf, BW, TINT, TADV, TSTART, TSTOP,
+                                polrep="mixed")
+    return im.observe_same_nonoise(empty, ttype="direct", verbose=False)
+
+
+@pytest.fixture(scope="module")
+def obs_lin_pol(asymmetric_image_pol, lin_array):
+    """Polarized clean observation of an all-linear array in the native 'lin'
+    polrep (feed basis matches polrep, for physically-consistent Jones)."""
+    im = asymmetric_image_pol
+    empty = lin_array.obsdata(im.ra, im.dec, im.rf, BW, TINT, TADV, TSTART, TSTOP,
+                              polrep="lin")
+    return im.observe_same_nonoise(empty, ttype="direct", verbose=False)
+
+
 # ---------------------------------------------------------------------------
 # make_uvpoints
 # ---------------------------------------------------------------------------
@@ -458,6 +492,46 @@ class TestMakeJones:
         for site_dict in jm.values():
             assert len(site_dict) > 0
 
+    def test_circular_golden_snapshot(self, obs_asym):
+        """Golden-rule regression: freeze make_jones's assembled matrix values so
+        the upcoming refactor (moving Jones assembly into pol_conventions) stays
+        bit-identical for homogeneous-circular input.
+
+        Drives only corruption whose values come from geometry (field rotation,
+        opacity) or tarr (fixed D-terms) -- NOT from hashrandn -- so the snapshot
+        is reproducible across processes without pinning PYTHONHASHSEED. This
+        exercises the full G*(I+D)*Phi assembly (diagonal gains, off-diagonal
+        D-terms, field-rotation phases) deterministically. The random gain/phase
+        paths flow through the same assembly and are covered transitively by the
+        forthcoming pol_conventions.assemble_jones unit test.
+        """
+        jm = os_sim.make_jones(obs_asym, ampcal=True, phasecal=True,
+                               opacitycal=False, taup=0.0,
+                               dcal=False, frcal=False, dterm_offset=0.0, seed=42)
+        mats = _all_jones(jm)
+
+        assert mats.shape == (856, 2, 2)
+
+        # Independent global reductions: any drift in the assembly changes these.
+        np.testing.assert_allclose(
+            mats.sum(), 226.70283377478205 + 2.9733093453652755j, rtol=1e-12)
+        np.testing.assert_allclose(
+            np.abs(mats).sum(), 1.642259141326637e+03, rtol=1e-12)
+        np.testing.assert_allclose(
+            (mats**2).sum(), -7.652189779067328 - 0.04215025965783799j, rtol=1e-12)
+
+        # Exact anchor matrices (first and last), full 2x2.
+        m0 = np.array([[-0.6270516546475777 - 0.7789776777313551j,
+                        -0.020330809870265105 + 0.009309037008151326j],
+                       [0.017955181712446103 - 0.0016159980424001142j,
+                        -0.6270516546475777 + 0.7789776777313551j]])
+        mlast = np.array([[0.6899314917976136 - 0.5848676363109235j,
+                           0.007949953472843035 + 0.018596667644194605j],
+                          [0.0018736996266877181 + 0.016197648740073442j,
+                           0.6899314917976136 + 0.5848676363109235j]])
+        np.testing.assert_allclose(mats[0], m0, rtol=0, atol=1e-12)
+        np.testing.assert_allclose(mats[-1], mlast, rtol=0, atol=1e-12)
+
     def test_seed_reproducible(self, obs):
         jm1 = os_sim.make_jones(obs, ampcal=False, phasecal=False, seed=42)
         jm2 = os_sim.make_jones(obs, ampcal=False, phasecal=False, seed=42)
@@ -587,6 +661,46 @@ class TestMakeJones:
         files = list(caldir.iterdir())
         assert len(files) > 0
 
+    def test_linear_array_jones_is_real_rotation(self, obs_lin):
+        """On an all-linear array, field rotation yields real orthogonal
+        rotation matrices (not the circular diagonal-phase form)."""
+        jm = os_sim.make_jones(obs_lin, frcal=False, seed=1)  # field rotation only
+        J = _all_jones(jm)
+        # linear Phi = [[cos, sin], [-sin, cos]]: real, orthogonal, det 1
+        np.testing.assert_allclose(J.imag, 0, atol=1e-12)
+        np.testing.assert_allclose(J @ J.transpose(0, 2, 1),
+                                   np.broadcast_to(np.eye(2), J.shape), atol=1e-10)
+        np.testing.assert_allclose(np.linalg.det(J), 1.0, atol=1e-10)
+        # rotation actually happens somewhere (off-diagonals not all ~0)
+        assert np.max(np.abs(J[:, 0, 1])) > 1e-3
+
+    def test_mixed_array_jones_per_station_feed_basis(self, obs_mixed):
+        """Heterogeneous array: each station's Jones matrix is built in its own
+        feed basis -- linear ('xy') stations get real rotations, circular ('rl')
+        stations get diagonal unit-modulus phases -- and both are exercised."""
+        jm = os_sim.make_jones(obs_mixed, frcal=False, seed=1)  # field rotation only
+        feed = {str(r["site"]): str(r["feed_type"]) for r in obs_mixed.tarr}
+        saw_lin_rotation = False
+        saw_circ_phase = False
+        for site, tdict in jm.items():
+            J = np.array(list(tdict.values()))  # (ntimes, 2, 2)
+            if feed[site] == "xy":
+                # linear: real orthogonal rotation
+                np.testing.assert_allclose(J.imag, 0, atol=1e-12)
+                np.testing.assert_allclose(J @ J.transpose(0, 2, 1),
+                                           np.broadcast_to(np.eye(2), J.shape), atol=1e-10)
+                if np.max(np.abs(J[:, 0, 1])) > 1e-6:
+                    saw_lin_rotation = True
+            else:  # 'rl' circular: diagonal, unit modulus, opposite phases
+                np.testing.assert_allclose(J[:, 0, 1], 0, atol=1e-12)
+                np.testing.assert_allclose(J[:, 1, 0], 0, atol=1e-12)
+                np.testing.assert_allclose(np.abs(J[:, 0, 0]), 1.0, atol=1e-12)
+                np.testing.assert_allclose(J[:, 0, 0], np.conj(J[:, 1, 1]), atol=1e-12)
+                if np.max(np.abs(J[:, 0, 0].imag)) > 1e-6:
+                    saw_circ_phase = True
+        assert saw_lin_rotation, "no linear station exhibited field-rotation mixing"
+        assert saw_circ_phase, "no circular station exhibited a rotation phase"
+
 
 # ---------------------------------------------------------------------------
 # make_jones_inverse
@@ -664,12 +778,69 @@ class TestMakeJonesInverse:
 
 class TestAddJonesAndNoise:
 
+    def test_circular_golden_snapshot(self, obs_pol_asym):
+        """Golden-rule regression: freeze the deterministic circular corruption
+        (geometry/tarr-driven, no thermal noise) so the generalization of
+        add_jones_and_noise to lin/mixed stays bit-identical for homogeneous-
+        circular input. See TestMakeJones.test_circular_golden_snapshot for the
+        cross-process reproducibility rationale."""
+        obs_circ = obs_pol_asym.switch_polrep('circ')
+        out = os_sim.add_jones_and_noise(
+            obs_circ, add_th_noise=False, verbose=False,
+            opacitycal=False, taup=0.0, dcal=False, frcal=False,
+            dterm_offset=0.0, seed=42)
+        assert len(out) == 1030
+        # (complex sum, abs sum) reference from the current circular code path.
+        refs = {
+            'rrvis': (56.9320983911918 + 45.76183280802089j, 2.106697842642e+02),
+            'llvis': (80.97232013367554 - 33.50067542284446j, 2.022889706126e+02),
+            'rlvis': (-0.6565234574877421 + 1.8765209227202262j, 2.108708588243e+01),
+            'lrvis': (-4.761736644962417 - 1.3786150379036752j, 2.512659399893e+01),
+            'rrsigma': (9.069973670591652 + 0j, 9.069973670592e+00),
+            'llsigma': (13.60496050588748 + 0j, 1.360496050589e+01),
+            'rlsigma': (11.108403736713875 + 0j, 1.110840373671e+01),
+            'lrsigma': (11.108403736713875 + 0j, 1.110840373671e+01),
+        }
+        for col, (csum, abssum) in refs.items():
+            v = np.asarray(out[col], dtype=complex)
+            np.testing.assert_allclose(v.sum(), csum, rtol=1e-12)
+            np.testing.assert_allclose(np.abs(v).sum(), abssum, rtol=1e-12)
+
     def test_identity_preserves_vis(self, obs):
         """All cal True, no thermal noise -> visibilities and sigmas unchanged."""
         obsdat = os_sim.add_jones_and_noise(obs, add_th_noise=False,
                                             verbose=False, seed=42)
         np.testing.assert_allclose(obsdat["vis"], obs.data["vis"], atol=1e-12)
         np.testing.assert_allclose(obsdat["sigma"], obs.data["sigma"], atol=1e-12)
+
+    def test_linear_array_identity_preserves_vis(self, obs_lin):
+        """Linear array, all cal True, no noise: round-trips through the generic
+        path (stokes -> lin -> lin -> stokes) with visibilities unchanged."""
+        out = os_sim.add_jones_and_noise(obs_lin, add_th_noise=False,
+                                         verbose=False, seed=42)
+        for col in ("vis", "qvis", "uvis", "vvis"):
+            np.testing.assert_allclose(out[col], obs_lin.data[col], atol=1e-10)
+
+    def test_mixed_array_identity_preserves_vis(self, obs_mixed):
+        """Heterogeneous array (native 'mixed' polrep), all cal True, no noise:
+        the identity Jones leaves the generic-slot correlations unchanged."""
+        out = os_sim.add_jones_and_noise(obs_mixed, add_th_noise=False,
+                                         verbose=False, seed=42)
+        for col in ("p1p1vis", "p2p2vis", "p1p2vis", "p2p1vis"):
+            np.testing.assert_allclose(out[col], obs_mixed.data[col], atol=1e-10)
+
+    def test_linear_array_corruption_changes_data(self, obs_lin):
+        """Gain corruption on a linear array actually perturbs the visibilities."""
+        out = os_sim.add_jones_and_noise(obs_lin, add_th_noise=False, ampcal=False,
+                                         verbose=False, seed=42)
+        assert not np.allclose(out["vis"], obs_lin.data["vis"])
+
+    def test_mixed_array_field_rotation_changes_data(self, obs_mixed):
+        """Field rotation on a mixed array perturbs the correlations (exercises
+        the per-station-basis Jones application with mixed feed pairings)."""
+        out = os_sim.add_jones_and_noise(obs_mixed, add_th_noise=False, frcal=False,
+                                         verbose=False, seed=42)
+        assert not np.allclose(out["p1p1vis"], obs_mixed.data["p1p1vis"])
 
     def test_seed_reproducible_no_noise(self, obs):
         """Without thermal noise, same seed -> identical output."""
@@ -824,6 +995,30 @@ class TestApplyJonesInverse:
         obs_back.data = os_sim.apply_jones_inverse(obs_corr, opacitycal=False, verbose=False)
         np.testing.assert_allclose(obs_back.data["vis"], obs.data["vis"], atol=1e-10)
 
+    @staticmethod
+    def _roundtrip_dterms_fr(obs, cols):
+        """Corrupt with D-terms + field rotation (deterministic: dterm_offset=0 so
+        the forward D-terms equal the tarr D-terms the inverse uses), then invert.
+        The inverse must recover the clean correlations to machine precision."""
+        obs_corr = obs.copy()
+        obs_corr.data = os_sim.add_jones_and_noise(
+            obs, add_th_noise=False, dcal=False, frcal=False, dterm_offset=0.0,
+            verbose=False, seed=1)
+        rec = os_sim.apply_jones_inverse(obs_corr, dcal=False, frcal=False, verbose=False)
+        for col in cols:
+            np.testing.assert_allclose(rec[col], obs.data[col], atol=1e-9,
+                                       err_msg=f"{col} not recovered")
+
+    def test_roundtrip_dterms_fr_circ(self, obs_pol_asym):
+        self._roundtrip_dterms_fr(obs_pol_asym.switch_polrep("circ"),
+                                  ("rrvis", "llvis", "rlvis", "lrvis"))
+
+    def test_roundtrip_dterms_fr_lin(self, obs_lin_pol):
+        self._roundtrip_dterms_fr(obs_lin_pol, ("xxvis", "yyvis", "xyvis", "yxvis"))
+
+    def test_roundtrip_dterms_fr_mixed(self, obs_mixed):
+        self._roundtrip_dterms_fr(obs_mixed, ("p1p1vis", "p2p2vis", "p1p2vis", "p2p1vis"))
+
 
 # ---------------------------------------------------------------------------
 # add_noise  (legacy path)
@@ -836,6 +1031,42 @@ class TestAddNoiseLegacy:
         out = os_sim.add_noise(obs, add_th_noise=False, verbose=False, seed=42)
         np.testing.assert_allclose(out["vis"], obs.data["vis"], atol=1e-12)
         np.testing.assert_allclose(out["sigma"], obs.data["sigma"], atol=1e-12)
+
+    def test_sigma_golden_snapshot(self, obs_pol_asym):
+        """Golden-rule: freeze the recomputed perfect sigmas (deterministic, no
+        noise) for stokes and circ, so the shared-helper refactor stays
+        bit-identical. Values from the pre-refactor code."""
+        refs = {
+            "stokes": {"sigma": 8.175563784107e+00, "qsigma": 7.854827610388e+00,
+                       "usigma": 7.854827610388e+00, "vsigma": 8.175563784107e+00},
+            "circ": {"rrsigma": 9.069973670592e+00, "llsigma": 1.360496050589e+01,
+                     "rlsigma": 1.110840373671e+01, "lrsigma": 1.110840373671e+01},
+        }
+        for rep, cols in refs.items():
+            out = os_sim.add_noise(obs_pol_asym.switch_polrep(rep),
+                                   add_th_noise=False, verbose=False, seed=42)
+            for col, s in cols.items():
+                np.testing.assert_allclose(np.asarray(out[col], float).sum(), s, rtol=1e-12)
+
+    def test_lin_array_stokes_runs(self, obs_lin):
+        """add_noise on a Stokes obs of a linear array no longer crashes and
+        preserves visibilities with all cal True + no noise (was UnboundLocalError)."""
+        out = os_sim.add_noise(obs_lin, add_th_noise=False, verbose=False, seed=42)
+        np.testing.assert_allclose(out["vis"], obs_lin.data["vis"], atol=1e-10)
+        assert np.all(np.asarray(out["sigma"], float) > 0)
+
+    def test_lin_polrep_runs(self, obs_lin_pol):
+        """add_noise on a native 'lin' obs: sigmas = the four correlation sigmas."""
+        out = os_sim.add_noise(obs_lin_pol, add_th_noise=False, verbose=False, seed=42)
+        for col in ("xxvis", "yyvis", "xyvis", "yxvis"):
+            np.testing.assert_allclose(out[col], obs_lin_pol.data[col], atol=1e-10)
+        assert np.all(np.asarray(out["xxsigma"], float) > 0)
+
+    def test_mixed_polrep_runs(self, obs_mixed):
+        """add_noise on a native 'mixed' obs preserves the generic-slot correlations."""
+        out = os_sim.add_noise(obs_mixed, add_th_noise=False, verbose=False, seed=42)
+        for col in ("p1p1vis", "p2p2vis", "p1p2vis", "p2p1vis"):
+            np.testing.assert_allclose(out[col], obs_mixed.data[col], atol=1e-10)
 
     def test_seed_reproducible(self, obs):
         o1 = os_sim.add_noise(obs, add_th_noise=False, ampcal=False,

--- a/tests/test_obs_simulate.py
+++ b/tests/test_obs_simulate.py
@@ -127,14 +127,10 @@ class TestMakeUvpoints:
         assert set(out.dtype.names) >= {"rrvis", "llvis", "rlvis", "lrvis",
                                         "rrsigma", "llsigma", "rlsigma", "lrsigma"}
 
-    # def test_invalid_polrep_raises(self, array):
-    #     with pytest.raises(Exception, match="only 'stokes' and 'circ'"):
-    #         os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
-    #                              TINT, TADV, TSTART, TSTOP, polrep="linear")
     def test_invalid_polrep_raises(self, array):
         with pytest.raises(ValueError, match="must be one of"):
             os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
-                                TINT, TADV, TSTART, TSTOP, polrep="linear")
+                                 TINT, TADV, TSTART, TSTOP, polrep="linear")
 
     def test_baseline_ordering(self, array):
         out = os_sim.make_uvpoints(array, 17.761, -29.0, 230e9, BW,
@@ -406,6 +402,31 @@ class TestSampleVisBranches:
                                   s * uv[:, 0] + c * uv[:, 1]])
         out_pa0 = os_sim.sample_vis(asymmetric_image, uv_rot, ttype="direct", verbose=False)[0]
         np.testing.assert_allclose(out_pa, out_pa0, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# pack_sampled_visibilities
+# ---------------------------------------------------------------------------
+
+
+class TestPackSampledVisibilities:
+    """Coverage for pack_sampled_visibilities (writes sampled vis into obsdata)."""
+
+    def test_mixed_none_stokes_treated_as_zeros(self, mixed_array):
+        """Unpolarized source: sample_vis returns None for Q/U/V. The mixed
+        branch must treat those as zeros rather than crash (regression)."""
+        empty = mixed_array.obsdata(17.761, -29.0, 230e9, BW,
+                                    TINT, TADV, TSTART, TSTOP, polrep="mixed")
+        n = len(empty.data)
+        ivis = np.arange(1, n + 1, dtype=complex)   # nonzero, distinct per row
+        zeros = np.zeros(n, dtype=complex)
+        # None for Q/U/V (unpolarized) must match passing explicit zeros
+        out_none = os_sim.pack_sampled_visibilities(
+            empty.data.copy(), [ivis, None, None, None], "mixed")
+        out_zero = os_sim.pack_sampled_visibilities(
+            empty.data.copy(), [ivis, zeros, zeros, zeros], "mixed")
+        for slot in ("p1p1vis", "p2p2vis", "p1p2vis", "p2p1vis"):
+            np.testing.assert_array_equal(out_none[slot], out_zero[slot])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pol_conventions.py
+++ b/tests/test_pol_conventions.py
@@ -251,6 +251,150 @@ def test_apply_inverse_jones_roundtrip_small_dterms():
     np.testing.assert_allclose(V_recovered, V_true, atol=1e-12)
 
 
+def test_apply_jones_forward_matches_definition_and_inverts():
+    """apply_jones_to_coherency == J1 V J2^dag, and apply_inverse recovers V."""
+    V_true = np.array([[1.0 + 0j, 0.05 + 0.02j],
+                       [0.05 - 0.02j, 0.8 + 0j]])
+    J1 = pc.jones_matrix(1.05 + 0.01j, 0.97 - 0.02j, 0.03, -0.02)
+    J2 = pc.jones_matrix(0.98 - 0.01j, 1.02 + 0.02j, -0.01, 0.04)
+    V_obs = pc.apply_jones_to_coherency(V_true, J1, J2)
+    np.testing.assert_allclose(V_obs, J1 @ V_true @ J2.conj().T, atol=1e-14)
+    V_rec = pc.apply_inverse_jones_to_coherency(V_obs, J1, J2)
+    np.testing.assert_allclose(V_rec, V_true, atol=1e-12)
+
+
+def test_apply_jones_forward_broadcasts():
+    """Leading axes broadcast (a stack of baselines/times)."""
+    V = np.broadcast_to(np.eye(2, dtype=complex), (4, 2, 2))
+    J = np.broadcast_to(np.diag([2.0 + 0j, 3.0 + 0j]), (4, 2, 2))
+    V_obs = pc.apply_jones_to_coherency(V, J, J)
+    expected = np.broadcast_to(np.diag([4.0 + 0j, 9.0 + 0j]), (4, 2, 2))
+    np.testing.assert_allclose(V_obs, expected, atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# Forward Jones assembly (field_rotation_matrix, assemble_jones)
+# ---------------------------------------------------------------------------
+
+
+def test_field_rotation_matrix_circular_diagonal_phase():
+    """'rl' field rotation is diag(exp(-i*phi), exp(+i*phi))."""
+    phi = np.array([0.0, 0.3, -1.2])
+    Phi = pc.field_rotation_matrix('rl', phi)
+    assert Phi.shape == (3, 2, 2)
+    np.testing.assert_allclose(Phi[:, 0, 0], np.exp(-1j * phi))
+    np.testing.assert_allclose(Phi[:, 1, 1], np.exp(1j * phi))
+    np.testing.assert_allclose(Phi[:, 0, 1], 0, atol=1e-15)
+    np.testing.assert_allclose(Phi[:, 1, 0], 0, atol=1e-15)
+
+
+def test_field_rotation_matrix_zero_is_identity():
+    np.testing.assert_allclose(pc.field_rotation_matrix('rl', 0.0), np.eye(2), atol=1e-15)
+
+
+def test_field_rotation_matrix_linear_real_rotation():
+    """'xy' field rotation is the real rotation [[cos, sin], [-sin, cos]]."""
+    phi = np.array([0.0, 0.3, -1.2])
+    Phi = pc.field_rotation_matrix('xy', phi)
+    assert Phi.shape == (3, 2, 2)
+    np.testing.assert_allclose(Phi[:, 0, 0], np.cos(phi))
+    np.testing.assert_allclose(Phi[:, 0, 1], np.sin(phi))
+    np.testing.assert_allclose(Phi[:, 1, 0], -np.sin(phi))
+    np.testing.assert_allclose(Phi[:, 1, 1], np.cos(phi))
+
+
+def test_field_rotation_matrix_linear_consistent_with_circular():
+    """The linear Phi is fixed by consistency with the circular convention:
+    Phi_lin == F^{-1} Phi_circ F, F = BASIS_LIN_TO_CIRC. (This is the ASSUMPTION
+    awaiting Andrew's sign confirmation; the test pins the derivation.)"""
+    F = pc.BASIS_LIN_TO_CIRC
+    for phi in [0.0, 0.3, 1.1, -0.7]:
+        Phi_circ = pc.field_rotation_matrix('rl', phi)
+        Phi_lin = pc.field_rotation_matrix('xy', phi)
+        np.testing.assert_allclose(np.linalg.inv(F) @ Phi_circ @ F, Phi_lin, atol=1e-14)
+
+
+def test_field_rotation_matrix_hybrid_not_implemented():
+    with pytest.raises(NotImplementedError):
+        pc.field_rotation_matrix('rx', 0.5)
+
+
+def test_assemble_jones_default_identity():
+    """Unit gains, no D-terms, no field rotation -> identity."""
+    J = pc.assemble_jones(1.0, 1.0, 0.0, 0.0, 'rl', 0.0)
+    np.testing.assert_allclose(J, np.eye(2), atol=1e-15)
+
+
+def test_assemble_jones_hybrid_not_implemented():
+    with pytest.raises(NotImplementedError):
+        pc.assemble_jones(1.0, 1.0, 0.0, 0.0, 'rx', 0.0)
+
+
+def test_assemble_jones_linear_forward_is_G_IpD_Philin():
+    """Linear feeds, fr_angle_D=0: J = G (I + D) Phi_lin."""
+    gX, gY = 1.05 + 0.01j, 0.97 - 0.02j
+    dX, dY = 0.03 + 0.0j, -0.02 + 0.0j
+    phi = 0.4
+    J = pc.assemble_jones(gX, gY, dX, dY, 'xy', phi, 0.0)
+    G = np.array([[gX, 0], [0, gY]])
+    IpD = np.array([[1, dX], [dY, 1]])
+    Phi = np.array([[np.cos(phi), np.sin(phi)], [-np.sin(phi), np.cos(phi)]])
+    np.testing.assert_allclose(J, G @ IpD @ Phi, atol=1e-14)
+
+
+def test_assemble_jones_linear_frD_not_implemented():
+    """Nonzero fr_angle_D with a non-circular feed is gated (see LIMITATION)."""
+    with pytest.raises(NotImplementedError):
+        pc.assemble_jones(1.0, 1.0, 0.0, 0.0, 'xy', 0.1, 0.2)
+
+
+def test_assemble_jones_matches_make_jones_formula():
+    """assemble_jones reproduces the explicit elementwise circular assembly in
+    obs_simulate.make_jones for arbitrary gains / D-terms / rotation angles.
+
+    This is the transitive guarantee that make_jones's random gain/phase paths
+    (which flow through the same assembly) stay bit-identical after it is
+    rewired to call assemble_jones.
+    """
+    rng = np.random.default_rng(0)
+    n = 7
+
+    def crand(shape):
+        return rng.standard_normal(shape) + 1j * rng.standard_normal(shape)
+
+    gR = crand(n)
+    gL = crand(n)
+    dR = 0.03 + 0.02j
+    dL = -0.01 + 0.04j
+    phi = rng.standard_normal(n)      # fr_angle
+    phiD = rng.standard_normal(n)     # fr_angle_D
+
+    # Reference: the exact matrix built in obs_simulate.make_jones (lines ~806-813).
+    J_ref = np.empty((n, 2, 2), dtype=complex)
+    for j in range(n):
+        J_ref[j] = np.array([
+            [np.exp(-1j * phi[j]) * gR[j],
+             np.exp(1j * (phi[j] + phiD[j])) * dR * gR[j]],
+            [np.exp(-1j * (phi[j] + phiD[j])) * dL * gL[j],
+             np.exp(1j * phi[j]) * gL[j]],
+        ])
+
+    J = pc.assemble_jones(gR, gL, dR, dL, 'rl', phi, phiD)
+    np.testing.assert_allclose(J, J_ref, atol=1e-13)
+
+
+def test_assemble_jones_frD_zero_is_G_IpD_Phi():
+    """With fr_angle_D=0 the assembly is exactly G (I + D) Phi."""
+    gR, gL = 1.05 + 0.01j, 0.97 - 0.02j
+    dR, dL = 0.03 + 0.0j, -0.02 + 0.0j
+    phi = 0.4
+    J = pc.assemble_jones(gR, gL, dR, dL, 'rl', phi, 0.0)
+    G = np.array([[gR, 0], [0, gL]])
+    IpD = np.array([[1, dR], [dL, 1]])
+    Phi = np.array([[np.exp(-1j * phi), 0], [0, np.exp(1j * phi)]])
+    np.testing.assert_allclose(J, G @ IpD @ Phi, atol=1e-14)
+
+
 # ---------------------------------------------------------------------------
 # MixedPolConventionWarning fires exactly once per session
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

Adds end-to-end support for **linear** and **mixed** feed polarization, previously gated behind `NotImplementedError`. 
Two coupled pieces:

**Phase 6 — simulation + forward Jones**
- `polrep` widened to `stokes`/`circ`/`lin`/`mixed` through `Array.obsdata` → `make_uvpoints` → `sample_vis`.
- `make_uvpoints`: per-station feed dispatch (`feed_dtype_for_polrep`); the four correlation sigmas are built by pairing each station's two feeds via `Array.sefd_for_feed`, replacing hardcoded R/L.
- `sample_vis`: `lin` branch mirrors `circ`; `mixed` samples Stokes and the caller converts per-baseline.
- New forward Jones layer in `pol_conventions.py`: `assemble_jones`, `field_rotation_matrix`, `apply_jones_to_coherency`, factored as **J = G·(I+D)·Φ** (Paper VII Eq. 4). `make_jones`/`make_jones_inverse`/`add_jones_and_noise`/`add_noise` are now polrep-agnostic (circ/lin/mixed).

**Phase 7 — uvfits load/save round-trip**
- `load_obs_uvfits`: per-station **POLTYA/POLTYB → `feed_type`**; native basis inferred from the feed-type set, not CRVAL3.
- `save_obs_uvfits`: `polrep_out` extended to lin/mixed; POLTYA/POLTYB emitted from `feed_type`.

**Docs:** `polarization_conventions.md` §9–12 rewritten (J = G(I+D)Φ, linear/mixed conventions).

## Why

Phase 6/7 of the mixed-pol track — the forward model and I/O prerequisites for joint polarimetric imaging on heterogeneous arrays (ALMA/VLA). Removes the lin/mixed simulation and loader gates.

## Design decisions worth discussing

- **Conversion in the caller (Option A):** Stokes→coherency for mixed baselines lives in a shared helper `pack_sampled_visibilities` (used by `Image.observe_same_nonoise` + `Movie`), keeping `sample_vis` a pure uv→vis sampler.
- **Φ is basis-dependent:** diagonal-phase `diag(e^{-iφ}, e^{+iφ})` for circular feeds, real rotation `[[cos,sin],[−sin,cos]]` for linear; `Φ_lin = F⁻¹Φ_circ F`. Absolute sign is convention-dependent (TMS §4.7) and matches our existing circular convention — confirmed by Rohan.
- **Native basis from the feed-type set, not CRVAL3** (for mixed, CRVAL3 is only a nominal 4-slot grid). CRVAL3/feed **disagreement** now raises loudly; non-unit-step CDELT3 is rejected.
- **`sefd_p1`/`sefd_p2`** replace whole-column `tarr['sefdr']` access — fixes a latent `TarrView` guard trip that blocked constructing *any* mixed `Obsdata`.

## Correctness

- Homogeneous-circular and stokes output stays **byte-identical** to base, including fixed-seed noise (`PYTHONHASHSEED=0`, ~1e-15) — pinned by regression tests.
- Corrupt→invert Jones round-trips to ~1e-9 for circ/lin/mixed; mixed pack→unpack at machine precision.
- Save→load→save round-trips lin+mixed (idempotent to the float32 uvfits floor ~3e-8, same as circ).

## How to test

\`\`\`bash
PYTHONHASHSEED=0 micromamba run -n jax-ehtim pytest \
  tests/test_mixedpol.py tests/test_obs_simulate.py tests/test_pol_conventions.py tests/test_image.py
\`\`\`
542 passed / 1 skipped locally against the current \`dev-backend-mixpol\` base.

## Intentionally gated (raise up front)

Hybrid `'rx'` feeds · non-circular `frcal=True, dcal=False` · `stokes → switch_polrep('mixed')` · `force_singlepol` on non-circ. Each raises a clear error rather than silently producing physically wrong results.

## Known open / out of scope (not blockers)

- CDELT3 positional-plane assumption not yet verified against a **real** mixed uvfits — need Iniyan's sample to confirm real STOKES/POLTY encoding.
- Pre-existing `obsdata.py:653` sorts `tarr` via whole-column `tarr['sefdr']` → breaks on lin/mixed `TarrView` (flagging, not fixing here).
- AIPS convention variance / hybrid `POLTYA=R, POLTYB=X` stations — open question.

## Not in this PR

- crc32 noise-seed fix → separate PR to `dev-backend` (`fix/stable-noise-seed`).
- Slot-variable rename (`rr_2d`/`llweight` → `p1p1`-style, ~211 edits) → deferred follow-up; behavior is test-pinned so it's independent.
- `caltable.py` for now (Phase 5 boundary — Jones layer owned here, calibration adapts it later).

Part of #212.