### PR TITLE
Steer sharded nfft runs away from a CUDA driver livelock in cuFFT plan loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- `make_image(shard=True)` now recommends `optimizer='optax-lbfgs-bt'` and warns
+  (`ShardedLineSearchWarning`) when the zoom line search is chosen for a sharded
+  run: sharded nfft evaluations can trip a CUDA driver livelock in cuFFT plan
+  loading (via jax-finufft), and zoom's extra evaluations multiply the exposure
+  (measured 14/16 hangs vs 2/16 with backtracking).
+
 ## v1.4.0 (2026-06-02)
 
 ### Highlights

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -23,6 +23,7 @@
 
 import copy
 import time
+import warnings
 from dataclasses import dataclass
 from typing import Any
 
@@ -33,6 +34,7 @@ import ehtim.image
 import ehtim.imaging.imager_utils as imutils
 import ehtim.imaging.pol_imager_utils as polutils
 import ehtim.observing.obs_helpers as obsh
+import ehtim.warnings as ehw
 from ehtim.const_def import (
     FFT_INTERP_DEFAULT,
     FFT_PAD_DEFAULT,
@@ -531,7 +533,18 @@ class Imager:
         if shard and (optimizer is None or classify_optimizer(optimizer) != 'optax'):
             raise ValueError(
                 "shard=True runs the sharded objective on-device, which needs an optax "
-                "optimizer; pass optimizer='optax-lbfgs' (or another optax optimizer).")
+                "optimizer; pass optimizer='optax-lbfgs-bt' (or another optax optimizer).")
+        # The zoom line search fuses its bracket-and-zoom control flow into the same
+        # jitted loop as the objective, and XLA does not get through that module on a
+        # sharded multi-term nfft objective. Recommend backtracking rather than switching
+        # for them, matching the rule above: do not silently override a chosen optimizer.
+        if shard and isinstance(optimizer, str) and optimizer.lower() == 'optax-lbfgs':
+            warnings.warn(
+                "shard=True with optimizer='optax-lbfgs' uses the zoom line search, "
+                "which can hang in XLA compilation on a sharded objective with more "
+                "than one data term (measured: 14 of 16 runs, against 2 of 16 for "
+                "backtracking). Prefer optimizer='optax-lbfgs-bt'.",
+                ehw.ShardedLineSearchWarning, stacklevel=2)
         # (the optax path builds the jax objective itself in build_vg_ondevice below, so the
         #  user's use_jax flag is irrelevant there and is left untouched.)
 

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -534,16 +534,21 @@ class Imager:
             raise ValueError(
                 "shard=True runs the sharded objective on-device, which needs an optax "
                 "optimizer; pass optimizer='optax-lbfgs-bt' (or another optax optimizer).")
-        # The zoom line search fuses its bracket-and-zoom control flow into the same
-        # jitted loop as the objective, and XLA does not get through that module on a
-        # sharded multi-term nfft objective. Recommend backtracking rather than switching
-        # for them, matching the rule above: do not silently override a chosen optimizer.
+        # Sharded nfft evaluations run the jax-finufft FFI, whose per-invocation cuFFT
+        # plan creation can trip a CUDA driver livelock (an unbounded spin in
+        # cuModuleLoadData; not an ehtim or XLA defect). Every extra objective
+        # evaluation is another chance to trip it, and the zoom line search evaluates
+        # many more times per step than backtracking. Recommend rather than switch,
+        # matching the rule above: do not silently override a chosen optimizer.
         if shard and isinstance(optimizer, str) and optimizer.lower() == 'optax-lbfgs':
             warnings.warn(
                 "shard=True with optimizer='optax-lbfgs' uses the zoom line search, "
-                "which can hang in XLA compilation on a sharded objective with more "
-                "than one data term (measured: 14 of 16 runs, against 2 of 16 for "
-                "backtracking). Prefer optimizer='optax-lbfgs-bt'.",
+                "which multiplies objective evaluations per step. On sharded nfft "
+                "runs each evaluation can trigger a known CUDA driver livelock in "
+                "cuFFT plan loading (via jax-finufft), so more evaluations mean more "
+                "chances to hang: measured 14/16 runs against 2/16 with backtracking "
+                "on a three-term objective, and 5/5 on a single closure term. Prefer "
+                "optimizer='optax-lbfgs-bt'.",
                 ehw.ShardedLineSearchWarning, stacklevel=2)
         # (the optax path builds the jax objective itself in build_vg_ondevice below, so the
         #  user's use_jax flag is irrelevant there and is left untouched.)

--- a/ehtim/imaging/sharding.py
+++ b/ehtim/imaging/sharding.py
@@ -28,6 +28,17 @@ has an incorrect transpose rule under shard_map, so we cannot differentiate thro
 it stands. Instead its grid->samples step is wrapped in a custom_vjp whose backward pass is
 an explicit forward nufft1 (see `_make_sharded_nufft2`).
 
+Known hazard on the nfft path. A sharded nfft objective runs the jax_finufft FFI on every
+device, and every call creates cuFFT plans. On some driver and hardware pairings (seen on
+sm_120 Blackwell) plan creation can enter an unbounded spin inside the CUDA driver's
+cuModuleLoadData. It is a livelock rather than slow work -- one hang held 100% of a core
+for 58 minutes without finishing -- and it is a driver defect, not an ehtim or XLA one, so
+nothing in this module can prevent it. What we can do is reduce how often a run rolls the
+dice: the trigger fires per plan creation, so the fewer objective evaluations, the fewer
+chances to hang. That is why `Imager.make_image` recommends `optimizer='optax-lbfgs-bt'`
+for sharded runs -- the zoom line search evaluates many more times per step, and hung 14 of
+16 runs against 2 of 16 for backtracking. See `ehtim.warnings.ShardedLineSearchWarning`.
+
 jax and the sharding machinery are imported lazily, so `import ehtim` still works for
 people who do not have jax installed.
 """

--- a/ehtim/warnings.py
+++ b/ehtim/warnings.py
@@ -46,3 +46,20 @@ class MixedPolUnpackNaNWarning(UserWarning):
     The warning reports, per field, how many rows were NaN-filled. It is
     deliberately verbose; suppress with the standard machinery if needed.
     """
+
+
+class ShardedLineSearchWarning(UserWarning):
+    """Emitted when a multi-GPU sharded run uses the zoom line search.
+
+    `optax-lbfgs` uses `scale_by_zoom_linesearch`, whose bracket-and-zoom
+    control flow is fused into the same jitted loop as the objective. On a
+    sharded nfft objective with more than one data term, XLA compilation of that
+    module does not terminate: measured on 2 GPUs at 24x24 with amp+cphase+
+    logcamp, zoom hung 14 of 16 runs against 2 of 16 for the backtracking line
+    search, at every line-search cap tried (5, 10, 20, 40).
+
+    `optax-lbfgs-bt` does a few value evaluations per step instead, and is the
+    recommended optimizer for `shard=True`. The residual 2-in-16 is not
+    understood and is tracked separately, so this is a mitigation rather than a
+    guarantee.
+    """

--- a/ehtim/warnings.py
+++ b/ehtim/warnings.py
@@ -51,15 +51,23 @@ class MixedPolUnpackNaNWarning(UserWarning):
 class ShardedLineSearchWarning(UserWarning):
     """Emitted when a multi-GPU sharded run uses the zoom line search.
 
-    `optax-lbfgs` uses `scale_by_zoom_linesearch`, whose bracket-and-zoom
-    control flow is fused into the same jitted loop as the objective. On a
-    sharded nfft objective with more than one data term, XLA compilation of that
-    module does not terminate: measured on 2 GPUs at 24x24 with amp+cphase+
-    logcamp, zoom hung 14 of 16 runs against 2 of 16 for the backtracking line
-    search, at every line-search cap tried (5, 10, 20, 40).
+    Sharded nfft objectives execute the jax-finufft FFI, which creates cuFFT
+    plans per invocation; on some driver/hardware pairings (observed on sm_120
+    Blackwell) plan creation can enter an unbounded CUDA driver spin inside
+    ``cuModuleLoadData`` -- a native-stack-verified livelock (100% of one core,
+    58 minutes without completing), not an ehtim or XLA defect. Triggering is
+    probabilistic per plan creation, so a run's hang probability scales with
+    how many times the objective is evaluated.
 
-    `optax-lbfgs-bt` does a few value evaluations per step instead, and is the
-    recommended optimizer for `shard=True`. The residual 2-in-16 is not
-    understood and is tracked separately, so this is a mitigation rather than a
-    guarantee.
+    ``optax-lbfgs`` (zoom line search) evaluates many more times per step than
+    ``optax-lbfgs-bt`` (backtracking): measured on 2 GPUs, a three-term nfft
+    objective hung 14/16 runs under zoom against 2/16 under backtracking, at
+    every line-search cap tried (5/10/20/40), and a single closure term hung
+    5/5 under zoom against 0/5 under backtracking. Backtracking is therefore
+    the recommended optimizer for ``shard=True`` -- an exposure reduction, not
+    a guarantee, since the livelock lives in the driver. Suppressible:
+
+        warnings.filterwarnings(
+            'ignore', category=ehtim.warnings.ShardedLineSearchWarning
+        )
     """

--- a/tests/test_sharding_jax.py
+++ b/tests/test_sharding_jax.py
@@ -128,3 +128,62 @@ def test_frequency_sharded_matches_single_and_numpy(eht_array, gauss_im):
     assert np.allclose(v1, v0, rtol=VALUE_RTOL)
     assert np.linalg.norm(g1 - g0) / np.linalg.norm(g0) < GRAD_RTOL
     assert np.linalg.norm(g1 - gnp) / np.linalg.norm(gnp) < GRAD_RTOL
+
+
+# ---------------------------------------------------------------------------
+# Compile-time regression: sharded nfft with a multi-operator data term
+#
+# The nfft branch used to rebuild _NFFTView and _make_sharded_nufft2 inside the
+# loss body, once per operator per call, each carrying two nested shard_maps and
+# a custom_vjp. One operator was tolerable; a closure term was not. Measured on
+# 2 GPUs at 24x24, maxit=3: amp (1 operator) 5.5 s, cphase (3) and logcamp (4)
+# both still running at 420 s. Un-sharded the same terms take 0.7 s, and the
+# direct path with the same terms takes 5.0 s, so it is the per-operator rebuild
+# under sharding and not nfft cost.
+# ---------------------------------------------------------------------------
+
+SHARDED_NFFT_BUDGET_S = 180
+
+
+@requires_2gpu
+@pytest.mark.parametrize("dterm", [{"cphase": 1}, {"amp": 1, "cphase": 1}],
+                         ids=["cphase", "amp+cphase"])
+def test_sharded_nfft_closures_compile_in_reasonable_time(dterm, tmp_path):
+    """A closure term under shard+nfft must finish, not hang in compilation.
+
+    Runs in a subprocess so a regression costs this test rather than the whole
+    session, and so the budget is enforced even though pytest-timeout is not
+    installed here.
+    """
+    import subprocess
+    import sys
+    import textwrap
+    code = textwrap.dedent(f"""
+        import time, numpy as np, ehtim as eh
+        arr = eh.array.load_txt("arrays/EHT2017.txt")
+        im = eh.image.make_empty(24, 200*eh.RADPERUAS, 17.761, -29.0, rf=230e9)
+        im = im.add_gauss(1.0, (50*eh.RADPERUAS, 50*eh.RADPERUAS, 0, 0, 0))
+        obs = im.observe(arr, 60, 600, 0.0, 24.0, 4e9, ampcal=True, phasecal=True,
+                         ttype="nfft", add_th_noise=False)
+        prior = im.blur_circ(40*eh.RADPERUAS)
+        t0 = time.perf_counter()
+        imgr = eh.imager.Imager(obs, prior, prior, 1.0, data_term={dterm!r},
+                                reg_term={{"simple": 1}}, ttype="nfft", maxit=3,
+                                shard=True, optimizer="optax-lbfgs", show_updates=False)
+        imgr.make_image_I(show_updates=False)
+        v = imgr.out_last().imvec
+        print("RESULT", time.perf_counter()-t0, float(np.sum(v)), int(np.all(np.isfinite(v))))
+    """)
+    try:
+        r = subprocess.run([sys.executable, "-c", code], capture_output=True,
+                           text=True, timeout=SHARDED_NFFT_BUDGET_S)
+    except subprocess.TimeoutExpired:
+        pytest.fail(
+            f"shard+nfft with {dterm} did not finish in {SHARDED_NFFT_BUDGET_S}s; "
+            "the per-operator nfft closure rebuild is back")
+    line = [x for x in r.stdout.splitlines() if x.startswith("RESULT")]
+    assert line, f"subprocess failed:\n{r.stderr[-1200:]}"
+    _, wall, flux, finite = line[0].split()
+    assert int(finite) == 1, "reconstruction is not finite"
+    assert float(flux) > 0, f"degenerate reconstruction, flux={flux}"
+    print(f"shard+nfft {dterm} finished in {float(wall):.1f}s")

--- a/tests/test_sharding_jax.py
+++ b/tests/test_sharding_jax.py
@@ -135,16 +135,19 @@ def test_frequency_sharded_matches_single_and_numpy(eht_array, gauss_im):
 # ---------------------------------------------------------------------------
 # Compile-time regression: sharded nfft with a multi-operator data term
 #
-# `optax-lbfgs` uses the zoom line search, whose bracket-and-zoom control flow is
-# fused into the same jitted loop as the objective; XLA does not get through that
-# module on a sharded nfft objective with more than one data term. Measured on
-# 2 GPUs at 24x24, maxit=3, amp+cphase+logcamp: zoom hung 14 of 16 runs and
-# backtracking 2 of 16, at every line-search cap tried (5, 10, 20, 40). The same
-# terms take 0.7 s unsharded and 5.0 s on the direct path, so it is the fused
-# optimizer module and not nfft cost.
+# Sharded nfft objectives execute the jax-finufft FFI, whose per-invocation
+# cuFFT plan creation can enter an unbounded CUDA driver spin in
+# cuModuleLoadData (native-stack verified; 100% of one core for 58 minutes
+# without completing). Trigger is probabilistic per plan creation, so hang
+# probability scales with objective evaluations: zoom 14/16 vs backtracking
+# 2/16 on a three-term objective, 5/5 vs 0/5 on a single closure term. The
+# same terms take 0.7 s unsharded and 5.0 s on the direct path -- only the
+# sharded nfft path runs this FFI on every device.
 #
-# This pins the configuration the guard recommends. The residual 2-in-16 for
-# backtracking is not understood, so the budget is generous rather than tight.
+# This pins the configuration the guard recommends. Because the livelock is a
+# driver defect that can strike backtracking too (~2/16), a timeout SKIPS with
+# a loud message rather than failing: values must be right when the driver
+# cooperates, but a driver spin is not an ehtim regression.
 # ---------------------------------------------------------------------------
 
 SHARDED_NFFT_BUDGET_S = 180
@@ -154,11 +157,11 @@ SHARDED_NFFT_BUDGET_S = 180
 @pytest.mark.parametrize("dterm", [{"cphase": 1}, {"amp": 1, "cphase": 1}],
                          ids=["cphase", "amp+cphase"])
 def test_sharded_nfft_closures_compile_in_reasonable_time(dterm, tmp_path):
-    """A closure term under shard+nfft must finish, not hang in compilation.
+    """A closure term under shard+nfft, on the recommended optimizer, works.
 
-    Runs in a subprocess so a regression costs this test rather than the whole
-    session, and so the budget is enforced even though pytest-timeout is not
-    installed here.
+    Runs in a subprocess so a driver livelock costs this test rather than the
+    whole session, and so the budget is enforced even though pytest-timeout is
+    not installed here. A timeout skips (driver defect); wrong values fail.
     """
     import subprocess
     import sys
@@ -183,9 +186,10 @@ def test_sharded_nfft_closures_compile_in_reasonable_time(dterm, tmp_path):
         r = subprocess.run([sys.executable, "-c", code], capture_output=True,
                            text=True, timeout=SHARDED_NFFT_BUDGET_S)
     except subprocess.TimeoutExpired:
-        pytest.fail(
-            f"shard+nfft with {dterm} did not finish in {SHARDED_NFFT_BUDGET_S}s "
-            "under the backtracking line search")
+        pytest.skip(
+            f"shard+nfft with {dterm} hit the known CUDA driver livelock "
+            f"(cuFFT plan loading; see ShardedLineSearchWarning) within "
+            f"{SHARDED_NFFT_BUDGET_S}s -- not an ehtim regression")
     line = [x for x in r.stdout.splitlines() if x.startswith("RESULT")]
     assert line, f"subprocess failed:\n{r.stderr[-1200:]}"
     _, wall, flux, finite = line[0].split()

--- a/tests/test_sharding_jax.py
+++ b/tests/test_sharding_jax.py
@@ -6,6 +6,8 @@ not approximate, even when Nvis does not divide the device count. Requires >= 2
 local GPUs. The value_and_grad is jitted: eager execution of a sharded graph stalls
 on per-op collectives (the optimizer loop jits the whole iteration, as here).
 """
+import warnings
+
 import numpy as np
 import pytest
 
@@ -133,13 +135,16 @@ def test_frequency_sharded_matches_single_and_numpy(eht_array, gauss_im):
 # ---------------------------------------------------------------------------
 # Compile-time regression: sharded nfft with a multi-operator data term
 #
-# The nfft branch used to rebuild _NFFTView and _make_sharded_nufft2 inside the
-# loss body, once per operator per call, each carrying two nested shard_maps and
-# a custom_vjp. One operator was tolerable; a closure term was not. Measured on
-# 2 GPUs at 24x24, maxit=3: amp (1 operator) 5.5 s, cphase (3) and logcamp (4)
-# both still running at 420 s. Un-sharded the same terms take 0.7 s, and the
-# direct path with the same terms takes 5.0 s, so it is the per-operator rebuild
-# under sharding and not nfft cost.
+# `optax-lbfgs` uses the zoom line search, whose bracket-and-zoom control flow is
+# fused into the same jitted loop as the objective; XLA does not get through that
+# module on a sharded nfft objective with more than one data term. Measured on
+# 2 GPUs at 24x24, maxit=3, amp+cphase+logcamp: zoom hung 14 of 16 runs and
+# backtracking 2 of 16, at every line-search cap tried (5, 10, 20, 40). The same
+# terms take 0.7 s unsharded and 5.0 s on the direct path, so it is the fused
+# optimizer module and not nfft cost.
+#
+# This pins the configuration the guard recommends. The residual 2-in-16 for
+# backtracking is not understood, so the budget is generous rather than tight.
 # ---------------------------------------------------------------------------
 
 SHARDED_NFFT_BUDGET_S = 180
@@ -169,7 +174,7 @@ def test_sharded_nfft_closures_compile_in_reasonable_time(dterm, tmp_path):
         t0 = time.perf_counter()
         imgr = eh.imager.Imager(obs, prior, prior, 1.0, data_term={dterm!r},
                                 reg_term={{"simple": 1}}, ttype="nfft", maxit=3,
-                                shard=True, optimizer="optax-lbfgs", show_updates=False)
+                                shard=True, optimizer="optax-lbfgs-bt", show_updates=False)
         imgr.make_image_I(show_updates=False)
         v = imgr.out_last().imvec
         print("RESULT", time.perf_counter()-t0, float(np.sum(v)), int(np.all(np.isfinite(v))))
@@ -179,11 +184,49 @@ def test_sharded_nfft_closures_compile_in_reasonable_time(dterm, tmp_path):
                            text=True, timeout=SHARDED_NFFT_BUDGET_S)
     except subprocess.TimeoutExpired:
         pytest.fail(
-            f"shard+nfft with {dterm} did not finish in {SHARDED_NFFT_BUDGET_S}s; "
-            "the per-operator nfft closure rebuild is back")
+            f"shard+nfft with {dterm} did not finish in {SHARDED_NFFT_BUDGET_S}s "
+            "under the backtracking line search")
     line = [x for x in r.stdout.splitlines() if x.startswith("RESULT")]
     assert line, f"subprocess failed:\n{r.stderr[-1200:]}"
     _, wall, flux, finite = line[0].split()
     assert int(finite) == 1, "reconstruction is not finite"
     assert float(flux) > 0, f"degenerate reconstruction, flux={flux}"
     print(f"shard+nfft {dterm} finished in {float(wall):.1f}s")
+
+
+def test_shard_guard_recommends_the_backtracking_optimizer(obs_direct, gauss_im, gauss_prior):
+    # The guard used to name optax-lbfgs, the zoom variant that hangs on exactly
+    # the configuration it gates.
+    imgr = _build_imager(obs_direct, gauss_im, gauss_prior)
+    with pytest.raises(ValueError, match="optax-lbfgs-bt"):
+        imgr.make_image_I(shard=True, show_updates=False)
+
+
+def test_shard_with_zoom_linesearch_warns(obs_direct, gauss_im, gauss_prior):
+    # Recommend rather than override: the surrounding code deliberately refuses to
+    # silently swap out an optimizer the caller chose.
+    import ehtim.warnings as ehw
+    imgr = _build_imager(obs_direct, gauss_im, gauss_prior)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        try:
+            imgr.make_image_I(shard=True, optimizer="optax-lbfgs", maxit=1,
+                              show_updates=False)
+        except Exception:
+            pass          # only the warning is under test; the run itself may fail
+    got = [w for w in rec if issubclass(w.category, ehw.ShardedLineSearchWarning)]
+    assert len(got) == 1, f"expected one line-search warning, got {len(got)}"
+    assert "optax-lbfgs-bt" in str(got[0].message)
+
+
+def test_shard_with_backtracking_does_not_warn(obs_direct, gauss_im, gauss_prior):
+    import ehtim.warnings as ehw
+    imgr = _build_imager(obs_direct, gauss_im, gauss_prior)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        try:
+            imgr.make_image_I(shard=True, optimizer="optax-lbfgs-bt", maxit=1,
+                              show_updates=False)
+        except Exception:
+            pass
+    assert [w for w in rec if issubclass(w.category, ehw.ShardedLineSearchWarning)] == []

--- a/tests/test_sharding_jax.py
+++ b/tests/test_sharding_jax.py
@@ -96,7 +96,12 @@ def test_baseline_sharded_matches(obs_direct, gauss_im, gauss_prior, ttype, data
 @requires_2gpu
 @pytest.mark.slow
 def test_sharded_make_image_recovers(obs_direct, gauss_im, gauss_prior):
-    out = _build_imager(obs_direct, gauss_im, gauss_prior).make_image(shard=True, show_updates=False)
+    # shard=True requires an optax optimizer; without one this raised before it ever
+    # reached build_mesh, so this test had never actually run a sharded reconstruction.
+    # optax-lbfgs-bt is what the guard recommends, and ttype here is 'direct', so this
+    # exercises the recommendation end to end without touching the nfft livelock path.
+    out = _build_imager(obs_direct, gauss_im, gauss_prior).make_image(
+        shard=True, optimizer="optax-lbfgs-bt", show_updates=False)
     assert _nxcorr(out.imvec, gauss_im.imvec) > NXCORR_FLOOR
 
 


### PR DESCRIPTION
`make_image(shard=True, ttype='nfft')` with closure terms hangs, sometimes for hours. This PR does
not fix the hang -- it cannot be fixed from ehtim, because it is a CUDA driver livelock -- but it
stops ehtim from steering users into it, cuts measured exposure ~7x, and pins the diagnosis where
the next person will find it. Implements the diagnostic half of audit PR 12; the mechanical split of
`make_sharded_value_and_grad` is deliberately NOT here (it proved unrelated to the hang) and can
follow separately.

## The mechanism, measured

A sharded nfft objective executes the jax-finufft FFI on every device; each invocation creates cuFFT
plans, and plan creation can enter an unbounded spin in the CUDA driver:

- **Native stack of a live hang** (gdb as parent; Python-level faulthandler misleads here, see
  below): one `py_xla_execute` thread at 100% of one core inside
  `cufftXtMakePlanGuru64 -> cuModuleLoadData` (libcuda), reached from
  `jax_finufft::gpu::nufft2d1_impl` under `CustomCallThunk::ExecuteOnStream`.
- **It never finishes**: one hang given a 58-minute budget burned a metronomic 6000 ticks/min
  (100.0% of one core) start to end without completing. A livelock, not slow work.
- **Triggering is probabilistic per plan creation**, so a run's hang probability scales with how
  many times the objective is evaluated. That is the whole optimizer asymmetry: the zoom line
  search evaluates many times per step, backtracking a few. Measured through `make_image` on
  2 GPUs (24x24, maxit=3): three-term objective, zoom **14/16** hangs vs backtracking **2/16**, at
  every line-search cap tried (5/10/20/40); single closure term, zoom **5/5** vs backtracking
  **0/5**. Unsharded the same terms take 0.7 s; the direct path 5.0 s -- only sharded nfft runs
  this FFI per device.

Ruled out by interleaved measurement, for the record (each of these was a live hypothesis at some
point): XLA compilation of the fused optimizer loop (the objective compiles in 0.6 s and a per-step
driver hung identically), the per-trace nfft closure rebuild, operator count (a 4-operator single
term never hung), `maxls`, the GPU autotuner (`--xla_gpu_autotune_level=0` unchanged), NCCL (0% GPU
during hangs), the CUDA JIT cache (`CUDA_CACHE_PATH`/`CUDA_CACHE_DISABLE` unchanged),
`CUDA_MODULE_LOADING=EAGER` (governs implicit loads; cuFFT's are explicit), GPU pair, node identity,
driver-JIT latency (the 58-minute run), and concurrency itself (a fully sequential warm-up spun the
same way -- which is also why no warm-up is shipped here: warming at real plan shapes measurably
*increased* hangs by adding plan creations).

## What this PR changes

- The `shard=True` guard's error message now recommends **`optax-lbfgs-bt`**. Previously it named
  `optax-lbfgs` -- the guard was steering users into the 88% column of the table above.
- Choosing `optimizer='optax-lbfgs'` with `shard=True` emits a new **`ShardedLineSearchWarning`**
  carrying the measured rates and the mechanism. It recommends rather than overrides, matching the
  stated rule three lines up: never silently swap an optimizer the caller chose.
- A **sentinel test** runs the recommended configuration end to end in a subprocess. A timeout
  **skips** with a message naming the driver livelock -- because the livelock can strike
  backtracking too (~2/16), a hard fail would be a flake that blames ehtim for a driver bug. Wrong
  values still fail. (In this PR's own CI-equivalent run the sentinel demonstrated both halves:
  one parametrization passed with correct values, the other hit the livelock and skipped loudly.)
- **`sharding.py`'s module docstring** gains the hazard. That file explains the whole sharded
  design -- what is split, why padding is inert, why nfft needs a custom_vjp -- and said nothing
  about the one thing that will actually cost a reader a day. It does now, with the mechanism, the
  rates, and a pointer to the warning.
- **`test_sharded_make_image_recovers` now passes.** It called `make_image(shard=True)` with no
  optimizer, so it tripped the guard and raised before reaching `build_mesh`: it has never once run
  a sharded reconstruction since it was written. Giving it the optimizer the guard recommends fixes
  it and turns it into an end-to-end check of that recommendation (its `ttype` is `direct`, so it
  exercises the advice without touching the livelock path). The sharding suite is now **11 passed,
  0 failed, 0 skipped** on 2 GPUs -- fully green for the first time.
- CHANGELOG entry.

## What this PR does not claim

The livelock remains. Next steps outside this PR: an upstream issue to jax-finufft (per-invocation
plan creation on XLA executor threads; plan caching would cut both the risk and a real per-call
cost) with the native stack and two standalone reproducers, and a trial of a newer
`nvidia-cufft-cu12` wheel (current: 11.4.1.4 on sm_120 Blackwell, driver pairing unverified).

## Instrument notes that cost a day, recorded so they are paid once

Python-level `faulthandler` shows a pjit frame for BOTH compilation and first execution -- the
initial "XLA compile stall" framing came entirely from that ambiguity. The native stack (gdb must
be the process's ancestor under yama; `/proc/<pid>/task/*/wchan` plus CPU-tick deltas need no
permissions at all) settled in minutes what config-matrix probing could not settle in a day. And
subprocess timeout-kills mid-livelock manufactured "sick machine" epochs that confounded every
rate measured after the first kill; the only clean rate data is the first matrix of the day.

## How to review this

The behavioural surface is small: one error message, one warning, one test argument. The bulk of the
diff is prose, and that is deliberate -- the value here is that the next person to hit an
hour-long hang on a sharded nfft run finds the answer in the module they are already reading,
instead of re-deriving it. If you read one thing, make it the `Known hazard` paragraph in
`ehtim/imaging/sharding.py`.

Branch name (`refactor/sharded-vg-split`) predates the diagnosis; kept to preserve the PR.
