### PR TITLE
Refuse jax and sharded runs on unsupported transforms and data terms

### DIFF
--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -49,6 +49,7 @@ from ehtim.imaging.imager_backend import (
     ImagerConfig,
     MfConfig,
     RegParams,
+    check_jax_supported,
     compute_chisq_dict,
     compute_chisqgrad_dict,
     compute_init_state,
@@ -534,6 +535,12 @@ class Imager:
                 "optimizer; pass optimizer='optax-lbfgs' (or another optax optimizer).")
         # (the optax path builds the jax objective itself in build_vg_ondevice below, so the
         #  user's use_jax flag is irrelevant there and is left untouched.)
+
+        # Refuse the combinations jax cannot run, before it fails somewhere inside a trace.
+        # Keyed on all three routes to jax, not just use_jax: optax builds the jax objective
+        # regardless of the flag, and sharding always does.
+        if use_jax or shard or classify_optimizer(optimizer) == 'optax':
+            check_jax_supported(self._config.ttype, self.dat_term_next)
 
         def build_vg_onhost():
             # (value, grad) as host callables, for scipy and for user-supplied optimizers.

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -506,19 +506,6 @@ class Imager:
         self._show_updates = kwargs.get('show_updates', True)
         self._update_interval = kwargs.get('update_interval', 1)
 
-        # Plot initial image
-        self.plotcur(self._init_vec, **kwargs)
-
-        # Minimize
-        print("Imaging . . .")
-        optdict = {'maxiter': self.maxit_next,
-                   'ftol': self.stop_next, 'gtol': self.stop_next,
-                   'maxcor': NHIST, 'maxls': MAXLS}
-        def callback_func(xcur):
-            self.plotcur(xcur, **kwargs)
-
-
-        tstart = time.time()
         optimizer = kwargs.get('optimizer', self._optimizer)
         use_jax = kwargs.get('use_jax', False)
         device = kwargs.get('jax_device', None)
@@ -542,6 +529,19 @@ class Imager:
         if use_jax or shard or classify_optimizer(optimizer) == 'optax':
             check_jax_supported(self._config.ttype, self.dat_term_next)
 
+        # Plot initial image
+        self.plotcur(self._init_vec, **kwargs)
+
+        # Minimize
+        print("Imaging . . .")
+        optdict = {'maxiter': self.maxit_next,
+                   'ftol': self.stop_next, 'gtol': self.stop_next,
+                   'maxcor': NHIST, 'maxls': MAXLS}
+        def callback_func(xcur):
+            self.plotcur(xcur, **kwargs)
+
+
+        tstart = time.time()
         def build_vg_onhost():
             # (value, grad) as host callables, for scipy and for user-supplied optimizers.
             if use_jax:    # jitted jax objective + autodiff gradient, as a host fun(x) -> (value, grad)

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -56,6 +56,12 @@ REGULARIZERS_ISPECTRAL = REGULARIZERS_SPECIND + REGULARIZERS_CURV
 REGULARIZERS_POLSPECTRAL = REGULARIZERS_SPECIND_P + REGULARIZERS_CURV_P + REGULARIZERS_RM + REGULARIZERS_CM
 REGULARIZERS_SPECTRAL = REGULARIZERS_ISPECTRAL + REGULARIZERS_POLSPECTRAL
 
+# What the jax backend covers. 'fast' has no jaxified kernels (no chisq_*_fft dispatches
+# through array_namespace and fft_imvec is hard numpy), and the _diag closures carry a
+# 2-tuple of per-scan matrices that jax cannot bind as an argument.
+JAX_TTYPES = ['direct', 'nfft']
+JAX_UNSUPPORTED_DATATERMS = ['cphase_diag', 'logcamp_diag']
+
 # Default initial-polarization parameters used when init image has no Q/U/V.
 MEANPOL_INIT = 0.2     # mean polarization fraction
 SIGMAPOL_INIT = 1.e-2  # perturbation scale
@@ -1978,6 +1984,37 @@ def compute_objective_grad(imvec, initvec, config,
     grad = datterm + regterm
     grad = transform_gradients(grad, imcur_prime, transforms, which_solve)
     return pack_imarr(grad, which_solve)
+
+
+def check_jax_supported(ttype, dat_terms):
+    """Check that the jax backend covers this transform and these data terms.
+
+    Call before building any jax objective. Without it the run fails deep inside jax with a
+    tracer or argument-binding error that says nothing about the cause, since the missing
+    kernels fall back to numpy on traced values.
+
+    Parameters
+    ----------
+    ttype : str
+        Transform type: 'direct', 'nfft' or 'fast'.
+    dat_terms : iterable of str
+        Names of the active data terms.
+
+    Raises
+    ------
+    ValueError
+        If the transform or any data term has no jax kernel.
+    """
+    if ttype not in JAX_TTYPES:
+        raise ValueError(
+            f"ttype={ttype!r} has no jax kernels; use ttype='nfft' (or 'direct') to run on "
+            f"jax, or drop use_jax and the optax optimizers to image it on numpy.")
+    unsupported = sorted(set(dat_terms) & set(JAX_UNSUPPORTED_DATATERMS))
+    if unsupported:
+        raise ValueError(
+            f"data terms {unsupported} have no jax kernels; use their undiagonalized "
+            f"counterparts ('cphase', 'logcamp') to run on jax, or drop use_jax and the "
+            f"optax optimizers to image them on numpy.")
 
 
 def _place_jax_arrays(data_tuples, priorvec, initvec, device=None):

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -2194,6 +2194,11 @@ def make_survey_value_and_grad(initvec, config, which_solve, data_tuples, logfre
         Places a host x0 on the device.
     chisq_dict : callable
         chisq_dict(imcur) -> per-term reduced chi^2, weight-independent, for ranking.
+
+    Raises
+    ------
+    ValueError
+        If the transform or a data term has no jax kernel, or if `n_obs` is not 1.
     """
     import jax
 

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -2193,6 +2193,14 @@ def make_survey_value_and_grad(initvec, config, which_solve, data_tuples, logfre
     """
     import jax
 
+    # dat_keys below are bare term names. With more than one observation the keys arrive
+    # already suffixed and compute_chisq_dict suffixes them again, which surfaced as
+    # KeyError: 'vis_0_0' rather than anything a caller could act on.
+    if n_obs != 1:
+        raise ValueError(
+            f"the survey handles a single observation, got {n_obs}; pass one Obsdata, or "
+            f"run a survey per observation.")
+
     data_d, prior_d, init_d, put = _place_jax_arrays(data_tuples, priorvec, initvec, device)
     dat_keys = sorted(data_d)            # single-frequency survey: keys are the data-term names
 

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -56,11 +56,13 @@ REGULARIZERS_ISPECTRAL = REGULARIZERS_SPECIND + REGULARIZERS_CURV
 REGULARIZERS_POLSPECTRAL = REGULARIZERS_SPECIND_P + REGULARIZERS_CURV_P + REGULARIZERS_RM + REGULARIZERS_CM
 REGULARIZERS_SPECTRAL = REGULARIZERS_ISPECTRAL + REGULARIZERS_POLSPECTRAL
 
-# What the jax backend covers. 'fast' has no jaxified kernels (no chisq_*_fft dispatches
-# through array_namespace and fft_imvec is hard numpy), and the _diag closures carry a
-# 2-tuple of per-scan matrices that jax cannot bind as an argument.
+# What the jax backend covers. 'fast' has no jaxified kernels: no chisq_*_fft dispatches
+# through array_namespace and fft_imvec is hard numpy, so it fails once the value is traced.
+# The _diag closures fail earlier, before any kernel runs: their data and sigma are ragged
+# dtype=object arrays, which device_put rejects outright. 'logamp' is numpy-only and is not
+# reachable through the Imager, but is a valid dispatch key.
 JAX_TTYPES = ['direct', 'nfft']
-JAX_UNSUPPORTED_DATATERMS = ['cphase_diag', 'logcamp_diag']
+JAX_UNSUPPORTED_DATATERMS = ['cphase_diag', 'logamp', 'logcamp_diag']
 
 # Default initial-polarization parameters used when init image has no Q/U/V.
 MEANPOL_INIT = 0.2     # mean polarization fraction
@@ -1989,9 +1991,10 @@ def compute_objective_grad(imvec, initvec, config,
 def check_jax_supported(ttype, dat_terms):
     """Check that the jax backend covers this transform and these data terms.
 
-    Call before building any jax objective. Without it the run fails deep inside jax with a
-    tracer or argument-binding error that says nothing about the cause, since the missing
-    kernels fall back to numpy on traced values.
+    Call before building any jax objective. Without it the run fails deep inside jax with an
+    error that says nothing about the cause: a tracer error for 'fast', whose kernels are
+    numpy-only, and a dtype error for the _diag terms, whose ragged data arrays never reach
+    a kernel at all.
 
     Parameters
     ----------
@@ -2066,6 +2069,7 @@ def _prepare_jax_loss(initvec, config, which_solve, data_tuples, logfreqratio_li
     to_device : callable
         Places a host x0 on the same device as those arrays.
     """
+    check_jax_supported(config.ttype, dat_term)
     data_d, prior_d, init_d, put = _place_jax_arrays(data_tuples, priorvec, initvec, device)
 
     def loss(x):
@@ -2193,9 +2197,13 @@ def make_survey_value_and_grad(initvec, config, which_solve, data_tuples, logfre
     """
     import jax
 
-    # dat_keys below are bare term names. With more than one observation the keys arrive
-    # already suffixed and compute_chisq_dict suffixes them again, which surfaced as
-    # KeyError: 'vis_0_0' rather than anything a caller could act on.
+    check_jax_supported(config.ttype, data_tuples)
+
+    # TODO: lift this. It is a keying bug, not a design limit: dat_keys below wants bare
+    # term names, but with more than one observation the keys arrive already suffixed and
+    # compute_chisq_dict suffixes them again, giving KeyError: 'vis_0_0'. Stripping the
+    # suffix here looks sufficient, but multi-observation surveys have no test coverage,
+    # so refuse clearly rather than ship an unverified path.
     if n_obs != 1:
         raise ValueError(
             f"the survey handles a single observation, got {n_obs}; pass one Obsdata, or "

--- a/ehtim/imaging/sharding.py
+++ b/ehtim/imaging/sharding.py
@@ -212,6 +212,14 @@ def make_sharded_value_and_grad(initvec, config, which_solve, data_tuples,
                         datterm = datterm + dat_term[dname] * (chi2[key] * correction[key] - 1.0)
                 return datterm + regterm_of(imcur, aux["prior"])
         else:
+            # 'fast' also lands here, and its gridded operator is a tuple, so it would take
+            # the isinstance branch below and die in _pad_rows with IndexError rather than
+            # reaching the NotImplementedError. Check the transform itself.
+            if config.ttype != "direct":
+                raise NotImplementedError(
+                    f"baseline sharding does not support ttype={config.ttype!r}; "
+                    f"use ttype='direct' or ttype='nfft'.")
+
             # direct: the operator is a dense (Nvis, Npix) matrix (or a list of them for
             # closure terms). Shard its rows; differentiating the dense matmul through
             # shard_map is correct, so the default jax.value_and_grad(loss) is used.

--- a/ehtim/imaging/sharding.py
+++ b/ehtim/imaging/sharding.py
@@ -35,6 +35,7 @@ import numpy as np
 
 import ehtim.imaging.multifreq_imager_utils as mfutils
 from ehtim.imaging.imager_backend import (
+    check_jax_supported,
     compute_chisq_dict,
     compute_chisq_term,
     compute_reg_dict,
@@ -70,10 +71,12 @@ def build_mesh(devices=None, axis="shard"):
     if devices is None:
         try:
             devices = jax.devices("gpu")
-        except RuntimeError:
+        except RuntimeError as e:
+            # chained deliberately: this also fires when the CUDA plugin fails to load, and
+            # that message is the only way to tell that apart from having no GPU at all
             raise ValueError(
                 "sharding defaults to the local GPUs and none are visible; pass "
-                "mesh=build_mesh(devices=...) to shard over specific devices.") from None
+                "mesh=build_mesh(devices=...) to shard over specific devices.") from e
     return jax.sharding.Mesh(np.asarray(devices), (axis,))
 
 
@@ -152,6 +155,7 @@ def make_sharded_value_and_grad(initvec, config, which_solve, data_tuples,
     stylistic: closing over sharded arrays makes jax partition them wrongly, reading from
     uninitialized device buffers, and you get NaNs that come and go between runs.
     """
+    check_jax_supported(config.ttype, dat_term)
     import jax
     import jax.numpy as jnp
     from jax.sharding import NamedSharding
@@ -235,14 +239,8 @@ def make_sharded_value_and_grad(initvec, config, which_solve, data_tuples,
                         datterm = datterm + dat_term[dname] * (chi2[key] * correction[key] - 1.0)
                 return datterm + regterm_of(imcur, aux["prior"])
         else:
-            # 'fast' also lands here, and its gridded operator is a tuple, so it would take
-            # the isinstance branch below and die in _pad_rows with IndexError rather than
-            # reaching the NotImplementedError. Check the transform itself.
-            if config.ttype != "direct":
-                raise NotImplementedError(
-                    f"baseline sharding does not support ttype={config.ttype!r}; "
-                    f"use ttype='direct' or ttype='nfft'.")
-
+            # only 'direct' reaches here: check_jax_supported above rejects 'fast', whose
+            # gridded operator is a tuple and used to reach _pad_rows and raise IndexError.
             # direct: the operator is a dense (Nvis, Npix) matrix (or a list of them for
             # closure terms). Shard its rows; differentiating the dense matmul through
             # shard_map is correct, so the default jax.value_and_grad(loss) is used.
@@ -257,7 +255,8 @@ def make_sharded_value_and_grad(initvec, config, which_solve, data_tuples,
                     a_spec = P(axis, None)
                 else:
                     raise NotImplementedError(
-                        f"baseline sharding does not support ttype={config.ttype!r}")
+                        f"cannot shard the operator for data term {key!r}: expected a dense "
+                        f"matrix or a tuple of them, got {type(A).__name__}")
                 data_d[key] = (data_s, sigma_s, A_s)
                 data_specs[key] = (P(axis), P(axis), a_spec)
                 correction[key] = (true_n + pad) / true_n

--- a/ehtim/imaging/sharding.py
+++ b/ehtim/imaging/sharding.py
@@ -48,9 +48,32 @@ def build_mesh(devices=None, axis="shard"):
 
     The sharded objective places its data on this mesh; the only requirement is that the
     sharded axis -- visibilities or channels, after padding -- divides evenly across it.
+
+    Parameters
+    ----------
+    devices : sequence of jax.Device, optional
+        Devices to build the mesh over. Defaults to every local GPU.
+    axis : str, optional
+        Name of the mesh axis the data is sharded along.
+
+    Returns
+    -------
+    jax.sharding.Mesh
+        A 1-D mesh over `devices`.
+
+    Raises
+    ------
+    ValueError
+        If no devices are given and no GPU is visible.
     """
     import jax
-    devices = devices if devices is not None else jax.devices("gpu")
+    if devices is None:
+        try:
+            devices = jax.devices("gpu")
+        except RuntimeError:
+            raise ValueError(
+                "sharding defaults to the local GPUs and none are visible; pass "
+                "mesh=build_mesh(devices=...) to shard over specific devices.") from None
     return jax.sharding.Mesh(np.asarray(devices), (axis,))
 
 

--- a/ehtim/imaging/survey_gpu.py
+++ b/ehtim/imaging/survey_gpu.py
@@ -95,6 +95,9 @@ def run_survey_gpu(imgr, *, weight_grid=None, regparam_grid=None, prior_fwhm=Non
                    device=None):
     """Reconstruct a hyperparameter grid, vmapping the scalar axes on device.
 
+    Single observation only, and jax-supported transforms and data terms only: raises
+    ValueError otherwise.
+
     Parameters
     ----------
     imgr : ehtim.imager.Imager

--- a/tests/test_jax_guards.py
+++ b/tests/test_jax_guards.py
@@ -1,0 +1,156 @@
+"""Capability guards for the jax, optax and sharded paths.
+
+Not every transform and data term has a jax kernel. Where one is missing the run used to
+die somewhere inside jax with a raw tracer or argument-binding error, which says nothing
+about what the user should do instead. These tests pin the refusal: a ValueError naming
+the unsupported thing and the alternative that works.
+
+The controls matter as much as the refusals. A guard that is too broad would block
+configurations that run fine today, so each rejection is paired with a case that must
+still be accepted.
+"""
+import numpy as np
+import pytest
+
+import ehtim as eh
+from ehtim.imaging.imager_backend import check_jax_supported
+
+pytestmark = pytest.mark.jax
+
+pytest.importorskip("optax")
+
+EPSILON_TV = 1e-10
+
+
+def _imager(obs, gauss_im, prior, ttype="direct", data_term=None):
+    return eh.imager.Imager(obs, prior, prior_im=prior, flux=gauss_im.total_flux(),
+                            data_term=data_term or {"vis": 1},
+                            reg_term={"simple": 1, "tv": 1}, ttype=ttype,
+                            maxit=2, epsilon_tv=EPSILON_TV)
+
+
+# ============================== the helper on its own ==============================
+class TestCheckJaxSupported:
+    """Direct tests of the predicate, independent of how the Imager calls it."""
+
+    @pytest.mark.parametrize("ttype", ["direct", "nfft"])
+    def test_supported_transforms_pass(self, ttype):
+        check_jax_supported(ttype, ["vis", "amp", "cphase", "logcamp"])
+
+    def test_fast_transform_is_refused(self):
+        with pytest.raises(ValueError, match="ttype='fast'"):
+            check_jax_supported("fast", ["vis"])
+
+    def test_the_refusal_names_a_working_alternative(self):
+        # a guard that only says no is not much better than the tracer error it replaces
+        with pytest.raises(ValueError, match="nfft"):
+            check_jax_supported("fast", ["vis"])
+
+    @pytest.mark.parametrize("term", ["cphase_diag", "logcamp_diag"])
+    def test_diag_closure_terms_are_refused(self, term):
+        with pytest.raises(ValueError, match=term):
+            check_jax_supported("direct", [term])
+
+    def test_it_reports_every_unsupported_term_at_once(self):
+        # fixing them one error at a time would be tedious
+        with pytest.raises(ValueError) as e:
+            check_jax_supported("direct", ["vis", "cphase_diag", "logcamp_diag"])
+        assert "cphase_diag" in str(e.value) and "logcamp_diag" in str(e.value)
+
+    def test_the_undiagonalized_closures_still_pass(self):
+        # cphase and logcamp are jaxified; only their _diag variants are not
+        check_jax_supported("direct", ["cphase", "logcamp", "camp", "bs"])
+
+
+# ============================== through the Imager ==============================
+class TestImagerRefusesUnsupportedJaxRuns:
+    def test_fast_ttype_with_use_jax(self, obs_direct, gauss_im, gauss_prior):
+        with pytest.raises(ValueError, match="ttype='fast'"):
+            _imager(obs_direct, gauss_im, gauss_prior, ttype="fast").make_image(
+                use_jax=True, show_updates=False)
+
+    def test_fast_ttype_on_the_optax_path_without_use_jax(self, obs_direct, gauss_im,
+                                                          gauss_prior):
+        # the subtle one: an optax optimizer builds the jax objective itself, so use_jax
+        # is not what decides whether jax runs. Keying the guard on the flag alone would
+        # let this straight through to the tracer error.
+        with pytest.raises(ValueError, match="ttype='fast'"):
+            _imager(obs_direct, gauss_im, gauss_prior, ttype="fast").make_image(
+                optimizer="optax-lbfgs", show_updates=False)
+
+    @pytest.mark.parametrize("term", ["cphase_diag", "logcamp_diag"])
+    def test_diag_dataterm_with_use_jax(self, obs_direct, gauss_im, gauss_prior, term):
+        with pytest.raises(ValueError, match=term):
+            _imager(obs_direct, gauss_im, gauss_prior, data_term={term: 1}).make_image(
+                use_jax=True, show_updates=False)
+
+    def test_fast_ttype_on_numpy_is_untouched(self, obs_direct, gauss_im, gauss_prior):
+        # control: the guard must not fire on the default numpy path, where fast works
+        with pytest.warns(DeprecationWarning):
+            out = _imager(obs_direct, gauss_im, gauss_prior, ttype="fast").make_image(
+                show_updates=False)
+        assert np.all(np.isfinite(out.imvec))
+
+    def test_diag_dataterm_on_numpy_is_untouched(self, obs_direct, gauss_im, gauss_prior):
+        # control: _diag closures image fine on numpy, they are only missing jax kernels
+        out = _imager(obs_direct, gauss_im, gauss_prior,
+                      data_term={"cphase_diag": 1}).make_image(show_updates=False)
+        assert np.all(np.isfinite(out.imvec))
+
+    def test_direct_with_use_jax_still_runs(self, obs_direct, gauss_im, gauss_prior):
+        # control: the supported combination must not be caught by the guard
+        out = _imager(obs_direct, gauss_im, gauss_prior).make_image(
+            use_jax=True, show_updates=False)
+        assert np.all(np.isfinite(out.imvec))
+
+
+# ============================== sharding and survey ==============================
+class TestShardingGuards:
+    def test_baseline_sharding_refuses_fast_ttype(self, obs_direct, gauss_im, gauss_prior):
+        # the existing NotImplementedError is unreachable: for 'fast' the operator is a
+        # tuple, so the isinstance branch is taken and the run dies in _pad_rows with
+        # IndexError instead.
+        jax = pytest.importorskip("jax")
+        from ehtim.imaging.sharding import build_mesh, make_sharded_value_and_grad
+        imgr = _imager(obs_direct, gauss_im, gauss_prior, ttype="fast")
+        imgr.init_imager()
+        args = (imgr._init_arr, imgr._config, imgr._which_solve, imgr._data_tuples,
+                imgr._logfreqratio_list, len(imgr.obslist_next), imgr.dat_term_next,
+                imgr.reg_term_next, imgr._prior_arr, imgr.norm_reg, imgr._regparams(),
+                imgr._embed_mask)
+        mesh = build_mesh(devices=jax.devices()[:1])
+        with pytest.raises(NotImplementedError, match="fast"):
+            make_sharded_value_and_grad(*args, mesh=mesh, shard_axis="baseline")
+
+    def test_build_mesh_without_gpus_points_at_the_mesh_kwarg(self, monkeypatch):
+        # monkeypatched rather than skipped, so it runs on GPU boxes too
+        jax = pytest.importorskip("jax")
+        import ehtim.imaging.sharding as sharding_mod
+
+        def no_gpu(kind=None):
+            raise RuntimeError("Unknown backend: 'gpu' requested")
+
+        monkeypatch.setattr(jax, "devices", no_gpu)
+        with pytest.raises(ValueError, match="mesh"):
+            sharding_mod.build_mesh()
+
+
+class TestSurveyGuards:
+    def test_survey_refuses_multiple_observations(self, obs_direct, gauss_im, gauss_prior):
+        # the survey keys its data terms by bare name; with n_obs > 1 they are already
+        # suffixed and get suffixed again, which surfaced as KeyError: 'vis_0_0'.
+        from ehtim.imaging.survey_gpu import run_survey_gpu
+        imgr = eh.imager.Imager([obs_direct, obs_direct], gauss_prior, prior_im=gauss_prior,
+                                flux=gauss_im.total_flux(), data_term={"vis": 1},
+                                reg_term={"simple": 1, "tv": 1}, ttype="direct",
+                                maxit=2, epsilon_tv=EPSILON_TV)
+        with pytest.raises(ValueError, match="single observation"):
+            run_survey_gpu(imgr, weight_grid={"tv": np.array([1.0])}, maxit=2)
+
+    def test_survey_still_runs_on_one_observation(self, obs_direct, gauss_im, gauss_prior):
+        # control: the guard must not fire on the supported case
+        from ehtim.imaging.survey_gpu import run_survey_gpu
+        images, objval, _, _ = run_survey_gpu(_imager(obs_direct, gauss_im, gauss_prior),
+                                              weight_grid={"tv": np.array([1.0, 10.0])},
+                                              maxit=4)
+        assert images.shape[0] == 2 and np.all(np.isfinite(objval))

--- a/tests/test_jax_guards.py
+++ b/tests/test_jax_guards.py
@@ -107,9 +107,8 @@ class TestImagerRefusesUnsupportedJaxRuns:
 # ============================== sharding and survey ==============================
 class TestShardingGuards:
     def test_baseline_sharding_refuses_fast_ttype(self, obs_direct, gauss_im, gauss_prior):
-        # the existing NotImplementedError is unreachable: for 'fast' the operator is a
-        # tuple, so the isinstance branch is taken and the run dies in _pad_rows with
-        # IndexError instead.
+        # 'fast' used to reach _pad_rows and raise IndexError: its operator is a tuple, so
+        # the isinstance branch was taken before the NotImplementedError below it.
         jax = pytest.importorskip("jax")
         from ehtim.imaging.sharding import build_mesh, make_sharded_value_and_grad
         imgr = _imager(obs_direct, gauss_im, gauss_prior, ttype="fast")
@@ -119,7 +118,7 @@ class TestShardingGuards:
                 imgr.reg_term_next, imgr._prior_arr, imgr.norm_reg, imgr._regparams(),
                 imgr._embed_mask)
         mesh = build_mesh(devices=jax.devices()[:1])
-        with pytest.raises(NotImplementedError, match="fast"):
+        with pytest.raises(ValueError, match="ttype='fast'"):
             make_sharded_value_and_grad(*args, mesh=mesh, shard_axis="baseline")
 
     def test_build_mesh_without_gpus_points_at_the_mesh_kwarg(self, monkeypatch):
@@ -154,3 +153,51 @@ class TestSurveyGuards:
                                               weight_grid={"tv": np.array([1.0, 10.0])},
                                               maxit=4)
         assert images.shape[0] == 2 and np.all(np.isfinite(objval))
+
+
+class TestBackendBuildersAreGuardedToo:
+    """The guard belongs to the backend, not only to Imager.make_image.
+
+    make_image is the common route but not the only one: run_survey_gpu and the jax
+    factories are public and were reachable with an unsupported ttype or data term, where
+    they raised the same raw errors make_image no longer does.
+    """
+
+    def _args(self, imgr):
+        imgr.init_imager()
+        return (imgr._init_arr, imgr._config, imgr._which_solve, imgr._data_tuples,
+                imgr._logfreqratio_list, len(imgr.obslist_next), imgr.dat_term_next,
+                imgr.reg_term_next, imgr._prior_arr, imgr.norm_reg, imgr._regparams(),
+                imgr._embed_mask)
+
+    def test_value_and_grad_factory_refuses_fast(self, obs_direct, gauss_im, gauss_prior):
+        from ehtim.imaging.imager_backend import make_value_and_grad_jax
+        args = self._args(_imager(obs_direct, gauss_im, gauss_prior, ttype="fast"))
+        with pytest.raises(ValueError, match="ttype='fast'"):
+            make_value_and_grad_jax(*args)
+
+    def test_objective_factory_refuses_diag_terms(self, obs_direct, gauss_im, gauss_prior):
+        from ehtim.imaging.imager_backend import make_objective_jax
+        args = self._args(_imager(obs_direct, gauss_im, gauss_prior,
+                                  data_term={"cphase_diag": 1}))
+        with pytest.raises(ValueError, match="cphase_diag"):
+            make_objective_jax(*args)
+
+    def test_survey_refuses_fast(self, obs_direct, gauss_im, gauss_prior):
+        from ehtim.imaging.survey_gpu import run_survey_gpu
+        with pytest.raises(ValueError, match="ttype='fast'"):
+            run_survey_gpu(_imager(obs_direct, gauss_im, gauss_prior, ttype="fast"),
+                           weight_grid={"tv": np.array([1.0])}, maxit=2)
+
+    def test_survey_refuses_diag_terms(self, obs_direct, gauss_im, gauss_prior):
+        from ehtim.imaging.survey_gpu import run_survey_gpu
+        with pytest.raises(ValueError, match="cphase_diag"):
+            run_survey_gpu(_imager(obs_direct, gauss_im, gauss_prior,
+                                   data_term={"cphase_diag": 1}),
+                           weight_grid={"tv": np.array([1.0])}, maxit=2)
+
+    def test_logamp_is_refused(self):
+        # numpy-only and unreachable through the Imager, but a valid dispatch key, so the
+        # public predicate should still say no
+        with pytest.raises(ValueError, match="logamp"):
+            check_jax_supported("direct", ["logamp"])

--- a/tests/test_jax_guards.py
+++ b/tests/test_jax_guards.py
@@ -15,9 +15,9 @@ import pytest
 import ehtim as eh
 from ehtim.imaging.imager_backend import check_jax_supported
 
-pytestmark = pytest.mark.jax
-
-pytest.importorskip("optax")
+# no module-level mark: TestCheckJaxSupported is pure python and should keep running even
+# when the jax tests are deselected. The classes that build imagers carry the mark instead.
+requires_jax = pytest.mark.jax
 
 EPSILON_TV = 1e-10
 
@@ -63,6 +63,7 @@ class TestCheckJaxSupported:
 
 
 # ============================== through the Imager ==============================
+@requires_jax
 class TestImagerRefusesUnsupportedJaxRuns:
     def test_fast_ttype_with_use_jax(self, obs_direct, gauss_im, gauss_prior):
         with pytest.raises(ValueError, match="ttype='fast'"):
@@ -105,6 +106,7 @@ class TestImagerRefusesUnsupportedJaxRuns:
 
 
 # ============================== sharding and survey ==============================
+@requires_jax
 class TestShardingGuards:
     def test_baseline_sharding_refuses_fast_ttype(self, obs_direct, gauss_im, gauss_prior):
         # 'fast' used to reach _pad_rows and raise IndexError: its operator is a tuple, so
@@ -134,6 +136,7 @@ class TestShardingGuards:
             sharding_mod.build_mesh()
 
 
+@requires_jax
 class TestSurveyGuards:
     def test_survey_refuses_multiple_observations(self, obs_direct, gauss_im, gauss_prior):
         # the survey keys its data terms by bare name; with n_obs > 1 they are already
@@ -155,6 +158,7 @@ class TestSurveyGuards:
         assert images.shape[0] == 2 and np.all(np.isfinite(objval))
 
 
+@requires_jax
 class TestBackendBuildersAreGuardedToo:
     """The guard belongs to the backend, not only to Imager.make_image.
 


### PR DESCRIPTION
Not every transform and data term has a jax kernel. Where one is missing the run does not produce wrong
numbers, it dies somewhere inside jax with an error that describes an internal invariant rather than
anything the caller did. This is a diagnostics PR: same set of working configurations, but the
unsupported ones now say what is unsupported and what to use instead.

What a user sees today, all reproduced on a compute node before writing anything:

    ttype='fast' + use_jax=True     TracerArrayConversionError: The numpy.ndarray conversion method
                                    __array__() was called on traced array with shape float32[32,32]
    cphase_diag  + use_jax=True     TypeError: Error interpreting argument to stage as a JAX value
    logcamp_diag + use_jax=True     TypeError: (same)
    sharded baseline, ttype='fast'  IndexError: tuple index out of range
    build_mesh() with no GPU        RuntimeError: Unknown backend: 'gpu' requested
    run_survey_gpu, 2 observations  KeyError: 'vis_0_0'

Controls run in the same session: `direct` + `use_jax` images fine, and `cphase_diag` on numpy converges
normally. So nothing here is a numerical fix.

## Where the guard goes, and what it keys on

`check_jax_supported(ttype, dat_terms)` in `imager_backend.py`, called from `make_image` next to the
existing `shard` refusal and from the three backend builders (`_prepare_jax_loss`, the survey, and the
sharded one), so the factories are guarded too and not only the `make_image` route.

The two failure modes are not the same shape. `ttype='fast'` has no jaxified kernels: no `chisq_*_fft`
dispatches through `array_namespace` and `fft_imvec` is hard numpy, so it fails once a value is traced.
The `_diag` terms fail earlier and never reach a kernel: their `data` and `sigma` come back as ragged
`dtype=object` arrays, which `device_put` rejects outright with `Dtype object is not a valid JAX array
type`. `logamp` is numpy-only too and is refused for the same reason, though the Imager never routes to
it.

The part worth reviewing is what the check is keyed on:

```python
if use_jax or shard or classify_optimizer(optimizer) == 'optax':
```

not `use_jax` alone, and it runs before the first iteration is printed rather than after, so an
unsupported run no longer prints a bogus `Imager run 1` header and a `J:` line before refusing.
`use_jax` is not what decides whether jax runs. `make_image` picks its builder by
optimizer class, and `build_vg_ondevice` builds a jax objective whether or not the flag is set, so
`optimizer='optax-lbfgs'` with `ttype='fast'` reaches the tracer error with `use_jax=False`. Sharding
always goes through the same path. There is a test for exactly this, and it is the one that fails if the
guard is written the obvious way.

## The other three

- **Baseline sharding, `ttype='fast'`.** The `NotImplementedError` at the bottom of that branch is
  unreachable: 'fast' hands over a tuple, so the `isinstance(A, (tuple, list))` branch is taken first and
  the run dies in `_pad_rows`. Test `config.ttype` at the top of the branch instead.
- **`build_mesh` with no GPU.** It defaults to `jax.devices("gpu")`, so a CPU box gets jax's own backend
  error. It now points at the `mesh=` kwarg, which is the actual way to shard over chosen devices.
- **`run_survey_gpu` with more than one observation.** The survey keys data terms by bare name; with
  `n_obs > 1` they arrive already suffixed and get suffixed again. This one is a keying bug rather than a
  design limit: stripping the suffix looks sufficient, and an external review got a two-observation survey
  running end to end that way. Multi-observation surveys have no test coverage, so this refuses clearly
  and carries a TODO rather than shipping an unverified path.

## What is still not guarded

Two survey `regparam_grid` sweeps turn `RegParams` fields into tracers and fail inside the regularizer
rather than at a boundary the guard can see: sweeping `flux` with `tvlog` / `tv2log`, and sweeping
`beam_size` with any tv-family term. Both fail loudly, so they are the same class of diagnostics gap as
the rest of this PR rather than a correctness one, but they need the regularizers themselves to change and
are not in scope here.

## Tests

`tests/test_jax_guards.py`, 24 tests, committed before the fixes. `TestCheckJaxSupported` is pure python
and carries no jax mark, so those 8 keep running even when the jax tests are deselected; the classes that
build imagers are marked individually. Every refusal is paired with a control
that must still be accepted, because a guard that is too broad is its own bug: `fast` and `cphase_diag`
both still image on numpy, `direct` + `use_jax` still runs, and the survey still runs on one observation.

Each of the five fixes was reverted in turn and the corresponding test confirmed to fail:

    remove the check_jax_supported call            -> imager guard tests fail
    key the guard on use_jax alone                 -> the optax-path test fails
    drop the ttype check in baseline sharding      -> sharding test fails
    restore build_mesh's bare jax.devices("gpu")   -> build_mesh test fails
    drop the survey n_obs guard                    -> survey test fails

The `build_mesh` test monkeypatches `jax.devices` rather than skipping when a GPU is present, so it runs
on GPU boxes too instead of only in CI. The sharding test builds a one-device mesh, so it needs no GPU
either: the transform check fires before any padding.

## How to test

    pytest tests/test_jax_guards.py

Full suite on a compute node, `-m "not gpu"`: **1932 passed, 1 skipped, 1 xfailed**, no failures. That
is the 1908-test baseline plus the 24 added here. (`tests/test_interactive.py` deselected: it blocks on a
plotting renderer on a headless node, unrelated to this change.)

