### PR TITLE
Avoid copying the Fourier operator on every gradient evaluation

### DIFF
--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -30,9 +30,10 @@ from ehtim.observing.pulses import trianglePulse2D
 # here shows up as ehtim.<name> automatically via the star import in __init__.py.
 __all__ = [
     "BHIMAGE", "BOUNDS_ERROR", "C", "COLORLIST", "DEC_DEFAULT", "DEC_M87",
-    "DEC_SGRA", "DEGREE", "DTAMP", "DTARR", "DTBIS", "DTCAL", "DTCAMP",
-    "DTCPHASE", "DTCPHASEDIAG", "DTERMPDEF", "DTLOGCAMPDIAG", "DTPOL_CIRC",
-    "DTPOL_STOKES", "DTSCANS", "EHTIMAGE", "ELEV_HIGH", "ELEV_LOW", "EP",
+    "DEC_SGRA", "DEGREE", "DIRECT_MATRIX_WARN_GB", "DTAMP", "DTARR", "DTBIS",
+    "DTCAL", "DTCAMP", "DTCPHASE", "DTCPHASEDIAG", "DTERMPDEF",
+    "DTLOGCAMPDIAG", "DTPOL_CIRC", "DTPOL_STOKES", "DTSCANS", "EHTIMAGE",
+    "ELEV_HIGH", "ELEV_LOW", "EP",
     "FFT_INTERP_DEFAULT", "FFT_PAD_DEFAULT", "FIELD_LABELS", "FIELDS",
     "FIELDS_AMPS", "FIELDS_PHASE", "FIELDS_SIGPHASE", "FIELDS_SIGS",
     "FIELDS_SNRS", "FWHM_MAJ", "FWHM_MIN", "GAINPDEF",
@@ -95,6 +96,16 @@ FFT_INTERP_DEFAULT = 3
 # imaging (ALMA polarimetry, SKA-class arrays). Tighten to 1e-12 for ~1e6
 # dynamic range; relax to 1e-6 for fast low-SNR work.
 NFFT_EPS_DEFAULT = 1e-9
+
+# Total dense DFT operator per data term, in GB, above which the direct
+# transform warns. Sized as nvis x npix x 16 bytes and summed over the matrices
+# a term holds (one for vis/amp, three for closure phase, four for closure
+# amplitude): fine at EHT sizes, ~10 GB for one term at 128x128, and hopeless at
+# ALMA channel counts. Frequency-sharded runs force ttype 'direct', so without a
+# warning an oversized run is just an OOM kill. Assign to
+# ehtim.const_def.DIRECT_MATRIX_WARN_GB to change it; the ehtim.* name is a
+# separate binding made by the star import and setting it has no effect.
+DIRECT_MATRIX_WARN_GB = 1.0
 
 # Valid two-character feed_type strings for a single station (lowercase).
 VALID_FEED_TYPES = frozenset({

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -7,10 +7,12 @@ from typing import NamedTuple
 
 import numpy as np
 
+import ehtim.const_def as ehc
 import ehtim.imaging.imager_utils as imutils
 import ehtim.imaging.multifreq_imager_utils as mfutils
 import ehtim.imaging.pol_imager_utils as polutils
 import ehtim.observing.obs_helpers as obsh
+import ehtim.warnings as ehw
 from ehtim.backends import array_namespace
 
 # -----------------------------------------------------------------------------
@@ -1070,8 +1072,42 @@ def compute_chisqdata_term(obs, prior, mask, dtype, config, **kwargs):
     # Only `direct` leaves take mask positionally; fast/nfft leaves index uv
     # coords from obs directly and ignore the embed mask.
     if ttype == 'direct':
-        return helper(obs, prior, mask, pol=pol, **kwargs)
+        out = helper(obs, prior, mask, pol=pol, **kwargs)
+        _warn_if_operator_oversized(out[2], dtype)
+        return out
     return helper(obs, prior, pol=pol, **kwargs)
+
+
+def _warn_if_operator_oversized(A, dtype):
+    """Warn once if a direct data term's dense operators exceed the threshold.
+
+    Checked here rather than in ``ftmatrix`` because the threshold is on the
+    total a term holds: closure phase builds three operators and closure
+    amplitude four, and it is the sum that runs a machine out of memory. This
+    is also the one place every direct data term passes through, so an
+    oversized run gets one warning per term instead of one per matrix.
+
+    Parameters
+    ----------
+    A : np.ndarray or tuple of np.ndarray
+        Operator(s) the data term just built.
+    dtype : str
+        Data term name, used in the message.
+    """
+
+    mats = A if isinstance(A, tuple) else (A,)
+    nbytes = sum(m.nbytes for m in mats if hasattr(m, 'nbytes'))
+    if nbytes <= ehc.DIRECT_MATRIX_WARN_GB*1e9:
+        return
+
+    count = f"{len(mats)} operators" if len(mats) > 1 else "1 operator"
+    warnings.warn(
+        f"data term {dtype!r} allocated {nbytes/1e9:.2f} GB of dense DFT "
+        f"operator ({count}) on the direct transform, and every other data "
+        f"term holds its own. Use ttype='nfft' for the same visibilities "
+        f"without the dense operator, or raise "
+        f"ehtim.const_def.DIRECT_MATRIX_WARN_GB.",
+        ehw.DirectMatrixSizeWarning, stacklevel=3)
 
 
 def _pol_solve_block(which_solve, pol):

--- a/ehtim/imaging/imager_utils.py
+++ b/ehtim/imaging/imager_utils.py
@@ -26,7 +26,7 @@ import scipy.sparse as sps
 import ehtim.const_def as ehc
 import ehtim.observing.obs_helpers as obsh
 from ehtim.backends import array_namespace
-from ehtim.observing.obs_helpers import nufft2_backend
+from ehtim.observing.obs_helpers import adjoint_dot, nufft2_backend
 
 ##################################################################################################
 # Constants & Definitions
@@ -144,7 +144,7 @@ def chisqgrad_vis(imvec, Amatrix, vis, sigma):
     samples = np.dot(Amatrix, imvec)
     wdiff = (vis - samples)/(sigma**2)
 
-    out = -np.real(np.dot(Amatrix.conj().T, wdiff))/len(vis)
+    out = -np.real(adjoint_dot(Amatrix, wdiff))/len(vis)
     return out
 
 

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -29,7 +29,13 @@ except ImportError:
     _HAS_NFFT = False
 
 from ehtim.const_def import FFT_PAD_DEFAULT, GRIDDER_P_RAD_DEFAULT, NFFT_EPS_DEFAULT, RADPERAS
-from ehtim.observing.obs_helpers import NFFTInfo, ftmatrix, nufft2_backend, ticks
+from ehtim.observing.obs_helpers import (
+    NFFTInfo,
+    adjoint_dot,
+    ftmatrix,
+    nufft2_backend,
+    ticks,
+)
 
 TANWIDTH_M = 0.5
 TANWIDTH_V = 1
@@ -494,23 +500,26 @@ def chisqgrad_p(imarr, Amatrix, p, sigmap,pol_solve=POL_SOLVE_DEFAULT):
     psamples = np.dot(Amatrix, pimage)
     pdiff = (p - psamples) / (sigmap**2)
 
+    # every slot applies the same adjoint product, so build it once
+    adj_pdiff = adjoint_dot(Amatrix, pdiff)
+
     # dchi2/dI
     if pol_solve[0]!=0:
-        gradi = -np.real(mimage * np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, pdiff)) / len(p)
+        gradi = -np.real(mimage * np.exp(-2j*chiimage) * adj_pdiff) / len(p)
         gradout[0] = gradi
     # dchi2/drho
     if pol_solve[1]!=0:
-        gradm = -np.real(iimage * np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, pdiff)) / len(p)
+        gradm = -np.real(iimage * np.exp(-2j*chiimage) * adj_pdiff) / len(p)
         gradrho = gradm * np.cos(psiimage)
         gradout[1] = gradrho
     # dchi2/dphi
     if pol_solve[2]!=0:
-        gradchi = -2 * np.imag(pimage.conj() * np.dot(Amatrix.conj().T, pdiff)) / len(p)
+        gradchi = -2 * np.imag(pimage.conj() * adj_pdiff) / len(p)
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
     # dchi2/dpsi
     if pol_solve[3]!=0:
-        gradm = -np.real(iimage * np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, pdiff)) / len(p)
+        gradm = -np.real(iimage * np.exp(-2j*chiimage) * adj_pdiff) / len(p)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
         gradout[3] = gradpsi
 
@@ -546,24 +555,27 @@ def chisqgrad_m(imarr, Amatrix, m, sigmam,pol_solve=POL_SOLVE_DEFAULT):
     msamples = psamples/isamples
     mdiff = (m - msamples) / (isamples.conj() * sigmam**2)
 
+    # every slot applies the same adjoint product, so build it once
+    adj_mdiff = adjoint_dot(Amatrix, mdiff)
+
     # dchi2/dI
     if pol_solve[0]!=0:
-        gradi = (-np.real(mimage * np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, mdiff)) / len(m) +
-                  np.real(np.dot(Amatrix.conj().T, msamples.conj() * mdiff)) / len(m))
+        gradi = (-np.real(mimage * np.exp(-2j*chiimage) * adj_mdiff) / len(m) +
+                  np.real(adjoint_dot(Amatrix, msamples.conj() * mdiff)) / len(m))
         gradout[0] = gradi
     # dchi2/drho
     if pol_solve[1]!=0:
-        gradm = -np.real(iimage*np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, mdiff)) / len(m)
+        gradm = -np.real(iimage*np.exp(-2j*chiimage) * adj_mdiff) / len(m)
         gradrho = gradm * np.cos(psiimage)
         gradout[1] = gradrho
     # dchi2/dphi
     if pol_solve[2]!=0:
-        gradchi = -2 * np.imag(pimage.conj() * np.dot(Amatrix.conj().T, mdiff)) / len(m)
+        gradchi = -2 * np.imag(pimage.conj() * adj_mdiff) / len(m)
         gradphi = 0.5*gradchi
         gradout[2] = gradphi
     # dchi2/dpsi
     if pol_solve[3]!=0:
-        gradm = -np.real(iimage*np.exp(-2j*chiimage) * np.dot(Amatrix.conj().T, mdiff)) / len(m)
+        gradm = -np.real(iimage*np.exp(-2j*chiimage) * adj_mdiff) / len(m)
         gradpsi = gradm * (-mimage*np.tan(psiimage))
         gradout[3] = gradpsi
 
@@ -597,18 +609,21 @@ def chisqgrad_vvis(imarr, Amatrix, v, sigmav, pol_solve=POL_SOLVE_DEFAULT_V):
     vsamples = np.dot(Amatrix, vimage)
     vdiff = (v - vsamples) / (sigmav**2)
 
+    # every slot applies the same adjoint product, so build it once
+    adj_vdiff = adjoint_dot(Amatrix, vdiff)
+
     # dchi2/dI
     if pol_solve[0]!=0:
-        gradi = -np.real(vfimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
+        gradi = -np.real(vfimage * adj_vdiff) / len(v)
         gradout[0] = gradi
     # dchi2/drho
     if pol_solve[1]!=0:
-        gradv = -np.real(iimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
+        gradv = -np.real(iimage * adj_vdiff) / len(v)
         gradrho = gradv*np.sin(psiimage)
         gradout[1] = gradrho
     # dchi2/dpsi
     if pol_solve[3]!=0:
-        gradv = -np.real(iimage * np.dot(Amatrix.conj().T, vdiff)) / len(v)
+        gradv = -np.real(iimage * adj_vdiff) / len(v)
         gradpsi = gradv * (vfimage/np.tan(psiimage))
         gradout[3] = gradpsi
 

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -1395,6 +1395,33 @@ def image_centroid(im):
     return np.array([x0, y0])
 
 
+def adjoint_dot(Amatrix, vec):
+    """Apply the adjoint of a DFT operator without copying the operator.
+
+    Reach for this instead of ``np.dot(Amatrix.conj().T, vec)`` wherever a
+    gradient applies the conjugate transpose of a dense Fourier operator.
+    ``Amatrix.conj()`` materializes a full (nvis, npix) copy of the operator and
+    only the following ``.T`` is free, so on a direct-transform run the copy
+    dominates the memory of the gradient. Conjugating the (nvis,) input and the
+    (npix,) output is the same arithmetic on vectors orders of magnitude
+    smaller, and returns bit-identical values.
+
+    Parameters
+    ----------
+    Amatrix : np.ndarray
+        Complex (nvis, npix) DFT operator.
+    vec : np.ndarray
+        Complex (nvis,) vector to apply the adjoint operator to.
+
+    Returns
+    -------
+    np.ndarray
+        Complex (npix,) result, equal to ``np.dot(Amatrix.conj().T, vec)``.
+    """
+
+    return np.dot(vec.conj(), Amatrix).conj()
+
+
 def ftmatrix(pdim, xdim, ydim, uvlist, pulse=ehc.PULSE_DEFAULT, mask=[]):
     """Return a DFT matrix for the xdim*ydim image with pixel width pdim
        that extracts spatial frequencies of the uv points in uvlist.

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -1442,15 +1442,21 @@ def ftmatrix(pdim, xdim, ydim, uvlist, pulse=ehc.PULSE_DEFAULT, mask=[]):
     # and then copying with np.array() holds two full operators at once, and
     # when a mask is given it builds the whole unmasked stack only to slice most
     # of it away.
+    #
+    # The memory order deliberately matches what the old code happened to
+    # produce: C from the unmasked reshape, F from the masked column indexing.
+    # np.dot dispatches on layout, so preserving it keeps direct-path
+    # chi-squared and gradients byte-for-byte unchanged.
+    uvlist = np.asarray(uvlist)
     npix = xdim*ydim
     if len(mask):
         cols = np.arange(npix)[mask]
-        ncol = len(cols)
+        ncol, order = len(cols), 'F'
     else:
         cols = slice(None)
-        ncol = npix
+        ncol, order = npix, 'C'
 
-    ftmatrices = np.empty((len(uvlist), ncol), dtype=np.complex128)
+    ftmatrices = np.empty((len(uvlist), ncol), dtype=np.complex128, order=order)
     for k, uv in enumerate(uvlist):
         row = (pulse(2*np.pi*uv[0], 2*np.pi*uv[1], pdim, dom="F") *
                np.outer(np.exp(2j*np.pi*ylist*uv[1]), np.exp(2j*np.pi*xlist*uv[0])))

--- a/ehtim/observing/obs_helpers.py
+++ b/ehtim/observing/obs_helpers.py
@@ -1437,13 +1437,24 @@ def ftmatrix(pdim, xdim, ydim, uvlist, pulse=ehc.PULSE_DEFAULT, mask=[]):
 
     # changed the sign convention to agree with BU data (Jan 2017)
     # this is correct for a u,v definition from site 1-2 as (x1-x2)/lambda
-    ftmatrices = [pulse(2*np.pi*uv[0], 2*np.pi*uv[1], pdim, dom="F") *
-                  np.outer(np.exp(2j*np.pi*ylist*uv[1]), np.exp(2j*np.pi*xlist*uv[0]))
-                  for uv in uvlist]
-    ftmatrices = np.reshape(np.array(ftmatrices), (len(uvlist), xdim*ydim))
-
+    #
+    # Rows are written straight into the final array. Collecting them in a list
+    # and then copying with np.array() holds two full operators at once, and
+    # when a mask is given it builds the whole unmasked stack only to slice most
+    # of it away.
+    npix = xdim*ydim
     if len(mask):
-        ftmatrices = ftmatrices[:, mask]
+        cols = np.arange(npix)[mask]
+        ncol = len(cols)
+    else:
+        cols = slice(None)
+        ncol = npix
+
+    ftmatrices = np.empty((len(uvlist), ncol), dtype=np.complex128)
+    for k, uv in enumerate(uvlist):
+        row = (pulse(2*np.pi*uv[0], 2*np.pi*uv[1], pdim, dom="F") *
+               np.outer(np.exp(2j*np.pi*ylist*uv[1]), np.exp(2j*np.pi*xlist*uv[0])))
+        ftmatrices[k] = row.reshape(npix)[cols]
 
     return ftmatrices
 

--- a/ehtim/warnings.py
+++ b/ehtim/warnings.py
@@ -38,6 +38,27 @@ class MixedPolClosureSkipWarning(UserWarning):
     """
 
 
+class DirectMatrixSizeWarning(UserWarning):
+    """Emitted when a direct-transform data term allocates more dense DFT
+    operator than ``ehtim.const_def.DIRECT_MATRIX_WARN_GB``.
+
+    The threshold is on the total for the term, not on a single matrix: a
+    closure term holds three or four (nvis, npix) operators at once, so the
+    aggregate is what runs a machine out of memory. The warning reports that
+    total and points at ``ttype='nfft'``, which computes the same visibilities
+    without the dense operator.
+
+    Raise the threshold by assigning to ``ehtim.const_def.DIRECT_MATRIX_WARN_GB``.
+    Note that ``ehtim.DIRECT_MATRIX_WARN_GB`` is a separate binding created by
+    the star import in ``ehtim/__init__.py``; setting that one has no effect.
+    Or silence the category outright:
+
+        warnings.filterwarnings(
+            'ignore', category=ehtim.warnings.DirectMatrixSizeWarning
+        )
+    """
+
+
 class MixedPolUnpackNaNWarning(UserWarning):
     """Emitted when ``Obsdata.unpack`` of a physical correlation (e.g. 'rrvis')
     on a mixed-feed observation returns NaN for rows whose feed basis does not

--- a/tests/test_chisquared.py
+++ b/tests/test_chisquared.py
@@ -7,6 +7,8 @@ tight direct-vs-nfft gradient bound pins nfft gradient correctness. All tests us
 image so xdim != ydim exercises the rectangular-image code paths (rect subsumes square).
 """
 
+import tracemalloc
+
 import numpy as np
 import pytest
 
@@ -17,7 +19,8 @@ from ehtim.imaging.imager_backend import (
     compute_chisq_term,
     compute_chisqdata_term,
 )
-from ehtim.imaging.imager_utils import chisq, chisqdata, chisqgrad
+from ehtim.imaging.imager_utils import chisq, chisqdata, chisqgrad, chisqgrad_vis
+from ehtim.imaging.pol_imager_utils import chisqgrad_m, chisqgrad_p, chisqgrad_vvis
 
 # Observation parameters (must match conftest.py)
 TINT_SEC = 5
@@ -274,3 +277,94 @@ class TestPolChisqConsistency:
             vals[tt] = compute_chisq_term(imcur, dtype, A, data, sigma, ttype=tt, mask=mask)
         frac = abs((vals["direct"] - vals["nfft"]) / abs(vals["direct"]))
         assert frac < POL_CHISQ_FRAC_TOL, f"{dtype}: chisq frac diff = {frac:.6f}"
+
+
+# ---------------------------------------------------------------------------
+# Operator memory: the direct-transform gradients must not copy the operator
+#
+# `Amatrix.conj()` materializes a full (nvis, npix) copy of the Fourier operator;
+# only the subsequent `.T` is free. Every gradient below needs nothing more than
+# `Amatrix.conj().T @ vec`, which is the same arithmetic as conjugating the
+# (nvis,) input and the (npix,) output, both orders of magnitude smaller. These
+# tests bound the peak allocation of each gradient well under the operator.
+# ---------------------------------------------------------------------------
+
+OP_NVIS = 1200
+OP_NPIX = 2048
+
+# Measured on saturn before the fix: peak is 1.00x the operator for every
+# gradient here. After it, peak is a handful of (nvis,) and (npix,) vectors,
+# under 1% of the operator. A quarter of the operator sits clearly between the
+# two and leaves room for BLAS scratch.
+OP_PEAK_FRACTION = 0.25
+
+
+def _peak_mib(fn):
+    """Peak traced allocation in MiB during fn(). NumPy registers its own
+    tracemalloc domain, so array allocations are counted."""
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    fn()
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return peak / 2**20
+
+
+@pytest.fixture(scope="module")
+def operator_setup():
+    """A dense complex operator plus matching Stokes-I and polarimetric inputs.
+
+    Synthetic rather than observation-derived: these tests measure allocation
+    against a known operator size, so the operator has to be sized here.
+    """
+    rng = np.random.default_rng(0)
+    A = (rng.standard_normal((OP_NVIS, OP_NPIX))
+         + 1j * rng.standard_normal((OP_NVIS, OP_NPIX)))
+    data = rng.standard_normal(OP_NVIS) + 1j * rng.standard_normal(OP_NVIS)
+    sigma = np.abs(rng.standard_normal(OP_NVIS)) + 0.1
+    imvec = np.abs(rng.standard_normal(OP_NPIX)) + 0.1
+    imarr = np.vstack([imvec,
+                       0.3 * np.ones(OP_NPIX),      # rho
+                       0.4 * np.ones(OP_NPIX),      # phi
+                       0.2 * np.ones(OP_NPIX)])     # psi
+    return {"A": A, "data": data, "sigma": sigma, "imvec": imvec, "imarr": imarr,
+            "op_mib": A.nbytes / 2**20}
+
+
+# (label, callable taking the setup dict) for every gradient that applies the
+# adjoint operator on the direct path.
+GRAD_CASES = [
+    ("chisqgrad_vis",
+     lambda s: chisqgrad_vis(s["imvec"], s["A"], s["data"], s["sigma"])),
+    ("chisqgrad_p",
+     lambda s: chisqgrad_p(s["imarr"], s["A"], s["data"], s["sigma"],
+                           pol_solve=(1, 1, 1, 1))),
+    ("chisqgrad_m",
+     lambda s: chisqgrad_m(s["imarr"], s["A"], s["data"], s["sigma"],
+                          pol_solve=(1, 1, 1, 1))),
+    ("chisqgrad_vvis",
+     lambda s: chisqgrad_vvis(s["imarr"], s["A"], s["data"], s["sigma"],
+                              pol_solve=(1, 1, 0, 1))),
+]
+
+
+class TestGradientOperatorNotCopied:
+    """Peak allocation during a direct-path gradient stays well under the operator."""
+
+    def test_tracemalloc_sees_numpy_allocations(self, operator_setup):
+        # Guard. If tracemalloc did not count numpy arrays every bound below
+        # would pass while the copies were still happening. Conjugating the
+        # operator outright must register as roughly its own size.
+        A, op_mib = operator_setup["A"], operator_setup["op_mib"]
+        peak = _peak_mib(lambda: A.conj())
+        assert peak > 0.9 * op_mib, (
+            f"tracemalloc reported {peak:.2f} MiB for an explicit copy of a "
+            f"{op_mib:.2f} MiB operator; the bounds below would be vacuous")
+
+    @pytest.mark.parametrize("label,call", GRAD_CASES, ids=[c[0] for c in GRAD_CASES])
+    def test_peak_allocation_well_under_operator(self, operator_setup, label, call):
+        op_mib = operator_setup["op_mib"]
+        peak = _peak_mib(lambda: call(operator_setup))
+        assert peak < OP_PEAK_FRACTION * op_mib, (
+            f"{label} peaked at {peak:.2f} MiB against a {op_mib:.2f} MiB "
+            f"operator ({peak/op_mib:.2f}x); it is copying the operator")

--- a/tests/test_chisquared.py
+++ b/tests/test_chisquared.py
@@ -294,19 +294,27 @@ OP_NPIX = 2048
 
 # Measured on saturn before the fix: peak is 1.00x the operator for every
 # gradient here. After it, peak is a handful of (nvis,) and (npix,) vectors,
-# under 1% of the operator. A quarter of the operator sits clearly between the
-# two and leaves room for BLAS scratch.
+# at most 1.1% of the operator. A quarter of the operator sits clearly between
+# the two and leaves room for BLAS scratch.
 OP_PEAK_FRACTION = 0.25
 
 
 def _peak_mib(fn):
-    """Peak traced allocation in MiB during fn(). NumPy registers its own
-    tracemalloc domain, so array allocations are counted."""
+    """Peak traced allocation in MiB during fn().
+
+    NumPy registers its own tracemalloc domain, so array allocations are
+    counted. fn() runs once first because the polarimetric gradients lazily
+    import jax on their first call, which puts ~26 MiB inside the measurement
+    window and makes the result about import cost rather than the operator.
+    """
+    fn()
+    was_tracing = tracemalloc.is_tracing()
     tracemalloc.start()
     tracemalloc.reset_peak()
     fn()
     _, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
+    if not was_tracing:
+        tracemalloc.stop()
     return peak / 2**20
 
 

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -4,11 +4,14 @@ Each test verifies that a backend function produces identical output
 to the corresponding Imager class method.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
 import ehtim as eh
 import ehtim.const_def as ehc
+import ehtim.warnings as ehw
 from ehtim.imaging.imager_backend import (
     DataWeighting,
     FourierGridParams,
@@ -3787,3 +3790,104 @@ class TestComputeRegularizerTerm:
         with pytest.raises(Exception, match="not recognized"):
             compute_regularizer_term(imvec, 'not_a_regularizer', mask)
 
+
+
+# ---------------------------------------------------------------------------
+# Direct-transform operator size guard
+#
+# The direct path holds a dense (nvis, npix) complex operator per data term,
+# and closure terms hold three or four at once. The threshold is on that
+# per-term total, checked in compute_chisqdata_term because it is the single
+# place every direct term passes through and the only one that sees the whole
+# set. Nothing warned before, so an oversized run was just an OOM kill.
+# ---------------------------------------------------------------------------
+
+
+def _direct_config(make_test_config):
+    return make_test_config(pol="I", mf=False)._replace(ttype="direct")
+
+
+def _chisqdata_warnings(obs, prior, dtype, config):
+    """Collect size warnings raised while building one direct data term.
+
+    catch_warnings(record=True) with "always" rather than simplefilter("error"):
+    a raising filter is subject to Python's per-location dedup, so it fires only
+    for whichever call reaches a given line first.
+    """
+    mask = np.ones(prior.xdim * prior.ydim, dtype=bool)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        out = compute_chisqdata_term(obs, prior, mask, dtype, config)
+    return [w for w in rec
+            if issubclass(w.category, ehw.DirectMatrixSizeWarning)], out
+
+
+class TestDirectMatrixSizeWarning:
+    """The guard fires on the per-term total, once, and only on direct."""
+
+    def test_silent_at_the_shipped_default(self, obs_direct, gauss_prior,
+                                           make_test_config):
+        # An ordinary EHT-scale run must not warn at the untouched default,
+        # or the guard is noise. This pins the default in one direction.
+        got, _ = _chisqdata_warnings(obs_direct, gauss_prior, "vis",
+                                     _direct_config(make_test_config))
+        assert got == []
+
+    def test_warns_when_the_term_total_exceeds_the_threshold(
+            self, obs_direct, gauss_prior, make_test_config, monkeypatch):
+        # Threshold set just under what this term actually allocates.
+        cfg = _direct_config(make_test_config)
+        _, out = _chisqdata_warnings(obs_direct, gauss_prior, "vis", cfg)
+        nbytes = out[2].nbytes
+        monkeypatch.setattr(ehc, "DIRECT_MATRIX_WARN_GB", 0.5 * nbytes / 1e9)
+        got, _ = _chisqdata_warnings(obs_direct, gauss_prior, "vis", cfg)
+        assert len(got) == 1
+        assert f"{nbytes/1e9:.2f} GB" in str(got[0].message)
+        assert "nfft" in str(got[0].message)
+
+    def test_threshold_is_the_term_total_not_a_single_matrix(
+            self, obs_direct, gauss_prior, make_test_config, monkeypatch):
+        # cphase holds three operators. A threshold between one matrix and the
+        # sum must warn: checking matrices individually would stay silent, which
+        # is exactly how the first version of this guard missed real runs.
+        cfg = _direct_config(make_test_config)
+        _, out = _chisqdata_warnings(obs_direct, gauss_prior, "cphase", cfg)
+        mats = out[2]
+        assert len(mats) == 3, "cphase should build three operators"
+        one, total = mats[0].nbytes, sum(m.nbytes for m in mats)
+        assert one < total
+        monkeypatch.setattr(ehc, "DIRECT_MATRIX_WARN_GB",
+                            0.5 * (one + total) / 1e9)
+        got, _ = _chisqdata_warnings(obs_direct, gauss_prior, "cphase", cfg)
+        assert len(got) == 1, "guard is measuring a single matrix, not the term"
+
+    def test_warns_once_per_term_not_once_per_matrix(
+            self, obs_direct, gauss_prior, make_test_config, monkeypatch):
+        monkeypatch.setattr(ehc, "DIRECT_MATRIX_WARN_GB", 1e-9)
+        for dtype in ("vis", "cphase", "logcamp"):
+            got, _ = _chisqdata_warnings(obs_direct, gauss_prior, dtype,
+                                         _direct_config(make_test_config))
+            assert len(got) == 1, f"{dtype} raised {len(got)} warnings"
+
+    @pytest.mark.parametrize("ttype", ["fast", "nfft"])
+    def test_silent_on_the_gridded_transforms(self, obs_direct, gauss_prior,
+                                              make_test_config, monkeypatch,
+                                              ttype):
+        # fast/nfft never build the dense operator, so the guard must not fire
+        # there however low the threshold goes.
+        monkeypatch.setattr(ehc, "DIRECT_MATRIX_WARN_GB", 1e-12)
+        cfg = make_test_config(pol="I", mf=False)._replace(ttype=ttype)
+        got, _ = _chisqdata_warnings(obs_direct, gauss_prior, "vis", cfg)
+        assert got == []
+
+    def test_documented_knob_actually_changes_the_threshold(
+            self, obs_direct, gauss_prior, make_test_config, monkeypatch):
+        # The docstring points at ehtim.const_def.DIRECT_MATRIX_WARN_GB, not
+        # ehtim.DIRECT_MATRIX_WARN_GB: the star import in ehtim/__init__.py
+        # makes the latter a separate binding that the guard never reads.
+        # Setting the documented name must silence a warning that fires.
+        cfg = _direct_config(make_test_config)
+        monkeypatch.setattr(ehc, "DIRECT_MATRIX_WARN_GB", 1e-9)
+        assert len(_chisqdata_warnings(obs_direct, gauss_prior, "vis", cfg)[0]) == 1
+        monkeypatch.setattr(ehc, "DIRECT_MATRIX_WARN_GB", 1e6)
+        assert _chisqdata_warnings(obs_direct, gauss_prior, "vis", cfg)[0] == []

--- a/tests/test_imager_backend.py
+++ b/tests/test_imager_backend.py
@@ -20,6 +20,7 @@ from ehtim.imaging.imager_backend import (
     MfConfig,
     RegParams,
     _pol_solve_block,
+    _warn_if_operator_oversized,
     compute_chisq_dict,
     compute_chisq_term,
     compute_chisqdata_term,
@@ -3832,6 +3833,27 @@ class TestDirectMatrixSizeWarning:
         got, _ = _chisqdata_warnings(obs_direct, gauss_prior, "vis",
                                      _direct_config(make_test_config))
         assert got == []
+
+    def test_default_threshold_sits_between_half_a_gigabyte_and_two(self):
+        # Pins the shipped default in BOTH directions. The sizes are absolute
+        # and deliberately NOT derived from DIRECT_MATRIX_WARN_GB, or the test
+        # moves with the constant and pins nothing. A term at 0.5 GB is an
+        # ordinary EHT-scale run and must stay quiet; 2 GB is heading for an
+        # OOM and must not. No gigabyte is allocated: the guard reads .nbytes.
+        class _Stub:
+            def __init__(self, nbytes):
+                self.nbytes = nbytes
+
+        for total_gb, expected in [(0.5, 0), (2.0, 1)]:
+            half = int(total_gb * 1e9 / 2)
+            with warnings.catch_warnings(record=True) as rec:
+                warnings.simplefilter("always")
+                _warn_if_operator_oversized((_Stub(half), _Stub(half)), "cphase")
+            got = [w for w in rec
+                   if issubclass(w.category, ehw.DirectMatrixSizeWarning)]
+            assert len(got) == expected, (
+                f"{total_gb} GB term raised {len(got)} warnings at the default "
+                f"threshold of {ehc.DIRECT_MATRIX_WARN_GB} GB")
 
     def test_warns_when_the_term_total_exceeds_the_threshold(
             self, obs_direct, gauss_prior, make_test_config, monkeypatch):

--- a/tests/test_obs_helpers.py
+++ b/tests/test_obs_helpers.py
@@ -8,6 +8,7 @@ import zlib
 import numpy as np
 import pytest
 
+import ehtim.const_def as ehc
 from ehtim.observing import obs_helpers as obsh
 
 # ---------------------------------------------------------------------------
@@ -117,3 +118,85 @@ def test_adjoint_dot_does_not_copy_the_operator():
     assert peak < ADJ_PEAK_FRACTION * op_mib, (
         f"adjoint_dot peaked at {peak:.2f} MiB against a {op_mib:.2f} MiB "
         f"operator ({peak/op_mib:.2f}x)")
+
+
+# ---------------------------------------------------------------------------
+# ftmatrix build cost
+#
+# The operator was assembled as a Python list of nvis separate (ydim, xdim)
+# arrays and then copied into one contiguous block by np.array() while the list
+# was still alive, so building it peaked at twice the array it returns. With a
+# mask it was worse: the full unmasked stack was built and then sliced down.
+# ---------------------------------------------------------------------------
+
+# Post-fix the peak is the returned array plus a single (npix,) row; pre-fix it
+# is 2.00x measured. 1.35x separates them with room for the row and scratch.
+FT_PEAK_FRACTION = 1.35
+
+
+def _ftmatrix_reference(pdim, xdim, ydim, uvlist, pulse=ehc.PULSE_DEFAULT, mask=[]):
+    """The list-then-copy implementation, kept here as the value reference.
+
+    Spelled out rather than imported so the test pins the actual arithmetic
+    (sign convention, outer-product axis order, row ordering) and not just
+    whatever ftmatrix currently happens to do.
+    """
+    xlist = np.arange(0, -xdim, -1)*pdim + (pdim*xdim)/2.0 - pdim/2.0
+    ylist = np.arange(0, -ydim, -1)*pdim + (pdim*ydim)/2.0 - pdim/2.0
+    mats = [pulse(2*np.pi*uv[0], 2*np.pi*uv[1], pdim, dom="F") *
+            np.outer(np.exp(2j*np.pi*ylist*uv[1]), np.exp(2j*np.pi*xlist*uv[0]))
+            for uv in uvlist]
+    out = np.reshape(np.array(mats), (len(uvlist), xdim*ydim))
+    if len(mask):
+        out = out[:, mask]
+    return out
+
+
+def _uvlist(nvis, seed=3):
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal((nvis, 2)) * 1e9
+
+
+# xdim != ydim throughout: a square grid hides axis-order mistakes.
+FT_XDIM, FT_YDIM = 16, 24
+FT_PSIZE = 200 * 4.848136811133344e-12 / FT_XDIM   # 200 uas FOV in radians
+
+
+def test_ftmatrix_matches_reference_unmasked():
+    uv = _uvlist(40)
+    got = obsh.ftmatrix(FT_PSIZE, FT_XDIM, FT_YDIM, uv)
+    assert np.array_equal(got, _ftmatrix_reference(FT_PSIZE, FT_XDIM, FT_YDIM, uv))
+
+
+def test_ftmatrix_matches_reference_masked():
+    # A partial mask is the interesting case: it is what the imager actually
+    # passes, and it is where a preallocating rewrite is easiest to get wrong.
+    uv = _uvlist(40)
+    rng = np.random.default_rng(11)
+    mask = rng.random(FT_XDIM * FT_YDIM) > 0.4
+    got = obsh.ftmatrix(FT_PSIZE, FT_XDIM, FT_YDIM, uv, mask=mask)
+    expected = _ftmatrix_reference(FT_PSIZE, FT_XDIM, FT_YDIM, uv, mask=mask)
+    assert got.shape == (len(uv), int(mask.sum()))
+    assert np.array_equal(got, expected)
+
+
+def test_ftmatrix_build_peak_stays_near_its_result():
+    uv = _uvlist(800)
+    peak = _peak_mib(lambda: obsh.ftmatrix(FT_PSIZE, 32, 32, uv))
+    result_mib = len(uv) * 32 * 32 * 16 / 2**20
+    assert peak < FT_PEAK_FRACTION * result_mib, (
+        f"ftmatrix peaked at {peak:.2f} MiB building a {result_mib:.2f} MiB "
+        f"operator ({peak/result_mib:.2f}x)")
+
+
+def test_ftmatrix_masked_build_does_not_allocate_the_full_stack():
+    # With a mask the returned array is much smaller than the full grid, and
+    # the build should never materialize the full one.
+    uv = _uvlist(800)
+    rng = np.random.default_rng(7)
+    mask = rng.random(32 * 32) > 0.75          # keep roughly a quarter
+    peak = _peak_mib(lambda: obsh.ftmatrix(FT_PSIZE, 32, 32, uv, mask=mask))
+    result_mib = len(uv) * int(mask.sum()) * 16 / 2**20
+    assert peak < FT_PEAK_FRACTION * result_mib, (
+        f"ftmatrix peaked at {peak:.2f} MiB building a {result_mib:.2f} MiB "
+        f"masked operator ({peak/result_mib:.2f}x)")

--- a/tests/test_obs_helpers.py
+++ b/tests/test_obs_helpers.py
@@ -85,19 +85,30 @@ def _adj_operator(nvis, npix, seed=0):
 
 
 def _peak_mib(fn):
+    """Peak traced allocation in MiB during fn().
+
+    Calls fn() once first: several of these paths lazily import jax on their
+    first invocation, which lands ~26 MiB inside the measurement window and
+    makes the result about import cost rather than about the operator.
+    """
+    fn()
+    was_tracing = tracemalloc.is_tracing()
     tracemalloc.start()
     tracemalloc.reset_peak()
     fn()
     _, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
+    if not was_tracing:
+        tracemalloc.stop()
     return peak / 2**20
 
 
 @pytest.mark.parametrize("nvis,npix", ADJ_SHAPES, ids=lambda v: str(v))
 def test_adjoint_dot_matches_explicit_conjugate_transpose(nvis, npix):
-    # Bit-identity, not just closeness: this is the whole claim of the helper,
-    # and it kills the plausible wrong forms (dropping either conjugation, or
-    # conjugating the operator instead of the vectors).
+    # Exact value equality, not just closeness. Note this does NOT catch
+    # np.dot(vec, Amatrix.conj()), which is also exact but copies the operator;
+    # test_adjoint_dot_does_not_copy_the_operator is what rules that one out.
+    # np.array_equal is value equality, so -0.0 == 0.0: the final .conj() flips
+    # a +0.0 imaginary part to -0.0, which is inert but not byte-identical.
     A, vec = _adj_operator(nvis, npix)
     expected = np.dot(A.conj().T, vec)
     assert np.array_equal(obsh.adjoint_dot(A, vec), expected)
@@ -200,3 +211,63 @@ def test_ftmatrix_masked_build_does_not_allocate_the_full_stack():
     assert peak < FT_PEAK_FRACTION * result_mib, (
         f"ftmatrix peaked at {peak:.2f} MiB building a {result_mib:.2f} MiB "
         f"masked operator ({peak/result_mib:.2f}x)")
+
+
+def test_ftmatrix_preserves_the_memory_order_of_the_old_implementation():
+    # np.dot dispatches on layout, so a C-vs-F flip changes the BLAS reduction
+    # order and shifts every direct-path chi-squared and gradient at the 1e-15
+    # level. The old code returned C unmasked (reshape) and F masked (advanced
+    # column indexing); np.array_equal is blind to this, so it is pinned here.
+    uv = _uvlist(40)
+    unmasked = obsh.ftmatrix(FT_PSIZE, FT_XDIM, FT_YDIM, uv)
+    assert unmasked.flags["C_CONTIGUOUS"] and not unmasked.flags["F_CONTIGUOUS"]
+
+    rng = np.random.default_rng(11)
+    for mask in (np.ones(FT_XDIM * FT_YDIM, dtype=bool),          # the imager's call
+                 rng.random(FT_XDIM * FT_YDIM) > 0.4):
+        masked = obsh.ftmatrix(FT_PSIZE, FT_XDIM, FT_YDIM, uv, mask=mask)
+        assert masked.flags["F_CONTIGUOUS"] and not masked.flags["C_CONTIGUOUS"]
+        assert np.array_equal(
+            masked, _ftmatrix_reference(FT_PSIZE, FT_XDIM, FT_YDIM, uv, mask=mask))
+
+
+def test_ftmatrix_uses_the_pulse_it_is_given():
+    # Every caller passes pulse=Prior.pulse, but nothing exercised a non-default
+    # pulse, so ignoring the argument entirely used to pass the whole suite.
+    from ehtim.observing.pulses import deltaPulse2D
+    uv = _uvlist(40)
+    delta = obsh.ftmatrix(FT_PSIZE, FT_XDIM, FT_YDIM, uv, pulse=deltaPulse2D)
+    assert np.array_equal(
+        delta, _ftmatrix_reference(FT_PSIZE, FT_XDIM, FT_YDIM, uv, pulse=deltaPulse2D))
+    # and it must actually differ from the default, or the check above is empty
+    assert not np.array_equal(delta, obsh.ftmatrix(FT_PSIZE, FT_XDIM, FT_YDIM, uv))
+
+
+@pytest.mark.parametrize("mask_kind", ["bool", "int_index", "all_false", "unsorted_int"])
+def test_ftmatrix_matches_reference_across_mask_forms(mask_kind):
+    # The mask reaches ftmatrix straight from compute_embed as a bool array, but
+    # the signature has always accepted index arrays too, and an all-False mask
+    # is reachable from a prior that is zero everywhere.
+    npix = FT_XDIM * FT_YDIM
+    rng = np.random.default_rng(5)
+    mask = {"bool": rng.random(npix) > 0.4,
+            "int_index": np.array([0, 3, 7, npix - 1]),
+            "all_false": np.zeros(npix, dtype=bool),
+            "unsorted_int": np.array([npix - 1, 0, 5])}[mask_kind]
+    uv = _uvlist(30)
+    got = obsh.ftmatrix(FT_PSIZE, FT_XDIM, FT_YDIM, uv, mask=mask)
+    assert np.array_equal(
+        got, _ftmatrix_reference(FT_PSIZE, FT_XDIM, FT_YDIM, uv, mask=mask))
+
+
+def test_ftmatrix_handles_an_empty_uvlist():
+    # np.empty + fill-by-index returns uninitialized memory for any row the loop
+    # never writes, so the row count has to come from the array actually iterated.
+    out = obsh.ftmatrix(FT_PSIZE, FT_XDIM, FT_YDIM, np.zeros((0, 2)))
+    assert out.shape == (0, FT_XDIM * FT_YDIM)
+
+
+def test_ftmatrix_accepts_a_list_uvlist():
+    uv = _uvlist(12)
+    assert np.array_equal(obsh.ftmatrix(FT_PSIZE, FT_XDIM, FT_YDIM, [list(p) for p in uv]),
+                          obsh.ftmatrix(FT_PSIZE, FT_XDIM, FT_YDIM, uv))

--- a/tests/test_obs_helpers.py
+++ b/tests/test_obs_helpers.py
@@ -2,7 +2,11 @@
 import os
 import subprocess
 import sys
+import tracemalloc
 import zlib
+
+import numpy as np
+import pytest
 
 from ehtim.observing import obs_helpers as obsh
 
@@ -54,3 +58,62 @@ def test_hash_helpers_reproducible_across_processes():
     # crc32 the drawn values are byte-identical across salts.
     results = {_run_with_hashseed(hs) for hs in ("0", "1", "999999")}
     assert len(results) == 1, f"noise varied across PYTHONHASHSEED: {results}"
+
+
+# ---------------------------------------------------------------------------
+# adjoint_dot: apply A^H without materializing conj(A)
+#
+# `Amatrix.conj()` copies the whole (nvis, npix) operator; only the `.T` after
+# it is free. adjoint_dot conjugates the (nvis,) input and the (npix,) output
+# instead, which is the same arithmetic on far smaller vectors.
+# ---------------------------------------------------------------------------
+
+ADJ_SHAPES = [(500, 1024), (1200, 2048), (37, 64)]
+
+# Pre-fix the equivalent expression peaks at 1.00x the operator; adjoint_dot
+# allocates two vectors. A quarter of the operator separates the two cleanly.
+ADJ_PEAK_FRACTION = 0.25
+
+
+def _adj_operator(nvis, npix, seed=0):
+    rng = np.random.default_rng(seed)
+    A = (rng.standard_normal((nvis, npix))
+         + 1j * rng.standard_normal((nvis, npix)))
+    vec = rng.standard_normal(nvis) + 1j * rng.standard_normal(nvis)
+    return A, vec
+
+
+def _peak_mib(fn):
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    fn()
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return peak / 2**20
+
+
+@pytest.mark.parametrize("nvis,npix", ADJ_SHAPES, ids=lambda v: str(v))
+def test_adjoint_dot_matches_explicit_conjugate_transpose(nvis, npix):
+    # Bit-identity, not just closeness: this is the whole claim of the helper,
+    # and it kills the plausible wrong forms (dropping either conjugation, or
+    # conjugating the operator instead of the vectors).
+    A, vec = _adj_operator(nvis, npix)
+    expected = np.dot(A.conj().T, vec)
+    assert np.array_equal(obsh.adjoint_dot(A, vec), expected)
+
+
+def test_adjoint_dot_tracemalloc_sees_numpy_allocations():
+    # Guard: if numpy allocations were invisible to tracemalloc the memory
+    # bound below would pass no matter what adjoint_dot did.
+    A, _ = _adj_operator(1200, 2048)
+    op_mib = A.nbytes / 2**20
+    assert _peak_mib(lambda: A.conj()) > 0.9 * op_mib
+
+
+def test_adjoint_dot_does_not_copy_the_operator():
+    A, vec = _adj_operator(1200, 2048)
+    op_mib = A.nbytes / 2**20
+    peak = _peak_mib(lambda: obsh.adjoint_dot(A, vec))
+    assert peak < ADJ_PEAK_FRACTION * op_mib, (
+        f"adjoint_dot peaked at {peak:.2f} MiB against a {op_mib:.2f} MiB "
+        f"operator ({peak/op_mib:.2f}x)")


### PR DESCRIPTION
Two pre-existing allocation problems on the direct transform, plus a size guard so an oversized
direct run says something before it dies. Implements PR 10 of the backend audit plan.

Numerical results are unchanged: the operator is byte-identical to `dev-backend`, and so are
chi-squared and gradients for every direct data term. The new warning is the only user-visible
change. Every number below is measured on saturn/singularity on this branch.

## 1. The gradients copied the whole operator to apply its adjoint

`np.dot(Amatrix.conj().T, vec)` looks free but is not: `.conj()` on a complex array materializes a
full (nvis, npix) copy of the operator and only the following `.T` is a view. `chisqgrad_amp`
already avoided this by left-multiplying; `chisqgrad_vis` and the polarimetric gradients did not.

New `adjoint_dot(Amatrix, vec)` in `obs_helpers.py` conjugates the (nvis,) input and the (npix,)
output instead, which is the same arithmetic on vectors that are orders of magnitude smaller.

The polarimetric gradients had a second problem on the same lines: they applied that adjoint
product **once per active `pol_solve` slot**, with identical arguments, so a full IQUV gradient
recomputed it up to four times and discarded three. It is now built once per call.

Peak *traced* allocation (`tracemalloc`, not RSS) and wall time, nvis=7902, npix=4096, 493.9 MiB
operator, full `pol_solve`, 8 CPUs:

| gradient | peak before | peak after | adjoint gemvs | wall time |
|---|---|---|---|---|
| `chisqgrad_vis` | 494.18 MiB (1.00x op) | 0.54 MiB | 1 -> 1 | 49.0 -> 9.0 ms |
| `chisqgrad_p` | 494.40 MiB (1.00x op) | 0.90 MiB | 4 -> 1 | 188.4 -> 9.7 ms |
| `chisqgrad_m` | 494.76 MiB (1.00x op) | 1.16 MiB | 5 -> 2 | 241.3 -> 18.3 ms |
| `chisqgrad_vvis` | 494.28 MiB (1.00x op) | 0.73 MiB | 3 -> 1 | 143.1 -> 9.4 ms |

The memory column is deterministic. The time column is old/new interleaved in one process, 15 reps,
median, 10-90 spread under 3% — but the ratios move with `cpus-per-task` (roughly 4-6x for
`chisqgrad_vis` and 15-26x for `chisqgrad_p` between 8 and 32 CPUs), because the "after" arm is
gemv-bound. Treat them as a size, not a constant.

Most of the polarimetric win is the redundant gemvs rather than the copy: with one slot active
(`pol_solve=(1,0,0,0)`, no redundancy to remove) `chisqgrad_p` still improves, but by a smaller and
less stable factor.

## 2. `ftmatrix` cost twice the operator it returns, and much more than that when masked

It built a Python list of nvis separate (ydim, xdim) arrays and then copied the lot with
`np.array()` while the list was still alive: 2.00-2.01x its own result at every size tried. Given a
mask it built the entire unmasked stack and then sliced it down with a boolean column index, which
is a second full copy.

Rows are now written straight into the final array, and only the kept columns are ever allocated.

**The masked path is the one that matters**: `compute_chisqdata_term` always forwards the embed mask
on `ttype='direct'`, so every imaging run takes it, and it is the case the first version of this PR
never measured. At the shapes an EHT run actually uses:

| `ftmatrix` call | before | after | |
|---|---|---|---|
| 64x64, 10352 vis, all-True mask | 3099.9 ms | 207.2 ms | **15.0x** |
| 64x64, 6495 vis, all-True mask | 1974.2 ms | 134.9 ms | **14.6x** |
| 64x64, 7902 vis, unmasked | 174.8 ms | 113.8 ms | 1.54x |
| 32x32, 500 vis, unmasked | 3.6 ms | 3.7 ms | neutral, distributions overlap |

Peak allocation drops from 2.00x the returned array to 1.00x unmasked, and from 8.01x to 1.00x on a
quarter mask.

Worth flagging since this swaps a list comprehension for an explicit row loop: the loop costs
nothing. It is a wash at small sizes and faster wherever real work happens, because the copies it
avoids cost more than the loop does.

## 3. Nothing warned before the direct path asked for too much

The direct transform holds a dense (nvis, npix) complex operator per data term, and closure terms
hold three or four at once. Nothing warned, so an oversized run was an OOM kill with no diagnostic
— and frequency-sharded runs are forced onto `ttype='direct'` (`sharding.py` accepts only dense
single-matrix terms), so a user can be routed there without choosing it.

The check lives in `compute_chisqdata_term`, not in `ftmatrix`. That matters: the threshold is on
the **total a term holds**, since it is the sum that runs a machine out of memory, and that
dispatcher is the one place every direct term passes through with its whole operator set in hand.
A per-matrix check in `ftmatrix` was the first draft and it was wrong in both directions — silent on
a 2269 MB run because no individual matrix crossed 1.0 GB, and eight warnings deep when it did fire,
because Python dedups on source line and the closure operators are built on distinct lines.

Per-term totals, EHT2017, 10352 visibilities, against the 1.0 GB default:

| image | amp | cphase (3 op) | logcamp (4 op) | run total | warnings |
|---|---|---|---|---|---|
| 32x32 | 0.17 GB | 0.32 GB | 0.36 GB | 0.85 GB | 0 |
| 64x64 | 0.68 GB | **1.28 GB** | **1.45 GB** | 3.40 GB | 2 |
| 128x128 | **2.71 GB** | **5.11 GB** | **5.78 GB** | 13.60 GB | 3 |

So a 64x64 direct run with closures warns twice. That is deliberate: the same run measures 2269 MB
peak RSS against 403 MB for `nfft`, which is the 5.6x the warning exists to point at. Suppress with
`warnings.filterwarnings('ignore', category=ehtim.warnings.DirectMatrixSizeWarning)`, or raise
`ehtim.const_def.DIRECT_MATRIX_WARN_GB`. Note that `ehtim.DIRECT_MATRIX_WARN_GB` is a *separate*
binding created by the star import in `ehtim/__init__.py`; assigning to it has no effect, and the
docstring says so.

## Results do not move

`ftmatrix` returns a **byte-identical** operator to `dev-backend` — not just equal values. The old
code produced a C-contiguous array unmasked (from `reshape`) and an F-contiguous one masked (numpy
returns F-order from advanced column indexing), and `np.dot` dispatches on layout, so a layout
change would shift every direct-path result at the 1e-15 level. The new code allocates with the
matching order on each branch. Verified at 32x32, 16x24 and 48x32, unmasked / all-True / partial
mask:

```
values=True  bytes=True  order_matches=True      (9 of 9 cases)
```

and end to end on a real observation, comparing chi-squared and gradients against a base-transcribed
`ftmatrix`:

```
vis / amp / bs / cphase / camp / logcamp
  chisq_equal=True   grad_values_equal=True   grad_bytes_equal=True
```

`adjoint_dot` is separately exact: `dot(A.conj().T, v)` and `dot(v.conj(), A).conj()` agree
bit-for-bit at every shape, order and dtype tried, because both dispatch to the same `zgemv` call.
One caveat recorded in the test: the final `.conj()` turns a `+0.0` imaginary part into `-0.0`, so
it is exact *value* equality, not byte equality, for that one case.

## Wall time end to end

Base and branch measured back to back in one session, 64x64, 10352 visibilities, maxit=30, niter=2,
median of 2. **nfft is the control** — it touches neither `ftmatrix` nor the changed gradients.

| run | base | this branch | | image checksum |
|---|---|---|---|---|
| amp+cphase, direct | 16.15 s | 8.06 s | **2.00x** | identical |
| amp+cphase, nfft (control) | 8.27 s | 8.18 s | 1.01x | — |
| `vis`, direct | 10.49 s | 3.10 s | **3.38x** | identical |
| `vis`, nfft (control) | 4.25 s | 4.30 s | 0.99x | — |
| IP `amp+cphase+pvis+m`, direct | 125.82 s | 24.09 s | **5.22x** | identical |
| IP, nfft (control) | 16.19 s | 17.14 s | 0.94x | — |

The three direct rows deliberately cover different code: amp+cphase reaches neither changed gradient
and is pure `ftmatrix`; `vis` adds `chisqgrad_vis`; the IP run adds `chisqgrad_p` and `chisqgrad_m`.

Unrelated but worth knowing: the nfft checksums differ slightly between the two runs even though
nothing on that path changed. That is pre-existing run-to-run nondeterminism in the multithreaded
finufft reduction; the direct path is byte-stable across the same pair.

## Testing

Reproduction tests were committed before each fix, failing for the right reason. `test_obs_helpers.py`
and `test_chisquared.py` gain coverage for the operator memory order (which `np.array_equal` cannot
see), the `pulse` argument, boolean / integer / unsorted / all-False masks, an empty `uvlist`, and a
list-of-lists `uvlist`.

Both memory suites carry a guard test asserting `tracemalloc` actually sees numpy allocations, so
the bounds cannot pass vacuously. The probes now warm up before measuring: the polarimetric
gradients lazily import jax on first call, which put ~26 MiB inside the measurement window and made
that test pass only because `conftest.py` preloads jax.

The guard has its own mutation suite, since the per-matrix draft shipped with eight surviving
mutants. All eight are now killed: skipping the masked path, the default moved in either direction,
the threshold scaled 4x, the reported size corrupted two ways, thresholding a single matrix instead
of the term, and dropping the `nfft` pointer from the message. The default is pinned in **both**
directions by absolute sizes (0.5 GB quiet, 2.0 GB warns) rather than sizes derived from the
constant, which would move with it and pin nothing.

Full suite on saturn: **1938 passed, 1 skipped, 1 xfailed, 0 failed** (18 gpu-marked deselected,
`test_interactive.py` ignored), against 1908 passed on the base. Ruff clean on the touched files.

`scripts/memray_baseline.py` peak RSS, base measured in the same environment rather than compared
against the six-week-old logged figure:

```
base (dev-backend e4517d6)   517.491 MB
this branch                  391.149 MB      -126.3 MB, -24.4%
```

The baseline workload is a single-frequency Stokes-I `make_image` over direct / fast / nfft with
`data_term={"vis": 1}`, so it runs straight through both changed paths. Logged in
`MEMORY_BASELINES.md`.
