### PR TITLE
Make the survey L-BFGS history tunable and drop the frequency-sharding host copy

### DIFF
--- a/ehtim/imaging/sharding.py
+++ b/ehtim/imaging/sharding.py
@@ -62,6 +62,52 @@ def _pad_rows(arr, pad, fill=0.0):
     return np.pad(np.asarray(arr), width, constant_values=fill)
 
 
+def stack_channels_on_device(per_channel, nf_pad, sharding, fill):
+    """Stack per-channel arrays onto the channel axis without staging them on host.
+
+    Use this instead of building the stack with ``np.zeros((nf_pad, ...))`` and
+    then ``device_put``: that holds a second full copy of the operator stack on
+    the host while the per-channel originals are still alive on the Imager, and
+    the padded stack is larger than the real data. Measured on 5 channels padded
+    to 8, 500 visibilities and 4096 pixels: 156 MiB of real operators became 250
+    MiB of host staging plus 250 MiB on device, 4.2x. Building shard by shard
+    materializes only the channels one device needs.
+
+    Padded channels (index >= len(per_channel)) are filled with `fill`; the
+    caller's validity mask zeroes their contribution.
+
+    Parameters
+    ----------
+    per_channel : sequence of np.ndarray
+        One array per real channel, all the same shape.
+    nf_pad : int
+        Padded channel count, a multiple of the mesh size.
+    sharding : jax.sharding.Sharding
+        Sharding for the (nf_pad, *tail) result, channel axis first.
+    fill : scalar
+        Value for padded channels (0 for data and operators, 1 for sigma).
+
+    Returns
+    -------
+    jax.Array
+        Sharded array of shape (nf_pad, *per_channel[0].shape).
+    """
+    import jax
+
+    first = np.asarray(per_channel[0])
+    tail, dtype, n_real = first.shape, first.dtype, len(per_channel)
+
+    def shard(index):
+        chans = range(*index[0].indices(nf_pad))
+        out = np.full((len(chans),) + tail, fill, dtype=dtype)
+        for j, i in enumerate(chans):
+            if i < n_real:
+                out[j] = np.asarray(per_channel[i])
+        return out[(slice(None),) + tuple(index[1:])]
+
+    return jax.make_array_from_callback((nf_pad,) + tail, sharding, shard)
+
+
 class _NFFTView:
     """A stand-in for NFFTInfo carrying just the fields the sharded jax path reads.
 
@@ -278,16 +324,10 @@ def make_sharded_value_and_grad(initvec, config, which_solve, data_tuples,
             if any(np.asarray(d).shape[0] != nvis for d, _, _ in per):
                 raise NotImplementedError("frequency sharding assumes equal Nvis per channel")
             npix = np.asarray(A0).shape[1]
-            data_st = np.zeros((nf_pad, nvis), dtype=np.asarray(per[0][0]).dtype)
-            sigma_st = np.ones((nf_pad, nvis), dtype=np.asarray(per[0][1]).dtype)
-            A_st = np.zeros((nf_pad, nvis, npix), dtype=np.asarray(A0).dtype)
-            for i, (d, s, A) in enumerate(per):
-                data_st[i] = np.asarray(d)
-                sigma_st[i] = np.asarray(s)
-                A_st[i] = np.asarray(A)
-            stacks[dname] = (jax.device_put(jnp.asarray(data_st), ch2d),
-                             jax.device_put(jnp.asarray(sigma_st), ch2d),
-                             jax.device_put(jnp.asarray(A_st), ch3d))
+            stacks[dname] = (
+                stack_channels_on_device([d for d, _, _ in per], nf_pad, ch2d, 0),
+                stack_channels_on_device([s for _, s, _ in per], nf_pad, ch2d, 1),
+                stack_channels_on_device([A for _, _, A in per], nf_pad, ch3d, 0))
         aux = {"init": init_d, "prior": prior_d, "stacks": stacks,
                "valid": jax.device_put(jnp.asarray(valid), ch),
                "logfreq": jax.device_put(jnp.asarray(logfreq), ch)}

--- a/ehtim/imaging/sharding.py
+++ b/ehtim/imaging/sharding.py
@@ -54,58 +54,69 @@ def build_mesh(devices=None, axis="shard"):
     return jax.sharding.Mesh(np.asarray(devices), (axis,))
 
 
-def _pad_rows(arr, pad, fill=0.0):
-    """Pad `pad` rows of `fill` onto axis 0 (no-op when pad == 0)."""
-    if pad == 0:
-        return arr
-    width = [(0, pad)] + [(0, 0)] * (arr.ndim - 1)
-    return np.pad(np.asarray(arr), width, constant_values=fill)
+def _sharded_padded(row_of, n_total, n_real, tail, dtype, sharding, fill):
+    """Build a sharded (n_total, *tail) array, taking real rows from `row_of`.
+
+    Rows `n_real:` are `fill`. The array is assembled per shard rather than
+    padded on the host and then transferred, because `jnp.asarray(padded)`
+    lands the *whole* array on the default device before the sharding is
+    applied: on 2 GPUs that peaks device 0 at 4x its share, and the factor grows
+    with the device count. Host cost is unchanged (jax materializes every
+    addressable shard before transferring); the saving is on device.
+
+    The leading axis is assumed to be the sharded one, which is true of every
+    sharding this module builds. Under a sharding that partitions a trailing
+    axis instead the values are still correct, but each shard materializes the
+    full leading extent first.
+    """
+    import jax
+
+    def shard(index):
+        rows = range(*index[0].indices(n_total))
+        out = np.full((len(rows),) + tuple(tail), fill, dtype=dtype)
+        for j, i in enumerate(rows):
+            if i < n_real:
+                out[j] = row_of(i)
+        return out[(slice(None),) + tuple(index[1:])]
+
+    return jax.make_array_from_callback((n_total,) + tuple(tail), sharding, shard)
 
 
 def stack_channels_on_device(per_channel, nf_pad, sharding, fill):
-    """Stack per-channel arrays onto the channel axis without staging them on host.
+    """Stack per-channel arrays onto the channel axis, assembled per shard.
 
-    Use this instead of building the stack with ``np.zeros((nf_pad, ...))`` and
-    then ``device_put``: that holds a second full copy of the operator stack on
-    the host while the per-channel originals are still alive on the Imager, and
-    the padded stack is larger than the real data. Measured on 5 channels padded
-    to 8, 500 visibilities and 4096 pixels: 156 MiB of real operators became 250
-    MiB of host staging plus 250 MiB on device, 4.2x. Building shard by shard
-    materializes only the channels one device needs.
-
-    Padded channels (index >= len(per_channel)) are filled with `fill`; the
-    caller's validity mask zeroes their contribution.
+    Channels beyond `len(per_channel)` are padded with `fill`; the caller's
+    validity mask zeroes their contribution. See `_sharded_padded` for why this
+    is built shard by shard rather than padded on the host.
 
     Parameters
     ----------
     per_channel : sequence of np.ndarray
         One array per real channel, all the same shape.
     nf_pad : int
-        Padded channel count, a multiple of the mesh size.
+        Padded channel count, a multiple of the mesh size. Must be >= the number
+        of real channels.
     sharding : jax.sharding.Sharding
         Sharding for the (nf_pad, *tail) result, channel axis first.
     fill : scalar
-        Value for padded channels (0 for data and operators, 1 for sigma).
+        Value for padded channels. The frequency path uses 0 for data and
+        operators and 1 for sigma; the baseline path uses a different convention
+        (see the padding note at the top of this file), so this is the caller's
+        choice, not a property of the term.
 
     Returns
     -------
     jax.Array
         Sharded array of shape (nf_pad, *per_channel[0].shape).
     """
-    import jax
-
+    n_real = len(per_channel)
+    if nf_pad < n_real:
+        raise ValueError(
+            f"nf_pad={nf_pad} is smaller than the {n_real} channels given; "
+            "padding cannot drop channels")
     first = np.asarray(per_channel[0])
-    tail, dtype, n_real = first.shape, first.dtype, len(per_channel)
-
-    def shard(index):
-        chans = range(*index[0].indices(nf_pad))
-        out = np.full((len(chans),) + tail, fill, dtype=dtype)
-        for j, i in enumerate(chans):
-            if i < n_real:
-                out[j] = np.asarray(per_channel[i])
-        return out[(slice(None),) + tuple(index[1:])]
-
-    return jax.make_array_from_callback((nf_pad,) + tail, sharding, shard)
+    return _sharded_padded(lambda i: per_channel[i], nf_pad, n_real,
+                           first.shape, first.dtype, sharding, fill)
 
 
 class _NFFTView:
@@ -205,9 +216,12 @@ def make_sharded_value_and_grad(initvec, config, which_solve, data_tuples,
         rows2d = NamedSharding(mesh, P(axis, None))  # (N, Npix) Fourier matrix
 
         def shard_rows(a, sharding, fill=0.0):
-            true_n = np.asarray(a).shape[0]
+            arr = np.asarray(a)
+            true_n = arr.shape[0]
             pad = (-true_n) % k
-            return jax.device_put(jnp.asarray(_pad_rows(a, pad, fill)), sharding), true_n, pad
+            out = _sharded_padded(lambda i: arr[i], true_n + pad, true_n,
+                                  arr.shape[1:], arr.dtype, sharding, fill)
+            return out, true_n, pad
 
         # Pad each data term out to a multiple of the device count, then split it by row.
         # Sigma is padded with infinity so the extra rows add nothing to chi^2, and the
@@ -323,11 +337,10 @@ def make_sharded_value_and_grad(initvec, config, which_solve, data_tuples,
             nvis = np.asarray(per[0][0]).shape[0]
             if any(np.asarray(d).shape[0] != nvis for d, _, _ in per):
                 raise NotImplementedError("frequency sharding assumes equal Nvis per channel")
-            npix = np.asarray(A0).shape[1]
             stacks[dname] = (
-                stack_channels_on_device([d for d, _, _ in per], nf_pad, ch2d, 0),
-                stack_channels_on_device([s for _, s, _ in per], nf_pad, ch2d, 1),
-                stack_channels_on_device([A for _, _, A in per], nf_pad, ch3d, 0))
+                stack_channels_on_device([d for d, _, _ in per], nf_pad, ch2d, fill=0),
+                stack_channels_on_device([s for _, s, _ in per], nf_pad, ch2d, fill=1),
+                stack_channels_on_device([A for _, _, A in per], nf_pad, ch3d, fill=0))
         aux = {"init": init_d, "prior": prior_d, "stacks": stacks,
                "valid": jax.device_put(jnp.asarray(valid), ch),
                "logfreq": jax.device_put(jnp.asarray(logfreq), ch)}

--- a/ehtim/imaging/sharding.py
+++ b/ehtim/imaging/sharding.py
@@ -102,7 +102,11 @@ def stack_channels_on_device(per_channel, nf_pad, sharding, fill):
         Value for padded channels. The frequency path uses 0 for data and
         operators and 1 for sigma; the baseline path uses a different convention
         (see the padding note at the top of this file), so this is the caller's
-        choice, not a property of the term.
+        choice, not a property of the term. Only the sigma fill actually
+        matters: the validity mask zeroes a padded channel's contribution, so
+        any data or operator value gives bit-identical results, but sigma
+        reaches a 1/sigma**2 first and a zero there makes the whole objective
+        NaN before the mask can apply.
 
     Returns
     -------

--- a/ehtim/imaging/survey_gpu.py
+++ b/ehtim/imaging/survey_gpu.py
@@ -25,7 +25,7 @@ from ehtim.imaging.imager_backend import (
 )
 from ehtim.imaging.optimizers import optimize_fixed, resolve_optax
 
-NHIST = 50   # optax-lbfgs memory
+NHIST = 50   # default optax-lbfgs memory; override per call with maxcor=
 MAXLS = 5    # zoom line-search cap; small so vmap doesn't pay the batch-worst-case every step
 
 
@@ -41,7 +41,8 @@ def _gaussian_prior(base, flux, fwhm_rad):
     return pri.add_gauss(flux * 1e-3, (fwhm_rad, fwhm_rad, 0, fwhm_rad, fwhm_rad))
 
 
-def _inner_survey(imgr, weight_grid, regparam_grid, maxit, x0, optimizer, device):
+def _inner_survey(imgr, weight_grid, regparam_grid, maxit, x0, optimizer, device,
+                  maxcor=NHIST):
     """Vmap the scalar sub-grid for the imager's current (already initialized) state.
 
     Returns (images[B, Npix], objval[B], grid{axis_name: [B]}, chisqs{dname: [B]}) for the
@@ -73,7 +74,8 @@ def _inner_survey(imgr, weight_grid, regparam_grid, maxit, x0, optimizer, device
         imgr._regparams(), imgr._embed_mask, device=device)
 
     maxit = int(maxit if maxit is not None else imgr.maxit_next)
-    gt, needs_ls = resolve_optax(optimizer, {"maxiter": maxit, "maxcor": NHIST, "maxls": MAXLS})
+    gt, needs_ls = resolve_optax(optimizer,
+                             {"maxiter": maxit, "maxcor": int(maxcor), "maxls": MAXLS})
     x0 = put(np.asarray(imgr._init_vec, float) if x0 is None else x0)
     init_d = put(np.asarray(imgr._init_arr))
     which_solve, transforms = imgr._which_solve, imgr._config.transforms
@@ -92,7 +94,7 @@ def _inner_survey(imgr, weight_grid, regparam_grid, maxit, x0, optimizer, device
 
 def run_survey_gpu(imgr, *, weight_grid=None, regparam_grid=None, prior_fwhm=None,
                    sys_noise=None, maxit=None, x0=None, optimizer="optax-lbfgs-bt",
-                   device=None):
+                   device=None, maxcor=NHIST):
     """Reconstruct a hyperparameter grid, vmapping the scalar axes on device.
 
     Parameters
@@ -112,6 +114,13 @@ def run_survey_gpu(imgr, *, weight_grid=None, regparam_grid=None, prior_fwhm=Non
         Fixed optax iterations per reconstruction (default imgr.maxit_next).
     x0, optimizer, device
         Shared start vector, optax optimizer name/GradientTransformation, jax device.
+    maxcor : int, optional
+        L-BFGS history length (default `NHIST`). The optimizer state is roughly
+        `2*maxcor+3` copies of the image vector and vmap replicates it per grid
+        point, so this is the term that decides whether a large grid fits: at
+        4096 pixels it is 3.22 MiB per point at the default 50, 25.75 GiB across
+        an 8192-point grid, against 5.75 GiB at 10. Lower it when the grid is
+        large; L-BFGS converges more slowly with a shorter history.
 
     Returns
     -------
@@ -144,7 +153,8 @@ def run_survey_gpu(imgr, *, weight_grid=None, regparam_grid=None, prior_fwhm=Non
                     imgr.obslist_next = [o.add_fractional_noise(sysn) for o in base_obs]
                 imgr.init_imager()
                 im_b, ob_b, gr_b, ch_b = _inner_survey(imgr, weight_grid, regparam_grid,
-                                                       maxit, x0, optimizer, device)
+                                                       maxit, x0, optimizer, device,
+                                                       maxcor=maxcor)
                 images.append(im_b)
                 objval.append(ob_b)
                 for k, v in gr_b.items():

--- a/ehtim/imaging/survey_gpu.py
+++ b/ehtim/imaging/survey_gpu.py
@@ -115,12 +115,17 @@ def run_survey_gpu(imgr, *, weight_grid=None, regparam_grid=None, prior_fwhm=Non
     x0, optimizer, device
         Shared start vector, optax optimizer name/GradientTransformation, jax device.
     maxcor : int, optional
-        L-BFGS history length (default `NHIST`). The optimizer state is roughly
+        L-BFGS history length (default `NHIST`). The optimizer state is exactly
         `2*maxcor+3` copies of the image vector and vmap replicates it per grid
-        point, so this is the term that decides whether a large grid fits: at
-        4096 pixels it is 3.22 MiB per point at the default 50, 25.75 GiB across
-        an 8192-point grid, against 5.75 GiB at 10. Lower it when the grid is
-        large; L-BFGS converges more slowly with a shorter history.
+        point, so it is the largest term that scales with the grid: at 4096
+        pixels that is 3.22 MiB per point at the default 50, or 25.75 GiB of
+        state across an 8192-point grid, against 5.75 GiB at 10. Measured device
+        peak moves by about two thirds of that arithmetic, since XLA reuses
+        buffers inside the jitted loop. Lower it when a grid will not fit;
+        L-BFGS converges more slowly with a shorter history (median chi^2 0.41
+        at 50 vs 0.60 at 10, 4096 px and 30 iterations), which is why the
+        default is unchanged. Ignored by the first-order optimizers (adam, sgd,
+        rmsprop) and by a GradientTransformation you construct yourself.
 
     Returns
     -------
@@ -133,6 +138,9 @@ def run_survey_gpu(imgr, *, weight_grid=None, regparam_grid=None, prior_fwhm=Non
     chisqs : dict
         {data_term: 1-D array of length B} reduced chi^2 of each reconstruction, per data term.
     """
+    if int(maxcor) < 1 or int(maxcor) != maxcor:
+        raise ValueError(f"maxcor must be a positive integer, got {maxcor!r}")
+
     weight_grid = weight_grid or {}
     regparam_grid = regparam_grid or {}
     fwhms = list(prior_fwhm) if prior_fwhm is not None else [None]

--- a/tests/test_sharding_jax.py
+++ b/tests/test_sharding_jax.py
@@ -12,9 +12,9 @@ import pytest
 import ehtim as eh
 from ehtim.imaging.imager_backend import make_value_and_grad_jax
 
-# Only `jax` at module level: every GPU-requiring test below carries its own
-# @requires_2gpu skip, so a module-level `gpu` mark would only stop the
-# CPU-runnable tests here from ever being collected in CI.
+# `jax` at module level; `gpu` rides on requires_2gpu instead of the module, so the
+# CPU-runnable stacking tests below can be collected while `-m gpu` still selects
+# exactly the tests that need hardware.
 pytestmark = pytest.mark.jax
 
 jax = pytest.importorskip("jax")
@@ -24,7 +24,10 @@ try:
     _N_GPU = len(jax.devices("gpu"))
 except RuntimeError:
     _N_GPU = 0
-requires_2gpu = pytest.mark.skipif(_N_GPU < 2, reason="needs >= 2 GPUs")
+def requires_2gpu(fn):
+    """Mark a test as needing >= 2 GPUs: `gpu` for selection, skipif for safety."""
+    return pytest.mark.gpu(
+        pytest.mark.skipif(_N_GPU < 2, reason="needs >= 2 GPUs")(fn))
 
 VALUE_RTOL = 1e-9
 GRAD_RTOL = 1e-9
@@ -101,8 +104,14 @@ def test_sharded_make_image_recovers(obs_direct, gauss_im, gauss_prior):
     assert _nxcorr(out.imvec, gauss_im.imvec) > NXCORR_FLOOR
 
 
+# nchan=2 on a 2-device mesh pads to 2, i.e. NOT AT ALL, so it never exercises the
+# padding fill or the validity mask. nchan=3 pads to 4 and does. Without the padded
+# case, flipping the sigma fill from 1 to 0 turns the sharded objective into NaN with
+# the whole suite still green.
 @requires_2gpu
-def test_frequency_sharded_matches_single_and_numpy(eht_array, gauss_im):
+@pytest.mark.parametrize("freqs", [(220e9, 240e9), (220e9, 230e9, 240e9)],
+                         ids=["nchan2-unpadded", "nchan3-padded"])
+def test_frequency_sharded_matches_single_and_numpy(eht_array, gauss_im, freqs):
     # multifrequency: shard the channel axis (channel count padded to the mesh
     # size with a validity mask). Must match single-device + numpy bit-for-bit.
     from ehtim.imaging.sharding import build_mesh, make_sharded_value_and_grad
@@ -110,7 +119,7 @@ def test_frequency_sharded_matches_single_and_numpy(eht_array, gauss_im):
     prior = im.blur_circ(40 * eh.RADPERUAS)
     obslist = [im.get_image_mf(nu).observe(eht_array, 5, 600, 0, 24, 4e9, ampcal=True,
                                            phasecal=True, ttype="direct", add_th_noise=True, seed=42)
-               for nu in (220e9, 240e9)]
+               for nu in freqs]
     imgr = eh.imager.Imager(obslist, prior, prior_im=prior, flux=im.total_flux(),
                             data_term={"vis": 1}, reg_term={"simple": 1, "tv": 1},
                             ttype="direct", pol="I", mf=True, mf_order=1, maxit=100, epsilon_tv=EPSILON_TV)
@@ -174,53 +183,83 @@ def test_stack_channels_preserves_dtype_and_shape():
     assert np.asarray(got).dtype == np.complex128
 
 
-def test_stack_channels_allocates_less_than_the_host_stack():
-    """A/B against the pre-existing build, in one subprocess with 8 shards.
+@pytest.mark.parametrize("ndev,n_real,nf_pad", [(4, 4, 4), (4, 3, 4), (4, 6, 8), (2, 3, 4)])
+def test_stack_channels_matches_the_host_stack_across_a_real_mesh(ndev, n_real, nf_pad):
+    """Values over a genuinely partitioned mesh, not SingleDeviceSharding.
 
-    Measured as an A/B rather than an absolute bound because on the CPU backend
-    "device" memory is host memory, so tracemalloc cannot separate the staging
-    copy from the result. The naive build pays for both the np.zeros stack and
-    the device copy; this one pays for the result plus a single shard.
+    SingleDeviceSharding hands the callback the whole axis, so the shard loop
+    degenerates and index-arithmetic bugs (an i/j swap, an off-by-one in the
+    real-vs-padded test) cannot show up. Forcing CPU devices exercises the real
+    branch without needing a GPU.
     """
     import subprocess
     import sys
     import textwrap
-    code = textwrap.dedent("""
+    code = textwrap.dedent(f"""
         import os
-        os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"
-        import numpy as np, jax, jax.numpy as jnp, tracemalloc
+        os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count={ndev}"
+        import numpy as np, jax
+        jax.config.update("jax_enable_x64", True)
         from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
         from ehtim.imaging.sharding import stack_channels_on_device
-        NF, NVIS, NPIX = 8, 200, 2048
-        per = [np.ones((NVIS, NPIX), dtype=np.complex128) for _ in range(NF)]
-        full = NF * NVIS * NPIX * 16 / 2**20
-        mesh = Mesh(np.array(jax.devices("cpu")[:8]), ("shard",))
+        rng = np.random.default_rng(0)
+        per = [rng.standard_normal((3, 5)) + 1j*rng.standard_normal((3, 5))
+               for _ in range({n_real})]
+        mesh = Mesh(np.array(jax.devices("cpu")[:{ndev}]), ("shard",))
         sh = NamedSharding(mesh, P("shard", None, None))
-
-        def peak(fn):
-            tracemalloc.start(); tracemalloc.reset_peak()
-            fn().block_until_ready()
-            _, pk = tracemalloc.get_traced_memory(); tracemalloc.stop()
-            return pk / 2**20
-
-        def naive():
-            st = np.zeros((NF, NVIS, NPIX), dtype=np.complex128)
+        for fill in (0, 1):
+            got = np.asarray(stack_channels_on_device(per, {nf_pad}, sh, fill))
+            ref = np.full(({nf_pad}, 3, 5), fill, dtype=per[0].dtype)
             for i, a in enumerate(per):
-                st[i] = np.asarray(a)
-            return jax.device_put(jnp.asarray(st), sh)
-
-        p_new = peak(lambda: stack_channels_on_device(per, NF, sh, 0))
-        p_old = peak(naive)
-        print("RESULT", full, p_old, p_new, len(jax.devices("cpu")))
+                ref[i] = a
+            assert np.array_equal(got, ref), f"mismatch at fill={{fill}}"
+        print("RESULT ok", len(jax.devices("cpu")))
     """)
     r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
     line = [x for x in r.stdout.splitlines() if x.startswith("RESULT")]
-    assert line, f"subprocess failed:\n{r.stderr[-800:]}"
-    _, full, p_old, p_new, ndev = line[0].split()
-    full, p_old, p_new, ndev = float(full), float(p_old), float(p_new), int(ndev)
-    if ndev < 8:
-        pytest.skip(f"only {ndev} cpu devices; the per-shard saving is not observable")
-    assert p_new < 0.75 * p_old, (
-        f"{full:.1f} MiB stack across {ndev} shards: naive peaked at "
-        f"{p_old:.1f} MiB, this build at {p_new:.1f} MiB ({p_new/p_old:.2f}x) "
-        f"-- expected a clear saving")
+    assert line, f"subprocess failed:\n{r.stderr[-1200:]}"
+    assert int(line[0].split()[-1]) >= ndev
+
+
+@requires_2gpu
+def test_stack_channels_does_not_spike_one_device():
+    """The saving is on device, not host.
+
+    The previous build did jnp.asarray(padded_stack) before applying the
+    sharding, which lands the whole stack on the default device and then
+    reshards: device 0 peaks at several times its share, and the factor grows
+    with the device count. Host cost is unchanged either way, because jax
+    materializes every addressable shard before transferring -- an earlier
+    version of this test asserted a host saving and only passed because its
+    subprocess ran in complex64.
+    """
+    import jax.numpy as jnp
+    from jax.sharding import Mesh, NamedSharding
+    from jax.sharding import PartitionSpec as P
+
+    from ehtim.imaging.sharding import stack_channels_on_device
+    devs = jax.devices("gpu")[:2]
+    mesh = Mesh(np.array(devs), ("shard",))
+    sh = NamedSharding(mesh, P("shard", None, None))
+    n, nvis, npix = 4, 1500, 4096
+    per = [np.ones((nvis, npix), dtype=np.complex128) for _ in range(n)]
+    share = n * nvis * npix * 16 / len(devs)
+
+    def peak_after(build):
+        for d in devs:
+            d.memory_stats()  # touch before measuring
+        out = build()
+        out.block_until_ready()
+        pk = devs[0].memory_stats()["peak_bytes_in_use"]
+        del out
+        return pk
+
+    new = peak_after(lambda: stack_channels_on_device(per, n, sh, 0))
+    naive_stack = np.stack(per)
+    old = peak_after(lambda: jax.device_put(jnp.asarray(naive_stack), sh))
+    assert old > 1.5 * share, (
+        f"expected the naive build to overshoot device 0's {share/2**20:.0f} MiB "
+        f"share; got {old/2**20:.0f} MiB -- the premise no longer holds")
+    assert new < 0.7 * old, (
+        f"device 0 peak: naive {old/2**20:.0f} MiB, sharded build "
+        f"{new/2**20:.0f} MiB ({new/old:.2f}x)")

--- a/tests/test_sharding_jax.py
+++ b/tests/test_sharding_jax.py
@@ -12,7 +12,10 @@ import pytest
 import ehtim as eh
 from ehtim.imaging.imager_backend import make_value_and_grad_jax
 
-pytestmark = [pytest.mark.jax, pytest.mark.gpu]
+# Only `jax` at module level: every GPU-requiring test below carries its own
+# @requires_2gpu skip, so a module-level `gpu` mark would only stop the
+# CPU-runnable tests here from ever being collected in CI.
+pytestmark = pytest.mark.jax
 
 jax = pytest.importorskip("jax")
 pytest.importorskip("optax")
@@ -128,3 +131,96 @@ def test_frequency_sharded_matches_single_and_numpy(eht_array, gauss_im):
     assert np.allclose(v1, v0, rtol=VALUE_RTOL)
     assert np.linalg.norm(g1 - g0) / np.linalg.norm(g0) < GRAD_RTOL
     assert np.linalg.norm(g1 - gnp) / np.linalg.norm(gnp) < GRAD_RTOL
+
+
+# ---------------------------------------------------------------------------
+# Channel stacking (CPU-runnable: no GPU, no mesh)
+#
+# The per-channel operators used to be copied into one np.zeros((nf_pad, Nvis,
+# Npix)) on the host and then device_put, while the originals were still alive
+# on the Imager. Measured at 5 channels padded to 8, 500 vis, 4096 pixels:
+# 156 MiB of real operators -> 250 MiB host staging + 250 MiB device, 4.2x.
+# ---------------------------------------------------------------------------
+
+
+def _naive_host_stack(per, nf_pad, fill):
+    """The pre-existing build, kept as the value reference."""
+    first = np.asarray(per[0])
+    out = np.full((nf_pad,) + first.shape, fill, dtype=first.dtype)
+    for i, a in enumerate(per):
+        out[i] = np.asarray(a)
+    return out
+
+
+@pytest.mark.parametrize("fill", [0, 1])
+@pytest.mark.parametrize("n_real,nf_pad", [(3, 4), (5, 8), (4, 4)])
+def test_stack_channels_matches_the_host_stack(n_real, nf_pad, fill):
+    from jax.sharding import SingleDeviceSharding
+
+    from ehtim.imaging.sharding import stack_channels_on_device
+    rng = np.random.default_rng(0)
+    per = [rng.standard_normal((7, 5)) for _ in range(n_real)]
+    got = stack_channels_on_device(per, nf_pad, SingleDeviceSharding(jax.devices()[0]), fill)
+    assert np.array_equal(np.asarray(got), _naive_host_stack(per, nf_pad, fill))
+
+
+def test_stack_channels_preserves_dtype_and_shape():
+    from jax.sharding import SingleDeviceSharding
+
+    from ehtim.imaging.sharding import stack_channels_on_device
+    per = [np.ones((3, 2), dtype=np.complex128) for _ in range(2)]
+    got = stack_channels_on_device(per, 4, SingleDeviceSharding(jax.devices()[0]), 0)
+    assert got.shape == (4, 3, 2)
+    assert np.asarray(got).dtype == np.complex128
+
+
+def test_stack_channels_allocates_less_than_the_host_stack():
+    """A/B against the pre-existing build, in one subprocess with 8 shards.
+
+    Measured as an A/B rather than an absolute bound because on the CPU backend
+    "device" memory is host memory, so tracemalloc cannot separate the staging
+    copy from the result. The naive build pays for both the np.zeros stack and
+    the device copy; this one pays for the result plus a single shard.
+    """
+    import subprocess
+    import sys
+    import textwrap
+    code = textwrap.dedent("""
+        import os
+        os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=8"
+        import numpy as np, jax, jax.numpy as jnp, tracemalloc
+        from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
+        from ehtim.imaging.sharding import stack_channels_on_device
+        NF, NVIS, NPIX = 8, 200, 2048
+        per = [np.ones((NVIS, NPIX), dtype=np.complex128) for _ in range(NF)]
+        full = NF * NVIS * NPIX * 16 / 2**20
+        mesh = Mesh(np.array(jax.devices("cpu")[:8]), ("shard",))
+        sh = NamedSharding(mesh, P("shard", None, None))
+
+        def peak(fn):
+            tracemalloc.start(); tracemalloc.reset_peak()
+            fn().block_until_ready()
+            _, pk = tracemalloc.get_traced_memory(); tracemalloc.stop()
+            return pk / 2**20
+
+        def naive():
+            st = np.zeros((NF, NVIS, NPIX), dtype=np.complex128)
+            for i, a in enumerate(per):
+                st[i] = np.asarray(a)
+            return jax.device_put(jnp.asarray(st), sh)
+
+        p_new = peak(lambda: stack_channels_on_device(per, NF, sh, 0))
+        p_old = peak(naive)
+        print("RESULT", full, p_old, p_new, len(jax.devices("cpu")))
+    """)
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    line = [x for x in r.stdout.splitlines() if x.startswith("RESULT")]
+    assert line, f"subprocess failed:\n{r.stderr[-800:]}"
+    _, full, p_old, p_new, ndev = line[0].split()
+    full, p_old, p_new, ndev = float(full), float(p_old), float(p_new), int(ndev)
+    if ndev < 8:
+        pytest.skip(f"only {ndev} cpu devices; the per-shard saving is not observable")
+    assert p_new < 0.75 * p_old, (
+        f"{full:.1f} MiB stack across {ndev} shards: naive peaked at "
+        f"{p_old:.1f} MiB, this build at {p_new:.1f} MiB ({p_new/p_old:.2f}x) "
+        f"-- expected a clear saving")

--- a/tests/test_survey_jax.py
+++ b/tests/test_survey_jax.py
@@ -130,7 +130,8 @@ def test_survey_lbfgs_history_is_tunable(obs_direct, gauss_im, gauss_prior, monk
     assert seen["maxcor"] == 7
 
 
-def test_survey_maxcor_sizes_the_optimizer_state():
+@pytest.mark.parametrize("name", ["optax-lbfgs", "optax-lbfgs-bt"])
+def test_survey_maxcor_sizes_the_optimizer_state(name):
     # Goes through resolve_optax, which is where the optdict "maxcor" key is
     # mapped onto optax's memory_size. Calling optax directly would not pin that
     # mapping: hardcoding memory_size=50 inside resolve_optax passes such a test
@@ -142,8 +143,7 @@ def test_survey_maxcor_sizes_the_optimizer_state():
     from ehtim.imaging.survey_gpu import MAXLS
 
     def state_bytes(m):
-        gt, _ = resolve_optax("optax-lbfgs-bt",
-                              {"maxiter": 1, "maxcor": m, "maxls": MAXLS})
+        gt, _ = resolve_optax(name, {"maxiter": 1, "maxcor": m, "maxls": MAXLS})
         st = gt.init(jnp.zeros(4096, dtype=jnp.float64))
         return sum(np.asarray(x).nbytes for x in jax.tree_util.tree_leaves(st))
 

--- a/tests/test_survey_jax.py
+++ b/tests/test_survey_jax.py
@@ -130,25 +130,52 @@ def test_survey_lbfgs_history_is_tunable(obs_direct, gauss_im, gauss_prior, monk
     assert seen["maxcor"] == 7
 
 
-def test_survey_lbfgs_history_reaches_optax_state(obs_direct, gauss_im, gauss_prior):
-    # Pins that maxcor actually sizes the optimizer state, not just that it is
-    # forwarded: a knob that is threaded but ignored would pass the spy tests.
-    optax = pytest.importorskip("optax")
+def test_survey_maxcor_sizes_the_optimizer_state():
+    # Goes through resolve_optax, which is where the optdict "maxcor" key is
+    # mapped onto optax's memory_size. Calling optax directly would not pin that
+    # mapping: hardcoding memory_size=50 inside resolve_optax passes such a test
+    # while making the knob inert.
+    pytest.importorskip("optax")
     import jax.numpy as jnp
 
+    from ehtim.imaging.optimizers import resolve_optax
+    from ehtim.imaging.survey_gpu import MAXLS
+
     def state_bytes(m):
-        st = optax.lbfgs(memory_size=m).init(jnp.zeros(4096, dtype=jnp.float64))
+        gt, _ = resolve_optax("optax-lbfgs-bt",
+                              {"maxiter": 1, "maxcor": m, "maxls": MAXLS})
+        st = gt.init(jnp.zeros(4096, dtype=jnp.float64))
         return sum(np.asarray(x).nbytes for x in jax.tree_util.tree_leaves(st))
 
+    # L-BFGS state is ~(2m+3) copies of the vector, so 50 must dominate 5.
     small, large = state_bytes(5), state_bytes(50)
     assert large > 4 * small, (
-        f"memory_size should dominate the state: 5 -> {small} B, 50 -> {large} B")
+        f"maxcor should size the state through resolve_optax: "
+        f"5 -> {small} B, 50 -> {large} B")
 
 
 def test_survey_smaller_history_still_reconstructs(obs_direct, gauss_im, gauss_prior):
+    # A shorter history converges more slowly, but must still reconstruct: an
+    # all-zero or noise result would pass a shape-and-finiteness check.
     from ehtim.imaging.survey_gpu import run_survey_gpu
-    imgs, objs, _, _ = run_survey_gpu(_imager(obs_direct, gauss_im, gauss_prior),
-                                      weight_grid={"tv": np.array([1.0, 10.0])},
-                                      maxit=15, maxcor=5)
+    imgs, objs, _, chis = run_survey_gpu(_imager(obs_direct, gauss_im, gauss_prior),
+                                         weight_grid={"tv": np.array([1.0, 10.0])},
+                                         maxit=60, maxcor=5)
     assert imgs.shape[0] == 2
     assert np.all(np.isfinite(imgs)) and np.all(np.isfinite(objs))
+    assert np.all(chis["vis"] > 0)
+    truth = gauss_im.imvec
+    for b in range(imgs.shape[0]):
+        a, t = imgs[b] - imgs[b].mean(), truth - truth.mean()
+        nx = float(np.sum(a * t) / np.sqrt(np.sum(a * a) * np.sum(t * t)))
+        assert nx > 0.8, f"grid point {b}: nxcorr {nx:.3f} against the source"
+
+
+@pytest.mark.parametrize("bad", [0, -1, 7.9, None])
+def test_survey_rejects_a_nonsense_maxcor(obs_direct, gauss_im, gauss_prior, bad):
+    # Without this these reach optax (or int()) only after run_survey_gpu has
+    # already rebuilt the prior and re-noised the observations for grid point 1.
+    from ehtim.imaging.survey_gpu import run_survey_gpu
+    with pytest.raises((ValueError, TypeError)):
+        run_survey_gpu(_imager(obs_direct, gauss_im, gauss_prior),
+                       weight_grid={"tv": np.array([1.0])}, maxit=3, maxcor=bad)

--- a/tests/test_survey_jax.py
+++ b/tests/test_survey_jax.py
@@ -84,3 +84,71 @@ def test_survey_sys_noise_outer_axis_and_restore(obs_direct, gauss_im, gauss_pri
                                             sys_noise=[0.0, 0.05], maxit=8)
     assert images.shape[0] == 2 and set(np.unique(rec["sys_noise"])) == {0.0, 0.05}
     assert imgr.prior_next is base_prior  # imager restored after the survey
+
+
+# ---------------------------------------------------------------------------
+# L-BFGS history size
+#
+# `optax.lbfgs(memory_size=m)` state is ~2m+3 copies of the image vector, and
+# _inner_survey vmaps the whole reconstruction, so the state is paid per batch
+# element. At the shipped memory_size=50 that is 3.22 MiB each (103x the 4096
+# pixel vector at float64): 3.22 GiB at B=1024 and 25.75 GiB at B=8192, the
+# Paper IV grid size this module models itself on. It was a module constant
+# with no way for a caller to change it.
+# ---------------------------------------------------------------------------
+
+
+def _spy_on_optdict(monkeypatch):
+    """Capture the option dict survey_gpu hands to resolve_optax."""
+    from ehtim.imaging import survey_gpu
+    seen = {}
+    real = survey_gpu.resolve_optax
+
+    def spy(optimizer, optdict):
+        seen.update(optdict)
+        return real(optimizer, optdict)
+
+    monkeypatch.setattr(survey_gpu, "resolve_optax", spy)
+    return seen
+
+
+def test_survey_lbfgs_history_defaults_to_the_module_constant(
+        obs_direct, gauss_im, gauss_prior, monkeypatch):
+    from ehtim.imaging.survey_gpu import NHIST, run_survey_gpu
+    seen = _spy_on_optdict(monkeypatch)
+    run_survey_gpu(_imager(obs_direct, gauss_im, gauss_prior),
+                   weight_grid={"tv": np.array([1.0])}, maxit=3)
+    assert seen["maxcor"] == NHIST
+
+
+def test_survey_lbfgs_history_is_tunable(obs_direct, gauss_im, gauss_prior, monkeypatch):
+    # The point of the knob: a large grid can trade convergence for memory.
+    from ehtim.imaging.survey_gpu import run_survey_gpu
+    seen = _spy_on_optdict(monkeypatch)
+    run_survey_gpu(_imager(obs_direct, gauss_im, gauss_prior),
+                   weight_grid={"tv": np.array([1.0])}, maxit=3, maxcor=7)
+    assert seen["maxcor"] == 7
+
+
+def test_survey_lbfgs_history_reaches_optax_state(obs_direct, gauss_im, gauss_prior):
+    # Pins that maxcor actually sizes the optimizer state, not just that it is
+    # forwarded: a knob that is threaded but ignored would pass the spy tests.
+    optax = pytest.importorskip("optax")
+    import jax.numpy as jnp
+
+    def state_bytes(m):
+        st = optax.lbfgs(memory_size=m).init(jnp.zeros(4096, dtype=jnp.float64))
+        return sum(np.asarray(x).nbytes for x in jax.tree_util.tree_leaves(st))
+
+    small, large = state_bytes(5), state_bytes(50)
+    assert large > 4 * small, (
+        f"memory_size should dominate the state: 5 -> {small} B, 50 -> {large} B")
+
+
+def test_survey_smaller_history_still_reconstructs(obs_direct, gauss_im, gauss_prior):
+    from ehtim.imaging.survey_gpu import run_survey_gpu
+    imgs, objs, _, _ = run_survey_gpu(_imager(obs_direct, gauss_im, gauss_prior),
+                                      weight_grid={"tv": np.array([1.0, 10.0])},
+                                      maxit=15, maxcor=5)
+    assert imgs.shape[0] == 2
+    assert np.all(np.isfinite(imgs)) and np.all(np.isfinite(objs))


### PR DESCRIPTION
Two pre-existing memory problems on the GPU survey and sharding paths. Implements PR 11 of the
backend audit plan. Both reproduced before anything was changed.

Results are unchanged: value and gradient are bit-identical to `dev-backend` across 131 checked
arrays at 2, 3, 4 and 5 channels (so both padded and unpadded), and an end-to-end
`make_image(shard=True)` over 40 L-BFGS iterations is byte-equal.

## 1. The survey L-BFGS history was hardcoded

`survey_gpu.py` set `NHIST = 50` as a module constant and passed it to `resolve_optax`, with no way
for a caller to change it short of monkeypatching the module.

The optax L-BFGS state is exactly `2m+3` copies of the image vector (verified: that model accounts
for 100% of vector-sized memory at every `m` tried, residual under 0.03%), and `_inner_survey` vmaps
the whole reconstruction, so it is paid **per grid point**. At 4096 pixels, float64:

| memory_size | state | x image vector |
|---|---|---|
| 10 | 0.719 MiB | 23x |
| 20 | 1.344 MiB | 43x |
| **50 (shipped)** | **3.219 MiB** | **103x** |

Across a grid that is 824.1 MiB at B=256, 3.22 GiB at B=1024 and 25.75 GiB at B=8192, the Paper IV
grid size this module models itself on.

`maxcor` is now a keyword on `run_survey_gpu`, validated, and defaulting to `NHIST`.

**The default is deliberately unchanged.** A shorter history costs reconstruction quality at fixed
iterations (median chi^2 0.41 at 50 against 0.60 at 10, 4096 px, 30 iterations), and this PR is not
the place to trade accuracy for memory silently. The docstring carries that number so the choice is
informed, and notes that measured device peak moves by about two thirds of the state arithmetic
because XLA reuses buffers inside the jitted loop.

## 2. Sharded operator stacks were built whole on one device

Both sharding paths padded an array on the host and then did `jax.device_put(jnp.asarray(padded))`.
The `jnp.asarray` lands the **entire** array on the default device before the sharding is applied,
so device 0 peaks at several times its share and the factor grows with the device count. Measured on
2 GPUs:

| | GPU 0 peak | GPU 1 peak |
|---|---|---|
| frequency stack, before | 772.8 MiB | 193.4 MiB |
| frequency stack, after | **193.4 MiB** | 193.4 MiB |
| baseline `shard_rows`, before | 375.0 MiB | 93.8 MiB |
| baseline `shard_rows`, after | **93.8 MiB** | 93.8 MiB |

Both paths now share one `_sharded_padded` builder that assembles the array per shard, so no single
device ever holds more than its slice. `_pad_rows` is gone with its only caller.

The baseline path matters most: `shard_axis` defaults to `'baseline'`, so that is what
`make_image(shard=True)` actually runs, and `shard_rows` is called once per operator (three or four
times for a closure term).

**Host memory is unchanged**, and an earlier revision of this PR claimed otherwise. jax materializes
every addressable shard before transferring (`jax/_src/array.py`), so there is no host-side saving;
in a single-process job every mesh device is addressable. The saving is on device, and it is
dtype-independent.

## Testing

Reproduction tests were committed before the survey fix. 20 new tests.

- `stack_channels_on_device` is checked against a spelled-out copy of the previous build over a
  genuinely partitioned mesh (forced CPU devices, 4 shardings x 2 fill values), not only
  `SingleDeviceSharding`. That matters: single-device hands the callback the whole axis, so the
  shard loop degenerates and index bugs cannot surface.
- The frequency-sharding test is parametrized over 2 and 3 channels. At 2 channels on a 2-device
  mesh `nf_pad` is 2, so **nothing is padded** and the fill values are never exercised; at 3 it pads
  to 4. Without the padded case, flipping the sigma fill from 1 to 0 turns the sharded objective
  into NaN with the whole suite still green.
- `maxcor` is pinned through `resolve_optax`, parametrized over both L-BFGS backends, because that
  is where the `maxcor` key is mapped onto optax's `memory_size`. A test that calls optax directly
  passes even if `run_survey_gpu` drops the knob on the floor.
- The device-memory claim is asserted on `peak_bytes_in_use` under `@requires_2gpu`. A previous
  revision asserted a *host* saving in a subprocess and only passed because that subprocess ran in
  complex64; with x64 on, the precision ehtim actually uses, it fails.

Only the sigma fill has any effect on results. The validity mask zeroes a padded channel's
contribution, so any data or operator fill gives bit-identical output, but sigma reaches a
`1/sigma**2` first and a zero there makes the objective NaN before the mask can apply. That is
documented in the helper so it is not "fixed" later.

Full suite: **1928 passed, 1 skipped, 1 xfailed, 0 failed**, against 1908 on the base. Ruff clean.
2-GPU suites: 32 passed, 1 failed. That failure is `test_sharded_make_image_recovers`, which fails
identically on `origin/dev-backend` (it passes no `optimizer`, so it raises before `build_mesh`).
Verified pre-existing.

## Test marker change

`tests/test_sharding_jax.py` had `pytestmark = [jax, gpu]` at module level. `gpu` now rides on
`requires_2gpu` instead, so the CPU-runnable stacking tests can be collected while `-m gpu` still
selects exactly the hardware tests. Collection counts on a 2-GPU box: `-m gpu` 7, `-m "not gpu"` 8,
`-m "not jax"` 0.

An earlier revision dropped the `gpu` mark entirely, which silently removed the whole sharding suite
from `-m gpu` and made the project's documented local run fail. Note also that `dev-backend` CI runs
`-m "not jax"`, so none of the tests here run in CI until #321 lands.
