### PR TITLE
Fix multifrequency polarimetric gradients (rho chain rule + alpha slot)

### DIFF
--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -610,13 +610,14 @@ def physical_grad_slots(pol_solve, transforms, mf_spectral_I=False):
     return mask
 
 
-# Rows 4 and 5 of a multifrequency imarr are the Stokes-I spectral index and curvature
-# (see multifreq_imager_utils.image_at_freq); the pol expansion terms follow at 6-9.
-MF_SPECTRAL_I_SLOTS = slice(4, 6)
+def _mf_solves_spectral_I(which_solve, mf):
+    """True when a multifrequency run solves for the Stokes-I spectral index or curvature.
 
-
-def mf_solves_spectral_I(which_solve, mf):
-    """True when a multifrequency run is solving for the Stokes-I spectral index or curvature.
+    Only the 10-row mf-pol layout needs this: there rows 4 and 5 are the Stokes-I spectral
+    index and curvature (see multifreq_imager_utils.image_at_freq), while the block gating
+    the chi^2 kernel is built from rows 0-3 alone, so the kernel never learns that a row it
+    cannot see depends on Stokes I. The 3-row Stokes-I mf layout runs an ungated kernel and
+    needs no widening.
 
     Parameters
     ----------
@@ -628,12 +629,10 @@ def mf_solves_spectral_I(which_solve, mf):
     Returns
     -------
     bool
-        Whether physical_grad_slots needs to request the Stokes-I gradient slot.
+        Whether physical_grad_slots should request the Stokes-I gradient slot.
     """
-    if not mf:
-        return False
     which_solve = np.asarray(which_solve)
-    return bool(np.any(which_solve[MF_SPECTRAL_I_SLOTS]))
+    return bool(mf and len(which_solve) == 10 and np.any(which_solve[4:6]))
 
 
 def make_initarr(image, mask, norm_init=False, flux=1,
@@ -1618,7 +1617,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, config,
     pol_solve = _pol_solve_block(which_solve, pol)
     pol_grad_slots = physical_grad_slots(
         pol_solve, config.transforms,
-        mf_spectral_I=mf_solves_spectral_I(which_solve, mf))
+        mf_spectral_I=_mf_solves_spectral_I(which_solve, mf))
     # np.array((...)) below copies, so sharing zero_row across iterations is safe.
     zero_row = np.zeros(nimage)
     is_pol_mode = pol in POLARIZATION_MODES

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -559,7 +559,7 @@ def transform_gradients(gradarr, imarr, transforms, which_solve):
     return outarr
 
 
-def physical_grad_slots(pol_solve, transforms):
+def physical_grad_slots(pol_solve, transforms, mf_spectral_I=False):
     """Physical gradout slots the gradient kernels must fill, given the DOF mask.
 
     pol_solve is the 4-wide Stokes DOF mask (I, rho/m', chi, psi/v'); the chisq
@@ -572,6 +572,25 @@ def physical_grad_slots(pol_solve, transforms):
     The transform <-> pol-mode pairing this branches on (mcv for P/QU/IP/IQU,
     vcv for V/IV, polcv for IPV/IQUV) is enforced in validate_params, so the
     mcv/vcv checks here are unambiguous and mutually exclusive.
+
+    Parameters
+    ----------
+    pol_solve : sequence of int
+        Stokes DOF mask, 4-wide for a polarization mode and shorter for single-pol.
+    transforms : sequence of str
+        Active change-of-variables names; only 'mcv' and 'vcv' widen the mask.
+    mf_spectral_I : bool, optional
+        Set when a multifrequency Stokes-I spectral coefficient (alpha or beta) is
+        being solved. Those coefficients reach the objective only through I(nu), so
+        mf_all_grads_chain builds their gradients out of the physical Stokes-I slot;
+        without this the kernel leaves that slot at zero and the spectral gradient
+        comes back identically zero. Pol modes under mf do not solve for I at the
+        reference frequency, which is exactly when the widening is needed.
+
+    Returns
+    -------
+    mask : np.ndarray of int
+        Physical slots the gradient kernel must populate.
     """
     mask = np.array(pol_solve, dtype=int).copy()
     # Cross-coupling only exists for the full 4-wide Stokes block. Single-pol
@@ -580,6 +599,8 @@ def physical_grad_slots(pol_solve, transforms):
     # check alone is not enough. Mirror transform_gradients' shape gating.
     if len(mask) < 4:
         return mask
+    if mf_spectral_I:                            # alpha/beta -> I (via mf_all_grads_chain)
+        mask[0] = 1
     if 'mcv' in transforms and pol_solve[1]:     # m' (slot 1) -> rho AND psi
         mask[1] = 1
         mask[3] = 1
@@ -587,6 +608,32 @@ def physical_grad_slots(pol_solve, transforms):
         mask[1] = 1
         mask[3] = 1
     return mask
+
+
+# Rows 4 and 5 of a multifrequency imarr are the Stokes-I spectral index and curvature
+# (see multifreq_imager_utils.image_at_freq); the pol expansion terms follow at 6-9.
+MF_SPECTRAL_I_SLOTS = slice(4, 6)
+
+
+def mf_solves_spectral_I(which_solve, mf):
+    """True when a multifrequency run is solving for the Stokes-I spectral index or curvature.
+
+    Parameters
+    ----------
+    which_solve : sequence of int
+        Full solved-DOF mask over the imarr rows.
+    mf : bool
+        Whether multifrequency imaging is active.
+
+    Returns
+    -------
+    bool
+        Whether physical_grad_slots needs to request the Stokes-I gradient slot.
+    """
+    if not mf:
+        return False
+    which_solve = np.asarray(which_solve)
+    return bool(np.any(which_solve[MF_SPECTRAL_I_SLOTS]))
 
 
 def make_initarr(image, mask, norm_init=False, flux=1,
@@ -1569,7 +1616,9 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, config,
 
     chi2grad_dict = {}
     pol_solve = _pol_solve_block(which_solve, pol)
-    pol_grad_slots = physical_grad_slots(pol_solve, config.transforms)
+    pol_grad_slots = physical_grad_slots(
+        pol_solve, config.transforms,
+        mf_spectral_I=mf_solves_spectral_I(which_solve, mf))
     # np.array((...)) below copies, so sharing zero_row across iterations is safe.
     zero_row = np.zeros(nimage)
     is_pol_mode = pol in POLARIZATION_MODES

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -559,7 +559,15 @@ def transform_gradients(gradarr, imarr, transforms, which_solve):
     return outarr
 
 
-def physical_grad_slots(pol_solve, transforms, mf_spectral_I=False):
+# Multifrequency pol imarr layout: 4 physical rows then 6 spectral ones. Each spectral row
+# reaches the objective only through the physical slot listed here.
+MF_POL_ROWS = 10
+MF_SPECTRAL_ROWS = {0: slice(4, 6),   # alpha, beta   -> I
+                    1: slice(6, 8),   # alpha_pol, beta_pol -> rho
+                    2: slice(8, 9)}   # rm            -> phi
+
+
+def physical_grad_slots(pol_solve, transforms, mf_solve=None):
     """Physical gradout slots the gradient kernels must fill, given the DOF mask.
 
     pol_solve is the 4-wide Stokes DOF mask (I, rho/m', chi, psi/v'); the chisq
@@ -579,13 +587,15 @@ def physical_grad_slots(pol_solve, transforms, mf_spectral_I=False):
         Stokes DOF mask, 4-wide for a polarization mode and shorter for single-pol.
     transforms : sequence of str
         Active change-of-variables names; only 'mcv' and 'vcv' widen the mask.
-    mf_spectral_I : bool, optional
-        Set when a multifrequency Stokes-I spectral coefficient (alpha or beta) is
-        being solved. Those coefficients reach the objective only through I(nu), so
-        mf_all_grads_chain builds their gradients out of the physical Stokes-I slot;
-        without this the kernel leaves that slot at zero and the spectral gradient
-        comes back identically zero. Pol modes under mf do not solve for I at the
-        reference frequency, which is exactly when the widening is needed.
+    mf_solve : sequence of int, optional
+        Full solved-DOF mask for a multifrequency run, if this is one. The 10-row mf-pol
+        layout carries spectral rows that reach the objective only through a physical slot
+        (rows 4,5 through I; 6,7 through rho; 8 through phi; see
+        multifreq_imager_utils.mf_all_grads_chain). pol_solve is built from rows 0-3 alone,
+        so the kernel never learns that a row it cannot see depends on one of them, and the
+        spectral gradient comes back identically zero. A solved spectral row therefore needs
+        its physical slot filled even when that slot is not itself a DOF. The 3-row Stokes-I
+        mf layout runs an ungated kernel and needs nothing.
 
     Returns
     -------
@@ -599,8 +609,15 @@ def physical_grad_slots(pol_solve, transforms, mf_spectral_I=False):
     # check alone is not enough. Mirror transform_gradients' shape gating.
     if len(mask) < 4:
         return mask
-    if mf_spectral_I:                            # alpha/beta -> I (via mf_all_grads_chain)
-        mask[0] = 1
+    if mf_solve is not None:
+        ms = np.asarray(mf_solve)
+        if len(ms) == MF_POL_ROWS:
+            # today only slot 0 can be off (pol='P'/'QU' hold I fixed) while a spectral row
+            # is solved, but keep all three symmetric so a future mode that holds rho0 or
+            # phi0 fixed does not reintroduce this one row over.
+            for slot, rows in MF_SPECTRAL_ROWS.items():
+                if np.any(ms[rows]):
+                    mask[slot] = 1
     if 'mcv' in transforms and pol_solve[1]:     # m' (slot 1) -> rho AND psi
         mask[1] = 1
         mask[3] = 1
@@ -608,31 +625,6 @@ def physical_grad_slots(pol_solve, transforms, mf_spectral_I=False):
         mask[1] = 1
         mask[3] = 1
     return mask
-
-
-def _mf_solves_spectral_I(which_solve, mf):
-    """True when a multifrequency run solves for the Stokes-I spectral index or curvature.
-
-    Only the 10-row mf-pol layout needs this: there rows 4 and 5 are the Stokes-I spectral
-    index and curvature (see multifreq_imager_utils.image_at_freq), while the block gating
-    the chi^2 kernel is built from rows 0-3 alone, so the kernel never learns that a row it
-    cannot see depends on Stokes I. The 3-row Stokes-I mf layout runs an ungated kernel and
-    needs no widening.
-
-    Parameters
-    ----------
-    which_solve : sequence of int
-        Full solved-DOF mask over the imarr rows.
-    mf : bool
-        Whether multifrequency imaging is active.
-
-    Returns
-    -------
-    bool
-        Whether physical_grad_slots should request the Stokes-I gradient slot.
-    """
-    which_solve = np.asarray(which_solve)
-    return bool(mf and len(which_solve) == 10 and np.any(which_solve[4:6]))
 
 
 def make_initarr(image, mask, norm_init=False, flux=1,
@@ -1616,8 +1608,7 @@ def compute_chisqgrad_dict(imcur, dat_term_keys, config,
     chi2grad_dict = {}
     pol_solve = _pol_solve_block(which_solve, pol)
     pol_grad_slots = physical_grad_slots(
-        pol_solve, config.transforms,
-        mf_spectral_I=_mf_solves_spectral_I(which_solve, mf))
+        pol_solve, config.transforms, mf_solve=which_solve if mf else None)
     # np.array((...)) below copies, so sharing zero_row across iterations is safe.
     zero_row = np.zeros(nimage)
     is_pol_mode = pol in POLARIZATION_MODES

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -1785,6 +1785,12 @@ def compute_reggrad_dict(imcur, reg_term_keys, config,
 
         if mf:
             if regname in REGULARIZERS_POL:
+                # No mf_spectral_I here, and the spectral rows below stay at zero on
+                # purpose: this regularizer is evaluated on the reference-frequency
+                # image (imcur[0:4]) and never runs through mf_all_grads_chain, so it
+                # genuinely does not depend on alpha/beta. The value side does the same
+                # thing, so the two agree. Regularizers that should see every frequency
+                # are the REGULARIZERS_ALLFREQS_I ('_mf') variants handled below.
                 pol_grad_slots = physical_grad_slots(
                     _pol_solve_block(which_solve, pol), config.transforms)
                 regp = compute_regularizergrad_term(

--- a/ehtim/imaging/multifreq_imager_utils.py
+++ b/ehtim/imaging/multifreq_imager_utils.py
@@ -126,9 +126,14 @@ def mf_all_grads_chain(funcgrad, image_cur, mfarr, log_freqratio):
             # TODO: what to do about rho=0?
             drho_drhoprime = (rhovec_prime**(-1-DD_RHOPOL))*((1 + rhovec_prime**(-DD_RHOPOL))**(-1-1/DD_RHOPOL))
 
-            dfunc_drho0     = dfunc_drho * drho_drhoprime * rhovec_cur / rho0
-            dfunc_dalphapol = dfunc_drho * drho_drhoprime * rhovec_cur * log_freqratio
-            dfunc_dbetapol  = dfunc_drho * drho_drhoprime * rhovec_cur * log_freqratio * log_freqratio
+            # rho reaches the coefficients through rho_prime, not directly: the spectral
+            # expansion is log(rho') = log(rho0) + alpha_pol*L + beta_pol*L^2, so
+            # d(rho')/d(rho0) = rho'/rho0 and the two spectral slots pick up rho' * L^n.
+            # rho itself only enters via drho_drhoprime above. (Stokes I at line 121 has no
+            # such second layer, which is why it uses imvec_cur directly.)
+            dfunc_drho0     = dfunc_drho * drho_drhoprime * rhovec_prime / rho0
+            dfunc_dalphapol = dfunc_drho * drho_drhoprime * rhovec_prime * log_freqratio
+            dfunc_dbetapol  = dfunc_drho * drho_drhoprime * rhovec_prime * log_freqratio * log_freqratio
 
             # apply chain rule for derivatives w/r/t phi and psi
             dfunc_dphi0 = dfunc_dphi

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -598,7 +598,8 @@ def mf_pol_setup(eht_array, make_asym_image):
         im_nu.rf = im.rf * np.exp(lfr)
         obs = im_nu.observe(eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
                             ampcal=True, phasecal=True, ttype="direct", add_th_noise=False)
-        data_tuples[f"pvis_{i}"] = compute_chisqdata_term(obs, im, mask, "pvis", config)
+        for dname in ("pvis", "m"):
+            data_tuples[f"{dname}_{i}"] = compute_chisqdata_term(obs, im, mask, dname, config)
 
     return {"config": config, "mask": mask, "data_tuples": data_tuples,
             "logfreqratios": logfreqratios, "mfarr": _mfarr_pol(im.imvec.size)}
@@ -618,7 +619,7 @@ class TestMfPolChisqGradient:
             ("config", "mask", "data_tuples", "logfreqratios", "mfarr"))
         which_solve = np.asarray(compute_which_solve(config), dtype=int)
         n_obs, nimage = len(lfrs), int(mask.sum())
-        keys = ["pvis"]
+        keys = ["pvis", "m"]
 
         def value(a):
             terms = compute_chisq_dict(a, keys, config, data_tuples, lfrs, n_obs, mask)
@@ -629,7 +630,7 @@ class TestMfPolChisqGradient:
         analytic = sum(np.asarray(g) for g in grads.values())
         fd = fd_grad(value, mfarr)
 
-        assert_nonvacuous(fd, label="mf pol pvis")
+        assert_nonvacuous(fd, label="mf pol chisq")
         assert which_solve.any(), "no slots solved: the setup exercises nothing"
         for slot in np.flatnonzero(which_solve):
-            assert_grad_close(analytic[slot], fd[slot], label=f"mf pol pvis slot{slot}")
+            assert_grad_close(analytic[slot], fd[slot], label=f"mf pol chisq slot{slot}")

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -32,13 +32,17 @@ from ehtim.imaging.imager_backend import (
     REGULARIZERS_SPECTRAL,
     ImagerConfig,
     MfConfig,
+    compute_chisq_dict,
     compute_chisq_term,
     compute_chisqdata_term,
+    compute_chisqgrad_dict,
     compute_chisqgrad_term,
     compute_regularizer_term,
     compute_regularizergrad_term,
+    compute_which_solve,
 )
 from ehtim.imaging.imager_utils import chisq, chisqdata, chisqgrad
+from ehtim.imaging.multifreq_imager_utils import image_at_freq, mf_all_grads_chain
 from ehtim.imaging.pol_imager_utils import (
     REGULARIZERS_POL,
     mcv,
@@ -491,3 +495,141 @@ class TestTransformGradient:
         if fixed is not None:
             held = float(np.max(np.abs(analytic[fixed - 1])))
             assert held < ABS_FLOOR, f"{name}: held slot {fixed} gradient not ~0 (got {held:.2e})"
+
+
+# ============================= S7: multifrequency ============================
+# The multifreq chain rule maps a gradient w.r.t. the image at one frequency back onto the
+# reference-frequency image and the spectral coefficients. Two levels, because the two ways
+# it can go wrong live in different places:
+#
+#   S7a  mf_all_grads_chain alone, against an arbitrary DENSE upstream gradient. Dense so
+#        every coefficient slot is exercised, the same reason S6 uses a dense grad_phys.
+#   S7b  the composed chi^2 path, which is where the upstream gradient is produced by a real
+#        pol kernel under pol_solve gating. A slot can be right in S7a and still arrive as
+#        zero here if the gating drops the physical slot it chains through.
+MF_LFR = 0.35     # log(nu/nu_ref); ~230 -> ~326 GHz
+MF_N = 24
+
+
+def _mfarr_si(n, seed=SEED):
+    """Stokes-I multifreq coefficients [I0, alpha, beta]."""
+    rng = np.random.default_rng(seed)
+    return np.stack([
+        0.5 + rng.random(n),                    # I0 > 0
+        -1.0 + 2.0 * rng.random(n),             # alpha
+        -0.3 + 0.6 * rng.random(n),             # beta
+    ])
+
+
+def _mfarr_pol(n, seed=SEED):
+    """Full-pol multifreq coefficients, reference-frequency image then spectral terms.
+
+    Rows are [I0, rho0, phi0, psi0, alpha, beta, alpha_pol, beta_pol, rm, cm]. rho0 stays
+    well inside (0,1) so the rho' <-> rho squashing transform and its inverse are both
+    finite, and psi0 is away from 0 so v != 0 and m != 0 at every pixel.
+    """
+    rng = np.random.default_rng(seed)
+    return np.stack([
+        0.5 + rng.random(n),                    # I0 > 0
+        0.2 + 0.5 * rng.random(n),              # rho0 in (0.2, 0.7)
+        2 * np.pi * rng.random(n),              # phi0 = 2*chi
+        0.3 + 0.5 * rng.random(n),              # psi0 in (0.3, 0.8)
+        -1.0 + 2.0 * rng.random(n),             # alpha
+        -0.3 + 0.6 * rng.random(n),             # beta
+        -1.0 + 2.0 * rng.random(n),             # alpha_pol
+        -0.3 + 0.6 * rng.random(n),             # beta_pol
+        -0.5 + 1.0 * rng.random(n),             # rm
+        -0.5 + 1.0 * rng.random(n),             # cm
+    ])
+
+
+# cm has no effect on the forward model yet: image_at_freq holds psi(nu) = psi0 pending the
+# psi in (-pi/2, pi/2) constraint, so both the finite difference and the analytic chain are
+# ~0 in that slot. Kept in the parametrization so it starts failing the day cm is wired up.
+MF_CASES = {"stokesI": (_mfarr_si, 1), "pol": (_mfarr_pol, 4)}
+
+
+class TestMfChainRule:
+    """mf_all_grads_chain matches finite differences of image_at_freq, slot by slot.
+
+    Checks the chain rule in isolation: given an arbitrary dense gradient w.r.t. the image at
+    one frequency, the returned gradient w.r.t. every reference-image and spectral coefficient
+    must match central differences of the same composition.
+    """
+
+    @pytest.mark.parametrize("case", list(MF_CASES))
+    def test_grad_matches_fd(self, case):
+        build, nrow = MF_CASES[case]
+        mfarr = build(MF_N)
+        funcgrad = np.random.default_rng(SEED + 11).standard_normal(
+            (MF_N,) if nrow == 1 else (nrow, MF_N))
+
+        image_cur = np.asarray(image_at_freq(mfarr, MF_LFR))
+        analytic = mf_all_grads_chain(funcgrad, image_cur, mfarr, MF_LFR)
+        fd = fd_grad(
+            lambda a: float(np.sum(funcgrad * np.asarray(image_at_freq(a, MF_LFR)))), mfarr)
+
+        assert_nonvacuous(fd, label=f"mf {case}")
+        for slot in range(mfarr.shape[0]):
+            assert_grad_close(analytic[slot], fd[slot],
+                              label=f"mf {case} slot{slot}", allow_zero=True)
+
+
+@pytest.fixture(scope="module")
+def mf_pol_setup(eht_array, make_asym_image):
+    """Two-frequency polarized observation plus the 10-row coefficient array to solve for.
+
+    pol='P' is the only polarization mode validate_params allows under mf. Returns everything
+    compute_chisq_dict / compute_chisqgrad_dict need, so the test drives the production
+    composition rather than reassembling it.
+    """
+    im = make_asym_image(4, 6)
+    im.imvec = im.imvec * 2.0 / im.total_flux()
+    im = im.add_random_pol(0.25, 40 * eh.RADPERUAS, cmag=0.06, ccorr=40 * eh.RADPERUAS, seed=7)
+
+    config = ImagerConfig(pol="P", transforms=[], ttype="direct", mf=True,
+                          mf_config=MfConfig(mf_order=1, mf_order_pol=1, mf_rm=1, mf_cm=0))
+    mask = np.ones(im.imvec.size, dtype=bool)
+    logfreqratios = [0.0, MF_LFR]
+
+    data_tuples = {}
+    for i, lfr in enumerate(logfreqratios):
+        im_nu = im.copy()
+        im_nu.rf = im.rf * np.exp(lfr)
+        obs = im_nu.observe(eht_array, TINT_SEC, TADV_SEC, TSTART_HR, TSTOP_HR, BW_HZ,
+                            ampcal=True, phasecal=True, ttype="direct", add_th_noise=False)
+        data_tuples[f"pvis_{i}"] = compute_chisqdata_term(obs, im, mask, "pvis", config)
+
+    return {"config": config, "mask": mask, "data_tuples": data_tuples,
+            "logfreqratios": logfreqratios, "mfarr": _mfarr_pol(im.imvec.size)}
+
+
+class TestMfPolChisqGradient:
+    """The composed mf-pol chi^2 gradient matches finite differences in every solved slot.
+
+    Only the slots compute_which_solve marks as solved are compared: the others never reach
+    the optimizer. The spectral index is one of them, and it chains through the Stokes-I
+    physical slot, so gating that slot away silently freezes it.
+    """
+
+    def test_grad_matches_fd(self, mf_pol_setup):
+        config, mask, data_tuples, lfrs, mfarr = (
+            mf_pol_setup[k] for k in
+            ("config", "mask", "data_tuples", "logfreqratios", "mfarr"))
+        which_solve = np.asarray(compute_which_solve(config), dtype=int)
+        n_obs, nimage = len(lfrs), int(mask.sum())
+        keys = ["pvis"]
+
+        def value(a):
+            terms = compute_chisq_dict(a, keys, config, data_tuples, lfrs, n_obs, mask)
+            return float(sum(terms.values()))
+
+        grads = compute_chisqgrad_dict(mfarr, keys, config, data_tuples, lfrs, n_obs,
+                                       mask, which_solve, nimage)
+        analytic = sum(np.asarray(g) for g in grads.values())
+        fd = fd_grad(value, mfarr)
+
+        assert_nonvacuous(fd, label="mf pol pvis")
+        assert which_solve.any(), "no slots solved: the setup exercises nothing"
+        for slot in np.flatnonzero(which_solve):
+            assert_grad_close(analytic[slot], fd[slot], label=f"mf pol pvis slot{slot}")

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -365,6 +365,34 @@ class TestPhysicalGradSlots:
         out = physical_grad_slots([1, 0, 0, 0], ["log"])
         np.testing.assert_array_equal(out, [1, 0, 0, 0])
 
+    def test_mf_spectral_rows_widen_their_physical_slot(self):
+        # each spectral row reaches the objective only through one physical slot, so solving
+        # it requires that slot even when it is not itself a DOF. pol='P' holds I fixed.
+        p_solve = [0, 1, 1, 0]
+        alpha = [0, 1, 1, 0, 1, 0, 0, 0, 0, 0]        # Stokes-I spectral index -> slot 0
+        np.testing.assert_array_equal(
+            physical_grad_slots(p_solve, [], mf_solve=alpha), [1, 1, 1, 0])
+
+        # and the same for the rows that are only safe today because compute_which_solve
+        # happens to hardcode do_rho / do_phi to 1
+        alpha_pol = [0, 0, 0, 0, 0, 0, 1, 0, 0, 0]    # -> slot 1
+        np.testing.assert_array_equal(
+            physical_grad_slots([0, 0, 0, 0], [], mf_solve=alpha_pol), [0, 1, 0, 0])
+        rm = [0, 0, 0, 0, 0, 0, 0, 0, 1, 0]           # -> slot 2
+        np.testing.assert_array_equal(
+            physical_grad_slots([0, 0, 0, 0], [], mf_solve=rm), [0, 0, 1, 0])
+
+    def test_mf_widening_only_for_solved_spectral_rows(self):
+        # no spectral row solved -> unchanged; cm (row 9) has no effect on the objective
+        no_spectral = [0, 1, 1, 0, 0, 0, 0, 0, 0, 1]
+        np.testing.assert_array_equal(
+            physical_grad_slots([0, 1, 1, 0], [], mf_solve=no_spectral), [0, 1, 1, 0])
+
+    def test_mf_widening_ignores_the_stokes_i_layout(self):
+        # the 3-row Stokes-I mf mask runs an ungated kernel and needs no widening
+        np.testing.assert_array_equal(
+            physical_grad_slots([1, 0, 0, 0], [], mf_solve=[1, 1, 1]), [1, 0, 0, 0])
+
     def test_single_pol_mask_passthrough_despite_mcv(self):
         # Stokes-I carries 'mcv' in transforms inertly; a sub-4-wide mask has
         # no rho/psi DOFs to couple and must pass through (no IndexError).

--- a/tests/test_objective_jax.py
+++ b/tests/test_objective_jax.py
@@ -279,10 +279,9 @@ def test_pol_nfft_grad_finite_difference(pol_imager_nfft, pol_nfft_x0):
     _assert_grad_fd(pol_imager_nfft, pol_nfft_x0)
 
 
-# ============================== Multifrequency (Stokes-I) ==============================
+# ============================== Multifrequency ==============================
 # TODO: this uses a 2-frequency synthetic Gaussian with a constant spectral index. Add
-# real multifrequency synthetic data (multiple realistic bands) for thorough coverage,
-# and extend to multifrequency *polarization* (currently only Stokes-I mf is covered).
+# real multifrequency synthetic data (multiple realistic bands) for thorough coverage.
 @pytest.fixture(scope="module")
 def _mf_setup(gauss_im, eht_array):
     im = gauss_im.copy().add_const_mf(1.0, 0)  # alpha=1, beta=0
@@ -323,6 +322,45 @@ def test_mf_grad_parity_autodiff_vs_analytic(mf_imager, mf_x0):
 
 def test_mf_grad_finite_difference(mf_imager, mf_x0):
     _assert_grad_fd(mf_imager, mf_x0)
+
+
+# Multifrequency polarization. jax.grad differentiates image_at_freq directly and never runs
+# mf_all_grads_chain, so this is an independent check of the hand-written mf chain rule rather
+# than a second reading of it. Both mf-pol gradient bugs fixed in this PR fail here.
+@pytest.fixture(scope="module")
+def mf_pol_imager(gauss_im_pol, eht_array):
+    im = gauss_im_pol.copy().add_const_mf(1.0, 0, alpha_pol=0.5)
+    prior = im.blur_circ(40 * eh.RADPERUAS)
+    obslist = [
+        im.get_image_mf(nu).observe(eht_array, 5, 600, 0, 24, 4e9, ampcal=True,
+                                    phasecal=True, ttype="direct", add_th_noise=True, seed=42)
+        for nu in (220e9, 240e9)
+    ]
+    imgr = eh.imager.Imager(
+        obslist, prior, prior_im=prior, flux=im.total_flux(),
+        data_term={"pvis": 100, "m": 50}, reg_term={"ptv": 1, "l2_alphap": 1},
+        ttype="direct", pol="P", mf=True, mf_order=1, mf_order_pol=1, mf_rm=1,
+        maxit=100, epsilon_tv=EPSILON_TV,
+    )
+    imgr.init_imager()
+    return imgr
+
+
+@pytest.fixture(scope="module")
+def mf_pol_x0(mf_pol_imager):
+    return _x0(mf_pol_imager)
+
+
+def test_mf_pol_value_numpy_jax_consistent(mf_pol_imager, mf_pol_x0):
+    _assert_value(mf_pol_imager, mf_pol_x0)
+
+
+def test_mf_pol_grad_parity_autodiff_vs_analytic(mf_pol_imager, mf_pol_x0):
+    _assert_grad_analytic(mf_pol_imager, mf_pol_x0)
+
+
+def test_mf_pol_grad_finite_difference(mf_pol_imager, mf_pol_x0):
+    _assert_grad_fd(mf_pol_imager, mf_pol_x0)
 
 
 # ============================== OO integration ==============================


### PR DESCRIPTION
Two bugs in the multifrequency polarimetric gradient, both pre-existing on `dev`, both silent: the run
converges, it just converges somewhere other than the objective it reports. Found while auditing the backend
ahead of the release.

## The spectral index was never fitted

`physical_grad_slots` builds its mask from the 4-wide Stokes block and knows nothing about multifrequency.
Under mf, `validate_params` only allows `pol='P'`, so Stokes I at the reference frequency is not a solved
DOF and the mask zeroes slot 0. But `mf_all_grads_chain` builds the spectral-index gradient out of exactly
that slot (`dfunc_dalpha = dfunc_dI * imvec * L`), so it came back identically zero and L-BFGS-B could never
move alpha.

Nothing else can fill that slot either: under mf, `validate_params` restricts the non-Stokes-I regularizers
to `REGULARIZERS_POL + REGULARIZERS_POLSPECTRAL`, so `l2_alpha` and friends are rejected outright and the
chi^2 term is the only possible source of gradient for alpha. With it zeroed, alpha had no gradient from
anywhere.

End to end on a two-frequency polarized observation, 200 iterations, true alpha = -0.7 starting from 0,
identical input with only the slot widening toggled:

| | specvec mean | specvec std | flux-weighted alpha |
|---|---|---|---|
| before | +0.00000 | 0.00000 | +0.0000 |
| after | -0.21414 | 0.42385 | **-0.6512** |
| truth | | | -0.7000 |

Before, alpha sat at its initial value to the last digit. After, it recovers the input spectral index to
about 7 per cent, at chi^2 0.97 and 0.96 on the two bands. (Flux-weighted because the faint pixels are
unconstrained and noisy; the unweighted mean is dominated by them.)

Under jax the same run always moved alpha, since autodiff never consulted the mask, so numpy and jax
disagreed on identical input.

## The rho chain rule used rho where it needs rho'

`multifreq_imager_utils.py:129-131`. The spectral expansion is on rho', not rho:

    log(rho') = log(rho0) + alpha_pol*L + beta_pol*L^2
    rho       = (rho'^-D + 1)^(-1/D)

so `d(rho')/d(rho0) = rho'/rho0` and the two spectral slots pick up `rho' * L^n`. The code used
`rhovec_cur`, the physical rho after the squashing transform, in all three. `rhovec_prime` was already
computed on line 111 and used only in `drho_drhoprime`. The old code's error factor is
`(1 - rho^D)^(1/D)`, which at the shipped `DD_RHOPOL=1` is `1 - rho`, so 20 to 45 per cent at ordinary
polarization fractions on `rho0`, `alpha_pol` and `beta_pol`. The fix is generic in `D`.

The Stokes-I block just above is correct, because I has no second transform layer between the coefficients
and the image. That is likely how the pol block came to be written this way.

## What changed

- `mf_all_grads_chain` uses `rhovec_prime` in the three rho-family slots.
- `physical_grad_slots` takes the multifrequency mask and fills the physical slot each solved spectral row
  chains through (rows 4,5 through I; 6,7 through rho; 8 through phi). `compute_chisqgrad_dict` is the only
  caller that passes it. Only slot 0 can currently be starved, since `compute_which_solve` hardcodes
  `do_rho = do_phi = 1` for every mf-pol run, but all three are handled symmetrically so that the first mode
  holding `rho0` or `phi0` fixed while solving `alpha_pol` or `rm` does not reintroduce this one row over.
- A comment on the pol regularizer branch explaining why its spectral rows stay at zero, which is correct
  and should not be "fixed" later: that regularizer is evaluated on the reference-frequency image and never
  runs through the mf chain, and the value side matches.

The widened slot does not leak anywhere it should not: `pack_imarr` drops unsolved slots, and `mcv_grad`,
`vcv_grad` and `polcv_grad` all read only `gradarr[1:4]`.

## Why it survived

No finite-difference test anywhere combined `mf=True` with a polarization mode. `test_gradients.py` had
`TTYPES = ["direct", "nfft"]` and no mf cases at all, the one mf gradient test asserted only `isfinite`, and
`test_objective_jax.py:283` has a comment saying as much.

## Tests

New section S7 in the canonical FD suite, committed first so it fails before either fix:

- `TestMfChainRule` finite-differences `mf_all_grads_chain` against `image_at_freq` using an arbitrary dense
  upstream gradient, so every coefficient slot is exercised. Same reason S6 uses a dense `grad_phys`: a real
  objective is blind to whichever slot it happens to zero. Stokes-I and full-pol cases, the Stokes-I one
  passing throughout as a control.
- `TestMfPolChisqGradient` drives the production composition through `compute_chisq_dict` and
  `compute_chisqgrad_dict` on a two-frequency polarized observation, comparing every slot
  `compute_which_solve` marks as solved.

Before the fixes: 0.47 max fractional error on the chain rule, 0.42 on the composed test at slot 1. After
the rho fix alone the composed test moved on to slot 4 at exactly 1.00, an analytic zero against a nonzero
finite difference, which is the second bug surfacing.

Also added, and the check most likely to catch the next one of these:

- **mf-pol cases in `test_objective_jax.py`.** `jax.grad` differentiates `image_at_freq` directly and never
  executes `mf_all_grads_chain`, so it is an independent opinion on the hand-written chain rule rather than
  a second reading of it. Reverting either fix fails it. It also means `use_jax=True` mf-pol runs were
  getting the correct gradient all along while numpy was not.
- Four unit tests of the slot widening in `test_imager_backend.py`, including the rows that are only
  latently at risk. `physical_grad_slots` had no test of this behaviour at all.

## How to test

    pytest tests/test_gradients.py -k "MfChainRule or MfPolChisq"

Full suite on a compute node, `-m "not gpu"`: **1911 passed, 1 skipped, 1 xfailed**, no failures.
(`tests/test_interactive.py` is deselected: it blocks on a plotting renderer on a headless node,
unrelated to this change. The 18 gpu-marked tests are run separately.)

## Noticed while in here, not fixed

The `REGULARIZERS_ALLFREQS_I` path is broken under mf-pol: `compute_reggrad_dict` passes a `(4, npix)` array
to `reggrad_flux`, which returns `np.ones(len(imvec))`, i.e. shape `(4,)`, and that feeds
`mf_all_grads_chain` as if it were four per-pixel Stokes rows. Silently wrong, reachable with `flux_mf` plus
mf-pol. Pre-existing and unrelated to these two fixes, so it wants its own PR.
