### PR TITLE
Make the optax driver report the objective it actually returns

### DIFF
--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -23,6 +23,7 @@
 
 import copy
 import time
+import warnings
 from dataclasses import dataclass
 from typing import Any
 
@@ -609,6 +610,14 @@ class Imager:
                 print(res.message.decode())
         except Exception:  # TODO -- issues for some users with res.message
             pass
+
+        # Outside the try above, which swallows everything: a non-finite solution means the
+        # image below is unusable, and printing alone is too easy to miss.
+        if not np.all(np.isfinite(res.x)):
+            warnings.warn(
+                f"the optimizer returned a non-finite image, so this result is not usable "
+                f"({getattr(res, 'message', 'no message')})",
+                RuntimeWarning, stacklevel=2)
 
         print("==============================")
 

--- a/ehtim/imaging/optimizers.py
+++ b/ehtim/imaging/optimizers.py
@@ -227,24 +227,31 @@ def _run_optax(gt, needs_ls, value_and_grad, loss, x0, optdict, aux=None):
             return (i + 1, x, st, jnp.linalg.norm(grad), val, rel)
 
         init = (0, x_init, gt.init(x_init), jnp.inf, jnp.inf, jnp.inf)
-        i, x, _, gnorm, _, dval = jax.lax.while_loop(cond, body, init)
-        # One extra evaluation, at the iterate we are about to hand back. The value carried
-        # through the loop belongs to the step's starting point, so reporting it would pair
-        # x_{k+1} with f(x_k).
-        return x, lossfn(x), i, gnorm, dval
+        i, x, _, _, _, dval = jax.lax.while_loop(cond, body, init)
+        # One extra evaluation at the iterate we hand back. The loop carries the value and
+        # gradient from the START of the last step, so reporting those would describe x_{k-1}
+        # and could call a converged run truncated.
+        val, grad = vg(x)
+        return x, val, i, jnp.linalg.norm(grad), dval
 
     x, val, nit, gnorm, dval = run(x0, aux)
     val, nit, gnorm, dval = float(val), int(nit), float(gnorm), float(dval)
 
-    # A NaN fails every comparison in cond, so the loop falls straight out and looks exactly
-    # like convergence. Check it first, and only trust gnorm if the loop actually ran (it
-    # starts at inf, which is not a real non-finite gradient when maxiter is 0).
-    if not np.isfinite(val) or (nit > 0 and not np.isfinite(gnorm)):
-        success, status = False, 3
-        message = "STOP: NON-FINITE OBJECTIVE OR GRADIENT"
-    elif gnorm <= gtol or dval <= ftol:
+    # A non-finite value fails every comparison in cond, so the loop falls straight out and
+    # looks exactly like convergence. Check that first. dval is inf until the loop has run
+    # twice, so only trust it from there.
+    if not np.isfinite(val) or not np.isfinite(gnorm) or (nit > 1 and not np.isfinite(dval)):
+        # scipy's L-BFGS-B answers a non-finite objective with status 2; 3 means success
+        # elsewhere in scipy (least_squares xtol), so do not reuse it.
+        success, status = False, 2
+        message = "ABNORMAL: NON-FINITE OBJECTIVE OR GRADIENT"
+    elif gnorm <= gtol:
         success, status = True, 0
-        message = "optax on-device convergence"
+        message = "CONVERGENCE: GRADIENT NORM <= GTOL"
+    elif dval <= ftol:
+        # Reported separately from gtol: a stalled step also lands here, with a large gradient.
+        success, status = True, 0
+        message = "CONVERGENCE: RELATIVE REDUCTION OF F <= FTOL"
     else:
         success, status = False, 1
         message = "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT"

--- a/ehtim/imaging/optimizers.py
+++ b/ehtim/imaging/optimizers.py
@@ -177,7 +177,26 @@ def _run_optax(gt, needs_ls, value_and_grad, loss, x0, optdict, aux=None):
     argument rather than a closure, because closing over sharded arrays makes jax
     re-partition them.
 
-    Returns a scipy OptimizeResult.
+    Parameters
+    ----------
+    gt : optax.GradientTransformation
+        The update rule, already resolved by `resolve_optax`.
+    needs_ls : bool
+        Whether `gt` runs a line search and so needs the value and a way to re-evaluate.
+    value_and_grad, loss : callable
+        On-device objective. Both take `(x, aux)` when `aux` is given, otherwise `(x)`.
+    x0 : jax array
+        Starting point, already placed on the device.
+    optdict : dict
+        Reads 'maxiter', 'gtol' and 'ftol'.
+    aux : optional
+        Sharded data to thread through as a jit argument.
+
+    Returns
+    -------
+    scipy.optimize.OptimizeResult
+        `.fun` is the objective at `.x`, and `.success`/`.status`/`.message` follow scipy's
+        convention: converged, out of iterations, or stopped on a non-finite value.
     """
     import jax
     import jax.numpy as jnp
@@ -208,14 +227,31 @@ def _run_optax(gt, needs_ls, value_and_grad, loss, x0, optdict, aux=None):
             return (i + 1, x, st, jnp.linalg.norm(grad), val, rel)
 
         init = (0, x_init, gt.init(x_init), jnp.inf, jnp.inf, jnp.inf)
-        i, x, _, _, val, _ = jax.lax.while_loop(cond, body, init)
-        return x, val, i
+        i, x, _, gnorm, _, dval = jax.lax.while_loop(cond, body, init)
+        # One extra evaluation, at the iterate we are about to hand back. The value carried
+        # through the loop belongs to the step's starting point, so reporting it would pair
+        # x_{k+1} with f(x_k).
+        return x, lossfn(x), i, gnorm, dval
 
-    x, val, nit = run(x0, aux)
+    x, val, nit, gnorm, dval = run(x0, aux)
+    val, nit, gnorm, dval = float(val), int(nit), float(gnorm), float(dval)
+
+    # A NaN fails every comparison in cond, so the loop falls straight out and looks exactly
+    # like convergence. Check it first, and only trust gnorm if the loop actually ran (it
+    # starts at inf, which is not a real non-finite gradient when maxiter is 0).
+    if not np.isfinite(val) or (nit > 0 and not np.isfinite(gnorm)):
+        success, status = False, 3
+        message = "STOP: NON-FINITE OBJECTIVE OR GRADIENT"
+    elif gnorm <= gtol or dval <= ftol:
+        success, status = True, 0
+        message = "optax on-device convergence"
+    else:
+        success, status = False, 1
+        message = "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT"
+
     return scipy.optimize.OptimizeResult(
-        x=np.asarray(x, dtype=np.float64), fun=float(val), nit=int(nit),
-        njev=int(nit), success=True, status=0,
-        message="optax on-device convergence")
+        x=np.asarray(x, dtype=np.float64), fun=val, nit=nit,
+        njev=nit, success=success, status=status, message=message)
 
 
 def optimize_fixed(value_and_grad, loss, x0, gt, needs_ls, maxiter):

--- a/tests/test_optimizers_jax.py
+++ b/tests/test_optimizers_jax.py
@@ -255,6 +255,23 @@ def test_nonfinite_gradient_behind_a_finite_value_is_reported_as_failure():
     assert np.isfinite(res.fun)
 
 
+def test_make_image_warns_when_the_optimizer_returns_a_non_finite_image(make_opt_imager,
+                                                                       monkeypatch):
+    # make_image prints the result inside a bare `except Exception: pass` and then builds the
+    # Image regardless, so without this the user gets a NaN image and no signal at all.
+    import ehtim.imager as imager_mod
+
+    def nan_result(*a, **kw):
+        n = np.asarray(kw["x0"]).size
+        return scipy.optimize.OptimizeResult(
+            x=np.full(n, np.nan), fun=np.nan, nit=1, njev=1, success=False, status=2,
+            message="ABNORMAL: NON-FINITE OBJECTIVE OR GRADIENT")
+
+    monkeypatch.setattr(imager_mod, "run_optimizer", nan_result)
+    with pytest.warns(RuntimeWarning, match="non-finite"):
+        make_opt_imager().make_image(show_updates=False)
+
+
 def test_nonfinite_value_behind_a_finite_gradient_is_reported_as_failure():
     # and the mirror image, so neither half of the finite check rests on the other.
     import jax.numpy as jnp

--- a/tests/test_optimizers_jax.py
+++ b/tests/test_optimizers_jax.py
@@ -184,33 +184,86 @@ def test_result_fun_is_the_objective_at_the_returned_x():
     assert res.fun == pytest.approx(float(loss(jnp.asarray(res.x))), rel=1e-9)
 
 
-def test_maxiter_truncation_is_not_reported_as_success():
-    # scipy returns success=False / status=1 when it runs out of iterations; the optax path
-    # should agree rather than calling every exit a convergence.
+def _quadratic():
     import jax.numpy as jnp
 
     def loss(x):
         return jnp.sum((x - 3.0) ** 2)
+    return loss
 
+
+def _single_where():
+    """Value takes the safe branch, derivative of the unsafe one is still NaN."""
+    import jax.numpy as jnp
+
+    def loss(x):
+        return jnp.sum(jnp.where(x > 0, jnp.sqrt(x), 0.0))
+    return loss
+
+
+def test_maxiter_truncation_is_not_reported_as_success():
+    # scipy returns success=False / status=1 when it runs out of iterations; the optax path
+    # should agree rather than calling every exit a convergence.
     x0 = np.array([0.0, 0.0, 0.0])
-    res = run_optimizer("adam", _toy_builder(loss), x0=x0, optdict=OPTDICT)
+    res = run_optimizer("adam", _toy_builder(_quadratic()), x0=x0, optdict=OPTDICT)
     assert res.nit == 1
     assert res.success is False
-    assert res.status != 0
+    assert res.status == 1
+
+
+def test_converged_run_reports_success():
+    # sgd at lr=0.5 lands exactly on this quadratic's optimum in one step. The stopping test is
+    # evaluated at the returned iterate, so that is convergence, not running out of iterations.
+    res = run_optimizer(optax.sgd(0.5), _toy_builder(_quadratic()),
+                        x0=np.array([0.0, 0.0]), optdict=OPTDICT)
+    assert res.success is True
+    assert res.status == 0
+    assert res.fun == pytest.approx(0.0, abs=1e-12)
+
+
+def test_zero_iterations_is_not_reported_as_success():
+    res = run_optimizer("adam", _toy_builder(_quadratic()), x0=np.array([0.0, 0.0]),
+                        optdict={**OPTDICT, "maxiter": 0})
+    assert res.nit == 0
+    assert res.success is False
+    assert res.status == 1
 
 
 def test_nonfinite_gradient_is_reported_as_failure():
-    # sqrt of a negative argument is NaN in both value and derivative, so the very first
+    # sqrt of a negative argument is NaN in value and derivative alike, so the very first
     # evaluation is non-finite. Both while_loop conditions compare False against NaN, so the
-    # loop falls straight out; without an explicit check that is indistinguishable from
-    # having converged, which would silently hand back a NaN image as a success.
+    # loop falls straight out; without an explicit check that is indistinguishable from having
+    # converged, and a NaN image comes back as a success.
     import jax.numpy as jnp
 
     def loss(x):
         return jnp.sum(jnp.sqrt(x))
 
-    x0 = np.array([-1.0, -1.0])
-    res = run_optimizer("adam", _toy_builder(loss), x0=x0, optdict=OPTDICT)
+    res = run_optimizer("adam", _toy_builder(loss), x0=np.array([-1.0, -1.0]), optdict=OPTDICT)
     assert res.success is False
+    assert res.status == 2
     assert not np.isfinite(res.fun)
-    assert "converge" not in res.message.lower()
+
+
+def test_nonfinite_gradient_behind_a_finite_value_is_reported_as_failure():
+    # the value check alone would miss this one: res.fun is finite and only the gradient is
+    # NaN, which is exactly what a single `where` produces.
+    res = run_optimizer("adam", _toy_builder(_single_where()), x0=np.array([-1.0, -1.0]),
+                        optdict={**OPTDICT, "maxiter": 0})
+    assert res.success is False
+    assert res.status == 2
+    assert np.isfinite(res.fun)
+
+
+def test_nonfinite_value_behind_a_finite_gradient_is_reported_as_failure():
+    # and the mirror image, so neither half of the finite check rests on the other.
+    import jax.numpy as jnp
+
+    def loss(x):
+        return jnp.sum(x ** 2) + jnp.asarray(jnp.nan)
+
+    res = run_optimizer("adam", _toy_builder(loss), x0=np.array([1.0, 1.0]),
+                        optdict={**OPTDICT, "maxiter": 0})
+    assert res.success is False
+    assert res.status == 2
+    assert not np.isfinite(res.fun)

--- a/tests/test_optimizers_jax.py
+++ b/tests/test_optimizers_jax.py
@@ -139,3 +139,78 @@ def test_custom_callable_recovers(make_opt_imager, gauss_im):
 def test_unknown_optimizer_raises(make_opt_imager):
     with pytest.raises(ValueError):
         make_opt_imager().make_image(optimizer="not-an-optimizer", show_updates=False)
+
+
+# ============================== what the optax path reports ==============================
+# The driver returns a scipy OptimizeResult, so callers read .x/.fun/.success the same way for
+# every backend and Imager.make_image prints .fun as "J:". These pin that the report describes
+# the run that actually happened. A small quadratic is enough: the objective is incidental,
+# what is under test is the bookkeeping around the loop.
+OPTDICT = {"maxiter": 1, "ftol": 1e-12, "gtol": 1e-12, "maxcor": NHIST, "maxls": MAXLS}
+
+
+def _toy_builder(loss_fn):
+    """build_loss for the optax path, wrapping a plain jax scalar function.
+
+    Parameters
+    ----------
+    loss_fn : callable
+        jax scalar objective of one array argument.
+
+    Returns
+    -------
+    build : callable
+        Takes a device and returns (value_and_grad, loss, to_device, aux), the four-tuple
+        run_optimizer hands to the optax driver.
+    """
+    import jax
+    import jax.numpy as jnp
+
+    def build(device):
+        return jax.value_and_grad(loss_fn), loss_fn, jnp.asarray, None
+    return build
+
+
+def test_result_fun_is_the_objective_at_the_returned_x():
+    # res.fun must describe res.x. Evaluating inside the step, before the update is applied,
+    # pairs the new iterate with the previous iterate's value.
+    import jax.numpy as jnp
+
+    def loss(x):
+        return jnp.sum((x - 3.0) ** 2)
+
+    x0 = np.array([0.0, 0.0, 0.0])
+    res = run_optimizer("adam", _toy_builder(loss), x0=x0, optdict=OPTDICT)
+    assert res.fun == pytest.approx(float(loss(jnp.asarray(res.x))), rel=1e-9)
+
+
+def test_maxiter_truncation_is_not_reported_as_success():
+    # scipy returns success=False / status=1 when it runs out of iterations; the optax path
+    # should agree rather than calling every exit a convergence.
+    import jax.numpy as jnp
+
+    def loss(x):
+        return jnp.sum((x - 3.0) ** 2)
+
+    x0 = np.array([0.0, 0.0, 0.0])
+    res = run_optimizer("adam", _toy_builder(loss), x0=x0, optdict=OPTDICT)
+    assert res.nit == 1
+    assert res.success is False
+    assert res.status != 0
+
+
+def test_nonfinite_gradient_is_reported_as_failure():
+    # sqrt of a negative argument is NaN in both value and derivative, so the very first
+    # evaluation is non-finite. Both while_loop conditions compare False against NaN, so the
+    # loop falls straight out; without an explicit check that is indistinguishable from
+    # having converged, which would silently hand back a NaN image as a success.
+    import jax.numpy as jnp
+
+    def loss(x):
+        return jnp.sum(jnp.sqrt(x))
+
+    x0 = np.array([-1.0, -1.0])
+    res = run_optimizer("adam", _toy_builder(loss), x0=x0, optdict=OPTDICT)
+    assert res.success is False
+    assert not np.isfinite(res.fun)
+    assert "converge" not in res.message.lower()


### PR DESCRIPTION
The optax driver returns a `scipy.optimize.OptimizeResult` so that callers read `.x`, `.fun` and
`.success` the same way whichever backend ran, and `Imager.make_image` prints `.fun` as `J:`. Three things
in that report did not describe the run that actually happened. Found while auditing the backend ahead of
the release; all three are in `_run_optax`, within about twenty lines of each other.

## `res.fun` was the objective one step behind `res.x`

`_optax_step` evaluates `value_and_grad(x)` and only then applies the update, so the value it hands back
belongs to the step's starting point. The while_loop carried that forward, which paired `x_{k+1}` with
`f(x_k)`. With `maxiter=1` from `x0 = [0,0,0]` on `sum((x-3)^2)`:

    res.fun        27.0        <- f(x0)
    loss(res.x)    26.8203     <- the iterate actually returned

`maxit=0` printed `J: inf`, because nothing ran and the carry starts at `jnp.inf`. The sibling driver
`optimize_fixed` already did this correctly (`return x, loss(x)`), so the two drivers in one file disagreed
about what the final objective was. `J:` is the number you compare across hyperparameter settings.

## A NaN gradient was reported as a successful convergence

The loop condition is `(i < maxiter) & (gnorm > gtol) & (dval > ftol)`. Both comparisons are False against
NaN, so a non-finite gradient falls straight out of the loop and was indistinguishable from having
converged: `success=True`, `status=0`, `message='optax on-device convergence'`, and a NaN image. That is
the case the project rule about never silently swallowing NaN exists for.

Latent rather than live: none of the shipped built-ins reaches it on the real objective, so the test
constructs it directly with `sqrt` of a negative argument rather than claiming a user-facing failure.

## `success=True, status=0` was unconditional

Including on maxiter truncation, where scipy returns `success=False, status=1` and
`'STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT'`. Combined with the two above, a diverged GPU run looked
exactly like a converged one.

## What changed

The loop now re-evaluates value **and** gradient once at the iterate it hands back, and derives the outcome
from why it stopped:

- non-finite value or gradient: `success=False`, `status=2`
- converged on `gtol`: `success=True`, `status=0`
- converged on `ftol`: `success=True`, `status=0`, reported separately so a stalled step (which also lands
  here, with a large gradient) is distinguishable
- otherwise out of iterations: `success=False`, `status=1`, with scipy's wording verbatim

The stopping quantities are recomputed rather than taken from the loop carry, which holds the value and
gradient from the *start* of the last step. Without that, `sgd(0.5)` landing bit-exactly on a quadratic's
optimum in one step reported `J: 0.000000` directly above "ITERATIONS REACHED LIMIT". Cost is one extra
forward+backward out of `maxiter` of them, and about +60 per cent on XLA compile for the extra HLO.

`status=2` rather than 3: scipy's L-BFGS-B, the sibling path in this same dispatcher, answers a non-finite
objective with 2, and 3 means *success* elsewhere in scipy (`least_squares` xtol).

Nothing branches on `.success` anywhere in the tree: `imager.py:604-609` prints `.fun` and `.message` and
that is all. So the visible change is that a truncated or diverged optax run now says so, in the same
words scipy uses.

## A non-finite image still came back silently

Fixing the report is only half of it. `make_image` prints the result inside a bare `except Exception: pass`
and then builds the `Image` regardless, so a NaN solution reached the caller with no signal at all. It now
warns on a non-finite `res.x`, outside that try/except so the warning cannot itself be swallowed. That is
one `warnings.warn` in `ehtim/imager.py`; nothing else there changes.

## Tests

Eight tests in `tests/test_optimizers_jax.py`, the first three committed before the fix so they fail
against the old code. They drive `run_optimizer` with a small quadratic rather than through the imager: the
objective is incidental, what is under test is the bookkeeping, and it keeps them fast enough for CI.

Each branch of the finite check is pinned separately, which matters because the obvious NaN case does not
distinguish them. `sqrt(x)` at negative `x` makes value and gradient NaN together, so either clause alone
would satisfy it. There is now a single `where` (finite value, NaN gradient, the pattern this codebase's
NaN-safety work is about) and its mirror (NaN value, finite gradient), plus a converged run asserting
`success is True`, `maxiter=0`, and explicit `status` assertions. The eighth drives `make_image` with a
stubbed optimizer returning a NaN vector and asserts the warning fires.

## How to test

    pytest tests/test_optimizers_jax.py

Full suite on a compute node, `-m "not gpu"`: **1916 passed, 1 skipped, 1 xfailed**, no failures. That is
the 1915-test baseline plus the one test added here. (`tests/test_interactive.py` deselected: it blocks on a plotting renderer on a
headless node, unrelated to this change.)

`_run_optax` is also the sharded driver, called with `aux` bound, and that path is gpu-marked so neither
CI nor the run above reaches it. Checked separately on 2 GPUs. `tests/test_sharding_jax.py` gives
**1 failed, 5 passed**, matching the baseline: the one failure is `test_sharded_make_image_recovers`, which
passes no `optimizer` and so raises at `imager.py:531` before `build_mesh()`. That is pre-existing on every
branch and is fixed in the next PR.

Note that failure is also the *only* test that would have covered this path: the five that pass call
`make_sharded_value_and_grad` directly and compare gradients, never going through `run_optimizer`. So I
drove it by hand, running the same imager with the optimizer that test forgets:

    prior baseline nxcorr   0.98876
    maxit=1     nxcorr 0.99260  finite  J: 22.998419  STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT
    maxit=100   nxcorr 0.99584  finite  J: -0.565182  STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT

The sharded driver is fine, and the new exit reason works there too: neither run met `gtol` or `ftol`, and
both now say so rather than reporting convergence.

Incidentally this reproduces, from a different direction, why the recovery thresholds need work: the
untouched prior already scores 0.98876 and a single iteration scores 0.99260, both far above the 0.8 floor
those tests assert. That is the next PR.
