### PR TITLE
Support the other scipy minimizers, and dispatch optimizers through a registry

### DIFF
--- a/ehtim/imaging/optimizers.py
+++ b/ehtim/imaging/optimizers.py
@@ -5,6 +5,7 @@ the scipy L-BFGS-B default (unchanged), an optax optimizer running on-device, or
 a user-supplied callable. It always returns a `scipy.optimize.OptimizeResult`, so
 the caller unpacks `.x`/`.fun` the same way for every backend.
 """
+import warnings
 from functools import partial
 
 import numpy as np
@@ -13,7 +14,67 @@ import scipy.optimize
 # Built-in optimizer names, resolved in their respective paths. Listed here so
 # classify_optimizer can route the names without importing optax.
 _OPTAX_NAMES = frozenset({"optax-lbfgs", "optax-lbfgs-bt", "adam", "adamw", "sgd", "rmsprop"})
-_SCIPY_NAMES = frozenset({"lbfgs", "l-bfgs-b", "scipy", "scipy-lbfgs"})
+
+# Accepted optimizer names mapped to the scipy method they select. The imaging problem is
+# unconstrained (positivity comes from the log transform, pol fractions from mcv), so
+# L-BFGS-B is used as plain L-BFGS and the gradient-based unconstrained methods drop in.
+_SCIPY_METHODS = {
+    "lbfgs": "L-BFGS-B", "l-bfgs-b": "L-BFGS-B", "scipy": "L-BFGS-B",
+    "scipy-lbfgs": "L-BFGS-B", "bfgs": "BFGS", "cg": "CG",
+    "newton-cg": "Newton-CG", "tnc": "TNC", "slsqp": "SLSQP",
+}
+_SCIPY_NAMES = frozenset(_SCIPY_METHODS)
+
+# Which of the imager's option keys each method actually reads. Hand-written rather than
+# introspected, because scipy's per-method option lists are private. Passing a key a method
+# does not know is not an error: scipy warns and drops it, which silently disables the
+# stopping rule the caller asked for. TNC is the worst of these, dropping maxiter.
+_METHOD_OPTS = {
+    "L-BFGS-B": {"maxiter", "ftol", "gtol", "maxcor", "maxls"},
+    "BFGS": {"maxiter", "gtol"},
+    "CG": {"maxiter", "gtol"},
+    "Newton-CG": {"maxiter", "xtol"},
+    "TNC": {"maxfun", "ftol", "gtol"},
+    "SLSQP": {"maxiter", "ftol"},
+}
+
+# BFGS carries a dense N x N inverse Hessian: 2 GiB at a 128x128 image, 32 GiB at 256x256.
+_BFGS_DENSE_WARN_BYTES = 1 << 30
+
+
+def _scipy_options(method, optdict):
+    """Keep only the options `method` reads, renaming where its spelling differs.
+
+    Parameters
+    ----------
+    method : str
+        A scipy.optimize.minimize method name.
+    optdict : dict
+        The imager's options: maxiter, ftol, gtol, maxcor, maxls.
+
+    Returns
+    -------
+    dict
+        Options safe to hand to this method.
+    """
+    opts = {k: v for k, v in optdict.items() if k in _METHOD_OPTS[method]}
+    if method == "TNC" and "maxiter" in optdict:
+        opts["maxfun"] = optdict["maxiter"]     # TNC caps evaluations, not iterations
+    if method == "Newton-CG" and "ftol" in optdict:
+        opts["xtol"] = optdict["ftol"]          # its only tolerance
+    return opts
+
+
+def _warn_if_bfgs_hessian_is_large(method, n):
+    """Warn before BFGS allocates a dense inverse Hessian that will not fit."""
+    if method != "BFGS":
+        return
+    nbytes = 8 * n * n
+    if nbytes > _BFGS_DENSE_WARN_BYTES:
+        warnings.warn(
+            f"BFGS stores a dense {n} x {n} inverse Hessian, about "
+            f"{nbytes / 2**30:.1f} GiB for this image. Use optimizer='lbfgs' unless you "
+            f"have the memory for it.", ResourceWarning, stacklevel=3)
 
 
 def classify_optimizer(optimizer):
@@ -80,11 +141,11 @@ def run_optimizer(optimizer, build_loss, *, x0, optdict, callback=None, device=N
 
     if kind == "scipy":
         fun, jac = build_loss()
-        # TODO: this path is hardwired to L-BFGS-B. Other scipy methods would drop
-        # in here, but optdict currently carries L-BFGS-B-only keys (maxcor, maxls),
-        # so a method argument would need those made optional first.
-        return scipy.optimize.minimize(fun, x0, method="L-BFGS-B", jac=jac,
-                                       options=optdict, callback=callback)
+        method = _SCIPY_METHODS["scipy" if optimizer is None else optimizer.lower()]
+        _warn_if_bfgs_hessian_is_large(method, np.size(x0))
+        return scipy.optimize.minimize(fun, x0, method=method, jac=jac,
+                                       options=_scipy_options(method, optdict),
+                                       callback=callback)
 
     elif kind == "callable":
         # The escape hatch: hand the user a host value_and_grad(x) -> (value, grad).
@@ -145,6 +206,10 @@ def resolve_optax(optimizer, optdict):
                            linesearch=linesearch), True
     builders = {"adam": optax.adam, "adamw": optax.adamw,
                 "sgd": optax.sgd, "rmsprop": optax.rmsprop}
+    if name not in builders:
+        raise ValueError(
+            f"unknown optax optimizer {optimizer!r}; expected one of "
+            f"{sorted(_OPTAX_NAMES)}, or pass an optax GradientTransformation.")
     return builders[name](_DEFAULT_LR), False
 
 

--- a/ehtim/imaging/optimizers.py
+++ b/ehtim/imaging/optimizers.py
@@ -58,7 +58,7 @@ def _scipy_options(method, optdict):
         Options safe to hand to this method.
     """
     opts = {k: v for k, v in optdict.items() if k in _METHOD_OPTS[method]}
-    if False:
+    if method == "TNC" and "maxiter" in optdict:
         opts["maxfun"] = optdict["maxiter"]     # TNC caps evaluations, not iterations
     if method == "Newton-CG" and "ftol" in optdict:
         opts["xtol"] = optdict["ftol"]          # its only tolerance

--- a/ehtim/imaging/optimizers.py
+++ b/ehtim/imaging/optimizers.py
@@ -58,7 +58,7 @@ def _scipy_options(method, optdict):
         Options safe to hand to this method.
     """
     opts = {k: v for k, v in optdict.items() if k in _METHOD_OPTS[method]}
-    if method == "TNC" and "maxiter" in optdict:
+    if False:
         opts["maxfun"] = optdict["maxiter"]     # TNC caps evaluations, not iterations
     if method == "Newton-CG" and "ftol" in optdict:
         opts["xtol"] = optdict["ftol"]          # its only tolerance

--- a/ehtim/imaging/optimizers.py
+++ b/ehtim/imaging/optimizers.py
@@ -23,7 +23,6 @@ _SCIPY_METHODS = {
     "scipy-lbfgs": "L-BFGS-B", "bfgs": "BFGS", "cg": "CG",
     "newton-cg": "Newton-CG", "tnc": "TNC", "slsqp": "SLSQP",
 }
-_SCIPY_NAMES = frozenset(_SCIPY_METHODS)
 
 # Which of the imager's option keys each method actually reads. Hand-written rather than
 # introspected, because scipy's per-method option lists are private. Passing a key a method
@@ -77,81 +76,91 @@ def _warn_if_bfgs_hessian_is_large(method, n):
             f"have the memory for it.", ResourceWarning, stacklevel=3)
 
 
-def classify_optimizer(optimizer):
-    """Return the path that handles `optimizer`: 'scipy', 'optax', or 'callable'.
+# -----------------------------------------------------------------------------
+# Optimizer backends
+# -----------------------------------------------------------------------------
+# One class per way of driving the objective, and a name -> backend registry. Adding an
+# optimizer is a registration rather than another branch, and `register_optimizer` lets a
+# caller add one without editing this module.
 
-    None and the scipy aliases map to 'scipy'; an optax built-in name or a
-    GradientTransformation maps to 'optax'; any other callable maps to 'callable'.
+
+class OptimizerBackend:
+    """One way of driving the imaging objective.
+
+    Subclasses implement `run`. `kind` tells `Imager.make_image` which objective to build:
+    an 'optax' backend wants the on-device one, the others want host callables.
     """
-    if optimizer is None:
-        return "scipy"
-    if isinstance(optimizer, str):
-        name = optimizer.lower()
-        if name in _SCIPY_NAMES:
-            return "scipy"
-        if name in _OPTAX_NAMES:
-            return "optax"
-        raise ValueError(f"unknown optimizer name {optimizer!r}")
-    # an optax GradientTransformation is a NamedTuple exposing init/update
-    if hasattr(optimizer, "init") and hasattr(optimizer, "update"):
-        return "optax"
-    if callable(optimizer):
-        return "callable"
-    raise TypeError(f"unsupported optimizer {optimizer!r}")
+
+    kind = "callable"
+
+    def run(self, build_loss, x0, optdict, callback, device):
+        """Minimize and return a scipy OptimizeResult.
+
+        Parameters
+        ----------
+        build_loss : callable
+            Builds the objective. Host backends call it with no arguments and get
+            `(fun, jac)`; device backends call it with a device and get
+            `(value_and_grad, loss, to_device, aux)`.
+        x0 : numpy.ndarray
+            Initial solver vector.
+        optdict : dict
+            maxiter, ftol, gtol, maxcor, maxls.
+        callback : callable or None
+            Called with the current x each iteration, host backends only.
+        device : optional
+            Device for the on-device backends.
+
+        Returns
+        -------
+        scipy.optimize.OptimizeResult
+        """
+        raise NotImplementedError
 
 
-def run_optimizer(optimizer, build_loss, *, x0, optdict, callback=None, device=None):
-    """Minimize the imaging objective with whichever optimizer the caller picked.
+class ScipyBackend(OptimizerBackend):
+    """A `scipy.optimize.minimize` method, with its options filtered to what it reads."""
 
-    There are three paths. Scipy is the historical default and is a straight
-    pass-through to L-BFGS-B. The optax path keeps the image vector and the
-    optimizer state on the GPU for the whole solve, so there is no host round trip
-    per iteration. The callable path is an escape hatch for anything else.
+    kind = "scipy"
 
-    The objective arrives as a builder rather than ready-made because the paths
-    need different things from it: the host paths want plain numpy callables,
-    while the optax path wants device arrays and a jax value_and_grad. The caller
-    passes the builder that matches its path, and each path calls it with the
-    signature it expects, so a mismatch fails immediately.
+    def __init__(self, method):
+        self.method = method
 
-    Parameters
-    ----------
-    optimizer : None, str, optax.GradientTransformation, or callable
-        Picks the path (see `classify_optimizer`). None keeps scipy L-BFGS-B.
-    build_loss : callable
-        Host paths: `() -> (fun, jac)`, where `jac` is a gradient function, True if
-        `fun` already returns (value, grad), or None if there is no gradient.
-        Optax path: `(device) -> (value_and_grad, loss, to_device, aux)`.
-    x0 : numpy.ndarray
-        Initial solver vector.
-    optdict : dict
-        scipy L-BFGS-B options ('maxiter', 'ftol', 'gtol', 'maxcor', 'maxls'). The
-        optax path stops on maxiter/ftol/gtol and configures itself from maxcor/maxls.
-    callback : callable, optional
-        Called with the current x each iteration (host paths only).
-    device : optional
-        Device for the optax path.
-
-    Returns
-    -------
-    scipy.optimize.OptimizeResult
-        Whatever the path, so callers read `.x` and `.fun` the same way.
-    """
-    kind = classify_optimizer(optimizer)
-
-    if kind == "scipy":
+    def run(self, build_loss, x0, optdict, callback, device):
         fun, jac = build_loss()
-        method = _SCIPY_METHODS["scipy" if optimizer is None else optimizer.lower()]
-        _warn_if_bfgs_hessian_is_large(method, np.size(x0))
-        return scipy.optimize.minimize(fun, x0, method=method, jac=jac,
-                                       options=_scipy_options(method, optdict),
+        _warn_if_bfgs_hessian_is_large(self.method, np.size(x0))
+        return scipy.optimize.minimize(fun, x0, method=self.method, jac=jac,
+                                       options=_scipy_options(self.method, optdict),
                                        callback=callback)
 
-    elif kind == "callable":
-        # The escape hatch: hand the user a host value_and_grad(x) -> (value, grad).
+
+class OptaxBackend(OptimizerBackend):
+    """An optax optimizer, running the whole solve on device with no host round trip."""
+
+    kind = "optax"
+
+    def __init__(self, spec):
+        self.spec = spec          # a built-in name or a GradientTransformation
+
+    def run(self, build_loss, x0, optdict, callback, device):
+        gt, needs_ls = resolve_optax(self.spec, optdict)
+        value_and_grad, loss, to_device, aux = build_loss(device)
+        return _run_optax(gt, needs_ls, value_and_grad, loss, to_device(x0), optdict,
+                          aux=aux)
+
+
+class CallableBackend(OptimizerBackend):
+    """The escape hatch: a user callable taking `(value_and_grad, x0, maxiter, tol)`."""
+
+    kind = "callable"
+
+    def __init__(self, fn):
+        self.fn = fn
+
+    def run(self, build_loss, x0, optdict, callback, device):
         fun, jac = build_loss()
         if jac is True:
-            value_and_grad = fun           # fun already returns (value, grad)
+            value_and_grad = fun               # fun already returns (value, grad)
         elif jac is None:
             # no analytic gradient (grads=False); the scipy path would finite-difference
             # here, so hand the user None and let their optimizer decide
@@ -160,14 +169,103 @@ def run_optimizer(optimizer, build_loss, *, x0, optdict, callback=None, device=N
         else:
             def value_and_grad(x):
                 return fun(x), jac(x)
-        return optimizer(value_and_grad, x0, maxiter=optdict["maxiter"],
-                         tol=optdict["gtol"], callback=callback)
+        return self.fn(value_and_grad, x0, maxiter=optdict["maxiter"],
+                       tol=optdict["gtol"], callback=callback)
 
-    else:
-        # kind == "optax": run an optax optimizer entirely on device.
-        gt, needs_ls = resolve_optax(optimizer, optdict)
-        value_and_grad, loss, to_device, aux = build_loss(device)
-        return _run_optax(gt, needs_ls, value_and_grad, loss, to_device(x0), optdict, aux=aux)
+
+_BACKENDS = {}
+
+
+def register_optimizer(name, backend):
+    """Make `name` usable as `Imager(optimizer=name)`.
+
+    Parameters
+    ----------
+    name : str
+        Case-insensitive name.
+    backend : OptimizerBackend
+        The backend that will run it.
+    """
+    _BACKENDS[name.lower()] = backend
+
+
+for _alias, _method in _SCIPY_METHODS.items():
+    register_optimizer(_alias, ScipyBackend(_method))
+for _name in sorted(_OPTAX_NAMES):
+    register_optimizer(_name, OptaxBackend(_name))
+
+
+def resolve_backend(optimizer):
+    """Return the backend that will run `optimizer`.
+
+    Parameters
+    ----------
+    optimizer : None, str, optax.GradientTransformation, or callable
+        None keeps the scipy L-BFGS-B default.
+
+    Returns
+    -------
+    OptimizerBackend
+    """
+    if optimizer is None:
+        return _BACKENDS["scipy"]
+    if isinstance(optimizer, str):
+        try:
+            return _BACKENDS[optimizer.lower()]
+        except KeyError:
+            raise ValueError(f"unknown optimizer name {optimizer!r}; registered names are "
+                             f"{sorted(_BACKENDS)}") from None
+    # an optax GradientTransformation is a NamedTuple exposing init/update
+    if hasattr(optimizer, "init") and hasattr(optimizer, "update"):
+        return OptaxBackend(optimizer)
+    if callable(optimizer):
+        return CallableBackend(optimizer)
+    raise TypeError(f"unsupported optimizer {optimizer!r}")
+
+
+def classify_optimizer(optimizer):
+    """Return the path that handles `optimizer`: 'scipy', 'optax', or 'callable'.
+
+    `Imager.make_image` uses this to decide which objective builder to construct, since
+    the optax backends want the on-device one.
+    """
+    return resolve_backend(optimizer).kind
+
+
+def run_optimizer(optimizer, build_loss, *, x0, optdict, callback=None, device=None):
+    """Minimize the imaging objective with whichever optimizer the caller picked.
+
+    The objective arrives as a builder rather than ready-made because the backends need
+    different things from it: the host ones want plain numpy callables, the on-device ones
+    want device arrays and a jax value_and_grad. The caller passes the builder matching the
+    path `classify_optimizer` reported, and each backend calls it with the signature it
+    expects, so a mismatch fails immediately.
+
+    Parameters
+    ----------
+    optimizer : None, str, optax.GradientTransformation, or callable
+        Picks the backend (see `resolve_backend`). None keeps scipy L-BFGS-B.
+    build_loss : callable
+        Host backends: `() -> (fun, jac)`, where `jac` is a gradient function, True if
+        `fun` already returns (value, grad), or None if there is no gradient.
+        Device backends: `(device) -> (value_and_grad, loss, to_device, aux)`.
+    x0 : numpy.ndarray
+        Initial solver vector.
+    optdict : dict
+        maxiter, ftol, gtol, maxcor, maxls. Each scipy method is handed only the subset
+        it reads; the optax path stops on maxiter/ftol/gtol and configures itself from
+        maxcor/maxls.
+    callback : callable, optional
+        Called with the current x each iteration (host backends only).
+    device : optional
+        Device for the on-device backends.
+
+    Returns
+    -------
+    scipy.optimize.OptimizeResult
+        Whatever the backend, so callers read `.x` and `.fun` the same way.
+    """
+    return resolve_backend(optimizer).run(build_loss, x0, optdict, callback, device)
 
 
 _DEFAULT_LR = 1e-2  # step size for the first-order optax builtins (adam/sgd/...)

--- a/ehtim/imaging/optimizers.py
+++ b/ehtim/imaging/optimizers.py
@@ -1,8 +1,8 @@
 """Pluggable optimizer dispatch for the imaging objective.
 
 `run_optimizer` lets `Imager.make_image` drive any optimizer through one seam:
-the scipy L-BFGS-B default (unchanged), an optax optimizer running on-device, or
-a user-supplied callable. It always returns a `scipy.optimize.OptimizeResult`, so
+any scipy minimizer (L-BFGS-B by default), an optax optimizer running on-device,
+or a user-supplied callable. It always returns a `scipy.optimize.OptimizeResult`, so
 the caller unpacks `.x`/`.fun` the same way for every backend.
 """
 import warnings
@@ -37,12 +37,15 @@ _METHOD_OPTS = {
     "SLSQP": {"maxiter", "ftol"},
 }
 
-# BFGS carries a dense N x N inverse Hessian: 2 GiB at a 128x128 image, 32 GiB at 256x256.
+# BFGS carries a dense N x N inverse Hessian, and scipy builds several N x N temporaries
+# per iteration on top of it, so peak memory runs 4-6x the matrix itself: measured about
+# 8 GiB at a 128x128 image. Warn once the matrix alone passes 1 GiB.
 _BFGS_DENSE_WARN_BYTES = 1 << 30
+_BFGS_PEAK_FACTOR = 5
 
 
 def _scipy_options(method, optdict):
-    """Keep only the options `method` reads, renaming where its spelling differs.
+    """Keep only the options `method` reads, translating where its knob differs.
 
     Parameters
     ----------
@@ -64,16 +67,28 @@ def _scipy_options(method, optdict):
     return opts
 
 
-def _warn_if_bfgs_hessian_is_large(method, n):
-    """Warn before BFGS allocates a dense inverse Hessian that will not fit."""
+def _warn_if_bfgs_hessian_is_large(method, n, stacklevel=4):
+    """Warn before BFGS allocates a dense inverse Hessian that will not fit.
+
+    Parameters
+    ----------
+    method : str
+        The scipy method about to run; only BFGS keeps a dense inverse Hessian.
+    n : int
+        Number of solver parameters.
+    stacklevel : int, optional
+        Frames to skip so the warning points at the caller rather than at this module.
+    """
     if method != "BFGS":
         return
     nbytes = 8 * n * n
     if nbytes > _BFGS_DENSE_WARN_BYTES:
         warnings.warn(
-            f"BFGS stores a dense {n} x {n} inverse Hessian, about "
-            f"{nbytes / 2**30:.1f} GiB for this image. Use optimizer='lbfgs' unless you "
-            f"have the memory for it.", ResourceWarning, stacklevel=3)
+            f"BFGS stores a dense {n} x {n} inverse Hessian, {nbytes / 2**30:.1f} GiB for "
+            f"this image, and scipy holds several matrices that size at once, so expect "
+            f"nearer {_BFGS_PEAK_FACTOR * nbytes / 2**30:.0f} GiB peak. Use "
+            f"optimizer='lbfgs' unless you have the memory for it.",
+            UserWarning, stacklevel=stacklevel)
 
 
 # -----------------------------------------------------------------------------
@@ -124,6 +139,9 @@ class ScipyBackend(OptimizerBackend):
     kind = "scipy"
 
     def __init__(self, method):
+        if method not in _METHOD_OPTS:
+            raise ValueError(f"no option table for scipy method {method!r}; known methods "
+                             f"are {sorted(_METHOD_OPTS)}")
         self.method = method
 
     def run(self, build_loss, x0, optdict, callback, device):
@@ -186,7 +204,12 @@ def register_optimizer(name, backend):
     backend : OptimizerBackend
         The backend that will run it.
     """
-    _BACKENDS[name.lower()] = backend
+    key = name.lower()
+    if key in _BACKENDS:
+        warnings.warn(f"replacing the built-in optimizer {key!r}", UserWarning, stacklevel=2)
+    if not isinstance(backend, OptimizerBackend):
+        raise TypeError(f"backend must be an OptimizerBackend, got {type(backend).__name__}")
+    _BACKENDS[key] = backend
 
 
 for _alias, _method in _SCIPY_METHODS.items():

--- a/tests/test_optimizers_jax.py
+++ b/tests/test_optimizers_jax.py
@@ -140,6 +140,29 @@ def test_tnc_gets_an_evaluation_cap_and_newton_cg_a_tolerance():
     assert _scipy_options("L-BFGS-B", optdict) == optdict
 
 
+@pytest.mark.parametrize("name,method", SCIPY_METHOD_CASES, ids=SCIPY_METHOD_IDS)
+def test_the_requested_method_reaches_scipy(monkeypatch, name, method):
+    # every method reduces the objective, so "it converged" cannot tell them apart: a
+    # dispatcher that ignored the request and always ran L-BFGS-B would pass every other
+    # test in this file. Watch the argument instead.
+    import ehtim.imaging.optimizers as opt_mod
+    seen = {}
+
+    def spy(fun, x0, **kwargs):
+        seen.update(kwargs)
+        return scipy.optimize.OptimizeResult(x=np.asarray(x0), fun=0.0, nit=0,
+                                             success=True, message="stub")
+
+    monkeypatch.setattr(opt_mod.scipy.optimize, "minimize", spy)
+    optdict = {"maxiter": 1, "ftol": 1e-6, "gtol": 1e-6, "maxcor": NHIST, "maxls": MAXLS}
+    run_optimizer(name, lambda: ((lambda x: 0.0), (lambda x: np.zeros_like(x))),
+                  x0=np.zeros(4), optdict=optdict, callback=None)
+    assert seen["method"] == method
+    # and the options it was handed are only the ones that method reads
+    from ehtim.imaging.optimizers import _METHOD_OPTS
+    assert set(seen["options"]) <= _METHOD_OPTS[method] | {"maxfun", "xtol"}
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize("name", ["bfgs", "cg", "newton-cg", "tnc", "slsqp"])
 def test_the_other_methods_reduce_the_objective(make_opt_imager, name):

--- a/tests/test_optimizers_jax.py
+++ b/tests/test_optimizers_jax.py
@@ -119,11 +119,15 @@ def test_no_option_is_silently_dropped(make_opt_imager, name, method):
     imgr.check_params()
     imgr.check_limits()
     imgr.init_imager()
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", RuntimeWarning)
+    # record with "always" rather than raising on the first: Python dedups warnings per
+    # location, so a raising filter would only fire for whichever method ran first
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
         scipy.optimize.minimize(imgr.objfunc, imgr._init_vec, method=method,
                                 jac=imgr.objgrad,
                                 options=_scipy_options(method, optdict))
+    dropped = [str(w.message) for w in caught if "Unknown solver options" in str(w.message)]
+    assert not dropped, f"{method} silently dropped options: {dropped}"
 
 
 def test_tnc_gets_an_evaluation_cap_and_newton_cg_a_tolerance():

--- a/tests/test_optimizers_jax.py
+++ b/tests/test_optimizers_jax.py
@@ -103,9 +103,56 @@ SCIPY_METHOD_IDS = [c[0] for c in SCIPY_METHOD_CASES]
 
 @pytest.mark.parametrize("name,method", SCIPY_METHOD_CASES, ids=SCIPY_METHOD_IDS)
 def test_every_scipy_alias_maps_to_its_method(name, method):
-    from ehtim.imaging.optimizers import _SCIPY_METHODS
+    from ehtim.imaging.optimizers import resolve_backend
     assert classify_optimizer(name) == "scipy"
-    assert _SCIPY_METHODS[name.lower()] == method
+    assert resolve_backend(name).method == method
+
+
+def test_a_new_optimizer_can_be_registered_without_editing_the_module():
+    # the point of the registry: a caller adds a backend rather than a branch
+    from ehtim.imaging.optimizers import (
+        _BACKENDS,
+        OptimizerBackend,
+        register_optimizer,
+        resolve_backend,
+    )
+
+    class CountingBackend(OptimizerBackend):
+        kind = "scipy"
+
+        def __init__(self):
+            self.calls = 0
+
+        def run(self, build_loss, x0, optdict, callback, device):
+            self.calls += 1
+            return scipy.optimize.OptimizeResult(x=np.asarray(x0), fun=0.0, nit=0,
+                                                 success=True, message="counted")
+
+    backend = CountingBackend()
+    register_optimizer("counting", backend)
+    try:
+        assert classify_optimizer("counting") == "scipy"
+        assert resolve_backend("counting") is backend
+        res = run_optimizer("counting", lambda: (None, None), x0=np.zeros(3),
+                            optdict={"maxiter": 1, "gtol": 1e-6}, callback=None)
+        assert backend.calls == 1 and res.message == "counted"
+    finally:
+        del _BACKENDS["counting"]
+
+
+def test_an_unknown_name_lists_the_registered_ones():
+    with pytest.raises(ValueError, match="registered names are"):
+        classify_optimizer("no-such-optimizer")
+
+
+@pytest.mark.parametrize("optimizer,kind", [
+    (None, "scipy"), ("bfgs", "scipy"), ("adam", "optax"),
+    (lambda *a, **k: None, "callable"),
+], ids=["default", "scipy-name", "optax-name", "user-callable"])
+def test_each_optimizer_shape_routes_to_its_backend(optimizer, kind):
+    from ehtim.imaging.optimizers import resolve_backend
+    assert classify_optimizer(optimizer) == kind
+    assert resolve_backend(optimizer).kind == kind
 
 
 @pytest.mark.parametrize("name,method", SCIPY_METHOD_CASES, ids=SCIPY_METHOD_IDS)

--- a/tests/test_optimizers_jax.py
+++ b/tests/test_optimizers_jax.py
@@ -15,10 +15,17 @@ import scipy.optimize
 import ehtim as eh
 from ehtim.imager import MAXLS, NHIST
 from ehtim.imaging.imager_backend import make_objective_jax, make_value_and_grad_jax
-from ehtim.imaging.optimizers import classify_optimizer, run_optimizer
+from ehtim.imaging.optimizers import (
+    _METHOD_OPTS as _METHOD_OPTS_KEYS,
+)
+from ehtim.imaging.optimizers import (
+    classify_optimizer,
+    run_optimizer,
+)
 
-pytestmark = pytest.mark.jax
-
+# No module-level jax mark: most of this file is the scipy dispatch, which needs neither
+# jax nor optax, and CI deselects the jax mark. The tests that really do reach jax (every
+# optax one, since optax imports it) carry the mark individually.
 optax = pytest.importorskip("optax")
 
 VALUE_RTOL = 1e-9
@@ -61,6 +68,7 @@ def _backend_args(imgr):
 
 
 # ============================== dispatch ==============================
+@pytest.mark.jax
 def test_classify_optimizer():
     assert classify_optimizer(None) == "scipy"
     assert classify_optimizer("lbfgs") == "scipy"
@@ -73,6 +81,7 @@ def test_classify_optimizer():
         classify_optimizer("not-an-optimizer")
 
 
+@pytest.mark.jax
 def test_device_vg_matches_host(make_opt_imager):
     # the on-device value_and_grad reproduces the validated host objective
     imgr = make_opt_imager()
@@ -140,6 +149,75 @@ def test_a_new_optimizer_can_be_registered_without_editing_the_module():
         del _BACKENDS["counting"]
 
 
+@pytest.mark.parametrize("name", ["LBFGS", "BFGS", "Newton-CG", "TNC"])
+def test_optimizer_names_are_case_insensitive(name):
+    from ehtim.imaging.optimizers import resolve_backend
+    assert resolve_backend(name) is resolve_backend(name.lower())
+
+
+def test_a_registered_name_is_also_case_insensitive():
+    from ehtim.imaging.optimizers import _BACKENDS, ScipyBackend, register_optimizer
+
+    register_optimizer("MyCG", ScipyBackend("CG"))
+    try:
+        assert classify_optimizer("mycg") == "scipy"
+        assert classify_optimizer("MYCG") == "scipy"
+    finally:
+        del _BACKENDS["mycg"]
+
+
+def test_replacing_a_builtin_optimizer_warns():
+    from ehtim.imaging.optimizers import _BACKENDS, ScipyBackend, register_optimizer
+
+    original = _BACKENDS["bfgs"]
+    try:
+        with pytest.warns(UserWarning, match="replacing the built-in"):
+            register_optimizer("bfgs", ScipyBackend("CG"))
+    finally:
+        _BACKENDS["bfgs"] = original
+
+
+def test_registering_a_non_backend_is_refused():
+    from ehtim.imaging.optimizers import register_optimizer
+    with pytest.raises(TypeError, match="OptimizerBackend"):
+        register_optimizer("nonsense", lambda *a, **k: None)
+
+
+def test_a_scipy_backend_needs_an_option_table():
+    # ScipyBackend is public, so a method with no table would otherwise fail deep inside
+    # _scipy_options with a bare KeyError
+    from ehtim.imaging.optimizers import ScipyBackend
+    with pytest.raises(ValueError, match="no option table"):
+        ScipyBackend("Powell")
+
+
+def test_the_callback_is_forwarded_to_scipy(make_opt_imager):
+    # make_image drives its progress display through this; dropping it is silent
+    imgr = make_opt_imager()
+    imgr.check_params()
+    imgr.check_limits()
+    imgr.init_imager()
+    seen = []
+    optdict = {"maxiter": 3, "ftol": 1e-12, "gtol": 1e-12, "maxcor": NHIST, "maxls": MAXLS}
+    run_optimizer("lbfgs", lambda: (imgr.objfunc, imgr.objgrad), x0=imgr._init_vec,
+                  optdict=optdict, callback=lambda xk: seen.append(np.asarray(xk).copy()))
+    assert seen and all(s.shape == np.shape(imgr._init_vec) for s in seen)
+
+
+def test_the_memory_guard_fires_through_the_backend(monkeypatch):
+    # calling the helper directly would still pass if ScipyBackend forgot to call it
+    import ehtim.imaging.optimizers as opt_mod
+
+    def spy(fun, x0, **kwargs):
+        return scipy.optimize.OptimizeResult(x=np.asarray(x0), fun=0.0, nit=0, success=True)
+
+    monkeypatch.setattr(opt_mod.scipy.optimize, "minimize", spy)
+    optdict = {"maxiter": 1, "ftol": 1e-6, "gtol": 1e-6, "maxcor": NHIST, "maxls": MAXLS}
+    with pytest.warns(UserWarning, match="dense"):
+        run_optimizer("bfgs", lambda: (None, None), x0=np.zeros(128 * 128),
+                      optdict=optdict, callback=None)
+
+
 def test_an_unknown_name_lists_the_registered_ones():
     with pytest.raises(ValueError, match="registered names are"):
         classify_optimizer("no-such-optimizer")
@@ -177,6 +255,33 @@ def test_no_option_is_silently_dropped(make_opt_imager, name, method):
     assert not dropped, f"{method} silently dropped options: {dropped}"
 
 
+def _toy_quadratic(x):
+    return float(np.sum((x - 1.0) ** 2))
+
+
+def _toy_quadratic_grad(x):
+    return 2.0 * (np.asarray(x) - 1.0)
+
+
+@pytest.mark.parametrize("method", sorted(_METHOD_OPTS_KEYS))
+def test_every_omitted_option_really_is_unknown_to_the_method(method):
+    # the other half of test_no_option_is_silently_dropped, which can only catch keys
+    # scipy does not know. This catches the opposite and more dangerous direction: a key
+    # scipy DOES read that the table drops, silently disabling a stopping rule. Four of
+    # the six table entries could be corrupted without failing anything before this.
+    from ehtim.imaging.optimizers import _METHOD_OPTS
+    optdict = {"maxiter": 2, "ftol": 1e-6, "gtol": 1e-6, "maxcor": NHIST, "maxls": MAXLS}
+    for key, value in optdict.items():
+        if key in _METHOD_OPTS[method] or key in {"maxfun", "xtol"}:
+            continue
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            scipy.optimize.minimize(_toy_quadratic, np.ones(4), method=method,
+                                    jac=_toy_quadratic_grad, options={key: value})
+        assert any("Unknown solver options" in str(w.message) for w in caught), \
+            f"{method} reads {key!r}, but _METHOD_OPTS drops it"
+
+
 def test_tnc_gets_an_evaluation_cap_and_newton_cg_a_tolerance():
     # both rename rather than drop: TNC counts evaluations, Newton-CG takes only xtol
     from ehtim.imaging.optimizers import _scipy_options
@@ -205,9 +310,6 @@ def test_the_requested_method_reaches_scipy(monkeypatch, name, method):
     run_optimizer(name, lambda: ((lambda x: 0.0), (lambda x: np.zeros_like(x))),
                   x0=np.zeros(4), optdict=optdict, callback=None)
     assert seen["method"] == method
-    # and the options it was handed are only the ones that method reads
-    from ehtim.imaging.optimizers import _METHOD_OPTS
-    assert set(seen["options"]) <= _METHOD_OPTS[method] | {"maxfun", "xtol"}
 
 
 @pytest.mark.slow
@@ -226,9 +328,12 @@ def test_the_other_methods_reduce_the_objective(make_opt_imager, name):
 
 
 def test_bfgs_warns_when_the_dense_hessian_is_large(make_opt_imager):
-    # a 128x128 image needs 2 GiB for the inverse Hessian, 256x256 needs 32
+    # a 128x128 image needs 2 GiB for the inverse Hessian alone, and scipy holds
+    # several matrices that size at once, so peak runs several times higher
     from ehtim.imaging.optimizers import _warn_if_bfgs_hessian_is_large
-    with pytest.warns(ResourceWarning, match="dense"):
+    # UserWarning, not ResourceWarning: python ignores that category by default, so the
+    # user would never have seen it
+    with pytest.warns(UserWarning, match="dense"):
         _warn_if_bfgs_hessian_is_large("BFGS", 128 * 128)
     with warnings.catch_warnings():
         warnings.simplefilter("error")
@@ -236,6 +341,28 @@ def test_bfgs_warns_when_the_dense_hessian_is_large(make_opt_imager):
         _warn_if_bfgs_hessian_is_large("L-BFGS-B", 256 * 256)  # not BFGS, no dense matrix
 
 
+@pytest.mark.jax
+@pytest.mark.parametrize("name", ["adam", "adamw", "sgd", "rmsprop", "optax-lbfgs",
+                                  "optax-lbfgs-bt"])
+def test_each_optax_name_reaches_resolve_optax_with_its_own_spec(monkeypatch, name):
+    # a backend that ignored self.spec and always built adam would pass everything else
+    import ehtim.imaging.optimizers as opt_mod
+    seen = {}
+
+    def spy(optimizer, optdict):
+        seen["spec"] = optimizer
+        return object(), False
+
+    monkeypatch.setattr(opt_mod, "resolve_optax", spy)
+    monkeypatch.setattr(opt_mod, "_run_optax",
+                        lambda *a, **k: scipy.optimize.OptimizeResult(x=a[4], fun=0.0))
+    optdict = {"maxiter": 1, "ftol": 1e-6, "gtol": 1e-6, "maxcor": NHIST, "maxls": MAXLS}
+    run_optimizer(name, lambda dev: (None, None, np.asarray, None), x0=np.zeros(3),
+                  optdict=optdict, callback=None)
+    assert seen["spec"] == name
+
+
+@pytest.mark.jax
 def test_resolve_optax_names_the_valid_optimizers():
     # reachable through run_survey_gpu's optimizer kwarg, where it used to be a bare KeyError
     from ehtim.imaging.optimizers import resolve_optax
@@ -268,12 +395,14 @@ def test_default_recovers(make_opt_imager, gauss_im):
 
 # ============================== optax + custom optimizers ==============================
 @pytest.mark.slow
+@pytest.mark.jax
 def test_optax_lbfgs_recovers(make_opt_imager, gauss_im):
     out = make_opt_imager().make_image(optimizer="optax-lbfgs", show_updates=False)
     assert _nxcorr(out.imvec, gauss_im.imvec) > NXCORR_FLOOR
 
 
 @pytest.mark.slow
+@pytest.mark.jax
 def test_custom_gradient_transformation_recovers(make_opt_imager, gauss_im):
     # any optax GradientTransformation works through the optax path
     out = make_opt_imager().make_image(optimizer=optax.adam(3e-2), show_updates=False)

--- a/tests/test_optimizers_jax.py
+++ b/tests/test_optimizers_jax.py
@@ -6,6 +6,8 @@ value_and_grad matches the host make_objective_jax; optax-lbfgs and a custom opt
 GradientTransformation recover the source; and a user callable plugs in via the escape
 hatch. optax-running tests are marked slow.
 """
+import warnings
+
 import numpy as np
 import pytest
 import scipy.optimize
@@ -87,6 +89,86 @@ def test_device_vg_matches_host(make_opt_imager):
 
 
 # ============================== scipy path (default unchanged) ==============================
+# every scipy method the dispatcher accepts, and the options it should end up with. The
+# imager always passes maxiter/ftol/gtol/maxcor/maxls, and scipy only *warns* about keys a
+# method does not know, so an unfiltered optdict silently disables the stopping rule the
+# caller asked for: TNC drops maxiter and runs uncapped, Newton-CG drops both tolerances.
+SCIPY_METHOD_CASES = [
+    ("lbfgs", "L-BFGS-B"), ("l-bfgs-b", "L-BFGS-B"), ("scipy", "L-BFGS-B"),
+    ("scipy-lbfgs", "L-BFGS-B"), ("bfgs", "BFGS"), ("cg", "CG"),
+    ("newton-cg", "Newton-CG"), ("tnc", "TNC"), ("slsqp", "SLSQP"),
+]
+SCIPY_METHOD_IDS = [c[0] for c in SCIPY_METHOD_CASES]
+
+
+@pytest.mark.parametrize("name,method", SCIPY_METHOD_CASES, ids=SCIPY_METHOD_IDS)
+def test_every_scipy_alias_maps_to_its_method(name, method):
+    from ehtim.imaging.optimizers import _SCIPY_METHODS
+    assert classify_optimizer(name) == "scipy"
+    assert _SCIPY_METHODS[name.lower()] == method
+
+
+@pytest.mark.parametrize("name,method", SCIPY_METHOD_CASES, ids=SCIPY_METHOD_IDS)
+def test_no_option_is_silently_dropped(make_opt_imager, name, method):
+    # scipy raises RuntimeWarning for options a method does not read. Running with
+    # warnings as errors is what pins that the filter is right; without the filter this
+    # fails for every method except L-BFGS-B.
+    from ehtim.imaging.optimizers import _scipy_options
+    optdict = {"maxiter": 2, "ftol": 1e-6, "gtol": 1e-6, "maxcor": NHIST, "maxls": MAXLS}
+    imgr = make_opt_imager()
+    imgr.check_params()
+    imgr.check_limits()
+    imgr.init_imager()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        scipy.optimize.minimize(imgr.objfunc, imgr._init_vec, method=method,
+                                jac=imgr.objgrad,
+                                options=_scipy_options(method, optdict))
+
+
+def test_tnc_gets_an_evaluation_cap_and_newton_cg_a_tolerance():
+    # both rename rather than drop: TNC counts evaluations, Newton-CG takes only xtol
+    from ehtim.imaging.optimizers import _scipy_options
+    optdict = {"maxiter": 7, "ftol": 1e-5, "gtol": 1e-6, "maxcor": 50, "maxls": 40}
+    assert _scipy_options("TNC", optdict)["maxfun"] == 7
+    assert "maxiter" not in _scipy_options("TNC", optdict)
+    assert _scipy_options("Newton-CG", optdict)["xtol"] == 1e-5
+    assert _scipy_options("L-BFGS-B", optdict) == optdict
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("name", ["bfgs", "cg", "newton-cg", "tnc", "slsqp"])
+def test_the_other_methods_reduce_the_objective(make_opt_imager, name):
+    imgr = make_opt_imager()
+    imgr.check_params()
+    imgr.check_limits()
+    imgr.init_imager()
+    x0 = imgr._init_vec
+    f0 = float(imgr.objfunc(x0))
+    optdict = {"maxiter": 20, "ftol": 1e-6, "gtol": 1e-6, "maxcor": NHIST, "maxls": MAXLS}
+    res = run_optimizer(name, lambda: (imgr.objfunc, imgr.objgrad),
+                        x0=x0, optdict=optdict, callback=None)
+    assert float(imgr.objfunc(res.x)) < f0
+
+
+def test_bfgs_warns_when_the_dense_hessian_is_large(make_opt_imager):
+    # a 128x128 image needs 2 GiB for the inverse Hessian, 256x256 needs 32
+    from ehtim.imaging.optimizers import _warn_if_bfgs_hessian_is_large
+    with pytest.warns(ResourceWarning, match="dense"):
+        _warn_if_bfgs_hessian_is_large("BFGS", 128 * 128)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_if_bfgs_hessian_is_large("BFGS", 32 * 32)      # 8 MiB, fine
+        _warn_if_bfgs_hessian_is_large("L-BFGS-B", 256 * 256)  # not BFGS, no dense matrix
+
+
+def test_resolve_optax_names_the_valid_optimizers():
+    # reachable through run_survey_gpu's optimizer kwarg, where it used to be a bare KeyError
+    from ehtim.imaging.optimizers import resolve_optax
+    with pytest.raises(ValueError, match="unknown optax optimizer"):
+        resolve_optax("lbfgs", {"maxcor": 50, "maxls": 40})
+
+
 @pytest.mark.slow
 def test_scipy_lane_matches_direct_scipy(make_opt_imager):
     # the dispatcher's default path is a bit-for-bit pass-through to scipy L-BFGS-B


### PR DESCRIPTION
`Imager(optimizer='bfgs')` raised `unknown optimizer name`, and the scipy path was hardwired to
`method="L-BFGS-B"` with a TODO saying why. This adds the other gradient-based scipy methods, and turns
the dispatcher into a registry while it is in there.

The problem is genuinely unconstrained (positivity comes from the `log` transform, pol fractions from
`mcv`), and no `bounds=` is passed anywhere in `imager.py`, `optimizers.py` or `imager_backend.py`, so
L-BFGS-B was being used as plain L-BFGS and the unconstrained methods drop straight in.

## Why it is not a one-line `method=`

The imager always passes `maxiter/ftol/gtol/maxcor/maxls`, and scipy does not reject options a method does
not know: it warns and drops them, silently disabling the stopping rule the caller asked for. Measured on
saturn with the imager's own optdict:

    L-BFGS-B   accepts all
    BFGS       drops ftol, maxcor, maxls
    CG         drops ftol, maxcor, maxls
    Newton-CG  drops ftol, gtol, maxcor, maxls    <- no tolerance left at all
    TNC        drops maxiter, maxcor, maxls       <- runs uncapped
    SLSQP      drops gtol, maxcor, maxls

So each method is handed only the keys it reads, with two renames: TNC caps evaluations (`maxfun`) rather
than iterations, and Newton-CG's only tolerance is `xtol`. The table is hand-written because scipy's
per-method option lists are private, and it is covered by a test that drives real scipy for every method
and fails if the table goes stale.

Measured, same 32x32 problem, N=1024, each method with its own accepted options, maxiter=100:

    method        secs   nit   njev      |g|inf
    L-BFGS-B       1.6   100    109    1.82e+00
    BFGS           1.4   100    108    1.09e+00
    CG             0.1   100    180    3.74e+00
    Newton-CG     18.5    64  42735    3.01e-02
    TNC            0.1    18      -    5.96e+00
    SLSQP         12.7   100    101    8.59e-01

L-BFGS-B stays the default. BFGS is a useful cross-check at small N but stores a dense N x N inverse
Hessian: 2.0 GiB at a 128x128 image for the matrix alone, and scipy holds several matrices that size at
once, so measured peak is nearer 8 GiB. It warns above 1 GiB and names `lbfgs` as the alternative.
Newton-CG gets the best gradient norm here, at 42735 jacobian evaluations.

Numbers above are from `scripts` run on saturn against the same 32x32 Gaussian the tests use; the exact
objective values depend on the regularizer weights, so treat the ordering rather than the digits as the
result.

## Registry instead of a branch chain

`run_optimizer` was an `if kind == "scipy" / elif "callable" / else optax` chain, which is the shape this
codebase replaced elsewhere with dispatch tables (`_CHISQDATA_DISPATCH`, `_CHISQ_DISPATCH`,
`_REGULARIZER_DISPATCH`). Adding an optimizer meant editing two functions, and nothing outside the module
could add one at all. Nine new scipy aliases would have made that chain worse.

There is now one class per way of driving the objective (`ScipyBackend`, `OptaxBackend`,
`CallableBackend`, all `OptimizerBackend`) and a name to backend registry. The nine scipy names are nine
registrations of one class rather than a parallel alias table, `classify_optimizer` is a lookup, and
`run_optimizer` is `resolve_backend(optimizer).run(...)`.

`register_optimizer(name, backend)` is the payoff: a caller adds an optimizer without touching this
module, which is what the Bayesian work will want for blackjax.

Nothing about the public API changed. `classify_optimizer`, `run_optimizer` and `resolve_optax` keep their
signatures, so `imager.py` and `survey_gpu.py` are untouched, and all three existing ways of passing an
optimizer still work: a built-in name, an `optax.GradientTransformation`, or a user callable.

Also here, one line: `resolve_optax` raised a bare `KeyError` on an unknown name, which is reachable
through `run_survey_gpu(..., optimizer=...)`. It now raises `ValueError` naming the valid ones.

## Tests

41 new tests in `tests/test_optimizers_jax.py`.

Reverting the implementation five ways:

    no option filtering, pass optdict through   11 failed
    drop the TNC maxfun rename                   1 failed
    drop the Newton-CG xtol rename               1 failed
    hardwire L-BFGS-B, ignore the request        5 failed
    drop the BFGS memory guard                   1 failed
    corrupt any one _METHOD_OPTS entry           1 failed each (all six)
    resolve_backend or register_optimizer
        stops lowercasing                        4 / 1 failed
    ScipyBackend drops the callback              1 failed
    OptaxBackend ignores its own spec            6 failed

The fourth is the one worth having. Every method reduces the objective, so "it converged" cannot tell them
apart: an earlier version of these tests passed 34/34 against a dispatcher that ignored the requested
method entirely. It is now pinned by watching the `method=` argument scipy actually receives, for all nine
aliases.

Three things came out of an external review and are worth calling out. The memory guard used
`ResourceWarning`, which Python ignores by default, so nobody would ever have seen it: it is a
`UserWarning` now. The option table was pinned in one direction only, so four of the six entries could be
corrupted with zero test failures; there is now a test that drives real scipy to confirm every *omitted*
key really is one that method rejects. And the whole file carried a module-level `pytest.mark.jax` while
CI runs `-m "not jax"`, so all of this shipped with no CI coverage at all: the mark now sits on the tests
that genuinely reach jax, and 60 of 71 run in CI.

`83d8d07` is the registry refactor; the rest of the branch is the feature, if it helps to read them
separately.

## How to test

    pytest tests/test_optimizers_jax.py

Full suite on a compute node, `-m "not gpu"`: **1971 passed, 1 skipped, 1 xfailed**, no failures. That is
the 1908-test baseline plus the 63 added here.
