### PR TITLE
Fix comments and docstrings that describe code that no longer exists

### DIFF
--- a/ehtim/array.py
+++ b/ehtim/array.py
@@ -86,7 +86,7 @@ class TarrView:
     fly by Array.tarr's property getter and adds no persisted state.
 
     Note: this guard catches whole-column access (tarr['sefdr']). It does
-    not catch row-form access (tarr[i]['sefdr']) — the row is a numpy
+    not catch row-form access (tarr[i]['sefdr']): the row is a numpy
     void object owned by numpy. New code should prefer
     Array.sefd_for_feed / Array.dterm_for_feed for per-station lookups.
     """
@@ -513,7 +513,7 @@ class Array:
 
         """Add a ground station to the array
 
-           Pass either the legacy symmetric kwargs (`sefd`, `dr`, `dl` — only
+           Pass either the legacy symmetric kwargs (`sefd`, `dr`, `dl`, only
            valid for feed_type='rl') OR the generic per-feed kwargs
            (`sefd_p1`/`sefd_p2`, `d_p1`/`d_p2`). Mixing legacy and generic
            kwargs for the same field raises ValueError.

--- a/ehtim/backends.py
+++ b/ehtim/backends.py
@@ -1,9 +1,15 @@
-"""NumPy / JAX backend selection for the imaging kernels.
+"""NumPy / JAX array-module dispatch for the imaging kernels.
 
-``set_backend("jax")`` runs the kernels on JAX (GPU, autodiff); the default
-"numpy" backend is unchanged. Kernels pick their array module from their inputs
-(``array_namespace``), so they stay single-sourced and jit-safe. JAX is imported
-lazily when selected; install it with the ``[dev]`` (CPU) or ``[gpu]`` (CUDA) extra.
+Kernels pick their array module from their *inputs* (``array_namespace``
+dispatches on whether an argument is a ``jax.Array``), so they stay
+single-sourced and jit-safe. That dispatch is what decides where the maths runs:
+pass jax arrays and the kernel runs on jax.
+
+``set_backend`` does not route anything. Its only side effect is enabling
+``jax_enable_x64`` when called with "jax"; the recorded name is readable via
+``get_backend`` but no kernel consults it. Use it to turn on double precision
+before building jax inputs, not as a switch. JAX is imported lazily when
+selected; install it with the ``[dev]`` (CPU) or ``[gpu]`` (CUDA) extra.
 """
 import contextlib
 import importlib.util

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -106,7 +106,7 @@ VALID_FEED_TYPES = frozenset({
 # Observation recarray datatypes
 # DTARR uses generic names primary because it is a single shared dtype across
 # all stations; legacy names are title aliases. Per-Obsdata/Caltable dtypes
-# (DTPOL_*, DTCAL_*) invert this — physical names primary, generic alias.
+# (DTPOL_*, DTCAL_*) invert this: physical names primary, generic alias.
 DTARR = [('site', 'U32'), ('x', 'f8'), ('y', 'f8'), ('z', 'f8'),
          (('sefdr', 'sefd_p1'), 'f8'), (('sefdl', 'sefd_p2'), 'f8'),
          (('dr', 'd_p1'), 'c16'), (('dl', 'd_p2'), 'c16'),

--- a/ehtim/imager.py
+++ b/ehtim/imager.py
@@ -450,6 +450,19 @@ class Imager:
                jax_device: jax device for the objective when use_jax=True; None uses the
                    jax default. e.g. jax.devices('gpu')[0] or jax.devices('cpu')[0]
 
+               optimizer: which minimizer to run. None (default) uses scipy L-BFGS-B;
+                   a name from ehtim.imaging.optimizers ('optax-lbfgs-bt', 'adam', ...)
+                   runs on device; an optax GradientTransformation is used as given; any
+                   other callable is invoked as
+                   optimizer(value_and_grad, x0, maxiter=, tol=, callback=) and must
+                   return a scipy OptimizeResult-like object with .x and .fun
+               shard (bool): split the data term across several GPUs. Requires an optax
+                   optimizer; see ehtim.imaging.sharding for what each axis supports, and
+                   prefer optimizer='optax-lbfgs-bt' (see ShardedLineSearchWarning)
+               mesh: jax device mesh for shard=True; None builds one over all local GPUs
+               shard_axis (str): 'baseline' (default, split visibilities) or 'frequency'
+                   (split channels; multifrequency and linear data terms only)
+
                show_updates (bool): whether or not to show imager progress
                update_interval (int): step interval for plotting if show_updates=True
 

--- a/ehtim/imaging/imager_backend.py
+++ b/ehtim/imaging/imager_backend.py
@@ -328,10 +328,14 @@ class ImagerConfig(NamedTuple):
 
     JAX note: this bundle is a *static* pytree, not a traced one. The string
     leaves (pol, ttype, transform names) and the dict leaf in the sibling
-    DataWeighting bundle (snrcut) aren't valid JAX traceable values. When
-    jitting backend functions that take a config, pass it as a
-    ``static_argname='config'`` so the structure participates in cache keying
-    rather than tracing.
+    DataWeighting bundle (snrcut) aren't valid JAX traceable values, so when
+    jitting a backend function that takes a config, mark it static:
+    ``jax.jit(fn, static_argnames=('config',))``.
+
+    A static argument has to be hashable, and this one is not as built:
+    ``transforms`` is a list. Convert it first, e.g.
+    ``config._replace(transforms=tuple(config.transforms))``, or jit will raise
+    ``unhashable type: 'list'``.
     """
     pol: str                       # imager polarization mode ('I', 'IP', 'IV', 'IPV', 'QU', ...)
     transforms: Sequence[str]      # bounded-value transform stack applied to imcur (e.g. ['log', 'mcv'])
@@ -1209,7 +1213,10 @@ def compute_regularizer_term(imvec_or_imarr, regname, mask, **kwargs):
     Returns
     -------
     float
-        Regularizer value, negated so positive values indicate a penalty to minimize.
+        Regularizer value as a penalty: larger means a worse image. The objective
+        adds ``weight * value`` and minimizes, so each leaf arranges its own sign
+        to that convention (most return a positive sum directly; ``reg_gs`` negates
+        an entropy that is otherwise maximized).
     """
     if regname not in _REGULARIZER_DISPATCH:
         raise Exception(f"regularizer term {regname} not recognized!")
@@ -1865,9 +1872,10 @@ def compute_objective(imvec, initvec, config,
     Notes
     -----
     The chi^2 and regularizer value kernels are backend-agnostic, so on the jax
-    backend ``jax.grad(compute_objective)`` will replace ``compute_objective_grad``
-    once ``unpack_imarr`` and ``transform_imarr`` are rewritten without their
-    in-place array assignment (jax cannot trace through it; see the TODOs there).
+    backend this function is differentiable as it stands: ``make_value_and_grad_jax``
+    builds ``jax.grad`` of it and is what the ``use_jax`` and sharded paths run.
+    ``compute_objective_grad`` remains the analytic gradient used by the numpy path,
+    and the two agree to within finite-difference tolerance.
     """
     transforms = config.transforms
 

--- a/ehtim/imaging/pol_imager_utils.py
+++ b/ehtim/imaging/pol_imager_utils.py
@@ -219,7 +219,7 @@ def mcv(imarr):
     """
 
     xp = array_namespace(imarr)
-    vfrac = imarr[3] # when using this transform, we interpret transformed imarr[3] as mfrac=\rho sin(\psi)
+    vfrac = imarr[3] # when using this transform, transformed imarr[3] is the fixed vfrac=\rho sin(\psi)
     mfrac_max = 1-xp.abs(vfrac)
 
     # transformed imarr[1] is m' --> the transformed mfrac = \rho cos(\psi)
@@ -817,7 +817,7 @@ def chisqgrad_vvis_nfft(imarr, A, v, sigmav,pol_solve=POL_SOLVE_DEFAULT):
 # Each returns the penalty value (defined positive; cf the old entropy style negative regularizers).
 # Spatial regularizers (ptv, vtv, vtv2) use `embed_imarr` (not `embed`) for the pre-step
 # and slice the gradient as `g[:, mask]` since the pol gradient is shaped (4, nimage)
-# — one row per Stokes component, gated on `pol_solve[0..3]`.
+# one row per Stokes component, gated on `pol_solve[0..3]`.
 ##################################################################################################
 
 def reg_msimple(imarr, mask, **kwargs):

--- a/ehtim/imaging/sharding.py
+++ b/ehtim/imaging/sharding.py
@@ -9,9 +9,13 @@ function with the same signature as the single-device one, so the optax loop in
 There are two ways to divide the work:
 
 - `shard_axis="baseline"` gives each GPU a slice of the visibilities. This is the general
-  case and works for any dataset.
-- `shard_axis="frequency"` gives each GPU a few frequency channels. Only useful for
-  multifrequency data, and you need at least as many channels as GPUs.
+  case: it takes any data term, but only the `direct` and `nfft` transforms (`fast` is
+  rejected).
+- `shard_axis="frequency"` gives each GPU a few frequency channels. Much narrower than it
+  sounds: multifrequency data only (`n_obs > 1` is enforced), dense single-matrix terms
+  only (vis/amp -- closure terms and all of nfft are rejected), and every channel must
+  carry the same number of visibilities. Note the code does not require one channel per
+  GPU; with fewer channels than devices the padding simply leaves some idle.
 
 Padding. jax insists that the split axis divide evenly across the GPUs, and real datasets
 rarely oblige, so each data term is padded up to a multiple of the device count. The padded
@@ -19,8 +23,9 @@ rows have to be inert. Sigma is set to infinity, so the row contributes exactly 
 chi^2, and the operator is set to one rather than zero, so the padded sample stays finite
 (a zero would put us at log(0) or angle(0) in the closure terms). Padding still inflates
 the 1/len(data) normalization, so each chi^2 is scaled back by pad_len/true_len. With that
-in place the sharded objective agrees with the single-device one to the last bit, for the
-linear terms (vis, amp) and the closure terms alike.
+in place the sharded objective agrees with the single-device one to the last bit. That
+holds for the linear terms (vis, amp) and the closure terms alike on the baseline axis;
+the frequency axis accepts only the linear terms in the first place.
 
 Fourier transforms. The `direct` transform simply shards its dense matrix and adds up the
 pieces with shard_map and pmean. The `nfft` transform needs more care: jax_finufft's nufft2

--- a/ehtim/observing/pol_conventions.py
+++ b/ehtim/observing/pol_conventions.py
@@ -245,7 +245,7 @@ def circ_to_lin(rr, ll, rl, lr):
 # TODO: these per-component sigma transforms are NOT invertible. The
 # basis transforms are linear combinations of the input visibilities, so
 # the output components are correlated even when the inputs are
-# independent — but we only return marginal variances per output
+# independent, but we only return marginal variances per output
 # component, dropping the off-diagonal covariance terms. A
 # round-trip (e.g. stokes_to_circ_sigma then circ_to_stokes_sigma)
 # generally does not recover the input sigmas.

--- a/ehtim/statistics/averaging.py
+++ b/ehtim/statistics/averaging.py
@@ -2,16 +2,16 @@
 
 Pure-NumPy implementations of three averaging routines:
 
-- :func:`coh_avg_vis` — coherent (complex) averaging into fixed time bins
+- :func:`coh_avg_vis`: coherent (complex) averaging into fixed time bins
   or per scan.
-- :func:`coh_moving_avg_vis` — coherent moving-window averaging.
-- :func:`incoh_avg_vis` — incoherent (amplitude) averaging with Rice
+- :func:`coh_moving_avg_vis`: coherent moving-window averaging.
+- :func:`incoh_avg_vis`: incoherent (amplitude) averaging with Rice
   debiasing.
 
 ``invvar_avg`` selects the value+sigma estimator pair on each routine.
 Both halves are gated together so each branch is internally consistent:
 
-  - ``invvar_avg=True`` (default) — inverse-variance weighted mean and
+  - ``invvar_avg=True`` (default): inverse-variance weighted mean and
     inverse-variance sigma:
 
     .. math:: \\langle V \\rangle = \\sum_i (V_i / \\sigma_i^2) / \\sum_i (1 / \\sigma_i^2)
@@ -22,7 +22,7 @@ Both halves are gated together so each branch is internally consistent:
     ``sqrt(max(<|V|^2>_w - (2 - 1/N) <sigma^2>_w, 0))``; the sigma is the
     same inverse-variance formula above.
 
-  - ``invvar_avg=False`` — legacy estimator formulas:
+  - ``invvar_avg=False``: legacy estimator formulas:
 
     * ``coh_avg_vis``: direct (unweighted) complex mean with
       ``sigma_avg = sqrt(sum sigma_i^2) / N``. Reproduces
@@ -109,7 +109,7 @@ def _assign_scan_bin(times_hr, scans):
     only, not both.
 
     Legacy behaviors deliberately NOT ported from
-    ``dataframes.get_bins_labels`` — flagged here in case a real dataset
+    ``dataframes.get_bins_labels``, flagged here in case a real dataset
     ever needs them back:
 
       1. **Edge padding.** The legacy default expanded each scan edge by
@@ -198,7 +198,7 @@ def _inverse_variance_weights(sig_per_row):
 def _window_sums(values, left, right):
     """Sliding-window segment sums for half-open index ranges ``[left, right)``.
 
-    ``cs[right] - cs[left]`` over a zero-prefixed cumulative sum — the
+    ``cs[right] - cs[left]`` over a zero-prefixed cumulative sum: the
     overlapping-window analogue of ``np.bincount`` over disjoint groups.
     Relies on float64 accumulation: the ``cs[right] - cs[left]``
     subtraction loses precision if ported to float32 (catastrophic
@@ -247,7 +247,7 @@ def _combine_sigma_inverse_variance(sum_w):
 def _combine_sigma_legacy(sum_sq, count):
     """Legacy sigma from segment sums: ``sqrt(sum(sigma**2)) / N``.
 
-    The formula used by ``dataframes.coh_avg_vis`` — NOT inverse variance;
+    The formula used by ``dataframes.coh_avg_vis``: NOT inverse variance;
     kept so ``invvar_avg=False`` reproduces legacy output bit-for-bit.
     Segments with no finite rows get ``NaN``.
     """
@@ -397,8 +397,8 @@ def _inverse_variance_mean_amplitude_group(amps_per_row, sigs_per_row, gids,
     weights: since ``w_i * sigma_i**2 = 1``, ``<sigma**2>_w = N / sum(w_i)``
     and the correction simplifies to ``(2N - 1) / sum(w_i)``. In the
     equal-sigma limit the amplitude reduces exactly to ``stats.deb_amp``;
-    the sigma does NOT reduce to ``stats.inc_sig`` — different estimator
-    families — see module docstring.
+    the sigma does NOT reduce to ``stats.inc_sig``: different estimator
+    families, see module docstring.
 
     Parameters
     ----------

--- a/ehtim/statistics/dataframes.py
+++ b/ehtim/statistics/dataframes.py
@@ -36,7 +36,7 @@ from ehtim.statistics.stats import bootstrap, circular_mean, mean_incoh_avg
 
 
 # pandas is required for the closure-quantity helpers in this module but is
-# otherwise optional for ehtim — visibility averaging lives in
+# otherwise optional for ehtim: visibility averaging lives in
 # `ehtim.statistics.averaging` and is pandas-free.  Make the import lazy: on
 # ImportError, substitute a stub that raises a clear message on first use, so
 # `import ehtim` keeps working without pandas installed.

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -79,7 +79,9 @@ def test_fill_nan_sigmas_order_dependent():
 # so these run in CI; two guarded tests use the real HL Tau files when present.
 # ---------------------------------------------------------------------------
 
-_HLTAU = "/scratch/year/rdahale/jax-ehtim/benchmarks/hltau_example"
+# Large reference dataset, not in the repo. Point EHTIM_HLTAU_DIR at a local copy to
+# run these; they skip otherwise, so a fresh clone is green without it.
+_HLTAU = os.environ.get("EHTIM_HLTAU_DIR", "")
 _HLTAU_SINGLE = os.path.join(_HLTAU, "hltau_mf_223.8.uvfits")
 _HLTAU_LINEAR = os.path.join(_HLTAU, "ALMA_data/Band7/HLTau_Band7_spw02_polswap.uvfits")
 

--- a/tutorials/ehtim_tutorial_jax.ipynb
+++ b/tutorials/ehtim_tutorial_jax.ipynb
@@ -136,15 +136,6 @@
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/nfs/horai.dgpsrv/year/rdahale/jax-ehtim/eht-imaging/ehtim/io/load.py:823: UserWarning: Input line 1 contained no data and will not be counted towards `max_rows=50000`.  This differs from the behaviour in NumPy <=1.22 which counted lines rather than rows.  If desired, the previous behaviour can be achieved by using `itertools.islice`.\n",
-      "Please see the 1.23 release notes for an example on how to do this.  If you wish to ignore this warning, use `warnings.filterwarnings`.  This warning is expected to be removed in the future and is given only once per `loadtxt` call.\n",
-      "  tdata = np.loadtxt(filename, dtype=bytes, comments='#').astype(str)\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [


### PR DESCRIPTION
Comments and docstrings across the backend that are actively wrong, plus two committed local
paths. Implements PR 14 of the backend audit plan. No behaviour changes: the only non-prose
edits are a test path that now comes from the environment and one stripped notebook output
block.

Every item below was verified against the code before being touched. Two of the plan's items
did not survive that check and were dropped; they are listed at the end.

## Comments that say something untrue

- **`imager_backend.py`** carried a note saying `jax.grad(compute_objective)` "will replace
  `compute_objective_grad` once `unpack_imarr` and `transform_imarr` are rewritten without
  their in-place array assignment ... see the TODOs there". Both were rewritten functionally in
  this same branch, there are zero TODOs in that range, and `make_value_and_grad_jax` already
  builds `jax.grad` of this function: it is what `use_jax` and the sharded path run today.
- **`pol_imager_utils.py`** read `vfrac = imarr[3] # ... we interpret transformed imarr[3] as
  mfrac=\rho sin(\psi)`. The variable is `vfrac`, and `dev` says `vfrac`; the rewrite introduced
  `mfrac`. Restored.
- **`ImagerConfig`'s** JAX note told you to pass ``static_argname='config'``. That is the wrong
  keyword (`static_argnames`), and more importantly it cannot work: the config is unhashable
  because `transforms` is a `list`, so jit raises ``unhashable type: 'list'``. Verified both the
  failure and the fix; the docstring now gives the working form, including
  ``config._replace(transforms=tuple(config.transforms))``.
- **`compute_regularizer_term`** documented its return as "negated so positive values indicate a
  penalty". The values are penalties, but not by negation: 34 of 35 leaves return a positive sum
  directly and only `reg_gs` negates (an entropy that is otherwise maximized). Now describes the
  convention rather than asserting a transformation that does not happen.
- **`backends.py`** opened with ``set_backend("jax")`` "runs the kernels on JAX (GPU, autodiff)".
  It does not. `_active` is written by `set_backend` and read only by `get_backend`; no kernel
  consults it, and `array_namespace` dispatches purely on whether an argument is a `jax.Array`.
  The only effect of the call is enabling `jax_enable_x64`. The docstring now says that, and says
  what actually decides where the maths runs.
- **`sharding.py`'s module docstring** made four claims the code contradicts: baseline sharding
  "works for any dataset" (it rejects `ttype='fast'`); bit-exact agreement "for the linear terms
  and the closure terms alike" (true on the baseline axis; the frequency axis rejects every
  closure term and all of nfft); frequency sharding needs "at least as many channels as GPUs"
  (the code only enforces `n_obs > 1`); and no mention of the equal-visibilities-per-channel
  constraint it does enforce. All four corrected.

## Documentation gaps

- **`make_image`'s** Args block documented `use_jax` and `jax_device` but not `optimizer`,
  `shard`, `mesh` or `shard_axis`, which it reads a few lines later. The user-callable optimizer
  contract existed only inside `run_optimizer`'s docstring. Now documented at the call site,
  including the callable's expected signature.

## Local paths out of the repo

- **`tests/test_io.py`** hardcoded `/scratch/year/rdahale/...` for the HL Tau dataset. It now
  reads `EHTIM_HLTAU_DIR`, so a fresh clone is green and the tests are opt-in by environment
  rather than by one developer's filesystem. Verified both directions: **2 skipped** without the
  variable, **2 passed** with it pointed at the real data.
- **`tutorials/ehtim_tutorial_jax.ipynb`** had committed output leaking `/nfs/horai/...`. Only
  the offending block is removed (a numpy `UserWarning` traceback, noise in any case). The other
  six cells keep their output, since seeing what the tutorial produces is the point of a
  tutorial.

## House style

16 em-dashes in module prose to colons or commas, concentrated in `statistics/averaging.py`.
Replaced individually rather than by a global substitution.

## Dropped after checking

- **"Note that `run_survey_gpu` handles a single observation."** It does not: `n_obs` is plumbed
  through `make_survey_value_and_grad`, and `run_survey_gpu` iterates the whole obslist
  (`[o.add_fractional_noise(sysn) for o in base_obs]`). Adding that line would have written a
  false limitation into a public docstring.
- **The blanket docstring sweep** over `sharding.py`, `survey_gpu.py` and `optimizers.py`. The
  measured gaps (10/15, 2/5, 8/14) are almost entirely nested closures: `loss`, `body`, `cond`,
  `vg`, `lossfn`, `col`, `reconstruct`. A NumPy Parameters/Returns block on a two-line
  `cond(carry)` inside a `while_loop` is noise, and the module-level API is already documented.
  The plan's own exclusion of prose-density churn applies here too.

## Testing

Full suite **1906 passed, 3 skipped, 1 xfailed, 0 failed**, ruff clean on every touched file.
The 1908 -> 1906 shift is exactly the two HL Tau tests becoming environment-gated, verified above;
nothing else moved. The notebook still parses as JSON and `ehtim` still imports.

## Note for whoever merges

This PR and #329 both edit `sharding.py`'s module docstring: #329 appends the CUDA driver
livelock hazard, this one corrects the axis-capability claims. Different sentences, so the merge
should be clean, but the second one in may need a trivial resolution.
