### PR TITLE
Caltable: split gains and D-terms into two tables

### DIFF
--- a/ehtim/calibrating/network_cal.py
+++ b/ehtim/calibrating/network_cal.py
@@ -410,8 +410,7 @@ def network_cal_scan(scan, zbl, sites, clustered_sites, polrep='stokes', pol='I'
 
             # Note: we may want to give two entries for the start/stop times
             # when a non-zero solution interval is used
-            # TODO: time-dependent D-term field added but unpopulated
-            caldict[site] = np.array((scan['time'][0], rscale, lscale, 0j, 0j), dtype=ehc.DTCAL)
+            caldict[site] = np.array((scan['time'][0], rscale, lscale), dtype=ehc.DTCAL)
 
         out = caldict
 

--- a/ehtim/calibrating/polgains_cal.py
+++ b/ehtim/calibrating/polgains_cal.py
@@ -268,8 +268,7 @@ def polgains_cal_scan(scan, reference='AA', sites=[], method='phase', minimizer_
             rscale = g_fit[site_key]**-1
             lscale = 1. + 0.j
 
-            # TODO: time-dependent D-term field added but unpopulated
-            caldict[site] = np.array((scan['time'][0], rscale, lscale, 0j, 0j), dtype=ehc.DTCAL)
+            caldict[site] = np.array((scan['time'][0], rscale, lscale), dtype=ehc.DTCAL)
         out = caldict
     else:
         g1_fit = g_fit[g1_keys]

--- a/ehtim/calibrating/self_cal.py
+++ b/ehtim/calibrating/self_cal.py
@@ -365,8 +365,7 @@ def self_cal_scan(scan, im, V_scan=[], sites=[], polrep='stokes', pol='I', apply
 
             # TODO: we may want to give two entries for the start/stop times
             # when a non-zero interval is used
-            # TODO: time-dependent D-term field added but unpopulated
-            caldict[site] = np.array((scan['time'][0], rscale, lscale, 0j, 0j), dtype=ehc.DTCAL)
+            caldict[site] = np.array((scan['time'][0], rscale, lscale), dtype=ehc.DTCAL)
 
         out = caldict
 

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -187,6 +187,11 @@ class Caltable:
                     show=True, grid=True, export_pdf=""):
         """Make a plot of the D-terms.
 
+           Plots the leakage recorded in the array table (tarr), one point per
+           site. The cal table's own D-term table (self.dterms) is not read
+           here: it can hold several rows per site, which a single point per
+           site cannot show.
+
            Args:
                sites (list) : list of sites to plot
                label (str) : title for plot
@@ -710,6 +715,10 @@ class Caltable:
 
     def save_txt(self, obs, datadir='.', sqrt_gains=False):
         """Saves a Caltable object to text files in the given directory
+
+           Gains and D-terms go to separate per-site files; see save_caltable
+           for the layout.
+
            Args:
                obs (Obsdata): The observation object associated with the Caltable
                datadir (str): directory to save caltable in
@@ -799,6 +808,12 @@ class Caltable:
 
 def load_caltable(obs, datadir, sqrt_gains=False):
     """Load apriori Caltable object from text files in the given directory
+
+       Reads the per-site gain files, and the per-site D-term files beside them
+       when present -- a directory written before D-terms had an on-disk slot
+       simply loads with no leakage. Gain files are what makes a directory a
+       cal table: with none, this returns False even if D-term files are there.
+
        Args:
            obs (Obsdata): The observation object associated with the Caltable
            datadir (str): directory to save caltable in
@@ -889,6 +904,15 @@ def load_caltable(obs, datadir, sqrt_gains=False):
 
 def save_caltable(caltable, obs, datadir='.', sqrt_gains=False):
     """Saves a Caltable object to text files in the given directory
+
+       Three kinds of file: array.txt for the telescope array, one
+       '<source>_<site>.txt' per site of gains (headerless, five columns:
+       time_mjd rre rim lre lim), and one '<source>_<site>_dterms.txt' per site
+       that carries leakage. The gain format is unchanged and stays headerless;
+       the D-term files, being new, open with a version line. A site with no
+       D-terms gets no D-term file, and sqrt_gains is a gain convention that
+       does not touch them.
+
        Args:
            obs (Obsdata): The observation object associated with the Caltable
            datadir (str): directory to save caltable in

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -149,7 +149,7 @@ class Caltable:
         if isinstance(datadict, dict):
             self.gains = {}
             for site, d in datadict.items():
-                site_gains, site_dterms = ehc.split_dtcal(d)
+                site_gains, site_dterms = ehc.upgrade_caltable(d)
                 self.gains[site] = site_gains
                 if site_dterms is not None:
                     self.dterms[site] = site_dterms
@@ -186,7 +186,7 @@ class Caltable:
             normalized = {}
             reshaped = False
             for site, table in datadict.items():
-                site_gains, site_dterms = ehc.split_dtcal(table)
+                site_gains, site_dterms = ehc.upgrade_caltable(table)
                 if site_dterms is not None:
                     raise TypeError(
                         f"data is the gain table, but the table for {site} "
@@ -220,7 +220,7 @@ class Caltable:
                     gains = {}
                     dterms = dict(state.get('dterms', {}))
                     for site, d in legacy.items():
-                        g, dt = ehc.split_dtcal(d)
+                        g, dt = ehc.upgrade_caltable(d)
                         gains[site] = g
                         if dt is not None:
                             dterms[site] = dt

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -90,20 +90,33 @@ class Caltable:
         self.tarr = ehc.upgrade_tarr(tarr)
         self.tkey = {self.tarr[i]['site']: i for i in range(len(self.tarr))}
 
-        # Save the data (upgrade per-site DTCAL recarrays as needed)
+        # Save the data, splitting out D-terms from any older welded tables
+        self.dterms = {}
         if isinstance(datadict, dict):
-            self.data = {site: ehc.upgrade_dtcal_circ(d)
-                         for site, d in datadict.items()}
+            self.data = {}
+            for site, d in datadict.items():
+                gains, dterms = ehc.split_dtcal(d)
+                self.data[site] = gains
+                if dterms is not None:
+                    self.dterms[site] = dterms
         else:
             self.data = datadict
 
     def __setstate__(self, state):
-        # Silently upgrade legacy pickles to the current mixedpol schema.
+        # Silently upgrade legacy pickles to the current schema.
         if 'tarr' in state:
             state['tarr'] = ehc.upgrade_tarr(state['tarr'])
         if 'data' in state and isinstance(state['data'], dict):
-            state['data'] = {site: ehc.upgrade_dtcal_circ(d)
-                             for site, d in state['data'].items()}
+            gains = {}
+            dterms = dict(state.get('dterms', {}))
+            for site, d in state['data'].items():
+                g, dt = ehc.split_dtcal(d)
+                gains[site] = g
+                if dt is not None:
+                    dterms[site] = dt
+            state['data'] = gains
+            state['dterms'] = dterms
+        state.setdefault('dterms', {})
         self.__dict__.update(state)
 
     def copy(self):
@@ -410,9 +423,8 @@ class Caltable:
                     preL = 1.
                     postL = 1.
 
-                # TODO: time-dependent D-term field added but unpopulated
-                valspre = np.array([(timepre, preR, preL, 0j, 0j)], dtype=ehc.DTCAL)
-                valspost = np.array([(timepost, postR, postL, 0j, 0j)], dtype=ehc.DTCAL)
+                valspre = np.array([(timepre, preR, preL)], dtype=ehc.DTCAL)
+                valspost = np.array([(timepost, postR, postL)], dtype=ehc.DTCAL)
 
                 gg = np.insert(gg, 0, valspre)
                 gg = np.append(gg, valspost)
@@ -595,9 +607,8 @@ class Caltable:
                     # TODO can we do this faster?
                     datatable = []
                     for i in range(len(times_merge)):
-                        # TODO: time-dependent D-term field added but unpopulated
                         datatable.append(
-                            np.array((times_merge[i], rscale_merge[i], lscale_merge[i], 0j, 0j),
+                            np.array((times_merge[i], rscale_merge[i], lscale_merge[i]),
                                      dtype=ehc.DTCAL))
                     data1[site] = np.array(datatable)
 
@@ -672,8 +683,7 @@ class Caltable:
                 gains_r_avg = np.mean(gains_r[np.array(times_stable == scan[0])])
 
                 # add them to a new datatable
-                # TODO: time-dependent D-term field added but unpopulated
-                datatable.append(np.array((scan[0], gains_r_avg, gains_l_avg, 0j, 0j), dtype=ehc.DTCAL))
+                datatable.append(np.array((scan[0], gains_r_avg, gains_l_avg), dtype=ehc.DTCAL))
 
             datatables[site] = np.array(datatable)
 
@@ -745,8 +755,7 @@ def load_caltable(obs, datadir, sqrt_gains=False):
             if sqrt_gains:
                 rscale = rscale**.5
                 lscale = lscale**.5
-            # TODO: time-dependent D-term field added but unpopulated
-            datatable.append(np.array((time, rscale, lscale, 0j, 0j), dtype=ehc.DTCAL))
+            datatable.append(np.array((time, rscale, lscale), dtype=ehc.DTCAL))
 
         datatables[site] = np.array(datatable)
     if len(datatables) > 0:
@@ -826,8 +835,7 @@ def make_caltable(obs, gains, sites, times):
         datatable = []
         for t in range(0, ntimes):
             gain = gains[s * ntimes + t]
-            # TODO: time-dependent D-term field added but unpopulated
-            datatable.append(np.array((times[t], gain, gain, 0j, 0j), dtype=ehc.DTCAL))
+            datatable.append(np.array((times[t], gain, gain), dtype=ehc.DTCAL))
         datatables[sites[s]] = np.array(datatable)
     if len(datatables) > 0:
         caltable = Caltable(obs.ra, obs.dec, obs.rf,

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -35,21 +35,27 @@ from ehtim.warnings import MixedPolConventionWarning
 # Caltable object
 ##################################################################################################
 
-# D-terms are saved beside the gain files, one per site. The gain files stay in
-# their long-standing headerless five-column format; these carry a version line
-# so the format can move later. np.loadtxt ignores '#' lines.
+# NOTE: caltables loaded from old data carry no D-term tables; any D-term
+# information stays in the tarr, assumed fixed over the observation.
+# TODO: when the new calibration module lands, decide what happens when both
+# the tarr and the caltable define D-terms (zero the tarr? warn and prefer
+# the table?).
+
+# Any optional time-dependent D-term tables are saved beside the gain files,
+# opened with a version line. Gain files keep their headerless 5-column format.
 DTERM_FILE_SUFFIX = '_dterms.txt'
 DTERM_FILE_HEADER = '# ehtim caltable dterms format v1: time_mjd d1re d1im d2re d2im'
 
 
 class Caltable:
-    """A calibration table holding per-station gains and leakage (D-terms).
+    """A calibration table of time-dependent station gains and leakage (D-terms).
 
-       Gains and D-terms are stored in two separate per-site tables, each with
-       its own time column, because the two quantities have different natural
-       cadences: gains vary with the atmosphere (solved per scan or finer) while
-       D-terms are instrumental and static or slowly varying. A single-row table
-       represents a time-constant quantity.
+       Gains and D-terms live in separate per-site tables, each with its own
+       time column; a single-row table represents a time-constant quantity.
+       A caltable with no D-term table falls back to the D-terms in the tarr,
+       assumed fixed over the observation.
+       TODO: flag or resolve cases where both the tarr and the caltable
+       define D-terms.
 
        Attributes:
            source (str): The source name
@@ -149,9 +155,8 @@ class Caltable:
 
     @data.setter
     def data(self, datadict):
-        # Same normalization the constructor does, so a solver's caldict works
-        # either way. Leakage is refused, not split: splitting would move the
-        # D-terms out of the caller's own dict.
+        # normalize like the constructor does, but refuse welded tables:
+        # splitting here would move D-terms out of the caller's own dict
         if isinstance(datadict, dict):
             normalized = {}
             reshaped = False
@@ -171,18 +176,15 @@ class Caltable:
         self.gains = datadict
 
     def __setstate__(self, state):
-        # Rebind the migration onto a copy. Unpickling hands over a throwaway
-        # dict, but a direct call (migration script, test) hands over one the
-        # caller still owns, and rewriting it in place would both surprise them
-        # and alias the migrated tables into every object restored from it.
+        # upgrade old pickled caltables to the current schema, on a copy of
+        # the state dict since a directly passed one belongs to the caller
         state = dict(state)
 
-        # Silently upgrade legacy pickles to the current schema.
         if 'tarr' in state:
             state['tarr'] = ehc.upgrade_tarr(state['tarr'])
 
-        # Pre-split pickles carry 'data'; pop it, since the property shadows any
-        # instance-dict entry of that name and the gains would become unreachable.
+        # deal with pickles from before the old 'data' attribute was renamed
+        # to 'gains' ('data' is a property now and would shadow the entry)
         if 'data' in state:
             legacy = state.pop('data')
             if 'gains' not in state:  # never overwrite new-style state
@@ -218,9 +220,8 @@ class Caltable:
         """Make a plot of the D-terms.
 
            Plots the leakage recorded in the array table (tarr), one point per
-           site. The cal table's own D-term table (self.dterms) is not read
-           here: it can hold several rows per site, which a single point per
-           site cannot show.
+           site. The caltable's own time-dependent D-term table (self.dterms)
+           is not read here.
 
            Args:
                sites (list) : list of sites to plot
@@ -557,7 +558,7 @@ class Caltable:
 
         if self.dterms:
             warnings.warn(
-                "This cal table carries D-terms for "
+                "This cal table carries time-dependent D-terms for "
                 f"{', '.join(sorted(self.dterms))}, but applycal corrects gains only: "
                 "the leakage is left in the data.",
                 MixedPolConventionWarning, stacklevel=2)
@@ -667,9 +668,8 @@ class Caltable:
 
         tarr1 = self.tarr.copy()
         tkey1 = self.tkey.copy()
-        # Copy the arrays, not just the dict: a site only this table has would
-        # otherwise be shared, and the merged table's invert_gains would then
-        # write back into this one.
+        # copy the arrays, not just the dict, so the merged table never
+        # writes back into this one
         data1 = {site: (table if table is None else table.copy())
                  for site, table in self.gains.items()}
         dterms1 = copy.deepcopy(self.dterms)
@@ -681,24 +681,18 @@ class Caltable:
             tarr2 = caltable.tarr.copy()
             tkey2 = caltable.tkey.copy()
 
-            # A site solved on one side only comes through as it is. Two
-            # solutions for the same site do compose, but not the way gains do:
-            # the leakage goes as d1*(b2/a2) + d2 to first order and the product
-            # does not commute, so it needs an order convention and the gains
-            # resampled onto the D-term grid. That waits for the solvers that
-            # write leakage into a cal table. Two tables loaded from disk can
-            # reach this.
+            # merging time-dependent D-term tables.
+            # If both caltables carry D-terms for a site, raise for now:
+            # composing D-terms requires full Jones treatment.
             for site, dterm_table in caltable.dterms.items():
                 if site in dterms1:
                     raise NotImplementedError(
                         f"merge: both caltables carry D-terms for site {site}. "
                         "Composing two leakage solutions is deferred; it is a "
                         "Jones product, not a gain-style multiply.")
-                # A site can carry leakage with no gain rows, so it would never
-                # reach the tarr append below. Its array row still has to come
-                # along: save_caltable walks tarr, so a site missing from it
-                # loses its solved leakage silently. tkey1 is refreshed here so
-                # the gain loop does not append the row a second time.
+                # if D-terms are only in the merged-in caltable, we can add them.
+                # Be sure to add the tarr row; it may be missed in the gain
+                # merge below.
                 if site not in tkey1 and site in tkey2:
                     tarr1 = np.append(tarr1, tarr2[tkey2[site]])
                     tkey1 = {tarr1[i]['site']: i for i in range(len(tarr1))}
@@ -744,8 +738,8 @@ class Caltable:
                 else:
                     if site not in tkey1.keys():
                         tarr1 = np.append(tarr1, tarr2[tkey2[site]])
-                    # Copy so the merged table does not share the input's array.
-                    # A site's table can be None, so there may be nothing to copy.
+                    # copy (None-safe) so the merged table does not share
+                    # the input's array
                     other = data2[site]
                     data1[site] = other if other is None else other.copy()
 
@@ -827,8 +821,8 @@ class Caltable:
             datatables[site] = np.array(datatable)
 
         if len(datatables) > 0:
-            # averaging is a gain-table operation; the leakage solution, which
-            # lives on its own time grid, is carried over as-is
+            # the D-term table is carried over as-is
+            # TODO: we may want to eventually have a function to average D-terms
             caltable = Caltable(obs.ra, obs.dec, obs.rf,
                                 obs.bw, datatables, obs.tarr, source=obs.source,
                                 mjd=obs.mjd, timetype=obs.timetype,
@@ -964,13 +958,9 @@ def _caltable_filenames(caltable, datadir):
 def save_caltable(caltable, obs, datadir='.', sqrt_gains=False, overwrite=False):
     """Saves a Caltable object to text files in the given directory
 
-       Three kinds of file: array.txt for the telescope array, one
-       '<source>_<site>.txt' per site of gains (headerless, five columns:
-       time_mjd rre rim lre lim), and one '<source>_<site>_dterms.txt' per site
-       that carries leakage. The gain format is unchanged and stays headerless;
-       the D-term files, being new, open with a version line. A site with no
-       D-terms gets no D-term file, and sqrt_gains is a gain convention that
-       does not touch them.
+       Writes array.txt, one '<source>_<site>.txt' per site of gains, and one
+       '<source>_<site>_dterms.txt' per site that carries time-dependent
+       leakage.
 
        Args:
            obs (Obsdata): The observation object associated with the Caltable

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -42,34 +42,6 @@ DTERM_FILE_SUFFIX = '_dterms.txt'
 DTERM_FILE_HEADER = '# ehtim caltable dterms format v1: time_mjd d1re d1im d2re d2im'
 
 
-def _as_dterm_table(table):
-    """Normalize one site's D-term table, or return None if there is nothing in it.
-
-    Solvers build rows the same way they build gain rows, which for a single
-    time gives a 0-d record rather than a one-row table, and a sidecar file
-    holding only its version line reads back as a plain empty array. Both would
-    otherwise be stored as leakage that later code cannot index.
-
-    Parameters
-    ----------
-    table : numpy.recarray or record or None
-        One site's D-terms, in any of those shapes.
-
-    Returns
-    -------
-    numpy.recarray or None
-        A one-dimensional D-term table, or None when it holds no rows.
-    """
-    if table is None:
-        return None
-    if not isinstance(table, np.ndarray):
-        table = np.asarray(table)
-    if table.dtype.names is None:
-        return None
-    table = np.atleast_1d(table)
-    return table if len(table) else None
-
-
 class Caltable:
     """A calibration table holding per-station gains and leakage (D-terms).
 
@@ -163,7 +135,7 @@ class Caltable:
                                 f"got {type(dterms).__name__}")
             self.dterms = {}
             for site, table in dterms.items():
-                site_dterms = _as_dterm_table(table)
+                site_dterms = ehc._normalize_recarray(table)
                 if site_dterms is not None:
                     self.dterms[site] = site_dterms
 

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -71,9 +71,8 @@ class Caltable:
 
     """
 
-    def __init__(self, ra, dec, rf, bw, datadict, tarr,
-                 source=ehc.SOURCE_DEFAULT, mjd=ehc.MJD_DEFAULT, timetype='UTC',
-                 *, dterms=None):
+    def __init__(self, ra, dec, rf, bw, datadict, tarr, dtermdict=None,
+                 source=ehc.SOURCE_DEFAULT, mjd=ehc.MJD_DEFAULT, timetype='UTC'):
         """A Calibration Table.
 
            Args:
@@ -87,14 +86,13 @@ class Caltable:
                                  DTCAL. Older welded tables carrying D-term columns are
                                  split into the gain and D-term tables automatically.
                tarr (numpy.recarray): The array of telescope data with datatype DTARR
+               dtermdict (dict): keys are sites in tarr, entries are D-term tables of
+                                 type DTDTERM, on their own time grid. When given, it
+                                 replaces anything split out of ``datadict``.
 
                source (str): The source name
                mjd (int): The integer MJD of the observation
                timetype (str): How to interpret tstart and tstop; either 'GMST' or 'UTC'
-
-               dterms (dict): keys are sites in tarr, entries are D-term tables of type
-                              DTDTERM, on their own time grid. Keyword-only. When given,
-                              it replaces anything split out of ``datadict``.
 
            Returns:
                (Caltable): an Caltable object
@@ -129,12 +127,12 @@ class Caltable:
             self.gains = datadict
 
         # An explicit D-term table replaces whatever the split produced
-        if dterms is not None:
-            if not isinstance(dterms, dict):
-                raise TypeError("dterms must be a dict keyed by site name, "
-                                f"got {type(dterms).__name__}")
+        if dtermdict is not None:
+            if not isinstance(dtermdict, dict):
+                raise TypeError("dtermdict must be a dict keyed by site name, "
+                                f"got {type(dtermdict).__name__}")
             self.dterms = {}
-            for site, table in dterms.items():
+            for site, table in dtermdict.items():
                 site_dterms = ehc._normalize_recarray(table)
                 if site_dterms is not None:
                     self.dterms[site] = site_dterms
@@ -538,7 +536,7 @@ class Caltable:
         # padding is a gain-table operation; leakage rides along untouched
         return Caltable(self.ra, self.dec, self.rf, self.bw, outdict, self.tarr,
                         source=self.source, mjd=self.mjd, timetype=self.timetype,
-                        dterms=copy.deepcopy(self.dterms))
+                        dtermdict=copy.deepcopy(self.dterms))
 
     def applycal(self, obs, interp='linear', extrapolate=None,
                  force_singlepol=False):
@@ -756,7 +754,7 @@ class Caltable:
 
         new_caltable = Caltable(self.ra, self.dec, self.rf, self.bw, data1, tarr1,
                                 source=self.source, mjd=self.mjd, timetype=self.timetype,
-                                dterms=dterms1)
+                                dtermdict=dterms1)
 
         return new_caltable
 
@@ -831,7 +829,7 @@ class Caltable:
             caltable = Caltable(obs.ra, obs.dec, obs.rf,
                                 obs.bw, datatables, obs.tarr, source=obs.source,
                                 mjd=obs.mjd, timetype=obs.timetype,
-                                dterms=copy.deepcopy(self.dterms))
+                                dtermdict=copy.deepcopy(self.dterms))
         else:
             caltable = False
 
@@ -942,7 +940,7 @@ def load_caltable(obs, datadir, sqrt_gains=False):
     if len(datatables) > 0:
         caltable = Caltable(obs.ra, obs.dec, obs.rf, obs.bw, datatables, tarr,
                             source=obs.source, mjd=obs.mjd, timetype=obs.timetype,
-                            dterms=dterm_tables)
+                            dtermdict=dterm_tables)
     else:
         print(f"COULD NOT FIND CALTABLE IN DIRECTORY {datadir}")
         caltable = False

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -35,7 +35,14 @@ import ehtim.observing.obs_helpers as obsh
 
 
 class Caltable:
-    """
+    """A calibration table holding per-station gains and leakage (D-terms).
+
+       Gains and D-terms are stored in two separate per-site tables, each with
+       its own time column, because the two quantities have different natural
+       cadences: gains vary with the atmosphere (solved per scan or finer) while
+       D-terms are instrumental and static or slowly varying. A single-row table
+       represents a time-constant quantity.
+
        Attributes:
            source (str): The source name
            ra (float): The source Right Ascension in fractional hours
@@ -48,12 +55,17 @@ class Caltable:
            tarr (numpy.recarray): The array of telescope data with datatype DTARR
            tkey (dict): A dictionary of rows in the tarr for each site name
 
-           data (dict): keys are sites in tarr, entries are calibration data tables of type DTCAL
+           gains (dict): keys are sites in tarr, entries are gain tables of type DTCAL
+           dterms (dict): keys are sites in tarr, entries are D-term tables of type
+                          DTDTERM. Empty when the table carries no leakage solution.
+           data (dict): backwards-compatible alias for ``gains``; it is the live
+                        dict, so in-place mutation through it is visible on the table
 
     """
 
     def __init__(self, ra, dec, rf, bw, datadict, tarr,
-                 source=ehc.SOURCE_DEFAULT, mjd=ehc.MJD_DEFAULT, timetype='UTC'):
+                 source=ehc.SOURCE_DEFAULT, mjd=ehc.MJD_DEFAULT, timetype='UTC',
+                 *, dterms=None):
         """A Calibration Table.
 
            Args:
@@ -63,12 +75,18 @@ class Caltable:
                mjd (int): The integer MJD of the observation
                bw (float): The observation bandwidth in Hz
 
-               datadict (dict):  keys are sites in tarr, entries are data tables of type DTCAL
+               datadict (dict):  keys are sites in tarr, entries are gain tables of type
+                                 DTCAL. Older welded tables carrying D-term columns are
+                                 split into the gain and D-term tables automatically.
                tarr (numpy.recarray): The array of telescope data with datatype DTARR
 
                source (str): The source name
                mjd (int): The integer MJD of the observation
                timetype (str): How to interpret tstart and tstop; either 'GMST' or 'UTC'
+
+               dterms (dict): keys are sites in tarr, entries are D-term tables of type
+                              DTDTERM, on their own time grid. Keyword-only. When given,
+                              it replaces anything split out of ``datadict``.
 
            Returns:
                (Caltable): an Caltable object
@@ -93,29 +111,56 @@ class Caltable:
         # Save the data, splitting out D-terms from any older welded tables
         self.dterms = {}
         if isinstance(datadict, dict):
-            self.data = {}
+            self.gains = {}
             for site, d in datadict.items():
-                gains, dterms = ehc.split_dtcal(d)
-                self.data[site] = gains
-                if dterms is not None:
-                    self.dterms[site] = dterms
+                site_gains, site_dterms = ehc.split_dtcal(d)
+                self.gains[site] = site_gains
+                if site_dterms is not None:
+                    self.dterms[site] = site_dterms
         else:
-            self.data = datadict
+            self.gains = datadict
+
+        # An explicit D-term table replaces whatever the split produced
+        if dterms is not None:
+            self.dterms = dict(dterms)
+
+    @property
+    def data(self):
+        """The gain table, under its legacy name.
+
+        Returns the live ``gains`` dict, so callers that mutate through
+        ``ct.data[site]`` or reassign ``ct.data[site] = ...`` still act on the
+        table itself.
+        """
+        return self.gains
+
+    @data.setter
+    def data(self, datadict):
+        self.gains = datadict
 
     def __setstate__(self, state):
         # Silently upgrade legacy pickles to the current schema.
         if 'tarr' in state:
             state['tarr'] = ehc.upgrade_tarr(state['tarr'])
-        if 'data' in state and isinstance(state['data'], dict):
-            gains = {}
-            dterms = dict(state.get('dterms', {}))
-            for site, d in state['data'].items():
-                g, dt = ehc.split_dtcal(d)
-                gains[site] = g
-                if dt is not None:
-                    dterms[site] = dt
-            state['data'] = gains
-            state['dterms'] = dterms
+
+        # Pre-split pickles carry 'data'; pop it, since the property shadows any
+        # instance-dict entry of that name and the gains would become unreachable.
+        if 'data' in state:
+            legacy = state.pop('data')
+            if 'gains' not in state:  # never overwrite new-style state
+                if isinstance(legacy, dict):
+                    gains = {}
+                    dterms = dict(state.get('dterms', {}))
+                    for site, d in legacy.items():
+                        g, dt = ehc.split_dtcal(d)
+                        gains[site] = g
+                        if dt is not None:
+                            dterms[site] = dt
+                    state['gains'] = gains
+                    state['dterms'] = dterms
+                else:
+                    # old __init__ stored non-dict datadicts verbatim
+                    state['gains'] = legacy
         state.setdefault('dterms', {})
         self.__dict__.update(state)
 
@@ -151,13 +196,13 @@ class Caltable:
         """
         # sites
         if (isinstance(sites,str) and sites.lower() == 'all'):
-            sites = list(self.data.keys())
+            sites = list(self.gains.keys())
 
         if isinstance(sites,str):
             sites = [sites]
 
         if len(sites)==0:
-            sites = list(self.data.keys())
+            sites = list(self.gains.keys())
 
         keys = [self.tkey[site] for site in sites]
 
@@ -222,13 +267,13 @@ class Caltable:
 
         # sites
         if (isinstance(sites,str) and sites.lower() == 'all'):
-            sites = sorted(list(self.data.keys()))
+            sites = sorted(list(self.gains.keys()))
 
         if isinstance(sites,str):
             sites = [sites]
 
         if len(sites)==0:
-            sites = sorted(list(self.data.keys()))
+            sites = sorted(list(self.gains.keys()))
 
         if len(markersize) == 1:
             markersize = markersize * np.ones(len(sites))
@@ -237,15 +282,15 @@ class Caltable:
         tmins = tmaxes = gmins = gmaxes = []
         for s in range(len(sites)):
             site = sites[s]
-            times = self.data[site]['time']
+            times = self.gains[site]['time']
             if timetype in ['UTC', 'utc'] and self.timetype == 'GMST':
                 times = obsh.gmst_to_utc(times, self.mjd)
             elif timetype in ['GMST', 'gmst'] and self.timetype == 'UTC':
                 times = obsh.utc_to_gmst(times, self.mjd)
             if pol == 'R':
-                gains = self.data[site]['rscale']
+                gains = self.gains[site]['rscale']
             elif pol == 'L':
-                gains = self.data[site]['lscale']
+                gains = self.gains[site]['lscale']
 
             if gain_type == 'amp':
                 gains = np.abs(gains)
@@ -326,24 +371,24 @@ class Caltable:
         """
 
         if len(sites) == 0:
-            sites = self.data.keys()
+            sites = self.gains.keys()
 
         caltab_pos = self.copy()
-        for site in self.data.keys():
+        for site in self.gains.keys():
             if site not in sites:
                 continue
-            if len(self.data[site]['rscale']) == 0:
+            if len(self.gains[site]['rscale']) == 0:
                 continue
 
             if method == 'min':
-                sitemin = np.min([np.abs(self.data[site]['rscale']),
-                                  np.abs(self.data[site]['lscale'])])
+                sitemin = np.min([np.abs(self.gains[site]['rscale']),
+                                  np.abs(self.gains[site]['lscale'])])
             elif method == 'mean':
-                sitemin = np.mean([np.abs(self.data[site]['rscale']),
-                                   np.abs(self.data[site]['lscale'])])
+                sitemin = np.mean([np.abs(self.gains[site]['rscale']),
+                                   np.abs(self.gains[site]['lscale'])])
             elif method == 'median':
-                sitemin = np.median([np.abs(self.data[site]['rscale']),
-                                     np.abs(self.data[site]['lscale'])])
+                sitemin = np.median([np.abs(self.gains[site]['rscale']),
+                                     np.abs(self.gains[site]['lscale'])])
             else:
                 print('Method ' + method + ' not recognized!')
                 return caltab_pos
@@ -351,8 +396,8 @@ class Caltable:
             if sitemin < min_gain:
                 if verbose:
                     print(method + ' gain for ' + site + ' is ' + str(sitemin) + '. Rescaling.')
-                caltab_pos.data[site]['rscale'] /= sitemin
-                caltab_pos.data[site]['lscale'] /= sitemin
+                caltab_pos.gains[site]['rscale'] /= sitemin
+                caltab_pos.gains[site]['lscale'] /= sitemin
             else:
                 if verbose:
                     print(method + ' gain for ' + site + ' is ' + str(sitemin) + '. Not adjusting.')
@@ -372,12 +417,12 @@ class Caltable:
         """
 
         outdict = {}
-        scopes = list(self.data.keys())
+        scopes = list(self.gains.keys())
         for scope in scopes:
-            if np.any(self.data[scope] is None) or len(self.data[scope]) == 0:
+            if np.any(self.gains[scope] is None) or len(self.gains[scope]) == 0:
                 continue
 
-            caldata = copy.deepcopy(self.data[scope])
+            caldata = copy.deepcopy(self.gains[scope])
 
             # Gather data into "scans"
             # TODO we could use a scan table for this as well!
@@ -477,16 +522,16 @@ class Caltable:
             site = self.tarr[s]['site']
 
             try:
-                self.data[site]
+                self.gains[site]
             except KeyError:
                 skipsites.append(site)
                 print(f"No Calibration  Data for {site} !")
                 continue
 
-            time_mjd = self.data[site]['time'] / 24.0 + self.mjd
-            rinterp[site] = relaxed_interp1d(time_mjd, self.data[site]['rscale'],
+            time_mjd = self.gains[site]['time'] / 24.0 + self.mjd
+            rinterp[site] = relaxed_interp1d(time_mjd, self.gains[site]['rscale'],
                                              kind=interp, fill_value=fill_value, bounds_error=False)
-            linterp[site] = relaxed_interp1d(time_mjd, self.data[site]['lscale'],
+            linterp[site] = relaxed_interp1d(time_mjd, self.gains[site]['lscale'],
                                              kind=interp, fill_value=fill_value, bounds_error=False)
 
         bllist = obs.bllist()
@@ -567,7 +612,7 @@ class Caltable:
 
         tarr1 = self.tarr.copy()
         tkey1 = self.tkey.copy()
-        data1 = self.data.copy()
+        data1 = self.gains.copy()
         for caltable in caltablelist:
 
             # TODO check metadata!
@@ -575,7 +620,7 @@ class Caltable:
             # TODO CHECK ARE THEY ALL REFERENCED TO SAME MJD???
             tarr2 = caltable.tarr.copy()
             tkey2 = caltable.tkey.copy()
-            data2 = caltable.data.copy()
+            data2 = caltable.gains.copy()
             sites2 = list(data2.keys())
             sites1 = list(data1.keys())
             for site in sites2:
@@ -648,7 +693,7 @@ class Caltable:
            Returns:
                (Caltable): the averaged Caltable object
         """
-        sites = list(self.data.keys())
+        sites = list(self.gains.keys())
         ntele = len(sites)
 
         datatables = {}
@@ -658,7 +703,7 @@ class Caltable:
             site = sites[s]
 
             # make a list of times that is the same value for all points in the same scan
-            times = self.data[site]['time']
+            times = self.gains[site]['time']
             times_stable = times.copy()
             obs.add_scans()
             scans = obs.scans
@@ -670,8 +715,8 @@ class Caltable:
 
             datatable = []
             for scan in scans:
-                gains_l = self.data[site]['lscale']
-                gains_r = self.data[site]['rscale']
+                gains_l = self.gains[site]['lscale']
+                gains_r = self.gains[site]['rscale']
 
                 # if incoherent average then average the magnitude of gains
                 if incoherent:
@@ -697,12 +742,17 @@ class Caltable:
         return caltable
 
     def invert_gains(self):
+        """Invert the gain table in place, leaving any D-term table untouched.
 
-        sites = self.data.keys()
+           Returns:
+               (Caltable): self, with every gain replaced by its reciprocal
+        """
+
+        sites = self.gains.keys()
 
         for site in sites:
-            self.data[site]['rscale'] = 1 / self.data[site]['rscale']
-            self.data[site]['lscale'] = 1 / self.data[site]['lscale']
+            self.gains[site]['rscale'] = 1 / self.gains[site]['rscale']
+            self.gains[site]['lscale'] = 1 / self.gains[site]['lscale']
 
         return self
 
@@ -782,7 +832,7 @@ def save_caltable(caltable, obs, datadir='.', sqrt_gains=False):
 
     ehtim.io.save.save_array_txt(obs.tarr, datadir + '/array.txt')
 
-    datatables = caltable.data
+    datatables = caltable.gains
     src = caltable.source
     for site_info in caltable.tarr:
         site = site_info['site']
@@ -954,16 +1004,15 @@ def plot_compare_gains(caltab1, caltab2, obs, sites='all', pol='R', gain_type='a
 
     # sites
     if (isinstance(sites,str) and sites.lower() == 'all'):
-        sites = list(set(caltab1.data.keys()).intersection(caltab2.data.keys()))
+        sites = list(set(caltab1.gains.keys()).intersection(caltab2.gains.keys()))
 
     if isinstance(sites,str):
         sites = [sites]
 
     if len(sites)==0:
-        sites = list(set(caltab1.data.keys()).intersection(caltab2.data.keys()))
+        sites = list(set(caltab1.gains.keys()).intersection(caltab2.gains.keys()))
 
     if site_name_dict is None:
-        print('hi')
         site_name_dict = {}
         for site in sites:
             site_name_dict[site] = site
@@ -978,11 +1027,11 @@ def plot_compare_gains(caltab1, caltab2, obs, sites='all', pol='R', gain_type='a
 
         site = sites[s]
         if pol == 'R':
-            gains1 = caltab1.data[site]['rscale']
-            gains2 = caltab2.data[site]['rscale']
+            gains1 = caltab1.gains[site]['rscale']
+            gains2 = caltab2.gains[site]['rscale']
         elif pol == 'L':
-            gains1 = caltab1.data[site]['lscale']
-            gains2 = caltab2.data[site]['lscale']
+            gains1 = caltab1.gains[site]['lscale']
+            gains2 = caltab2.gains[site]['lscale']
 
         if gain_type == 'amp':
             gains1 = np.abs(gains1)

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -133,7 +133,7 @@ class Caltable:
             self.dterms = {}
             for site, table in dtermdict.items():
                 site_dterms = ehc._normalize_recarray(table)
-                if site_dterms is not None:
+                if site_dterms is not None and len(site_dterms):
                     self.dterms[site] = site_dterms
 
     @property

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -19,6 +19,7 @@
 
 import copy
 import os
+import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -28,6 +29,7 @@ import ehtim.const_def as ehc
 import ehtim.io.load
 import ehtim.io.save
 import ehtim.observing.obs_helpers as obsh
+from ehtim.warnings import MixedPolConventionWarning
 
 ##################################################################################################
 # Caltable object
@@ -509,6 +511,13 @@ class Caltable:
         if not (self.tarr == obs.tarr).all():
             raise Exception("The telescope array in the Caltable is not the same as in the Obsdata")
 
+        if self.dterms:
+            warnings.warn(
+                "This cal table carries D-terms for "
+                f"{', '.join(sorted(self.dterms))}, but applycal corrects gains only: "
+                "the leakage is left in the data.",
+                MixedPolConventionWarning, stacklevel=2)
+
         if extrapolate is True:  # extrapolate can be a tuple or numpy array
             fill_value = "extrapolate"
         else:
@@ -620,15 +629,21 @@ class Caltable:
 
             # TODO check metadata!
 
-            # Leakage: a site solved on only one side is carried through, but
-            # two leakage solutions for the same site cannot be composed by
-            # multiplying interpolants the way gains can. Fail rather than
-            # return a silently wrong table.
+            # Leakage: a site solved on only one side is carried through. Two
+            # solutions for the same site compose exactly, since J = G(I+D) is
+            # closed under multiplication, but not the way gains do: the leakage
+            # goes as d1*(b2/a2) + d2 to first order, weighted by the other
+            # table's gain ratio, and the product does not commute. That needs a
+            # documented order convention and the gains sampled on the D-term
+            # grid, so it waits for the solvers that actually write leakage into
+            # a cal table. Nothing produces such a table yet, so this is
+            # unreachable through the normal API.
             for site, dterm_table in caltable.dterms.items():
                 if site in dterms1:
                     raise NotImplementedError(
                         f"merge: both caltables carry D-terms for site {site}. "
-                        "Composing two leakage solutions is not supported.")
+                        "Composing two leakage solutions is deferred; it is a "
+                        "Jones product, not a gain-style multiply.")
                 dterms1[site] = copy.deepcopy(dterm_table)
 
             # TODO CHECK ARE THEY ALL REFERENCED TO SAME MJD???

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -437,7 +437,7 @@ class Caltable:
                     scandata.append(caldata[i])
 
             # This adds the last scan
-            scandata = np.array(scandata)
+            scandata = np.array(scandata, dtype=ehc.DTCAL)
             gathered_data.append(scandata)
 
             # Compute padding values and pad scans
@@ -487,8 +487,10 @@ class Caltable:
             else:
                 outdict[scope] = caldata_out
 
+        # padding is a gain-table operation; leakage rides along untouched
         return Caltable(self.ra, self.dec, self.rf, self.bw, outdict, self.tarr,
-                        source=self.source, mjd=self.mjd, timetype=self.timetype)
+                        source=self.source, mjd=self.mjd, timetype=self.timetype,
+                        dterms=copy.deepcopy(self.dterms))
 
     def applycal(self, obs, interp='linear', extrapolate=None,
                  force_singlepol=False):
@@ -613,9 +615,21 @@ class Caltable:
         tarr1 = self.tarr.copy()
         tkey1 = self.tkey.copy()
         data1 = self.gains.copy()
+        dterms1 = copy.deepcopy(self.dterms)
         for caltable in caltablelist:
 
             # TODO check metadata!
+
+            # Leakage: a site solved on only one side is carried through, but
+            # two leakage solutions for the same site cannot be composed by
+            # multiplying interpolants the way gains can. Fail rather than
+            # return a silently wrong table.
+            for site, dterm_table in caltable.dterms.items():
+                if site in dterms1:
+                    raise NotImplementedError(
+                        f"merge: both caltables carry D-terms for site {site}. "
+                        "Composing two leakage solutions is not supported.")
+                dterms1[site] = copy.deepcopy(dterm_table)
 
             # TODO CHECK ARE THEY ALL REFERENCED TO SAME MJD???
             tarr2 = caltable.tarr.copy()
@@ -661,13 +675,15 @@ class Caltable:
                 else:
                     if site not in tkey1.keys():
                         tarr1 = np.append(tarr1, tarr2[tkey2[site]])
-                    data1[site] = data2[site]
+                    # copy, so the merged table does not share the input's array
+                    data1[site] = data2[site].copy()
 
             # update tkeys every time
             tkey1 = {tarr1[i]['site']: i for i in range(len(tarr1))}
 
         new_caltable = Caltable(self.ra, self.dec, self.rf, self.bw, data1, tarr1,
-                                source=self.source, mjd=self.mjd, timetype=self.timetype)
+                                source=self.source, mjd=self.mjd, timetype=self.timetype,
+                                dterms=dterms1)
 
         return new_caltable
 
@@ -733,9 +749,12 @@ class Caltable:
             datatables[site] = np.array(datatable)
 
         if len(datatables) > 0:
+            # averaging is a gain-table operation; the leakage solution, which
+            # lives on its own time grid, is carried over as-is
             caltable = Caltable(obs.ra, obs.dec, obs.rf,
                                 obs.bw, datatables, obs.tarr, source=obs.source,
-                                mjd=obs.mjd, timetype=obs.timetype)
+                                mjd=obs.mjd, timetype=obs.timetype,
+                                dterms=copy.deepcopy(self.dterms))
         else:
             caltable = False
 

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -116,15 +116,15 @@ class Caltable:
 
         # Save the data, splitting out D-terms from any older welded tables
         self.dterms = {}
-        if isinstance(datadict, dict):
-            self.gains = {}
-            for site, d in datadict.items():
-                site_gains, site_dterms = ehc.upgrade_caltable(d)
-                self.gains[site] = site_gains
-                if site_dterms is not None:
-                    self.dterms[site] = site_dterms
-        else:
-            self.gains = datadict
+        if not isinstance(datadict, dict):
+            raise TypeError("datadict must be a dict of per-site gain tables "
+                            f"keyed by site name, got {type(datadict).__name__}")
+        self.gains = {}
+        for site, d in datadict.items():
+            site_gains, site_dterms = ehc.upgrade_caltable(d)
+            self.gains[site] = site_gains
+            if site_dterms is not None:
+                self.dterms[site] = site_dterms
 
         # An explicit D-term table replaces whatever the split produced
         if dtermdict is not None:

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -130,6 +130,9 @@ class Caltable:
 
         # An explicit D-term table replaces whatever the split produced
         if dterms is not None:
+            if not isinstance(dterms, dict):
+                raise TypeError("dterms must be a dict keyed by site name, "
+                                f"got {type(dterms).__name__}")
             self.dterms = dict(dterms)
 
     @property
@@ -147,6 +150,12 @@ class Caltable:
         self.gains = datadict
 
     def __setstate__(self, state):
+        # Rebind the migration onto a copy. Unpickling hands over a throwaway
+        # dict, but a direct call (migration script, test) hands over one the
+        # caller still owns, and rewriting it in place would both surprise them
+        # and alias the migrated tables into every object restored from it.
+        state = dict(state)
+
         # Silently upgrade legacy pickles to the current schema.
         if 'tarr' in state:
             state['tarr'] = ehc.upgrade_tarr(state['tarr'])
@@ -640,6 +649,10 @@ class Caltable:
 
             # TODO check metadata!
 
+            # TODO CHECK ARE THEY ALL REFERENCED TO SAME MJD???
+            tarr2 = caltable.tarr.copy()
+            tkey2 = caltable.tkey.copy()
+
             # Leakage: a site solved on only one side is carried through. Two
             # solutions for the same site compose exactly, since J = G(I+D) is
             # closed under multiplication, but not the way gains do: the leakage
@@ -655,11 +668,15 @@ class Caltable:
                         f"merge: both caltables carry D-terms for site {site}. "
                         "Composing two leakage solutions is deferred; it is a "
                         "Jones product, not a gain-style multiply.")
+                # A site can carry leakage with no gain rows, so it would never
+                # reach the tarr append below. Its array row still has to come
+                # along: save_caltable walks tarr, so a site missing from it
+                # loses its solved leakage silently. tkey1 is refreshed here so
+                # the gain loop does not append the row a second time.
+                if site not in tkey1 and site in tkey2:
+                    tarr1 = np.append(tarr1, tarr2[tkey2[site]])
+                    tkey1 = {tarr1[i]['site']: i for i in range(len(tarr1))}
                 dterms1[site] = copy.deepcopy(dterm_table)
-
-            # TODO CHECK ARE THEY ALL REFERENCED TO SAME MJD???
-            tarr2 = caltable.tarr.copy()
-            tkey2 = caltable.tkey.copy()
             data2 = caltable.gains.copy()
             sites2 = list(data2.keys())
             sites1 = list(data1.keys())
@@ -1013,6 +1030,12 @@ def make_caltable(obs, gains, sites, times):
 
 
 def relaxed_interp1d(x, y, **kwargs):
+    # TODO: the single-row fallback below invents a flat segment of half-width
+    # 0.5 in whatever units x carries -- half an hour for merge, which
+    # interpolates in raw hours, half a day for applycal, which interpolates in
+    # MJD. Harmless while it only ever pads a stray one-row gain table, but a
+    # time-constant D-term table is one row by construction, so the width stops
+    # being incidental as soon as leakage is interpolated. Make it explicit then.
     try:
         len(x)
     except TypeError:

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -35,6 +35,12 @@ from ehtim.warnings import MixedPolConventionWarning
 # Caltable object
 ##################################################################################################
 
+# D-terms are saved beside the gain files, one per site. The gain files stay in
+# their long-standing headerless five-column format; these carry a version line
+# so the format can move later. np.loadtxt ignores '#' lines.
+DTERM_FILE_SUFFIX = '_dterms.txt'
+DTERM_FILE_HEADER = '# ehtim caltable dterms format v1: time_mjd d1re d1im d2re d2im'
+
 
 class Caltable:
     """A calibration table holding per-station gains and leakage (D-terms).
@@ -813,11 +819,12 @@ def load_caltable(obs, datadir, sqrt_gains=False):
         site = tarr[s]['site']
         filename = os.path.join(datadir, obs.source + '_' + site + '.txt')
         try:
-            data = np.loadtxt(filename, dtype=bytes).astype(str)
+            # ndmin=2 so a one-row file still iterates as rows, not characters
+            data = np.loadtxt(filename, dtype=bytes, ndmin=2).astype(str)
         except OSError:
             try:
                 filename = datadir + site + '.txt'
-                data = np.loadtxt(filename, dtype=bytes).astype(str)
+                data = np.loadtxt(filename, dtype=bytes, ndmin=2).astype(str)
             except OSError:
                 continue
 
@@ -842,9 +849,38 @@ def load_caltable(obs, datadir, sqrt_gains=False):
             datatable.append(np.array((time, rscale, lscale), dtype=ehc.DTCAL))
 
         datatables[site] = np.array(datatable)
+
+    # D-terms, if this directory has them. Written by save_caltable next to the
+    # gain files; older directories simply have none.
+    dterm_tables = {}
+    for s in range(0, len(tarr)):
+        site = tarr[s]['site']
+        filename = os.path.join(datadir, obs.source + '_' + site + DTERM_FILE_SUFFIX)
+        try:
+            # skip the version line explicitly: letting loadtxt treat it as a
+            # comment makes numpy warn about the skipped line on every load
+            with open(filename) as dterm_file:
+                skiprows = 1 if dterm_file.readline().lstrip().startswith('#') else 0
+            data = np.loadtxt(filename, dtype=bytes, ndmin=2,
+                              skiprows=skiprows, comments=None).astype(str)
+        except OSError:
+            continue
+
+        dterm_table = []
+        for row in data:
+            if len(row) != 5:
+                raise Exception("cannot load caltable D-terms -- format unknown!")
+            time = (float(row[0]) - obs.mjd) * 24.0  # time is given in mjd
+            d_p1 = float(row[1]) + 1j * float(row[2])
+            d_p2 = float(row[3]) + 1j * float(row[4])
+            dterm_table.append(np.array((time, d_p1, d_p2), dtype=ehc.DTDTERM))
+
+        dterm_tables[site] = np.array(dterm_table)
+
     if len(datatables) > 0:
         caltable = Caltable(obs.ra, obs.dec, obs.rf, obs.bw, datatables, tarr,
-                            source=obs.source, mjd=obs.mjd, timetype=obs.timetype)
+                            source=obs.source, mjd=obs.mjd, timetype=obs.timetype,
+                            dterms=dterm_tables)
     else:
         print(f"COULD NOT FIND CALTABLE IN DIRECTORY {datadir}")
         caltable = False
@@ -896,6 +932,27 @@ def save_caltable(caltable, obs, datadir='.', sqrt_gains=False):
                        str(float(lreal)) + ' ' + str(float(limag)) + '\n')
             outfile.write(outline)
         outfile.close()
+
+    # D-terms go in their own per-site files, on their own time grid. Looping
+    # over tarr again rather than over the gain sites: a site can carry leakage
+    # without gains. sqrt_gains is a gain convention and does not touch these.
+    for site_info in caltable.tarr:
+        site = site_info['site']
+
+        if len(caltable.dterms.get(site, [])) == 0:
+            continue
+
+        filename = datadir + '/' + src + '_' + site + DTERM_FILE_SUFFIX
+        with open(filename, 'w') as outfile:
+            outfile.write(DTERM_FILE_HEADER + '\n')
+            for entry in caltable.dterms[site]:
+                time = entry['time'] / 24.0 + obs.mjd
+                outline = (str(float(time)) + ' ' +
+                           str(float(np.real(entry['d_p1']))) + ' ' +
+                           str(float(np.imag(entry['d_p1']))) + ' ' +
+                           str(float(np.real(entry['d_p2']))) + ' ' +
+                           str(float(np.imag(entry['d_p2']))) + '\n')
+                outfile.write(outline)
 
     return
 

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -88,9 +88,8 @@ class Caltable:
                mjd (int): The integer MJD of the observation
                bw (float): The observation bandwidth in Hz
 
-               datadict (dict):  keys are sites in tarr, entries are gain tables of type
-                                 DTCAL. Older welded tables carrying D-term columns are
-                                 split into the gain and D-term tables automatically.
+               datadict (dict):  keys are sites in tarr, entries are gain tables of
+                                 type DTCAL. Legacy tables are upgraded automatically.
                tarr (numpy.recarray): The array of telescope data with datatype DTARR
                dtermdict (dict): keys are sites in tarr, entries are D-term tables of
                                  type DTDTERM, on their own time grid. When given, it
@@ -120,19 +119,13 @@ class Caltable:
         self.tarr = ehc.upgrade_tarr(tarr)
         self.tkey = {self.tarr[i]['site']: i for i in range(len(self.tarr))}
 
-        # Save the data, splitting out D-terms from any older welded tables
-        self.dterms = {}
+        # Store the gains, upgrading any legacy per-site tables
         if not isinstance(datadict, dict):
             raise TypeError("datadict must be a dict of per-site gain tables "
                             f"keyed by site name, got {type(datadict).__name__}")
-        self.gains = {}
-        for site, d in datadict.items():
-            site_gains, site_dterms = ehc.upgrade_caltable(d)
-            self.gains[site] = site_gains
-            if site_dterms is not None:
-                self.dterms[site] = site_dterms
+        self.gains = {site: ehc.upgrade_caltable(d) for site, d in datadict.items()}
 
-        # An explicit D-term table replaces whatever the split produced
+        self.dterms = {}
         if dtermdict is not None:
             if not isinstance(dtermdict, dict):
                 raise TypeError("dtermdict must be a dict keyed by site name, "
@@ -155,25 +148,15 @@ class Caltable:
 
     @data.setter
     def data(self, datadict):
-        # normalize like the constructor does, but refuse welded tables:
-        # splitting here would move D-terms out of the caller's own dict
-        if isinstance(datadict, dict):
-            normalized = {}
-            reshaped = False
-            for site, table in datadict.items():
-                site_gains, site_dterms = ehc.upgrade_caltable(table)
-                if site_dterms is not None:
-                    raise TypeError(
-                        f"data is the gain table, but the table for {site} "
-                        "carries D-term columns. Assign gains to .data and "
-                        "leakage to .dterms, or hand the welded table to the "
-                        "constructor, which splits it.")
-                reshaped |= site_gains is not table
-                normalized[site] = site_gains
-            # keep the caller's own dict when nothing needed reshaping
-            if reshaped:
-                datadict = normalized
-        self.gains = datadict
+        # normalize like the constructor does
+        if not isinstance(datadict, dict):
+            raise TypeError("data must be a dict of per-site gain tables "
+                            f"keyed by site name, got {type(datadict).__name__}")
+        normalized = {site: ehc.upgrade_caltable(t) for site, t in datadict.items()}
+        # keep the caller's own dict when nothing needed reshaping
+        if all(normalized[site] is datadict[site] for site in normalized):
+            normalized = datadict
+        self.gains = normalized
 
     def __setstate__(self, state):
         # upgrade old pickled caltables to the current schema, on a copy of
@@ -189,15 +172,8 @@ class Caltable:
             legacy = state.pop('data')
             if 'gains' not in state:  # never overwrite new-style state
                 if isinstance(legacy, dict):
-                    gains = {}
-                    dterms = dict(state.get('dterms', {}))
-                    for site, d in legacy.items():
-                        g, dt = ehc.upgrade_caltable(d)
-                        gains[site] = g
-                        if dt is not None:
-                            dterms[site] = dt
-                    state['gains'] = gains
-                    state['dterms'] = dterms
+                    state['gains'] = {site: ehc.upgrade_caltable(d)
+                                      for site, d in legacy.items()}
                 else:
                     # old __init__ stored non-dict datadicts verbatim
                     state['gains'] = legacy

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -758,7 +758,7 @@ class Caltable:
 
         return new_caltable
 
-    def save_txt(self, obs, datadir='.', sqrt_gains=False):
+    def save_txt(self, obs, datadir='.', sqrt_gains=False, overwrite=False):
         """Saves a Caltable object to text files in the given directory
 
            Gains and D-terms go to separate per-site files; see save_caltable
@@ -768,11 +768,14 @@ class Caltable:
                obs (Obsdata): The observation object associated with the Caltable
                datadir (str): directory to save caltable in
                sqrt_gains (bool): If True, we square gains before saving.
+               overwrite (bool): If True, allow existing caltable files in datadir
+                                 to be overwritten or deleted
 
            Returns:
         """
 
-        return save_caltable(self, obs, datadir=datadir, sqrt_gains=sqrt_gains)
+        return save_caltable(self, obs, datadir=datadir, sqrt_gains=sqrt_gains,
+                             overwrite=overwrite)
 
     def scan_avg(self, obs, incoherent=True):
         """average the gains across scans.
@@ -947,7 +950,18 @@ def load_caltable(obs, datadir, sqrt_gains=False):
     return caltable
 
 
-def save_caltable(caltable, obs, datadir='.', sqrt_gains=False):
+def _caltable_filenames(caltable, datadir):
+    """Every file save_caltable writes to or removes in datadir."""
+    src = caltable.source
+    names = [datadir + '/array.txt']
+    for site_info in caltable.tarr:
+        site = site_info['site']
+        names.append(datadir + '/' + src + '_' + site + '.txt')
+        names.append(datadir + '/' + src + '_' + site + DTERM_FILE_SUFFIX)
+    return names
+
+
+def save_caltable(caltable, obs, datadir='.', sqrt_gains=False, overwrite=False):
     """Saves a Caltable object to text files in the given directory
 
        Three kinds of file: array.txt for the telescope array, one
@@ -962,12 +976,20 @@ def save_caltable(caltable, obs, datadir='.', sqrt_gains=False):
            obs (Obsdata): The observation object associated with the Caltable
            datadir (str): directory to save caltable in
            sqrt_gains (bool): If True, we square gains before saving.
+           overwrite (bool): If True, allow existing caltable files in datadir
+                             to be overwritten or deleted
 
        Returns:
     """
 
     if not os.path.exists(datadir):
         os.makedirs(datadir)
+
+    # don't clobber an existing caltable unless asked
+    existing = [f for f in _caltable_filenames(caltable, datadir) if os.path.exists(f)]
+    if existing and not overwrite:
+        raise Exception(f"{len(existing)} caltable file(s) in {datadir} would be "
+                        "overwritten or deleted; pass overwrite=True to allow it")
 
     # The table's tarr, not the observation's: load_caltable rebuilds tarr from
     # this file, so a site only the table knows about has to appear here.
@@ -977,11 +999,14 @@ def save_caltable(caltable, obs, datadir='.', sqrt_gains=False):
     src = caltable.source
     for site_info in caltable.tarr:
         site = site_info['site']
+        filename = datadir + '/' + src + '_' + site + '.txt'
 
         if len(datatables.get(site, [])) == 0:
+            # a stale file would be read back as this table's gains
+            if os.path.exists(filename):
+                os.remove(filename)
             continue
 
-        filename = datadir + '/' + src + '_' + site + '.txt'
         outfile = open(filename, 'w')
         site_data = datatables[site]
         for entry in site_data:
@@ -1004,16 +1029,14 @@ def save_caltable(caltable, obs, datadir='.', sqrt_gains=False):
             outfile.write(outline)
         outfile.close()
 
-    # D-terms go in their own per-site files, on their own time grid. Looping
-    # over tarr again rather than over the gain sites: a site can carry leakage
-    # without gains. sqrt_gains is a gain convention and does not touch these.
+    # Time-dependent D-terms go in their own per-site files. Loop over tarr, not
+    # the gain sites: a site can carry leakage with no gains.
     for site_info in caltable.tarr:
         site = site_info['site']
         filename = datadir + '/' + src + '_' + site + DTERM_FILE_SUFFIX
 
         if len(caltable.dterms.get(site, [])) == 0:
-            # Left over from an earlier save into this directory; it would be
-            # read back as this table's leakage.
+            # a stale file would be read back as this table's leakage
             if os.path.exists(filename):
                 os.remove(filename)
             continue

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -147,6 +147,20 @@ class Caltable:
 
     @data.setter
     def data(self, datadict):
+        # This name means the gain table. A welded (pre-split) table assigned
+        # here would be stored as-is and then fail deep inside pad_scans with a
+        # numpy cast error, so refuse it at the assignment instead. Splitting it
+        # silently is the other option and is worse: it would move leakage out
+        # of the caller's dict into self.dterms, where they never put it.
+        if isinstance(datadict, dict):
+            for site, table in datadict.items():
+                fields = getattr(getattr(table, 'dtype', None), 'fields', None)
+                if fields and ('d_p1' in fields or 'dr' in fields):
+                    raise TypeError(
+                        f"data is the gain table, but the table for {site} "
+                        "carries D-term columns. Assign gains to .data and "
+                        "leakage to .dterms, or hand the welded table to the "
+                        "constructor, which splits it.")
         self.gains = datadict
 
     def __setstate__(self, state):

--- a/ehtim/caltable.py
+++ b/ehtim/caltable.py
@@ -42,6 +42,34 @@ DTERM_FILE_SUFFIX = '_dterms.txt'
 DTERM_FILE_HEADER = '# ehtim caltable dterms format v1: time_mjd d1re d1im d2re d2im'
 
 
+def _as_dterm_table(table):
+    """Normalize one site's D-term table, or return None if there is nothing in it.
+
+    Solvers build rows the same way they build gain rows, which for a single
+    time gives a 0-d record rather than a one-row table, and a sidecar file
+    holding only its version line reads back as a plain empty array. Both would
+    otherwise be stored as leakage that later code cannot index.
+
+    Parameters
+    ----------
+    table : numpy.recarray or record or None
+        One site's D-terms, in any of those shapes.
+
+    Returns
+    -------
+    numpy.recarray or None
+        A one-dimensional D-term table, or None when it holds no rows.
+    """
+    if table is None:
+        return None
+    if not isinstance(table, np.ndarray):
+        table = np.asarray(table)
+    if table.dtype.names is None:
+        return None
+    table = np.atleast_1d(table)
+    return table if len(table) else None
+
+
 class Caltable:
     """A calibration table holding per-station gains and leakage (D-terms).
 
@@ -133,7 +161,11 @@ class Caltable:
             if not isinstance(dterms, dict):
                 raise TypeError("dterms must be a dict keyed by site name, "
                                 f"got {type(dterms).__name__}")
-            self.dterms = dict(dterms)
+            self.dterms = {}
+            for site, table in dterms.items():
+                site_dterms = _as_dterm_table(table)
+                if site_dterms is not None:
+                    self.dterms[site] = site_dterms
 
     @property
     def data(self):
@@ -147,20 +179,25 @@ class Caltable:
 
     @data.setter
     def data(self, datadict):
-        # This name means the gain table. A welded (pre-split) table assigned
-        # here would be stored as-is and then fail deep inside pad_scans with a
-        # numpy cast error, so refuse it at the assignment instead. Splitting it
-        # silently is the other option and is worse: it would move leakage out
-        # of the caller's dict into self.dterms, where they never put it.
+        # Same normalization the constructor does, so a solver's caldict works
+        # either way. Leakage is refused, not split: splitting would move the
+        # D-terms out of the caller's own dict.
         if isinstance(datadict, dict):
+            normalized = {}
+            reshaped = False
             for site, table in datadict.items():
-                fields = getattr(getattr(table, 'dtype', None), 'fields', None)
-                if fields and ('d_p1' in fields or 'dr' in fields):
+                site_gains, site_dterms = ehc.split_dtcal(table)
+                if site_dterms is not None:
                     raise TypeError(
                         f"data is the gain table, but the table for {site} "
                         "carries D-term columns. Assign gains to .data and "
                         "leakage to .dterms, or hand the welded table to the "
                         "constructor, which splits it.")
+                reshaped |= site_gains is not table
+                normalized[site] = site_gains
+            # keep the caller's own dict when nothing needed reshaping
+            if reshaped:
+                datadict = normalized
         self.gains = datadict
 
     def __setstate__(self, state):
@@ -230,15 +267,25 @@ class Caltable:
            Returns:
                matplotlib.axes
         """
-        # sites
+        if self.dterms:
+            warnings.warn(
+                "This plot shows the array table's D-terms. This cal table also "
+                f"carries its own solved leakage for {', '.join(sorted(self.dterms))}, "
+                "in self.dterms, which is not what is drawn here.",
+                MixedPolConventionWarning, stacklevel=2)
+
+        # sites: a site can carry leakage without gains, so take both dicts
+        all_sites = list(self.gains.keys())
+        all_sites += [site for site in self.dterms if site not in self.gains]
+
         if (isinstance(sites,str) and sites.lower() == 'all'):
-            sites = list(self.gains.keys())
+            sites = all_sites
 
         if isinstance(sites,str):
             sites = [sites]
 
         if len(sites)==0:
-            sites = list(self.gains.keys())
+            sites = all_sites
 
         keys = [self.tkey[site] for site in sites]
 
@@ -466,46 +513,39 @@ class Caltable:
             scandata = [caldata[0]]
             for i in range(1, len(caldata)):
                 if (caldata[i]['time'] - caldata[i - 1]['time']) * 3600 > maxdiff:
-                    scandata = np.array(scandata, dtype=ehc.DTCAL)
+                    scandata = np.array(scandata, dtype=caldata.dtype)
                     gathered_data.append(scandata)
                     scandata = [caldata[i]]
                 else:
                     scandata.append(caldata[i])
 
             # This adds the last scan
-            scandata = np.array(scandata, dtype=ehc.DTCAL)
+            scandata = np.array(scandata, dtype=caldata.dtype)
             gathered_data.append(scandata)
 
             # Compute padding values and pad scans
             for i in range(len(gathered_data)):
                 gg = gathered_data[i]
 
-                medR = np.median(gg['rscale'])
-                medL = np.median(gg['lscale'])
-
+                # Generic feed names throughout, so a linear-feed table pads
+                # as itself instead of being recast as circular.
                 timepre = gg['time'][0] - maxdiff / 2. / 3600.
                 timepost = gg['time'][-1] + maxdiff / 2. / 3600.
 
                 if padtype == 'median':  # pad with median scan value
-                    medR = np.median(gg['rscale'])
-                    medL = np.median(gg['lscale'])
-                    preR = medR
-                    postR = medR
-                    preL = medL
-                    postL = medL
+                    pre1 = post1 = np.median(gg['p1scale'])
+                    pre2 = post2 = np.median(gg['p2scale'])
                 elif padtype == 'endval':  # pad with endpoints
-                    preR = gg['rscale'][0]
-                    postR = gg['rscale'][-1]
-                    preL = gg['lscale'][0]
-                    postL = gg['lscale'][-1]
+                    pre1 = gg['p1scale'][0]
+                    post1 = gg['p1scale'][-1]
+                    pre2 = gg['p2scale'][0]
+                    post2 = gg['p2scale'][-1]
                 else:  # pad with ones
-                    preR = 1.
-                    postR = 1.
-                    preL = 1.
-                    postL = 1.
+                    pre1 = post1 = 1.
+                    pre2 = post2 = 1.
 
-                valspre = np.array([(timepre, preR, preL)], dtype=ehc.DTCAL)
-                valspost = np.array([(timepost, postR, postL)], dtype=ehc.DTCAL)
+                valspre = np.array([(timepre, pre1, pre2)], dtype=caldata.dtype)
+                valspost = np.array([(timepost, post1, post2)], dtype=caldata.dtype)
 
                 gg = np.insert(gg, 0, valspre)
                 gg = np.append(gg, valspost)
@@ -657,7 +697,11 @@ class Caltable:
 
         tarr1 = self.tarr.copy()
         tkey1 = self.tkey.copy()
-        data1 = self.gains.copy()
+        # Copy the arrays, not just the dict: a site only this table has would
+        # otherwise be shared, and the merged table's invert_gains would then
+        # write back into this one.
+        data1 = {site: (table if table is None else table.copy())
+                 for site, table in self.gains.items()}
         dterms1 = copy.deepcopy(self.dterms)
         for caltable in caltablelist:
 
@@ -667,15 +711,13 @@ class Caltable:
             tarr2 = caltable.tarr.copy()
             tkey2 = caltable.tkey.copy()
 
-            # Leakage: a site solved on only one side is carried through. Two
-            # solutions for the same site compose exactly, since J = G(I+D) is
-            # closed under multiplication, but not the way gains do: the leakage
-            # goes as d1*(b2/a2) + d2 to first order, weighted by the other
-            # table's gain ratio, and the product does not commute. That needs a
-            # documented order convention and the gains sampled on the D-term
-            # grid, so it waits for the solvers that actually write leakage into
-            # a cal table. Nothing produces such a table yet, so this is
-            # unreachable through the normal API.
+            # A site solved on one side only comes through as it is. Two
+            # solutions for the same site do compose, but not the way gains do:
+            # the leakage goes as d1*(b2/a2) + d2 to first order and the product
+            # does not commute, so it needs an order convention and the gains
+            # resampled onto the D-term grid. That waits for the solvers that
+            # write leakage into a cal table. Two tables loaded from disk can
+            # reach this.
             for site, dterm_table in caltable.dterms.items():
                 if site in dterms1:
                     raise NotImplementedError(
@@ -732,8 +774,10 @@ class Caltable:
                 else:
                     if site not in tkey1.keys():
                         tarr1 = np.append(tarr1, tarr2[tkey2[site]])
-                    # copy, so the merged table does not share the input's array
-                    data1[site] = data2[site].copy()
+                    # Copy so the merged table does not share the input's array.
+                    # A site's table can be None, so there may be nothing to copy.
+                    other = data2[site]
+                    data1[site] = other if other is None else other.copy()
 
             # update tkeys every time
             tkey1 = {tarr1[i]['site']: i for i in range(len(tarr1))}
@@ -955,7 +999,9 @@ def save_caltable(caltable, obs, datadir='.', sqrt_gains=False):
     if not os.path.exists(datadir):
         os.makedirs(datadir)
 
-    ehtim.io.save.save_array_txt(obs.tarr, datadir + '/array.txt')
+    # The table's tarr, not the observation's: load_caltable rebuilds tarr from
+    # this file, so a site only the table knows about has to appear here.
+    ehtim.io.save.save_array_txt(caltable.tarr, datadir + '/array.txt')
 
     datatables = caltable.gains
     src = caltable.source
@@ -993,11 +1039,15 @@ def save_caltable(caltable, obs, datadir='.', sqrt_gains=False):
     # without gains. sqrt_gains is a gain convention and does not touch these.
     for site_info in caltable.tarr:
         site = site_info['site']
+        filename = datadir + '/' + src + '_' + site + DTERM_FILE_SUFFIX
 
         if len(caltable.dterms.get(site, [])) == 0:
+            # Left over from an earlier save into this directory; it would be
+            # read back as this table's leakage.
+            if os.path.exists(filename):
+                os.remove(filename)
             continue
 
-        filename = datadir + '/' + src + '_' + site + DTERM_FILE_SUFFIX
         with open(filename, 'w') as outfile:
             outfile.write(DTERM_FILE_HEADER + '\n')
             for entry in caltable.dterms[site]:

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -31,7 +31,8 @@ from ehtim.observing.pulses import trianglePulse2D
 __all__ = [
     "BHIMAGE", "BOUNDS_ERROR", "C", "COLORLIST", "DEC_DEFAULT", "DEC_M87",
     "DEC_SGRA", "DEGREE", "DTAMP", "DTARR", "DTBIS", "DTCAL", "DTCAMP",
-    "DTCPHASE", "DTCPHASEDIAG", "DTERMPDEF", "DTLOGCAMPDIAG", "DTPOL_CIRC",
+    "DTCPHASE", "DTCPHASEDIAG", "DTDTERM", "DTERMPDEF", "DTLOGCAMPDIAG",
+    "DTPOL_CIRC",
     "DTPOL_STOKES", "DTSCANS", "EHTIMAGE", "ELEV_HIGH", "ELEV_LOW", "EP",
     "FFT_INTERP_DEFAULT", "FFT_PAD_DEFAULT", "FIELD_LABELS", "FIELDS",
     "FIELDS_AMPS", "FIELDS_PHASE", "FIELDS_SIGPHASE", "FIELDS_SIGS",
@@ -181,6 +182,17 @@ DTCAL_LIN = [('time', 'f8'),
              ('d_p1', 'c16'), ('d_p2', 'c16')]
 
 DTCAL = DTCAL_CIRC  # legacy alias
+
+# D-term (leakage) tables, kept separate from the gain tables (DTCAL_*) so gains
+# and D-terms can be sampled on independent time grids. The CIRC field specs
+# mirror the D-term columns of DTCAL_CIRC; DTDTERM_LIN mirrors DTCAL_LIN's
+# asymmetry (no established physical names for linear leakage).
+DTDTERM_CIRC = [('time', 'f8'),
+                (('d_p1', 'dr'), 'c16'), (('d_p2', 'dl'), 'c16')]
+
+DTDTERM_LIN = [('time', 'f8'), ('d_p1', 'c16'), ('d_p2', 'c16')]
+
+DTDTERM = DTDTERM_CIRC  # legacy alias
 
 DTSCANS = [('time', 'f8'), ('interval', 'f8'), ('startvis', 'f8'), ('endvis', 'f8')]
 

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -272,19 +272,16 @@ def _normalize_recarray(arr):
 
 # Field names a legacy caltable can carry, used to interpret old tables
 _CAL_GAIN_FIELDS = frozenset({'rscale', 'lscale', 'xscale', 'yscale', 'p1scale', 'p2scale'})
-_CAL_DTERM_FIELDS = frozenset({'dr', 'dl', 'dx', 'dy', 'd_p1', 'd_p2'})
 
 
 def upgrade_caltable(data):
-    """Upgrade legacy per-site caltable data to the current mixed-pol format.
+    """Upgrade legacy per-site caltable gains to the current mixed-pol format.
 
-    Returns (gains, dterms). D-term columns appended to the gain table by a
-    brief older format come back as their own table; dterms is None otherwise.
     Idempotent; raises on field names it cannot interpret.
     """
     import numpy as _np
     if data is None:
-        return data, None
+        return None
     if not isinstance(data, _np.ndarray):
         data = _np.asarray(data)  # solvers can hand over a bare record or [record]
     if data.dtype.names is None:
@@ -308,39 +305,18 @@ def upgrade_caltable(data):
             _warnings.warn("cannot tell the feed basis from generic field names; "
                            "assuming circular", _MPW, stacklevel=2)
     gain_t = _np.dtype(DTCAL_LIN if lin else DTCAL_CIRC)
-    dterm_t = _np.dtype(DTDTERM_LIN if lin else DTDTERM_CIRC)
 
     if data.dtype == gain_t:
-        return data, None
+        return data
 
-    # gains only: copy into the current dtype (a copy, not a view, so the
+    # legacy gains: copy into the current dtype (a copy, not a view, so the
     # caller's array is never written through and byte order is converted)
-    if not any(k in fields for k in _CAL_DTERM_FIELDS):
-        if len(names) != 3 or names[0] != 'time' or not set(names[1:]) <= _CAL_GAIN_FIELDS:
-            raise Exception(f"cannot interpret fields {names} as a caltable gain table")
-        gains = _np.zeros(len(data), dtype=gain_t)
-        for src, dst in zip(names, gain_t.names):
-            gains[dst] = data[src]
-        return gains, None
-
-    # everything below handles the rare case where D-term columns were
-    # appended to the gain table (a brief dev-era format)
-    if (len(names) != 5 or names[0] != 'time'
-            or not set(names[1:3]) <= _CAL_GAIN_FIELDS
-            or not set(names[3:]) <= _CAL_DTERM_FIELDS):
-        raise Exception(f"cannot interpret fields {names} as a caltable")
+    if len(names) != 3 or names[0] != 'time' or not set(names[1:]) <= _CAL_GAIN_FIELDS:
+        raise Exception(f"cannot interpret fields {names} as a caltable gain table")
     gains = _np.zeros(len(data), dtype=gain_t)
-    for src, dst in zip(names[:3], gain_t.names):
+    for src, dst in zip(names, gain_t.names):
         gains[dst] = data[src]
-    d1 = data[names[3]]
-    d2 = data[names[4]]
-    if _np.any(d1 != 0) or _np.any(d2 != 0):
-        dterms = _np.zeros(len(data), dtype=dterm_t)
-        dterms['time'] = data['time']
-        dterms[dterm_t.names[1]] = d1
-        dterms[dterm_t.names[2]] = d2
-        return gains, dterms
-    return gains, None
+    return gains
 
 
 @functools.lru_cache(maxsize=16)

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -271,7 +271,8 @@ def split_dtcal(data):
     Returns
     -------
     gains : numpy.recarray
-        The gain table, dtype DTCAL_CIRC or DTCAL_LIN.
+        The gain table, dtype DTCAL_CIRC or DTCAL_LIN. A fresh array whenever
+        the dtype changed, so the caller's own table is never written through.
     dterms : numpy.recarray or None
         The D-terms lifted out of a welded table, on their own time column,
         or None if there were none to lift. Anything unrecognized is passed
@@ -295,9 +296,15 @@ def split_dtcal(data):
         return data, None
 
     if 'd_p1' not in fields and 'dr' not in fields:
-        # gains only: a view when the layout already matches, else leave it be
-        if data.dtype.names == gain_t.names and data.dtype.itemsize == gain_t.itemsize:
-            return data.view(gain_t), None
+        # Gains only. Copy per field rather than re-viewing the buffer: a view
+        # would hand the caller's own array back to Caltable, so invert_gains
+        # and enforce_positive would write through to it, and it would also
+        # reinterpret a byte-swapped (big-endian) table instead of converting.
+        if data.dtype.names == gain_t.names:
+            gains = _np.zeros(len(data), dtype=gain_t)
+            for name in gain_t.names:
+                gains[name] = data[name]
+            return gains, None
         return data, None
 
     if 'p1scale' not in fields:

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -253,73 +253,76 @@ def upgrade_dtpol_circ(data):
     return data
 
 
-def split_dtcal(data):
-    """Split a per-site cal recarray into separate gain and D-term tables.
+# Field names a legacy caltable can carry, used to interpret old tables
+_CAL_GAIN_FIELDS = frozenset({'rscale', 'lscale', 'xscale', 'yscale', 'p1scale', 'p2scale'})
+_CAL_DTERM_FIELDS = frozenset({'dr', 'dl', 'dx', 'dy', 'd_p1', 'd_p2'})
 
-    Cal tables used to carry the D-terms in the gain rows, sharing one time
-    column. Gains and D-terms vary on different timescales, so they are stored
-    as two tables now. Use this on anything handed to Caltable to normalize it,
-    whichever vintage it came from: a legacy gains-only recarray, one of the
-    old welded recarrays, or an already-split table. Idempotent.
 
-    Parameters
-    ----------
-    data : numpy.recarray or list or None
-        One site's cal table. Solvers can hand over a bare record or a list
-        holding one, so those are accepted too and promoted to one row.
+def upgrade_caltable(data):
+    """Upgrade legacy per-site caltable data to the current mixed-pol format.
 
-    Returns
-    -------
-    gains : numpy.recarray
-        The gain table, dtype DTCAL_CIRC or DTCAL_LIN. A fresh array whenever
-        the dtype changed, so the caller's own table is never written through.
-    dterms : numpy.recarray or None
-        The D-terms lifted out of a welded table, on their own time column,
-        or None if there were none to lift. Anything unrecognized is passed
-        back untouched with no D-terms.
+    Returns (gains, dterms). D-term columns appended to the gain table by a
+    brief older format come back as their own table; dterms is None otherwise.
+    Idempotent; raises on field names it cannot interpret.
     """
     import numpy as _np
     if data is None:
         return data, None
     if not isinstance(data, _np.ndarray):
-        data = _np.asarray(data)
+        data = _np.asarray(data)  # solvers can hand over a bare record or [record]
     if data.dtype.names is None:
-        return data, None
+        raise Exception("cannot interpret caltable data: array has no named fields")
     data = _np.atleast_1d(data)
 
     fields = data.dtype.fields
-    lin = 'xscale' in fields
+    names = data.dtype.names
+
+    # feed basis from the field names; generic-only names default to circular
+    if 'xscale' in fields or 'yscale' in fields:
+        lin = True
+    elif 'rscale' in fields or 'lscale' in fields:
+        lin = False
+    else:
+        lin = False
+        if 'p1scale' in fields:
+            import warnings as _warnings
+
+            from ehtim.warnings import MixedPolConventionWarning as _MPW
+            _warnings.warn("cannot tell the feed basis from generic field names; "
+                           "assuming circular", _MPW, stacklevel=2)
     gain_t = _np.dtype(DTCAL_LIN if lin else DTCAL_CIRC)
     dterm_t = _np.dtype(DTDTERM_LIN if lin else DTDTERM_CIRC)
 
     if data.dtype == gain_t:
         return data, None
 
-    if 'd_p1' not in fields and 'dr' not in fields:
-        # Gains only. Copy per field rather than re-viewing the buffer: a view
-        # would hand the caller's own array back to Caltable, so invert_gains
-        # and enforce_positive would write through to it, and it would also
-        # reinterpret a byte-swapped (big-endian) table instead of converting.
-        if data.dtype.names == gain_t.names:
-            gains = _np.zeros(len(data), dtype=gain_t)
-            for name in gain_t.names:
-                gains[name] = data[name]
-            return gains, None
-        return data, None
+    # gains only: copy into the current dtype (a copy, not a view, so the
+    # caller's array is never written through and byte order is converted)
+    if not any(k in fields for k in _CAL_DTERM_FIELDS):
+        if len(names) != 3 or names[0] != 'time' or not set(names[1:]) <= _CAL_GAIN_FIELDS:
+            raise Exception(f"cannot interpret fields {names} as a caltable gain table")
+        gains = _np.zeros(len(data), dtype=gain_t)
+        for src, dst in zip(names, gain_t.names):
+            gains[dst] = data[src]
+        return gains, None
 
-    if 'p1scale' not in fields:
-        return data, None
-
+    # everything below handles the rare case where D-term columns were
+    # appended to the gain table (a brief dev-era format)
+    if (len(names) != 5 or names[0] != 'time'
+            or not set(names[1:3]) <= _CAL_GAIN_FIELDS
+            or not set(names[3:]) <= _CAL_DTERM_FIELDS):
+        raise Exception(f"cannot interpret fields {names} as a caltable")
     gains = _np.zeros(len(data), dtype=gain_t)
-    for name in ('time', 'p1scale', 'p2scale'):
-        gains[name] = data[name]
-
-    if _np.any(data['d_p1'] != 0) or _np.any(data['d_p2'] != 0):
+    for src, dst in zip(names[:3], gain_t.names):
+        gains[dst] = data[src]
+    d1 = data[names[3]]
+    d2 = data[names[4]]
+    if _np.any(d1 != 0) or _np.any(d2 != 0):
         dterms = _np.zeros(len(data), dtype=dterm_t)
-        for name in ('time', 'd_p1', 'd_p2'):
-            dterms[name] = data[name]
+        dterms['time'] = data['time']
+        dterms[dterm_t.names[1]] = d1
+        dterms[dterm_t.names[2]] = d2
         return gains, dterms
-
     return gains, None
 
 

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -253,6 +253,23 @@ def upgrade_dtpol_circ(data):
     return data
 
 
+def _normalize_recarray(arr):
+    """Return arr as a 1-D recarray, or None if it has no rows or no named fields.
+
+    Fixes the 0-d single-record edge case and treats a truly empty array as
+    no data at all.
+    """
+    import numpy as _np
+    if arr is None:
+        return None
+    if not isinstance(arr, _np.ndarray):
+        arr = _np.asarray(arr)
+    if arr.dtype.names is None:
+        return None
+    arr = _np.atleast_1d(arr)
+    return arr if len(arr) else None
+
+
 # Field names a legacy caltable can carry, used to interpret old tables
 _CAL_GAIN_FIELDS = frozenset({'rscale', 'lscale', 'xscale', 'yscale', 'p1scale', 'p2scale'})
 _CAL_DTERM_FIELDS = frozenset({'dr', 'dl', 'dx', 'dy', 'd_p1', 'd_p2'})

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -181,14 +181,14 @@ DTCAL_LIN = [('time', 'f8'),
 
 DTCAL = DTCAL_CIRC  # legacy alias
 
-# D-term (leakage) tables, kept separate from the gain tables (DTCAL_*) so gains
-# and D-terms can be sampled on independent time grids. The CIRC field specs
-# mirror the D-term columns of DTCAL_CIRC; DTDTERM_LIN mirrors DTCAL_LIN's
-# asymmetry (no established physical names for linear leakage).
+# D-term (leakage) tables, one per site, on their own time grid so gains and
+# D-terms can be sampled independently. Generic d_p1/d_p2 alias the physical
+# names: dr/dl for circular feeds, dx/dy for linear.
 DTDTERM_CIRC = [('time', 'f8'),
                 (('d_p1', 'dr'), 'c16'), (('d_p2', 'dl'), 'c16')]
 
-DTDTERM_LIN = [('time', 'f8'), ('d_p1', 'c16'), ('d_p2', 'c16')]
+DTDTERM_LIN = [('time', 'f8'),
+               (('d_p1', 'dx'), 'c16'), (('d_p2', 'dy'), 'c16')]
 
 DTDTERM = DTDTERM_CIRC  # legacy alias
 

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -254,10 +254,10 @@ def upgrade_dtpol_circ(data):
 
 
 def _normalize_recarray(arr):
-    """Return arr as a 1-D recarray, or None if it has no rows or no named fields.
+    """Return arr as a 1-D recarray, or None if it has no named fields.
 
-    Fixes the 0-d single-record edge case and treats a truly empty array as
-    no data at all.
+    Fixes the 0-d single-record edge case. Callers decide what an empty
+    table means: dropped for D-terms, kept as an empty gain table.
     """
     import numpy as _np
     if arr is None:
@@ -266,8 +266,7 @@ def _normalize_recarray(arr):
         arr = _np.asarray(arr)
     if arr.dtype.names is None:
         return None
-    arr = _np.atleast_1d(arr)
-    return arr if len(arr) else None
+    return _np.atleast_1d(arr)
 
 
 # Field names a legacy caltable can carry, used to interpret old tables
@@ -282,11 +281,9 @@ def upgrade_caltable(data):
     import numpy as _np
     if data is None:
         return None
-    if not isinstance(data, _np.ndarray):
-        data = _np.asarray(data)  # solvers can hand over a bare record or [record]
-    if data.dtype.names is None:
+    data = _normalize_recarray(data)  # solvers can hand over a bare record or [record]
+    if data is None:
         raise Exception("cannot interpret caltable data: array has no named fields")
-    data = _np.atleast_1d(data)
 
     fields = data.dtype.fields
     names = data.dtype.names

--- a/ehtim/const_def.py
+++ b/ehtim/const_def.py
@@ -174,12 +174,10 @@ DTLOGCAMPDIAG = [('time', 'f8'), ('camp', 'f8'), ('sigmaca', 'f8'),
                  ('quadrangles', 'O'), ('u', 'O'), ('v', 'O'), ('tform_matrix', 'O')]
 
 DTCAL_CIRC = [('time', 'f8'),
-              (('p1scale', 'rscale'), 'c16'), (('p2scale', 'lscale'), 'c16'),
-              (('d_p1', 'dr'), 'c16'), (('d_p2', 'dl'), 'c16')]
+              (('p1scale', 'rscale'), 'c16'), (('p2scale', 'lscale'), 'c16')]
 
 DTCAL_LIN = [('time', 'f8'),
-             (('p1scale', 'xscale'), 'c16'), (('p2scale', 'yscale'), 'c16'),
-             ('d_p1', 'c16'), ('d_p2', 'c16')]
+             (('p1scale', 'xscale'), 'c16'), (('p2scale', 'yscale'), 'c16')]
 
 DTCAL = DTCAL_CIRC  # legacy alias
 
@@ -255,23 +253,67 @@ def upgrade_dtpol_circ(data):
     return data
 
 
-def upgrade_dtcal_circ(data):
-    """Upgrade a legacy DTCAL recarray (time, rscale, lscale) to DTCAL_CIRC.
+def split_dtcal(data):
+    """Split a per-site cal recarray into separate gain and D-term tables.
 
-    Legacy DTCAL has no D-term fields; the upgrade allocates a new recarray
-    and zero-fills dr/dl. Idempotent.
+    Cal tables used to carry the D-terms in the gain rows, sharing one time
+    column. Gains and D-terms vary on different timescales, so they are stored
+    as two tables now. Use this on anything handed to Caltable to normalize it,
+    whichever vintage it came from: a legacy gains-only recarray, one of the
+    old welded recarrays, or an already-split table. Idempotent.
+
+    Parameters
+    ----------
+    data : numpy.recarray or list or None
+        One site's cal table. Solvers can hand over a bare record or a list
+        holding one, so those are accepted too and promoted to one row.
+
+    Returns
+    -------
+    gains : numpy.recarray
+        The gain table, dtype DTCAL_CIRC or DTCAL_LIN.
+    dterms : numpy.recarray or None
+        The D-terms lifted out of a welded table, on their own time column,
+        or None if there were none to lift. Anything unrecognized is passed
+        back untouched with no D-terms.
     """
     import numpy as _np
-    target = _np.dtype(DTCAL_CIRC)
-    if data.dtype == target:
-        return data
-    names = data.dtype.names or ()
-    if 'rscale' in names and 'dr' not in names:
-        new = _np.zeros(len(data), dtype=target)
-        for name in ('time', 'rscale', 'lscale'):
-            new[name] = data[name]
-        return new
-    return data
+    if data is None:
+        return data, None
+    if not isinstance(data, _np.ndarray):
+        data = _np.asarray(data)
+    if data.dtype.names is None:
+        return data, None
+    data = _np.atleast_1d(data)
+
+    fields = data.dtype.fields
+    lin = 'xscale' in fields
+    gain_t = _np.dtype(DTCAL_LIN if lin else DTCAL_CIRC)
+    dterm_t = _np.dtype(DTDTERM_LIN if lin else DTDTERM_CIRC)
+
+    if data.dtype == gain_t:
+        return data, None
+
+    if 'd_p1' not in fields and 'dr' not in fields:
+        # gains only: a view when the layout already matches, else leave it be
+        if data.dtype.names == gain_t.names and data.dtype.itemsize == gain_t.itemsize:
+            return data.view(gain_t), None
+        return data, None
+
+    if 'p1scale' not in fields:
+        return data, None
+
+    gains = _np.zeros(len(data), dtype=gain_t)
+    for name in ('time', 'p1scale', 'p2scale'):
+        gains[name] = data[name]
+
+    if _np.any(data['d_p1'] != 0) or _np.any(data['d_p2'] != 0):
+        dterms = _np.zeros(len(data), dtype=dterm_t)
+        for name in ('time', 'd_p1', 'd_p2'):
+            dterms[name] = data[name]
+        return gains, dterms
+
+    return gains, None
 
 
 @functools.lru_cache(maxsize=16)

--- a/ehtim/modeling/modeling_utils.py
+++ b/ehtim/modeling/modeling_utils.py
@@ -1650,9 +1650,8 @@ def modeler_func(Obsdata, model_init, model_prior,
             caldict[site] = []
 
         for j in range(len(gains)):
-            # TODO: time-dependent D-term field added but unpopulated
             caldict[gain_list[j][1]].append(
-                (gain_list[j][0], (1.0 + gains[j]), (1.0 + gains[j]), 0j, 0j))
+                (gain_list[j][0], (1.0 + gains[j]), (1.0 + gains[j])))
 
         for site in caldict.keys():
             caldict[site] = np.array(caldict[site], dtype=DTCAL)

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -738,11 +738,13 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
         out[site] = j_matrices
 
         if caltable_path:
+            # the D-terms live on the tarr, which is what gets saved alongside
+            # the gains; the cal table itself carries gains only
             obs_tmp.tarr[i]['dr'] = dR
             obs_tmp.tarr[i]['dl'] = dL
             datatable = []
             for j in range(len(times)):
-                datatable.append(np.array((times[j], gainR[j], gainL[j], dR, dL),
+                datatable.append(np.array((times[j], gainR[j], gainL[j]),
                                           dtype=ehc.DTCAL))
             datatables[site] = np.array(datatable)
 

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -755,7 +755,9 @@ def make_jones(obs, opacitycal=True, ampcal=True, phasecal=True, dcal=True,
                             datatables, obs_tmp.tarr, source=obs_tmp.source,
                             mjd=obs_tmp.mjd, timetype=obs_tmp.timetype)
 
-        caltable.save_txt(obs_tmp, datadir=caltable_path+'_simdata_caltable')
+        # each simulation rewrites its own truth table
+        caltable.save_txt(obs_tmp, datadir=caltable_path+'_simdata_caltable',
+                          overwrite=True)
 
     return out
 

--- a/ehtim/observing/obs_simulate.py
+++ b/ehtim/observing/obs_simulate.py
@@ -1,6 +1,9 @@
 # obs_simulate.py
 # functions to simulate interferometric observations
 #
+# TODO: consider adding time-variable D-terms to the simulated caltables
+# (D-terms are fixed per site for now, and saved via the tarr)
+#
 #    Copyright (C) 2018 Andrew Chael
 #
 #    This program is free software: you can redistribute it and/or modify

--- a/ehtim/plotting/interactive.py
+++ b/ehtim/plotting/interactive.py
@@ -2114,8 +2114,11 @@ def dashboard(
             gain_indices[mode].append(len(fig.data) - 1)
 
     # --- Panel 4: D-terms (R and L) in complex plane ---
-    # TODO: schema-coupled - tarr['dr'] / tarr['dl'] move to caltable.dterms
-    # in MixPol Phase 1; this lookup needs to follow.
+    # TODO: schema-coupled - a cal table can now carry leakage itself, in
+    # caltable.dterms, on its own time axis. This lookup should prefer that
+    # when it is populated and keep tarr as the fallback, since the leakage
+    # solvers still write there. Note a dterms table may hold more than one
+    # row per site, so the panel stops being one point per site once it does.
     # Two legends: legend4 = per-site (toggle hides both R and L for that
     # site via legendgroup); legend5 = R/L type (two dummy markers showing
     # the symbol convention).

--- a/ehtim/survey.py
+++ b/ehtim/survey.py
@@ -362,7 +362,7 @@ class ParameterSet:
         # Save caltab
         if hasattr(self, 'save_caltab') and self.save_caltab:
             outcal = os.path.join(self.outpath, f'{self.outfile}/')
-            eh.caltable.save_caltable(self.caltab, self.obs_sc_init, outcal)
+            eh.caltable.save_caltable(self.caltab, self.obs_sc_init, outcal, overwrite=True)
 
         # Save self-calibrated uvfits
         if self.save_uvfits:

--- a/scripts/imaging.py
+++ b/scripts/imaging.py
@@ -176,7 +176,7 @@ if image_pol:
     if realdata:
         # FIX FOR ER5 DATA! rotate polarization because of error in ALMA ... do not have to do this normally
         datadict = {t['site']:np.array([(0.0, 0.0 + 1j*1.0, 1.0 + 1j*0.0)], dtype=eh.DTCAL) for t in obs_sc_pol.tarr}
-        caltab = eh.caltable.Caltable(obs_sc_pol.ra,obs_sc_pol.dec,obs_sc_pol.rf,obs_sc_pol.bw,datadict,obs_sc_pol.tarr,source=obs_sc_pol.source,mjd=obs_sc_pol.mjd)
+        caltab = eh.caltable.Caltable(obs_sc_pol.ra,obs_sc_pol.dec,obs_sc_pol.rf,obs_sc_pol.bw,datadict,obs_sc_pol.tarr,obs_sc_pol.source,obs_sc_pol.mjd)
         obs_sc_pol = caltab.applycal(obs_sc_pol, interp='nearest',extrapolate=True)
 
 

--- a/scripts/imaging.py
+++ b/scripts/imaging.py
@@ -176,7 +176,7 @@ if image_pol:
     if realdata:
         # FIX FOR ER5 DATA! rotate polarization because of error in ALMA ... do not have to do this normally
         datadict = {t['site']:np.array([(0.0, 0.0 + 1j*1.0, 1.0 + 1j*0.0)], dtype=eh.DTCAL) for t in obs_sc_pol.tarr}
-        caltab = eh.caltable.Caltable(obs_sc_pol.ra,obs_sc_pol.dec,obs_sc_pol.rf,obs_sc_pol.bw,datadict,obs_sc_pol.tarr,obs_sc_pol.source,obs_sc_pol.mjd)
+        caltab = eh.caltable.Caltable(obs_sc_pol.ra,obs_sc_pol.dec,obs_sc_pol.rf,obs_sc_pol.bw,datadict,obs_sc_pol.tarr,source=obs_sc_pol.source,mjd=obs_sc_pol.mjd)
         obs_sc_pol = caltab.applycal(obs_sc_pol, interp='nearest',extrapolate=True)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -439,9 +439,11 @@ def obs_with_dterms(obs_pol_direct):
     Deterministic seed; ~0.05 magnitude per hand per site. For leakage_cal
     recovery tests.
 
-    TODO(mixpol): the mixpol branch carries time-dependent D-terms as a
-    separate attribute (not embedded in tarr). Update the injection schema
-    when porting these fixtures to dev-backend-mixpol.
+    Injection goes into the Obsdata tarr, which is still where the leakage
+    solvers (pol_cal.py, pol_cal_new.py) read and write D-terms. A cal table
+    now stores leakage separately, on its own time axis (Caltable.dterms), so
+    this fixture is deliberately tarr-based and follows the solvers onto that
+    store when they move to it.
     """
     import numpy as np
     out = obs_pol_direct.copy()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -410,7 +410,7 @@ def injected_gain_caltable_factory(obs_direct):
 
 @pytest.fixture(scope="session")
 def dterm_dict_factory():
-    """Factory: a DTDTERM datadict keyed by site name, for Caltable(dterms=...).
+    """Factory: a DTDTERM datadict keyed by site name, for Caltable(dtermdict=...).
 
     Tests call as ``dterm_dict_factory(sites)`` for a single-row table -- the
     storage form of a track-constant leakage -- or pass ``times=`` for a

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -409,6 +409,30 @@ def injected_gain_caltable_factory(obs_direct):
 
 
 @pytest.fixture(scope="session")
+def dterm_dict_factory():
+    """Factory: a DTDTERM datadict keyed by site name, for Caltable(dterms=...).
+
+    Tests call as ``dterm_dict_factory(sites)`` for a single-row table -- the
+    storage form of a track-constant leakage -- or pass ``times=`` for a
+    multi-row one. D-terms live on their own time grid, independent of the gain
+    table's. Returns fresh arrays per call so tests can mutate freely.
+    """
+    def _factory(sites, times=(0.0,), dr=0.03 + 0.01j, dl=-0.02 + 0.04j):
+        import numpy as np
+
+        from ehtim.const_def import DTDTERM
+
+        times = np.asarray(times, dtype=float)
+        n = len(times)
+        template = np.zeros(n, dtype=DTDTERM)
+        template['time'] = times
+        template['dr'] = np.broadcast_to(np.asarray(dr, dtype=complex), (n,))
+        template['dl'] = np.broadcast_to(np.asarray(dl, dtype=complex), (n,))
+        return {site: template.copy() for site in sites}
+    return _factory
+
+
+@pytest.fixture(scope="session")
 def obs_with_dterms(obs_pol_direct):
     """obs_pol_direct with synthetic complex D-terms injected into tarr['dr']/['dl'].
 

--- a/tests/test_caltable.py
+++ b/tests/test_caltable.py
@@ -812,13 +812,8 @@ class TestMerge:
 
 # The row dtype from the era when D-terms shared the gain rows (PR #254),
 # reproduced here so the migration paths can be driven from a caller's side.
-_WELDED_DTCAL = [('time', 'f8'),
-                 (('p1scale', 'rscale'), 'c16'), (('p2scale', 'lscale'), 'c16'),
-                 (('d_p1', 'dr'), 'c16'), (('d_p2', 'dl'), 'c16')]
-
 # Gains and leakage used across the split tests. The gain is complex and not
-# unity so an applycal comparison has teeth; the D-terms are nonzero so the
-# split actually extracts a table instead of dropping an all-zero one.
+# unity so an applycal comparison has teeth.
 SPLIT_GAIN_R = 1.4 - 0.2j
 SPLIT_GAIN_L = 0.8 + 0.5j
 SPLIT_DR = 0.03 + 0.01j
@@ -827,20 +822,8 @@ SPLIT_DL = -0.02 + 0.04j
 SPLIT_DTERM_TIME = 0.0
 
 
-def _welded_caldict(sites, times):
-    """A pre-split datadict: gains and D-terms welded into one row dtype."""
-    times = np.asarray(times, dtype=float)
-    template = np.zeros(len(times), dtype=_WELDED_DTCAL)
-    template['time'] = times
-    template['rscale'] = SPLIT_GAIN_R
-    template['lscale'] = SPLIT_GAIN_L
-    template['dr'] = SPLIT_DR
-    template['dl'] = SPLIT_DL
-    return {site: template.copy() for site in sites}
-
-
 def _clean_caldict(sites, times):
-    """The gains-only equivalent of :func:`_welded_caldict`."""
+    """A datadict of constant complex gains for every listed site."""
     times = np.asarray(times, dtype=float)
     template = np.zeros(len(times), dtype=DTCAL)
     template['time'] = times
@@ -886,20 +869,17 @@ class TestDataAliasesGains:
         ct.data = replacement
         assert ct.gains is replacement
 
-    def test_data_setter_rejects_welded_tables(self, obs_direct, unity_caltable):
-        """A welded table assigned to .data is refused where the mistake is made.
+    def test_data_setter_rejects_combined_tables(self, obs_direct, unity_caltable):
+        """A combined gain+D-term table assigned to .data raises.
 
-        Stored verbatim it would survive the assignment and then fail inside
-        pad_scans with a numpy cast error, far from the cause. Splitting it here
-        instead would be worse: leakage would move into .dterms silently.
+        That short-lived format is no longer read anywhere.
         """
         ct = unity_caltable.copy()
-        welded = _welded_caldict(_first_sites(obs_direct, 1),
-                                 _span_times(obs_direct))
-        with pytest.raises(TypeError, match="carries D-term columns"):
-            ct.data = welded
-        # the failed assignment left the table alone
-        assert ct.gains is not welded
+        combined = np.zeros(2, dtype=[('time', 'f8'), ('rscale', 'c16'),
+                                      ('lscale', 'c16'), ('dr', 'c16'), ('dl', 'c16')])
+        site = _first_sites(obs_direct, 1)[0]
+        with pytest.raises(Exception, match="cannot interpret"):
+            ct.data = {site: combined}
 
     def test_dterms_defaults_empty(self, unity_caltable):
         """A table built without leakage has an empty dterms dict."""
@@ -907,65 +887,39 @@ class TestDataAliasesGains:
 
 
 class TestConstructorSplit:
-    """``__init__`` splits welded input and honours an explicit ``dtermdict=``."""
+    """``__init__`` upgrades legacy gains and honours an explicit ``dtermdict=``."""
 
-    def test_constructor_welded_datadict_autosplits(self, obs_direct):
-        """A pre-split datadict is separated into the two tables on construction.
-
-        The extracted D-terms keep the time column they were welded to, which is
-        the faithful migration of an old table.
-        """
+    def test_constructor_rejects_combined_datadict(self, obs_direct):
+        """A combined gain+D-term table raises; that format is no longer read."""
         times = _span_times(obs_direct)
-        sites = _first_sites(obs_direct)
-        ct = eh.caltable.Caltable(
-            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
-            _welded_caldict(sites, times), obs_direct.tarr,
-            source=obs_direct.source, mjd=obs_direct.mjd,
-        )
-        for site in sites:
-            assert ct.gains[site].dtype.names == ('time', 'rscale', 'lscale')
-            np.testing.assert_array_equal(ct.gains[site]['rscale'], SPLIT_GAIN_R)
-            np.testing.assert_array_equal(ct.gains[site]['lscale'], SPLIT_GAIN_L)
-            np.testing.assert_array_equal(ct.dterms[site]['dr'], SPLIT_DR)
-            np.testing.assert_array_equal(ct.dterms[site]['dl'], SPLIT_DL)
-            # the extracted D-terms keep the time column they were welded to
-            np.testing.assert_array_equal(ct.dterms[site]['time'], times)
+        site = _first_sites(obs_direct, 1)[0]
+        combined = np.zeros(len(times), dtype=[('time', 'f8'), ('rscale', 'c16'),
+                                               ('lscale', 'c16'), ('dr', 'c16'),
+                                               ('dl', 'c16')])
+        with pytest.raises(Exception, match="cannot interpret"):
+            eh.caltable.Caltable(
+                obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+                {site: combined}, obs_direct.tarr,
+                source=obs_direct.source, mjd=obs_direct.mjd,
+            )
 
     def test_constructor_dtermdict_kwarg(self, obs_direct, dterm_dict_factory):
-        """Gains and D-terms passed separately keep their own independent time grids."""
+        """Gains and D-terms keep their own independent time grids."""
         times = _span_times(obs_direct)
         sites = _first_sites(obs_direct)
         ct = eh.caltable.Caltable(
             obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
             _clean_caldict(sites, times), obs_direct.tarr,
-            source=obs_direct.source, mjd=obs_direct.mjd,
             dtermdict=dterm_dict_factory(sites, times=(SPLIT_DTERM_TIME,),
-                                      dr=SPLIT_DR, dl=SPLIT_DL),
+                                         dr=SPLIT_DR, dl=SPLIT_DL),
+            source=obs_direct.source, mjd=obs_direct.mjd,
         )
         for site in sites:
-            # gains keep their own (two-point) grid, D-terms their one-row grid
             assert len(ct.gains[site]) == len(times)
             assert len(ct.dterms[site]) == 1
             assert ct.dterms[site]['time'][0] == SPLIT_DTERM_TIME
             np.testing.assert_array_equal(ct.gains[site]['rscale'], SPLIT_GAIN_R)
-
-    def test_constructor_explicit_dterms_overrides_autosplit(self, obs_direct,
-                                                             dterm_dict_factory):
-        """An explicit dtermdict= wins over whatever a welded datadict would have contributed."""
-        times = _span_times(obs_direct)
-        sites = _first_sites(obs_direct, 1)
-        site = sites[0]
-        override = 0.5 + 0.5j
-        ct = eh.caltable.Caltable(
-            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
-            _welded_caldict(sites, times), obs_direct.tarr,
-            source=obs_direct.source, mjd=obs_direct.mjd,
-            dtermdict=dterm_dict_factory(sites, dr=override, dl=override),
-        )
-        # the explicit table replaces what the weld would have contributed
-        assert len(ct.dterms[site]) == 1
-        assert ct.dterms[site]['dr'][0] == override
-        np.testing.assert_array_equal(ct.gains[site]['rscale'], SPLIT_GAIN_R)
+            np.testing.assert_array_equal(ct.dterms[site]['dr'], SPLIT_DR)
 
     def test_constructor_single_record_list_site(self, obs_direct):
         """A site handed over as a bare list of records is normalised, not rejected.
@@ -1009,16 +963,19 @@ class TestConstructorSplit:
 class TestSplitStateRoundTrips:
     """copy / pickle carry both tables, and legacy states still migrate."""
 
-    def _welded_caltable(self, obs):
+    def _dterm_caltable(self, obs):
+        sites = _first_sites(obs)
+        dterms = {site: np.array([(SPLIT_DTERM_TIME, SPLIT_DR, SPLIT_DL)],
+                                 dtype=ehc.DTDTERM) for site in sites}
         return eh.caltable.Caltable(
             obs.ra, obs.dec, obs.rf, obs.bw,
-            _welded_caldict(_first_sites(obs), _span_times(obs)), obs.tarr,
+            _clean_caldict(sites, _span_times(obs)), obs.tarr, dtermdict=dterms,
             source=obs.source, mjd=obs.mjd,
         )
 
     def test_copy_preserves_dterms_independently(self, obs_direct):
         """copy() deep-copies the leakage table as well as the gains."""
-        ct = self._welded_caltable(obs_direct)
+        ct = self._dterm_caltable(obs_direct)
         site = _first_sites(obs_direct, 1)[0]
         cp = ct.copy()
         np.testing.assert_array_equal(cp.dterms[site]['dr'], SPLIT_DR)
@@ -1027,7 +984,7 @@ class TestSplitStateRoundTrips:
 
     def test_pickle_roundtrip_with_dterms(self, obs_direct):
         """Both tables survive a pickle round trip, and data comes back as an alias."""
-        ct = self._welded_caltable(obs_direct)
+        ct = self._dterm_caltable(obs_direct)
         revived = pickle.loads(pickle.dumps(ct))
         assert set(revived.dterms) == set(ct.dterms)
         for site in ct.gains:
@@ -1040,7 +997,7 @@ class TestSplitStateRoundTrips:
         """A pre-split pickle whose 'data' was never a dict is passed through untouched."""
         site = _first_sites(obs_direct, 1)[0]
         arr = _clean_caldict([site], _span_times(obs_direct))[site]
-        ct = self._welded_caltable(obs_direct)
+        ct = self._dterm_caltable(obs_direct)
         state = dict(ct.__dict__)
         state.pop('gains')
         state.pop('dterms')
@@ -1057,7 +1014,7 @@ class TestSplitStateRoundTrips:
         data is a property now, and a property shadows an instance-dict entry of
         the same name, so leaving one behind would make those gains unreachable.
         """
-        ct = self._welded_caltable(obs_direct)
+        ct = self._dterm_caltable(obs_direct)
         site = _first_sites(obs_direct, 1)[0]
         state = dict(ct.__dict__)
         state.pop('gains')
@@ -1081,7 +1038,7 @@ class TestSplitStateRoundTrips:
         constructor has -- hand it the same arrays and you get the same buffers.
         """
         site = _first_sites(obs_direct, 1)[0]
-        ct = self._welded_caltable(obs_direct)
+        ct = self._dterm_caltable(obs_direct)
         state = dict(ct.__dict__)
         state.pop('gains')
         state.pop('dterms')
@@ -1100,38 +1057,36 @@ class TestSplitStateRoundTrips:
 
 
 class TestSplitLeavesApplycalUnchanged:
-    """Splitting the input must not perturb gain application."""
+    """Carrying a D-term table must not perturb gain application."""
 
-    def test_applycal_welded_equals_clean_gains(self, obs_direct):
-        """Splitting the input does not perturb gain application.
-
-        A welded table carrying leakage calibrates identically to the equivalent
-        gains-only table, since applycal has never applied D-terms.
-        """
+    def test_applycal_with_dterms_equals_without(self, obs_direct, dterm_dict_factory):
+        """applycal ignores the D-term table, so the two give identical output."""
         times = _span_times(obs_direct)
         sites = obs_direct.tarr['site']
         kwargs = dict(source=obs_direct.source, mjd=obs_direct.mjd,
                       timetype=obs_direct.timetype)
-        ct_welded = eh.caltable.Caltable(
+        ct_leaky = eh.caltable.Caltable(
             obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
-            _welded_caldict(sites, times), obs_direct.tarr, **kwargs)
+            _clean_caldict(sites, times), obs_direct.tarr,
+            dtermdict=dterm_dict_factory(list(sites), dr=SPLIT_DR, dl=SPLIT_DL),
+            **kwargs)
         ct_clean = eh.caltable.Caltable(
             obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
             _clean_caldict(sites, times), obs_direct.tarr, **kwargs)
 
-        # the welded input carries leakage, the clean one does not
-        assert ct_welded.dterms
+        assert ct_leaky.dterms
         assert ct_clean.dterms == {}
 
-        out_welded = ct_welded.applycal(obs_direct, interp='nearest')
+        with pytest.warns(MixedPolConventionWarning):
+            out_leaky = ct_leaky.applycal(obs_direct, interp='nearest')
         out_clean = ct_clean.applycal(obs_direct, interp='nearest')
 
-        circ_w = out_welded.switch_polrep('circ')
+        circ_l = out_leaky.switch_polrep('circ')
         circ_c = out_clean.switch_polrep('circ')
         for field in ('rrvis', 'llvis', 'rlvis', 'lrvis'):
-            np.testing.assert_array_equal(circ_w.data[field], circ_c.data[field])
+            np.testing.assert_array_equal(circ_l.data[field], circ_c.data[field])
         for field in ('rrsigma', 'llsigma', 'rlsigma', 'lrsigma'):
-            np.testing.assert_array_equal(circ_w.data[field], circ_c.data[field])
+            np.testing.assert_array_equal(circ_l.data[field], circ_c.data[field])
 
 
 class TestSplitFixups:
@@ -1185,13 +1140,6 @@ class TestSplitFixups:
 
         assert isinstance(ct.gains[site], np.ndarray)
         assert ct.gains[site]['rscale'][0] == SPLIT_GAIN_R
-
-    def test_data_setter_rejects_welded_table(self, unity_caltable, obs_direct):
-        """Assigning leakage-bearing rows to the gain alias raises."""
-        ct = unity_caltable.copy()
-        sites = _first_sites(obs_direct, 1)
-        with pytest.raises(TypeError, match="D-term"):
-            ct.data = _welded_caldict(sites, _span_times(obs_direct))
 
     def test_constructor_normalizes_zero_d_dterm_record(self, obs_direct):
         """A 0-d D-term record becomes a one-row table.
@@ -1569,7 +1517,7 @@ class TestTransformsCarryDterms:
         np.testing.assert_array_equal(out.dterms[site]['dr'], SPLIT_DR)
         # padding the gain grid must not resample leakage: one row in, one out
         assert len(out.dterms[site]) == 1
-        # forwarded as a deep copy, so the output is not welded to the input
+        # forwarded as a deep copy, so the output does not share the input's array
         out.dterms[site]['dr'] *= 10
         np.testing.assert_array_equal(ct.dterms[site]['dr'], SPLIT_DR)
 

--- a/tests/test_caltable.py
+++ b/tests/test_caltable.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 import ehtim as eh
-from ehtim.const_def import DTCAL
+from ehtim.const_def import DTARR, DTCAL
 from ehtim.warnings import MixedPolConventionWarning
 
 # ---------------------------------------------------------------------------
@@ -967,6 +967,17 @@ class TestConstructorSplit:
         assert len(ct.gains[site]) == 1
         assert ct.gains[site]['rscale'][0] == SPLIT_GAIN_R
 
+    def test_constructor_rejects_non_dict_dterms(self, obs_direct, dterm_dict_factory):
+        """A non-dict dterms= names the problem instead of failing inside dict()."""
+        site = _first_sites(obs_direct, 1)[0]
+        table = dterm_dict_factory([site])[site]     # the bare table, not a dict
+        with pytest.raises(TypeError, match="dterms must be a dict"):
+            eh.caltable.Caltable(
+                obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+                _clean_caldict([site], _span_times(obs_direct)), obs_direct.tarr,
+                source=obs_direct.source, mjd=obs_direct.mjd, dterms=table,
+            )
+
     def test_constructor_non_dict_datadict_stored_verbatim(self, obs_direct):
         """A non-dict datadict is stored as-is, the way it always was."""
         site = _first_sites(obs_direct, 1)[0]
@@ -1041,6 +1052,35 @@ class TestSplitStateRoundTrips:
         revived.__setstate__(state)
         assert 'data' not in revived.__dict__
         np.testing.assert_array_equal(revived.gains[site]['rscale'], SPLIT_GAIN_R)
+
+    def test_setstate_leaves_the_caller_state_dict_alone(self, obs_direct):
+        """__setstate__ migrates onto a copy, not onto the dict it was handed.
+
+        Unpickling passes a throwaway dict, but a direct call passes one the
+        caller still owns, so consuming its 'data' key in place is visible to
+        them. It also breaks the next restore from that dict: the migration is
+        skipped as already-done and both objects end up on one gains dict.
+
+        The row arrays stay shared, which is the same zero-copy contract the
+        constructor has -- hand it the same arrays and you get the same buffers.
+        """
+        site = _first_sites(obs_direct, 1)[0]
+        ct = self._welded_caltable(obs_direct)
+        state = dict(ct.__dict__)
+        state.pop('gains')
+        state.pop('dterms')
+        state['data'] = _clean_caldict([site], _span_times(obs_direct))
+        keys_before = set(state)
+
+        first = eh.caltable.Caltable.__new__(eh.caltable.Caltable)
+        first.__setstate__(state)
+        assert set(state) == keys_before      # 'data' not consumed, no 'gains' added
+
+        second = eh.caltable.Caltable.__new__(eh.caltable.Caltable)
+        second.__setstate__(state)
+        assert first.gains is not second.gains
+        first.gains['EXTRASITE'] = None
+        assert 'EXTRASITE' not in second.gains
 
 
 class TestSplitLeavesApplycalUnchanged:
@@ -1168,6 +1208,33 @@ class TestDtermPersistence:
 
         assert eh.caltable.load_caltable(obs_direct, str(tmp_path)) is False
 
+    def test_gains_only_save_dir_byte_identical_to_pre_split(self, obs_direct,
+                                                             tmp_path):
+        """The gain files keep their historic headerless five-column layout.
+
+        Every cal directory anyone already has on disk is in this format, so the
+        split must leave it alone byte for byte. The times here land on whole
+        MJDs and the gains on exact binary fractions, which makes the expected
+        bytes something this test can spell out rather than recompute.
+        """
+        site = _first_sites(obs_direct, 1)[0]
+        table = np.zeros(2, dtype=DTCAL)
+        table['time'] = [0.0, 24.0]              # mjd exactly, then mjd + 1
+        table['rscale'] = 2.0 + 0j
+        table['lscale'] = 0.5 + 0j
+        ct = eh.caltable.Caltable(
+            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+            {site: table}, obs_direct.tarr, source=obs_direct.source,
+            mjd=obs_direct.mjd, timetype=obs_direct.timetype)
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
+
+        mjd = float(obs_direct.mjd)
+        written = (tmp_path / f"{obs_direct.source}_{site}.txt").read_text()
+        assert written == (f"{mjd} 2.0 0.0 0.5 0.0\n"
+                           f"{mjd + 1.0} 2.0 0.0 0.5 0.0\n")
+        # and a leakage-free table grows no D-term sidecar
+        assert not list(tmp_path.glob("*" + eh.caltable.DTERM_FILE_SUFFIX))
+
 
 class TestLoadSingleRowAndLegacyGainFiles:
     """Regressions for the gain loader: one-row files used to fail with
@@ -1244,6 +1311,28 @@ class TestApplycalWarnsOnDterms:
         for field in ('vis', 'sigma'):
             np.testing.assert_array_equal(out_plain.data[field],
                                           out_leaky.data[field])
+
+
+class TestPlottingWithDterms:
+    """The gain plot is unaffected by leakage riding along in the same table."""
+
+    def test_plot_gains_smoke_with_dterms_present(self, obs_direct,
+                                                 constant_gain_caltable_factory,
+                                                 dterm_dict_factory):
+        import matplotlib.pyplot as plt
+
+        ct = constant_gain_caltable_factory(CONST_REAL_GAIN)
+        ct.dterms = dterm_dict_factory(_first_sites(obs_direct, 1))
+
+        original_backend = plt.get_backend()
+        plt.switch_backend('Agg')                 # never open a window in CI
+        try:
+            axis = ct.plot_gains(_first_sites(obs_direct, 2), show=False)
+            assert axis is not None
+            assert len(axis.get_lines()) > 0
+        finally:
+            plt.close('all')
+            plt.switch_backend(original_backend)
 
 
 class TestTransformsCarryDterms:
@@ -1339,6 +1428,42 @@ class TestTransformsCarryDterms:
         assert set(out.dterms) == {site_a, site_b}
         np.testing.assert_array_equal(out.dterms[site_a]['dr'], SPLIT_DR)
         np.testing.assert_array_equal(out.dterms[site_b]['dr'], SPLIT_DL)
+
+    def test_merge_keeps_tarr_row_for_dterm_only_site(
+            self, obs_direct, constant_gain_caltable_factory, dterm_dict_factory):
+        # A site can carry leakage with no gain rows. Its array row has to come
+        # along, or save_caltable -- which walks tarr -- drops the solved
+        # leakage without a word.
+        ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
+        ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
+
+        foreign = np.zeros(1, dtype=DTARR)
+        foreign['site'] = ['NEWSITE']
+        foreign['feed_type'] = ['rl']
+        ct_b.tarr = np.append(ct_b.tarr, foreign)
+        ct_b.tkey = {s: i for i, s in enumerate(ct_b.tarr['site'])}
+        ct_b.dterms = dterm_dict_factory(['NEWSITE'], dr=SPLIT_DR, dl=SPLIT_DL)
+
+        out = ct_a.merge([ct_b])
+
+        assert 'NEWSITE' in out.dterms
+        assert 'NEWSITE' in list(out.tarr['site'])
+        assert 'NEWSITE' not in out.gains          # leakage only, no gains
+        # exactly one row, i.e. the gain loop did not append it a second time
+        assert list(out.tarr['site']).count('NEWSITE') == 1
+
+    def test_merge_dterm_site_absent_from_both_tarrs_is_tolerated(
+            self, obs_direct, constant_gain_caltable_factory, dterm_dict_factory):
+        # No array row exists to copy, so merge cannot invent one; it must not
+        # raise either. Persisting such a site is a separate problem.
+        ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
+        ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
+        ct_b.dterms = dterm_dict_factory(['GHOST'], dr=SPLIT_DR, dl=SPLIT_DL)
+
+        out = ct_a.merge([ct_b])
+
+        assert 'GHOST' in out.dterms
+        assert 'GHOST' not in list(out.tarr['site'])
 
     def test_merge_disjoint_site_gains_not_aliased(
             self, obs_direct, constant_gain_caltable_factory):

--- a/tests/test_caltable.py
+++ b/tests/test_caltable.py
@@ -995,16 +995,15 @@ class TestConstructorSplit:
                 source=obs_direct.source, mjd=obs_direct.mjd, dtermdict=table,
             )
 
-    def test_constructor_non_dict_datadict_stored_verbatim(self, obs_direct):
-        """A non-dict datadict is stored as-is, the way it always was."""
+    def test_constructor_rejects_non_dict_datadict(self, obs_direct):
+        """A bare array as datadict raises; the gains are a dict keyed by site."""
         site = _first_sites(obs_direct, 1)[0]
         arr = _clean_caldict([site], _span_times(obs_direct))[site]
-        ct = eh.caltable.Caltable(
-            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
-            arr, obs_direct.tarr, source=obs_direct.source, mjd=obs_direct.mjd,
-        )
-        assert ct.gains is arr
-        assert ct.data is arr
+        with pytest.raises(TypeError, match="datadict must be a dict"):
+            eh.caltable.Caltable(
+                obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+                arr, obs_direct.tarr, source=obs_direct.source, mjd=obs_direct.mjd,
+            )
 
 
 class TestSplitStateRoundTrips:

--- a/tests/test_caltable.py
+++ b/tests/test_caltable.py
@@ -1173,6 +1173,21 @@ class TestSplitFixups:
         )
         assert ct.dterms == {}
 
+    def test_empty_typed_dterm_table_is_not_stored(self, obs_direct):
+        """A zero-row table of the right dtype is dropped like an untyped one.
+
+        The shared normalizer keeps empty tables so that an empty gain table
+        survives; dropping them is the D-term side's own rule.
+        """
+        site = _first_sites(obs_direct, 1)[0]
+        ct = eh.caltable.Caltable(
+            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+            _clean_caldict([site], _span_times(obs_direct)), obs_direct.tarr,
+            source=obs_direct.source, mjd=obs_direct.mjd,
+            dtermdict={site: np.zeros(0, dtype=ehc.DTDTERM)},
+        )
+        assert ct.dterms == {}
+
     def test_stale_dterm_file_removed_on_resave(self, obs_direct,
                                                 injected_gain_caltable_factory,
                                                 dterm_dict_factory, tmp_path):

--- a/tests/test_caltable.py
+++ b/tests/test_caltable.py
@@ -1239,7 +1239,8 @@ class TestSplitFixups:
         assert list(tmp_path.glob("*" + eh.caltable.DTERM_FILE_SUFFIX))
 
         ct.dterms = {}
-        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path),
+                                  overwrite=True)
 
         assert not list(tmp_path.glob("*" + eh.caltable.DTERM_FILE_SUFFIX))
         assert eh.caltable.load_caltable(obs_direct, str(tmp_path)).dterms == {}
@@ -1400,6 +1401,51 @@ class TestDtermPersistence:
                            f"{mjd + 1.0} 2.0 0.0 0.5 0.0\n")
         # and a leakage-free table grows no D-term sidecar
         assert not list(tmp_path.glob("*" + eh.caltable.DTERM_FILE_SUFFIX))
+
+
+class TestSaveOverwriteGuard:
+    """save_caltable refuses to clobber an existing caltable unless told to."""
+
+    def test_resave_raises_without_overwrite(self, obs_direct,
+                                             injected_gain_caltable_factory,
+                                             tmp_path):
+        """A second save into the same directory raises by default."""
+        ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
+        with pytest.raises(Exception, match="overwrite=True"):
+            eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
+
+    def test_resave_with_overwrite_replaces(self, obs_direct,
+                                            injected_gain_caltable_factory,
+                                            tmp_path):
+        """overwrite=True re-saves, and the directory reflects the new gains."""
+        ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
+        site = _first_sites(obs_direct, 1)[0]
+        ct.gains[site]['rscale'] *= 2
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path),
+                                  overwrite=True)
+        loaded = eh.caltable.load_caltable(obs_direct, str(tmp_path))
+        np.testing.assert_allclose(loaded.gains[site]['rscale'],
+                                   ct.gains[site]['rscale'], rtol=GAIN_RTOL)
+
+    def test_stale_gain_file_removed_on_resave(self, obs_direct,
+                                               injected_gain_caltable_factory,
+                                               tmp_path):
+        """A site dropped from the table loses its file, same as D-terms do."""
+        ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
+        site = _first_sites(obs_direct, 1)[0]
+        gainfile = tmp_path / f"{ct.source}_{site}.txt"
+        assert gainfile.exists()
+
+        ct.gains.pop(site)
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path),
+                                  overwrite=True)
+
+        assert not gainfile.exists()
+        loaded = eh.caltable.load_caltable(obs_direct, str(tmp_path))
+        assert site not in loaded.gains
 
 
 class TestLoadSingleRowAndLegacyGainFiles:

--- a/tests/test_caltable.py
+++ b/tests/test_caltable.py
@@ -21,6 +21,14 @@ from ehtim.warnings import MixedPolConventionWarning
 # works; the tests assert on the warning and on output equality, not on it.
 APPLYCAL_WARN_GAIN = 1.3 + 0.4j
 
+# D-term persistence tests. DTERM_TIMES is deliberately not the gain time grid:
+# the two tables are sampled independently. TIME_ATOL is in hours and covers
+# the MJD round-trip, where a double holds ~1e-9 hr of resolution near MJD 5e4.
+SEED_DTERM_ROUNDTRIP = 20260810
+DTERM_TIMES = (0.5, 3.25)
+SINGLE_ROW_TIME_HR = 2.0
+TIME_ATOL = 1e-6
+
 BIT_CLEAN_RTOL = 1e-12
 BIT_CLEAN_ATOL = 1e-12
 
@@ -987,6 +995,126 @@ class TestSplitLeavesApplycalUnchanged:
             np.testing.assert_array_equal(circ_w.data[field], circ_c.data[field])
         for field in ('rrsigma', 'llsigma', 'rlsigma', 'lrsigma'):
             np.testing.assert_array_equal(circ_w.data[field], circ_c.data[field])
+
+
+class TestDtermPersistence:
+    """D-terms round-trip through their own per-site files. The gain files keep
+    their long-standing format, so directories written before the split still
+    load and directories written now are still readable by older code."""
+
+    def test_save_load_roundtrip_with_dterms(self, obs_direct,
+                                             injected_gain_caltable_factory,
+                                             dterm_dict_factory, tmp_path):
+        ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
+        ct.dterms = dterm_dict_factory(list(ct.data), times=DTERM_TIMES)
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
+
+        loaded = eh.caltable.load_caltable(obs_direct, str(tmp_path))
+        assert set(loaded.dterms) == set(ct.dterms)
+        for site in ct.dterms:
+            np.testing.assert_allclose(loaded.dterms[site]['dr'],
+                                       ct.dterms[site]['dr'], rtol=GAIN_RTOL)
+            np.testing.assert_allclose(loaded.dterms[site]['dl'],
+                                       ct.dterms[site]['dl'], rtol=GAIN_RTOL)
+            np.testing.assert_allclose(loaded.dterms[site]['time'],
+                                       ct.dterms[site]['time'], atol=TIME_ATOL)
+
+    def test_single_row_dterm_file_roundtrip(self, obs_direct,
+                                             injected_gain_caltable_factory,
+                                             dterm_dict_factory, tmp_path):
+        # one row is the canonical shape for a track-constant D-term
+        ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
+        ct.dterms = dterm_dict_factory(list(ct.data))
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
+
+        loaded = eh.caltable.load_caltable(obs_direct, str(tmp_path))
+        for site in ct.dterms:
+            assert len(loaded.dterms[site]) == 1
+            np.testing.assert_allclose(loaded.dterms[site]['dr'],
+                                       ct.dterms[site]['dr'], rtol=GAIN_RTOL)
+
+    def test_dterm_file_has_version_header(self, obs_direct,
+                                           injected_gain_caltable_factory,
+                                           dterm_dict_factory, tmp_path):
+        ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
+        site = _first_sites(obs_direct, 1)[0]
+        ct.dterms = dterm_dict_factory([site])
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
+
+        path = tmp_path / f"{ct.source}_{site}{eh.caltable.DTERM_FILE_SUFFIX}"
+        first_line = path.read_text().splitlines()[0]
+        assert first_line == eh.caltable.DTERM_FILE_HEADER
+
+    def test_gains_only_dir_has_no_dterm_files(self, obs_direct,
+                                               injected_gain_caltable_factory,
+                                               tmp_path):
+        # a table with no leakage writes exactly what it always did
+        ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
+        assert ct.dterms == {}
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
+
+        assert not list(tmp_path.glob("*" + eh.caltable.DTERM_FILE_SUFFIX))
+        loaded = eh.caltable.load_caltable(obs_direct, str(tmp_path))
+        assert loaded.dterms == {}
+
+    def test_sqrt_gains_does_not_touch_dterms(self, obs_direct,
+                                              injected_gain_caltable_factory,
+                                              dterm_dict_factory, tmp_path):
+        # sqrt_gains is a gain-side convention; leakage is written as-is
+        ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
+        site = _first_sites(obs_direct, 1)[0]
+        ct.dterms = dterm_dict_factory([site])
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path),
+                                  sqrt_gains=True)
+
+        loaded = eh.caltable.load_caltable(obs_direct, str(tmp_path),
+                                           sqrt_gains=True)
+        np.testing.assert_allclose(loaded.dterms[site]['dr'],
+                                   ct.dterms[site]['dr'], rtol=GAIN_RTOL)
+
+    def test_dterm_files_without_gains_returns_false(self, obs_direct,
+                                                     injected_gain_caltable_factory,
+                                                     dterm_dict_factory, tmp_path):
+        # the directory gate is unchanged: no gain files means no caltable,
+        # even if leakage files are sitting there
+        ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
+        ct.dterms = dterm_dict_factory(list(ct.data))
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
+        for gain_file in tmp_path.glob(f"{ct.source}_*.txt"):
+            if not gain_file.name.endswith(eh.caltable.DTERM_FILE_SUFFIX):
+                gain_file.unlink()
+
+        assert eh.caltable.load_caltable(obs_direct, str(tmp_path)) is False
+
+
+class TestLoadSingleRowAndLegacyGainFiles:
+    """Regressions for the gain loader: one-row files used to fail with
+    "format unknown" because a 1-D loadtxt result iterates as characters."""
+
+    def test_single_row_gain_file_loads(self, obs_direct, tmp_path):
+        site = _first_sites(obs_direct, 1)[0]
+        time_mjd = obs_direct.mjd + SINGLE_ROW_TIME_HR / 24.0
+        path = tmp_path / f"{obs_direct.source}_{site}.txt"
+        path.write_text(f"{time_mjd} 1.5 0.25 2.5 -0.5\n")
+
+        loaded = eh.caltable.load_caltable(obs_direct, str(tmp_path))
+        assert len(loaded.data[site]) == 1
+        np.testing.assert_allclose(loaded.data[site]['rscale'][0], 1.5 + 0.25j)
+        np.testing.assert_allclose(loaded.data[site]['lscale'][0], 2.5 - 0.5j)
+        np.testing.assert_allclose(loaded.data[site]['time'][0],
+                                   SINGLE_ROW_TIME_HR, atol=TIME_ATOL)
+
+    def test_load_legacy_three_column_real_gains(self, obs_direct, tmp_path):
+        # the oldest on-disk vintage: real-valued gains, three columns
+        site = _first_sites(obs_direct, 1)[0]
+        t0 = obs_direct.mjd + SINGLE_ROW_TIME_HR / 24.0
+        t1 = obs_direct.mjd + (SINGLE_ROW_TIME_HR + 1.0) / 24.0
+        path = tmp_path / f"{obs_direct.source}_{site}.txt"
+        path.write_text(f"{t0} 1.5 2.5\n{t1} 3.5 4.5\n")
+
+        loaded = eh.caltable.load_caltable(obs_direct, str(tmp_path))
+        np.testing.assert_allclose(loaded.data[site]['rscale'], [1.5, 3.5])
+        np.testing.assert_allclose(loaded.data[site]['lscale'], [2.5, 4.5])
 
 
 class TestApplycalWarnsOnDterms:

--- a/tests/test_caltable.py
+++ b/tests/test_caltable.py
@@ -1,12 +1,14 @@
 """Tests for ehtim.caltable.Caltable."""
 
 import pickle
+import warnings
 
 import numpy as np
 import pytest
 
 import ehtim as eh
 from ehtim.const_def import DTCAL
+from ehtim.warnings import MixedPolConventionWarning
 
 # ---------------------------------------------------------------------------
 # Constants used across the module
@@ -15,6 +17,10 @@ from ehtim.const_def import DTCAL
 # Bit-clean numerical-equality tolerances for applycal scaling and gain
 # round-trips. 1e-12 is the float-roundoff floor for products and inversions
 # of double-precision complex numbers across this module.
+# Gain used by the applycal D-term warning tests. Any well-conditioned value
+# works; the tests assert on the warning and on output equality, not on it.
+APPLYCAL_WARN_GAIN = 1.3 + 0.4j
+
 BIT_CLEAN_RTOL = 1e-12
 BIT_CLEAN_ATOL = 1e-12
 
@@ -981,6 +987,47 @@ class TestSplitLeavesApplycalUnchanged:
             np.testing.assert_array_equal(circ_w.data[field], circ_c.data[field])
         for field in ('rrsigma', 'llsigma', 'rlsigma', 'lrsigma'):
             np.testing.assert_array_equal(circ_w.data[field], circ_c.data[field])
+
+
+class TestApplycalWarnsOnDterms:
+    """applycal corrects gains only. If the table carries leakage, say so
+    rather than letting it look like the data came back fully calibrated."""
+
+    def test_applycal_warns_on_unapplied_dterms(self, obs_direct,
+                                                constant_gain_caltable_factory,
+                                                dterm_dict_factory):
+        ct = constant_gain_caltable_factory(APPLYCAL_WARN_GAIN)
+        site = _first_sites(obs_direct, 1)[0]
+        ct.dterms = dterm_dict_factory([site])
+
+        with pytest.warns(MixedPolConventionWarning, match=site):
+            ct.applycal(obs_direct)
+
+    def test_applycal_silent_without_dterms(self, obs_direct,
+                                            constant_gain_caltable_factory):
+        ct = constant_gain_caltable_factory(APPLYCAL_WARN_GAIN)
+        assert ct.dterms == {}
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", MixedPolConventionWarning)
+            ct.applycal(obs_direct)
+
+    def test_warning_does_not_change_the_output(self, obs_direct,
+                                                constant_gain_caltable_factory,
+                                                dterm_dict_factory):
+        # the warning is advisory: the returned data is the gains-only result,
+        # identical to the same table with no leakage attached
+        ct_plain = constant_gain_caltable_factory(APPLYCAL_WARN_GAIN)
+        ct_leaky = constant_gain_caltable_factory(APPLYCAL_WARN_GAIN)
+        ct_leaky.dterms = dterm_dict_factory(list(ct_leaky.data))
+
+        out_plain = ct_plain.applycal(obs_direct)
+        with pytest.warns(MixedPolConventionWarning):
+            out_leaky = ct_leaky.applycal(obs_direct)
+
+        for field in ('vis', 'sigma'):
+            np.testing.assert_array_equal(out_plain.data[field],
+                                          out_leaky.data[field])
 
 
 class TestTransformsCarryDterms:

--- a/tests/test_caltable.py
+++ b/tests/test_caltable.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 import ehtim as eh
-from ehtim.const_def import DTCAL, DTDTERM
+from ehtim.const_def import DTCAL
 
 # ---------------------------------------------------------------------------
 # Constants used across the module
@@ -561,7 +561,7 @@ class TestRelaxedInterp1d:
 def _multi_scan_caltable(obs, n_scans, samples_per_scan=PAD_SCAN_NSAMPLES,
                          dt_in_scan_sec=PAD_SCAN_DT_SEC,
                          gap_sec=PAD_SCAN_GAP_SEC,
-                         rscale=1.0 + 0j, lscale=1.0 + 0j):
+                         rscale=1.0 + 0j, lscale=1.0 + 0j, dterms=None):
     """Build a Caltable whose times form `n_scans` blocks separated by `gap_sec`.
 
     Each block has `samples_per_scan` points spaced by `dt_in_scan_sec`. The
@@ -582,11 +582,12 @@ def _multi_scan_caltable(obs, n_scans, samples_per_scan=PAD_SCAN_NSAMPLES,
     caldict = {site: template.copy().view(np.recarray) for site in obs.tarr['site']}
     return eh.caltable.Caltable(
         obs.ra, obs.dec, obs.rf, obs.bw, caldict, obs.tarr,
-        source=obs.source, mjd=obs.mjd, timetype=obs.timetype,
+        source=obs.source, mjd=obs.mjd, timetype=obs.timetype, dterms=dterms,
     )
 
 
-def _scan_aligned_caltable(obs, gains_per_scan, samples_per_scan=PAD_SCAN_NSAMPLES):
+def _scan_aligned_caltable(obs, gains_per_scan, samples_per_scan=PAD_SCAN_NSAMPLES,
+                           dterms=None):
     """Build a Caltable whose times fall inside the first len(gains_per_scan)
     scans of `obs` (so scan_avg's per-scan bucketing finds the samples).
 
@@ -617,7 +618,7 @@ def _scan_aligned_caltable(obs, gains_per_scan, samples_per_scan=PAD_SCAN_NSAMPL
     caldict = {site: template.copy().view(np.recarray) for site in obs.tarr['site']}
     return eh.caltable.Caltable(
         obs.ra, obs.dec, obs.rf, obs.bw, caldict, obs.tarr,
-        source=obs.source, mjd=obs.mjd, timetype=obs.timetype,
+        source=obs.source, mjd=obs.mjd, timetype=obs.timetype, dterms=dterms,
     )
 
 
@@ -777,16 +778,6 @@ def _clean_caldict(sites, times):
     return {site: template.copy() for site in sites}
 
 
-def _dterm_dict(sites, times=(SPLIT_DTERM_TIME,), dr=SPLIT_DR, dl=SPLIT_DL):
-    """A D-term table dict on its own (by default single-row) time grid."""
-    times = np.asarray(times, dtype=float)
-    template = np.zeros(len(times), dtype=DTDTERM)
-    template['time'] = times
-    template['dr'] = dr
-    template['dl'] = dl
-    return {site: template.copy() for site in sites}
-
-
 def _span_times(obs):
     return [obs.data['time'].min() - 1.0, obs.data['time'].max() + 1.0]
 
@@ -843,14 +834,15 @@ class TestConstructorSplit:
             # the extracted D-terms keep the time column they were welded to
             np.testing.assert_array_equal(ct.dterms[site]['time'], times)
 
-    def test_constructor_dterms_kwarg(self, obs_direct):
+    def test_constructor_dterms_kwarg(self, obs_direct, dterm_dict_factory):
         times = _span_times(obs_direct)
         sites = _first_sites(obs_direct)
         ct = eh.caltable.Caltable(
             obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
             _clean_caldict(sites, times), obs_direct.tarr,
             source=obs_direct.source, mjd=obs_direct.mjd,
-            dterms=_dterm_dict(sites),
+            dterms=dterm_dict_factory(sites, times=(SPLIT_DTERM_TIME,),
+                                      dr=SPLIT_DR, dl=SPLIT_DL),
         )
         for site in sites:
             # gains keep their own (two-point) grid, D-terms their one-row grid
@@ -859,7 +851,8 @@ class TestConstructorSplit:
             assert ct.dterms[site]['time'][0] == SPLIT_DTERM_TIME
             np.testing.assert_array_equal(ct.gains[site]['rscale'], SPLIT_GAIN_R)
 
-    def test_constructor_explicit_dterms_overrides_autosplit(self, obs_direct):
+    def test_constructor_explicit_dterms_overrides_autosplit(self, obs_direct,
+                                                             dterm_dict_factory):
         times = _span_times(obs_direct)
         sites = _first_sites(obs_direct, 1)
         site = sites[0]
@@ -868,7 +861,7 @@ class TestConstructorSplit:
             obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
             _welded_caldict(sites, times), obs_direct.tarr,
             source=obs_direct.source, mjd=obs_direct.mjd,
-            dterms=_dterm_dict(sites, dr=override, dl=override),
+            dterms=dterm_dict_factory(sites, dr=override, dl=override),
         )
         # the explicit table replaces what the weld would have contributed
         assert len(ct.dterms[site]) == 1
@@ -988,3 +981,110 @@ class TestSplitLeavesApplycalUnchanged:
             np.testing.assert_array_equal(circ_w.data[field], circ_c.data[field])
         for field in ('rrsigma', 'llsigma', 'rlsigma', 'lrsigma'):
             np.testing.assert_array_equal(circ_w.data[field], circ_c.data[field])
+
+
+class TestTransformsCarryDterms:
+    """pad_scans / scan_avg / merge resample gains; the leakage table rides
+    along on its own time grid instead of being silently dropped."""
+
+    def test_pad_scans_forwards_dterms_deepcopy(self, obs_direct, dterm_dict_factory):
+        site = _first_sites(obs_direct, 1)[0]
+        dterms = dterm_dict_factory([site], dr=SPLIT_DR, dl=SPLIT_DL)
+        ct = _multi_scan_caltable(obs_direct, n_scans=len(PAD_SCAN_MEDIAN_GAINS),
+                                  rscale=PAD_SCAN_ENDVAL_GAIN,
+                                  lscale=PAD_SCAN_ENDVAL_GAIN,
+                                  dterms=dterms)
+        out = ct.pad_scans(maxdiff=PAD_SCAN_MAXDIFF_SEC, padtype='endval')
+
+        np.testing.assert_array_equal(out.dterms[site]['dr'], SPLIT_DR)
+        # padding the gain grid must not resample leakage: one row in, one out
+        assert len(out.dterms[site]) == 1
+        # forwarded as a deep copy, so the output is not welded to the input
+        out.dterms[site]['dr'] *= 10
+        np.testing.assert_array_equal(ct.dterms[site]['dr'], SPLIT_DR)
+
+    def test_scan_avg_forwards_dterms(self, obs_direct, dterm_dict_factory):
+        site = _first_sites(obs_direct, 1)[0]
+        dterms = dterm_dict_factory([site], dr=SPLIT_DR, dl=SPLIT_DL)
+        ct = _scan_aligned_caltable(obs_direct, np.array(SCAN_COH_GAINS),
+                                    dterms=dterms)
+        out = ct.scan_avg(obs_direct, incoherent=False)
+
+        np.testing.assert_array_equal(out.dterms[site]['dr'], SPLIT_DR)
+        assert len(out.dterms[site]) == 1
+        out.dterms[site]['dr'] *= 10
+        np.testing.assert_array_equal(ct.dterms[site]['dr'], SPLIT_DR)
+
+    def test_merge_forwards_one_sided_dterms_no_aliasing(
+            self, obs_direct, constant_gain_caltable_factory, dterm_dict_factory):
+        # Only the merged-in table carries leakage ⇒ it passes through, deep
+        # copied so the merged table does not share the input's array.
+        ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
+        ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
+        site = _first_sites(obs_direct, 1)[0]
+        ct_b.dterms = dterm_dict_factory([site], dr=SPLIT_DR, dl=SPLIT_DL)
+
+        out = ct_a.merge([ct_b])
+
+        np.testing.assert_array_equal(out.dterms[site]['dr'], SPLIT_DR)
+        assert out.dterms[site] is not ct_b.dterms[site]
+        out.dterms[site]['dr'] *= 10
+        np.testing.assert_array_equal(ct_b.dterms[site]['dr'], SPLIT_DR)
+
+    def test_merge_one_sided_dterms_leave_gains_alone(
+            self, obs_direct, constant_gain_caltable_factory, dterm_dict_factory):
+        # Carrying leakage through must not perturb the gain product.
+        ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
+        ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
+        ct_b.dterms = dterm_dict_factory(_first_sites(obs_direct, 1),
+                                         dr=SPLIT_DR, dl=SPLIT_DL)
+        out = ct_a.merge([ct_b])
+        out_r, out_l = _stack_gains(out)
+        np.testing.assert_allclose(out_r, MERGE_GAIN_A * MERGE_GAIN_B,
+                                   rtol=INTERP_RTOL)
+        np.testing.assert_allclose(out_l, MERGE_GAIN_A * MERGE_GAIN_B,
+                                   rtol=INTERP_RTOL)
+
+    def test_merge_both_sides_dterms_raises(
+            self, obs_direct, constant_gain_caltable_factory, dterm_dict_factory):
+        # Composing two leakage solutions is Part C; failing loudly beats
+        # returning a table that looks calibrated and is not.
+        ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
+        ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
+        sites = _first_sites(obs_direct, 1)
+        ct_a.dterms = dterm_dict_factory(sites, dr=SPLIT_DR, dl=SPLIT_DL)
+        ct_b.dterms = dterm_dict_factory(sites, dr=SPLIT_DL, dl=SPLIT_DR)
+
+        with pytest.raises(NotImplementedError, match="D-terms"):
+            ct_a.merge([ct_b])
+
+    def test_merge_disjoint_dterm_sites_both_kept(
+            self, obs_direct, constant_gain_caltable_factory, dterm_dict_factory):
+        # Different sites on each side is not a conflict; both survive.
+        ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
+        ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
+        site_a, site_b = _first_sites(obs_direct, 2)
+        ct_a.dterms = dterm_dict_factory([site_a], dr=SPLIT_DR, dl=SPLIT_DL)
+        ct_b.dterms = dterm_dict_factory([site_b], dr=SPLIT_DL, dl=SPLIT_DR)
+
+        out = ct_a.merge([ct_b])
+
+        assert set(out.dterms) == {site_a, site_b}
+        np.testing.assert_array_equal(out.dterms[site_a]['dr'], SPLIT_DR)
+        np.testing.assert_array_equal(out.dterms[site_b]['dr'], SPLIT_DL)
+
+    def test_merge_disjoint_site_gains_not_aliased(
+            self, obs_direct, constant_gain_caltable_factory):
+        # For a site only the other table has, merge adopts its gain array.
+        # That must be a copy, or mutating the merged table reaches back into
+        # the input caltable.
+        ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
+        ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
+        site = _first_sites(obs_direct, 1)[0]
+        ct_a.data.pop(site)
+
+        out = ct_a.merge([ct_b])
+
+        assert out.data[site] is not ct_b.data[site]
+        out.data[site]['rscale'] *= 10
+        np.testing.assert_allclose(ct_b.data[site]['rscale'], MERGE_GAIN_B)

--- a/tests/test_caltable.py
+++ b/tests/test_caltable.py
@@ -647,7 +647,7 @@ def _multi_scan_caltable(obs, n_scans, samples_per_scan=PAD_SCAN_NSAMPLES,
     caldict = {site: template.copy().view(np.recarray) for site in obs.tarr['site']}
     return eh.caltable.Caltable(
         obs.ra, obs.dec, obs.rf, obs.bw, caldict, obs.tarr,
-        source=obs.source, mjd=obs.mjd, timetype=obs.timetype, dterms=dterms,
+        source=obs.source, mjd=obs.mjd, timetype=obs.timetype, dtermdict=dterms,
     )
 
 
@@ -683,7 +683,7 @@ def _scan_aligned_caltable(obs, gains_per_scan, samples_per_scan=PAD_SCAN_NSAMPL
     caldict = {site: template.copy().view(np.recarray) for site in obs.tarr['site']}
     return eh.caltable.Caltable(
         obs.ra, obs.dec, obs.rf, obs.bw, caldict, obs.tarr,
-        source=obs.source, mjd=obs.mjd, timetype=obs.timetype, dterms=dterms,
+        source=obs.source, mjd=obs.mjd, timetype=obs.timetype, dtermdict=dterms,
     )
 
 
@@ -907,7 +907,7 @@ class TestDataAliasesGains:
 
 
 class TestConstructorSplit:
-    """``__init__`` splits welded input and honours an explicit ``dterms=``."""
+    """``__init__`` splits welded input and honours an explicit ``dtermdict=``."""
 
     def test_constructor_welded_datadict_autosplits(self, obs_direct):
         """A pre-split datadict is separated into the two tables on construction.
@@ -931,7 +931,7 @@ class TestConstructorSplit:
             # the extracted D-terms keep the time column they were welded to
             np.testing.assert_array_equal(ct.dterms[site]['time'], times)
 
-    def test_constructor_dterms_kwarg(self, obs_direct, dterm_dict_factory):
+    def test_constructor_dtermdict_kwarg(self, obs_direct, dterm_dict_factory):
         """Gains and D-terms passed separately keep their own independent time grids."""
         times = _span_times(obs_direct)
         sites = _first_sites(obs_direct)
@@ -939,7 +939,7 @@ class TestConstructorSplit:
             obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
             _clean_caldict(sites, times), obs_direct.tarr,
             source=obs_direct.source, mjd=obs_direct.mjd,
-            dterms=dterm_dict_factory(sites, times=(SPLIT_DTERM_TIME,),
+            dtermdict=dterm_dict_factory(sites, times=(SPLIT_DTERM_TIME,),
                                       dr=SPLIT_DR, dl=SPLIT_DL),
         )
         for site in sites:
@@ -951,7 +951,7 @@ class TestConstructorSplit:
 
     def test_constructor_explicit_dterms_overrides_autosplit(self, obs_direct,
                                                              dterm_dict_factory):
-        """An explicit dterms= wins over whatever a welded datadict would have contributed."""
+        """An explicit dtermdict= wins over whatever a welded datadict would have contributed."""
         times = _span_times(obs_direct)
         sites = _first_sites(obs_direct, 1)
         site = sites[0]
@@ -960,7 +960,7 @@ class TestConstructorSplit:
             obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
             _welded_caldict(sites, times), obs_direct.tarr,
             source=obs_direct.source, mjd=obs_direct.mjd,
-            dterms=dterm_dict_factory(sites, dr=override, dl=override),
+            dtermdict=dterm_dict_factory(sites, dr=override, dl=override),
         )
         # the explicit table replaces what the weld would have contributed
         assert len(ct.dterms[site]) == 1
@@ -984,15 +984,15 @@ class TestConstructorSplit:
         assert len(ct.gains[site]) == 1
         assert ct.gains[site]['rscale'][0] == SPLIT_GAIN_R
 
-    def test_constructor_rejects_non_dict_dterms(self, obs_direct, dterm_dict_factory):
-        """A non-dict dterms= names the problem instead of failing inside dict()."""
+    def test_constructor_rejects_non_dict_dtermdict(self, obs_direct, dterm_dict_factory):
+        """A non-dict dtermdict= names the problem instead of failing inside dict()."""
         site = _first_sites(obs_direct, 1)[0]
         table = dterm_dict_factory([site])[site]     # the bare table, not a dict
-        with pytest.raises(TypeError, match="dterms must be a dict"):
+        with pytest.raises(TypeError, match="dtermdict must be a dict"):
             eh.caltable.Caltable(
                 obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
                 _clean_caldict([site], _span_times(obs_direct)), obs_direct.tarr,
-                source=obs_direct.source, mjd=obs_direct.mjd, dterms=table,
+                source=obs_direct.source, mjd=obs_direct.mjd, dtermdict=table,
             )
 
     def test_constructor_non_dict_datadict_stored_verbatim(self, obs_direct):
@@ -1206,7 +1206,7 @@ class TestSplitFixups:
         ct = eh.caltable.Caltable(
             obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
             _clean_caldict([site], _span_times(obs_direct)), obs_direct.tarr,
-            source=obs_direct.source, mjd=obs_direct.mjd, dterms={site: rec},
+            source=obs_direct.source, mjd=obs_direct.mjd, dtermdict={site: rec},
         )
         assert len(ct.dterms[site]) == 1
         assert ct.dterms[site]['dr'][0] == SPLIT_DR
@@ -1222,7 +1222,7 @@ class TestSplitFixups:
             obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
             _clean_caldict([site], _span_times(obs_direct)), obs_direct.tarr,
             source=obs_direct.source, mjd=obs_direct.mjd,
-            dterms={site: np.array([])},
+            dtermdict={site: np.array([])},
         )
         assert ct.dterms == {}
 

--- a/tests/test_caltable.py
+++ b/tests/test_caltable.py
@@ -135,8 +135,10 @@ def test_applycal_unity_preserves_data(obs_direct):
 
 
 class TestCaltableConstruction:
+    """Building a table from a datadict, and the make_caltable helper."""
 
     def test_init_sets_scalar_attrs(self, unity_caltable, obs_direct):
+        """The observation's scalar metadata is copied onto the table."""
         ct = unity_caltable
         assert ct.source == obs_direct.source
         assert ct.ra == obs_direct.ra
@@ -147,12 +149,14 @@ class TestCaltableConstruction:
         assert ct.timetype == obs_direct.timetype
 
     def test_init_builds_tkey_from_tarr(self, unity_caltable):
+        """tkey maps each site name to its row index in tarr."""
         ct = unity_caltable
         idx = np.fromiter((ct.tkey[s] for s in ct.tarr['site']),
                           dtype=int, count=len(ct.tarr))
         np.testing.assert_array_equal(idx, np.arange(len(ct.tarr)))
 
     def test_init_rejects_bad_timetype(self, obs_direct):
+        """Only 'GMST' and 'UTC' are accepted as time conventions."""
         with pytest.raises(Exception, match="GMST"):
             eh.caltable.Caltable(
                 obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
@@ -160,11 +164,15 @@ class TestCaltableConstruction:
             )
 
     def test_init_data_keys_match_sites(self, unity_caltable, obs_direct):
+        """Every site in the array gets an entry in the gain table."""
         assert set(unity_caltable.data.keys()) == set(obs_direct.tarr['site'])
 
     def test_make_caltable_square_ntele_eq_ntimes(self, obs_direct):
-        # ntele == ntimes: indexing gains[s*ntele + t] coincides with the
-        # intended gains[s*ntimes + t] so the mapping is correct.
+        """make_caltable lays the flat gain list out as gains[site*ntimes + time].
+
+        Square case, ntele == ntimes, where a transposed index would still agree;
+        the rectangular test below is the one that can tell them apart.
+        """
         sites = list(obs_direct.tarr['site'])[:3]
         times = [obs_direct.data['time'].min(),
                  (obs_direct.data['time'].min() + obs_direct.data['time'].max()) / 2,
@@ -177,11 +185,11 @@ class TestCaltableConstruction:
         assert ct.data[sites[1]][2]['lscale'] == 5 + 0j
 
     def test_make_caltable_returns_false_on_empty(self, obs_direct):
+        """With no sites or times there is nothing to build, so it returns False."""
         assert eh.caltable.make_caltable(obs_direct, [], [], []) is False
 
     def test_make_caltable_rect_ntele_ne_ntimes(self, obs_direct):
-        # ntele=2, ntimes=3. With the correct s*ntimes + t indexing, gain at
-        # (site i, time j) is gains[i*ntimes + j].
+        """Two sites and three times, where a transposed index would disagree."""
         sites = list(obs_direct.tarr['site'])[:2]
         times = [obs_direct.data['time'].min(),
                  (obs_direct.data['time'].min() + obs_direct.data['time'].max()) / 2,
@@ -201,16 +209,20 @@ class TestCaltableConstruction:
 
 
 class TestCaltableCopy:
+    """copy() is a deep copy: the result shares no array with the original."""
 
     def test_copy_returns_caltable_instance(self, unity_caltable):
+        """copy() hands back a Caltable, not a bare dict."""
         assert isinstance(unity_caltable.copy(), eh.caltable.Caltable)
 
     def test_copy_preserves_scalar_attrs(self, unity_caltable):
+        """The copy carries the same scalar metadata."""
         ct = unity_caltable.copy()
         for attr in ('source', 'ra', 'dec', 'rf', 'bw', 'mjd', 'timetype'):
             assert getattr(ct, attr) == getattr(unity_caltable, attr)
 
     def test_copy_data_is_independent(self, constant_gain_caltable_factory):
+        """Mutating the copy's gains leaves the original alone."""
         original = constant_gain_caltable_factory(2.0 + 0j)
         cp = original.copy()
         first_site = next(iter(cp.data))
@@ -218,6 +230,7 @@ class TestCaltableCopy:
         assert original.data[first_site]['rscale'][0] == 2 + 0j
 
     def test_copy_tarr_is_independent(self, unity_caltable):
+        """The telescope array is deep-copied too, not shared."""
         cp = unity_caltable.copy()
         cp.tarr['sefdr'][0] = -1234.0
         assert unity_caltable.tarr['sefdr'][0] != -1234.0
@@ -229,8 +242,10 @@ class TestCaltableCopy:
 
 
 class TestInvertGains:
+    """invert_gains() replaces every gain by its reciprocal, in place."""
 
     def test_invert_unity_is_unity(self, unity_caltable):
+        """Inverting unit gains leaves them at unity."""
         ct = unity_caltable.copy()
         ct.invert_gains()
         r_stack, l_stack = _stack_gains(ct)
@@ -238,6 +253,7 @@ class TestInvertGains:
         np.testing.assert_allclose(l_stack, 1 + 0j)
 
     def test_invert_constant_g_yields_reciprocal(self, constant_gain_caltable_factory):
+        """A constant gain g becomes 1/g."""
         ct = constant_gain_caltable_factory(CONST_REAL_GAIN)
         ct.invert_gains()
         r_stack, l_stack = _stack_gains(ct)
@@ -245,6 +261,7 @@ class TestInvertGains:
         np.testing.assert_allclose(l_stack, 1 / CONST_REAL_GAIN)
 
     def test_invert_twice_is_identity(self, injected_gain_caltable_factory):
+        """Inverting twice returns the original gains, to roundoff."""
         ct = injected_gain_caltable_factory(seed=SEED_INVERT_ROUNDTRIP)
         ref_r, _ = _stack_gains(ct)
         ct.invert_gains()
@@ -253,6 +270,7 @@ class TestInvertGains:
         np.testing.assert_allclose(r_stack, ref_r, rtol=BIT_CLEAN_RTOL)
 
     def test_invert_returns_self(self, unity_caltable):
+        """It works in place and returns the same object, so calls can be chained."""
         ct = unity_caltable.copy()
         assert ct.invert_gains() is ct
 
@@ -283,10 +301,14 @@ def _caltable_with_times(obs, times, rscale=1.0 + 0j, lscale=1.0 + 0j):
 
 
 class TestApplycalConstantGain:
+    """applycal scales each visibility by g_i * conj(g_j) for its two stations."""
 
     def test_real_gain_scales_amp_by_g_squared(self, obs_direct,
                                                constant_gain_caltable_factory):
-        # g_i * conj(g_j) = g**2 for every baseline when all stations share g.
+        """A real gain shared by every station scales each visibility by |g|^2.
+
+        Each baseline picks up g_i * conj(g_j).
+        """
         g = CONST_REAL_GAIN
         out = constant_gain_caltable_factory(g).applycal(obs_direct, interp='nearest')
         for f in ('vis', 'qvis', 'uvis', 'vvis'):
@@ -296,7 +318,10 @@ class TestApplycalConstantGain:
             )
 
     def test_pure_phase_gain_preserves_amplitude(self, obs_direct):
-        # |g_i * conj(g_j)| = 1 for any common phase ⇒ amplitudes invariant.
+        """A phase shared by every station leaves the amplitudes untouched.
+
+        |g_i * conj(g_j)| = 1 for any phase common to all stations.
+        """
         g = np.exp(1j * CONST_PHASE)
         ct = _caltable_with_times(
             obs_direct,
@@ -312,10 +337,14 @@ class TestApplycalConstantGain:
 
 
 class TestApplycalSiteSubset:
+    """Stations missing from the table are treated as already calibrated."""
 
     def test_missing_site_baselines_unscaled(self, obs_direct,
                                              constant_gain_caltable_factory):
-        # Sites absent from caltable.data fall back to gain = 1.
+        """A site with no gain entry falls back to gain 1.
+
+        Its baselines then scale by the surviving station's g rather than g^2.
+        """
         g = CONST_REAL_GAIN
         ct = constant_gain_caltable_factory(g)
         dropped = obs_direct.tarr['site'][0]
@@ -340,20 +369,25 @@ class TestApplycalSiteSubset:
 
 
 class TestApplycalPolrep:
+    """applycal works in circular internally and hands back the caller's polrep."""
 
     def test_stokes_input_returns_stokes(self, obs_direct, unity_caltable):
+        """A Stokes observation comes back as Stokes."""
         out = unity_caltable.applycal(obs_direct, interp='nearest')
         assert out.polrep == 'stokes'
 
     def test_circ_input_returns_circ(self, obs_direct, unity_caltable):
+        """A circular observation comes back as circular."""
         obs_circ = obs_direct.switch_polrep('circ')
         out = unity_caltable.applycal(obs_circ, interp='nearest')
         assert out.polrep == 'circ'
 
 
 class TestApplycalRejectsMismatchedTarr:
+    """The table and the observation have to describe the same array."""
 
     def test_different_tarr_raises(self, obs_direct, unity_caltable):
+        """One perturbed station coordinate makes applycal refuse rather than mis-apply."""
         obs_mut = obs_direct.copy()
         obs_mut.tarr['x'][0] += 1.0
         with pytest.raises(Exception, match="telescope array"):
@@ -361,10 +395,11 @@ class TestApplycalRejectsMismatchedTarr:
 
 
 class TestApplycalInterpModes:
+    """The interp kwarg chooses how gains are sampled between cal-table times."""
 
     @pytest.mark.parametrize("interp", ["nearest", "linear"])
     def test_constant_gain_recovered_at_every_time(self, obs_direct, interp):
-        # Both modes return g**2 at every obs time when the caltable is flat.
+        """A flat table returns |g|^2 at every observation time, in either interp mode."""
         g = CONST_INTERP_GAIN
         ct = _caltable_with_times(
             obs_direct,
@@ -379,7 +414,7 @@ class TestApplycalInterpModes:
         )
 
     def test_cubic_requires_four_points(self, obs_direct):
-        # cubic interp needs >= 4 anchor points; constant g recovers g**2.
+        """Cubic interpolation needs four anchors; given them, a constant gain still comes back exactly."""
         g = CONST_CUBIC_GAIN
         t0 = obs_direct.data['time'].min() - 1.0
         t1 = obs_direct.data['time'].max() + 1.0
@@ -393,14 +428,15 @@ class TestApplycalInterpModes:
 
 
 class TestApplycalExtrapolation:
+    """What happens outside the table's time span.
 
-    # The applycal docstring only documents extrapolate=True; the False/None
-    # behaviour is left to the underlying scipy.interpolate.interp1d default
-    # (NaN fill). These tests pin that delegated behaviour rather than treat
-    # it as a bug: with extrapolate=None, samples outside the caltable span
-    # come back NaN, exactly on those rows.
+    applycal only documents extrapolate=True; the None case falls through to
+    scipy's interp1d default, which is a NaN fill. These pin that inherited
+    behaviour rather than treating it as a bug.
+    """
 
     def test_extrapolate_none_yields_nan_only_outside_span(self, obs_direct):
+        """Rows past the end of the table come back NaN, and only those rows."""
         t0 = obs_direct.data['time'].min()
         t_mid = 0.5 * (obs_direct.data['time'].min()
                        + obs_direct.data['time'].max())
@@ -413,8 +449,7 @@ class TestApplycalExtrapolation:
         assert np.all(np.isfinite(out.data['vis'][inside]))
 
     def test_extrapolate_true_fills_outside_span(self, obs_direct):
-        # With extrapolate=True, scipy's 'extrapolate' fill value is used and
-        # the calibrated visibilities are finite everywhere.
+        """With extrapolate=True scipy fills the ends and every row stays finite."""
         t0 = obs_direct.data['time'].min()
         t_mid = 0.5 * (obs_direct.data['time'].min()
                        + obs_direct.data['time'].max())
@@ -429,10 +464,12 @@ class TestApplycalExtrapolation:
 
 
 class TestSaveLoadRoundtrip:
+    """Gains survive a trip out to the per-site text files and back."""
 
     def test_save_caltable_load_caltable_roundtrip(self, obs_direct,
                                                    injected_gain_caltable_factory,
                                                    tmp_path):
+        """Saving then loading recovers the gains and their times."""
         ct = injected_gain_caltable_factory(seed=SEED_SAVE_LOAD_ROUNDTRIP)
         eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
         loaded = eh.caltable.load_caltable(obs_direct, str(tmp_path))
@@ -448,9 +485,11 @@ class TestSaveLoadRoundtrip:
     def test_sqrt_gains_roundtrip_preserves_squared_gain(self, obs_direct,
                                                         injected_gain_caltable_factory,
                                                         tmp_path):
-        # On-disk quantity is the squared gain, so loaded**2 == original**2
-        # is the exact round-trip. Comparing squares also sidesteps the
-        # principal-branch sqrt sign flip outside (-pi/2, pi/2).
+        """With sqrt_gains the on-disk quantity is the squared gain.
+
+        Comparing squares is the exact round-trip and also sidesteps the sqrt
+        branch cut, which flips sign outside (-pi/2, pi/2).
+        """
         ct = injected_gain_caltable_factory(seed=SEED_SQRT_ROUNDTRIP)
         eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path),
                                   sqrt_gains=True)
@@ -469,7 +508,7 @@ class TestSaveLoadRoundtrip:
     def test_save_txt_method_matches_module_function(self, obs_direct,
                                                      injected_gain_caltable_factory,
                                                      tmp_path):
-        # Caltable.save_txt is a thin wrapper; files should be byte-identical.
+        """Caltable.save_txt is a thin wrapper, so it writes byte-identical files."""
         ct = injected_gain_caltable_factory(seed=SEED_SAVE_TXT_MATCH)
         out_a = tmp_path / "a"
         out_b = tmp_path / "b"
@@ -489,8 +528,10 @@ class TestSaveLoadRoundtrip:
 
 
 class TestEnforcePositive:
+    """enforce_positive rescales a whole gain curve so no station sits below min_gain."""
 
     def test_no_op_when_all_gains_above_min(self, unity_caltable):
+        """Gains already above the floor are left alone."""
         out = unity_caltable.enforce_positive(method='median', min_gain=0.5,
                                               verbose=False)
         out_r, out_l = _stack_gains(out)
@@ -499,8 +540,7 @@ class TestEnforcePositive:
         np.testing.assert_allclose(out_l, in_l)
 
     def test_rescales_low_gains_above_threshold(self, constant_gain_caltable_factory):
-        # All gains g = CONST_LOW_GAIN < DEFAULT_MIN_GAIN ⇒ median |g| = |g|,
-        # rescale by 1/|g| ⇒ new |gain| = 1.
+        """A curve sitting below the floor is divided by its median, landing at |gain| = 1."""
         ct = constant_gain_caltable_factory(CONST_LOW_GAIN)
         out = ct.enforce_positive(method='median', min_gain=DEFAULT_MIN_GAIN,
                                   verbose=False)
@@ -509,6 +549,7 @@ class TestEnforcePositive:
         np.testing.assert_allclose(np.abs(out_l), 1.0)
 
     def test_unknown_method_returns_unchanged_copy(self, constant_gain_caltable_factory):
+        """An unrecognised method returns an unchanged copy instead of raising."""
         ct = constant_gain_caltable_factory(CONST_LOW_GAIN)
         out = ct.enforce_positive(method='nope', min_gain=DEFAULT_MIN_GAIN,
                                   verbose=False)
@@ -517,6 +558,7 @@ class TestEnforcePositive:
                                    ct.data[first]['rscale'])
 
     def test_sites_subset_only_affects_listed(self, constant_gain_caltable_factory):
+        """Passing sites= confines the rescaling to those stations."""
         ct = constant_gain_caltable_factory(CONST_LOW_GAIN)
         first, second = list(ct.data.keys())[:2]
         out = ct.enforce_positive(method='median', min_gain=DEFAULT_MIN_GAIN,
@@ -526,6 +568,7 @@ class TestEnforcePositive:
                                    np.abs(CONST_LOW_GAIN))
 
     def test_returns_independent_copy(self, constant_gain_caltable_factory):
+        """The result is a copy; mutating it does not reach the original."""
         ct = constant_gain_caltable_factory(CONST_LOW_GAIN)
         out = ct.enforce_positive(method='median', min_gain=DEFAULT_MIN_GAIN,
                                   verbose=False)
@@ -540,8 +583,15 @@ class TestEnforcePositive:
 
 
 class TestRelaxedInterp1d:
+    """relaxed_interp1d wraps scipy's interp1d so degenerate inputs still work."""
 
     def test_single_point_falls_back_to_constant(self):
+        """A one-point table is expanded to a flat two-point segment.
+
+        The value is recovered at the anchor and on either side of it. Note the
+        segment is only half a unit wide in x, which is why a one-row table is
+        constant over a limited window rather than for all time.
+        """
         f = eh.caltable.relaxed_interp1d(np.array([3.0]), np.array([2.5]),
                                          kind='linear')
         # The helper expands a 1-point input to a 2-point [x-0.5, x+0.5]
@@ -551,13 +601,12 @@ class TestRelaxedInterp1d:
         assert f(3.3) == pytest.approx(2.5)
 
     def test_scalar_x_y_are_promoted_to_arrays(self):
-        # The bare-scalar code path catches TypeError on len(x) and recovers.
+        """Bare scalars are caught by the len() TypeError path and promoted to arrays."""
         f = eh.caltable.relaxed_interp1d(0.0, 1.5, kind='linear')
         assert f(0.0) == pytest.approx(1.5)
 
     def test_multi_point_matches_scipy_interp1d(self):
-        # When len(x) > 1, relaxed_interp1d delegates straight to
-        # scipy.interpolate.interp1d ⇒ bit-identical outputs.
+        """With more than one point it delegates straight to scipy, bit for bit."""
         import scipy.interpolate as spi
         x = np.linspace(0.0, 1.0, 5)
         y = x ** 2
@@ -637,10 +686,14 @@ def _scan_aligned_caltable(obs, gains_per_scan, samples_per_scan=PAD_SCAN_NSAMPL
 
 
 class TestPadScans:
+    """pad_scans adds a row on each side of every scan.
+
+    Gains are solved per chunk but applied by interpolation, so without the
+    padding the interpolant ramps across the gaps between scans.
+    """
 
     def test_endval_padding_inserts_endpoint_gains(self, obs_direct):
-        # Constant gains within each scan; endval padding ⇒ the pre and post
-        # rows must equal the first/last sample of the scan (= the constant).
+        """endval padding repeats each scan's first and last sample into the pad rows."""
         n_scans = len(PAD_SCAN_MEDIAN_GAINS)
         ct = _multi_scan_caltable(obs_direct, n_scans=n_scans,
                                   rscale=PAD_SCAN_ENDVAL_GAIN,
@@ -654,7 +707,7 @@ class TestPadScans:
         np.testing.assert_allclose(out_l, PAD_SCAN_ENDVAL_GAIN)
 
     def test_median_padding_uses_per_scan_median(self, obs_direct):
-        # Each scan gets its own constant gain ⇒ that constant is the median.
+        """median padding uses each scan's own median, not one median for the track."""
         gains = np.repeat(np.array(PAD_SCAN_MEDIAN_GAINS), PAD_SCAN_NSAMPLES)
         ct = _multi_scan_caltable(obs_direct, n_scans=len(PAD_SCAN_MEDIAN_GAINS),
                                   rscale=gains, lscale=gains)
@@ -673,13 +726,15 @@ class TestPadScans:
 
 
 class TestScanAvg:
+    """scan_avg collapses each scan to a single averaged gain.
 
-    # scan_avg emits one row per scan in obs.scans (regardless of caltable
-    # coverage). Scans without caltable data come back as NaN, so the tests
-    # below assert (i) the first n_scans rows recover the input values and
-    # (ii) every other row is NaN.
+    It emits one row per scan in obs.scans whatever the table covers, so scans
+    with no cal data come back NaN. The tests check the covered scans recover
+    their input and every later row is NaN.
+    """
 
     def test_incoherent_avg_recovers_per_scan_magnitudes(self, obs_direct):
+        """Averaging |g| across random phases recovers each scan's magnitude."""
         magnitudes = np.array(SCAN_INCOH_MAGNITUDES)
         n_scans = len(magnitudes)
         rng = np.random.default_rng(SEED_SCAN_AVG_PHASES)
@@ -699,6 +754,7 @@ class TestScanAvg:
             assert np.all(np.isnan(lscale[n_scans:]))
 
     def test_coherent_avg_keeps_phase(self, obs_direct):
+        """Coherent averaging keeps the complex gain, phase included."""
         per_scan = np.array(SCAN_COH_GAINS)
         n_scans = len(per_scan)
         ct = _scan_aligned_caltable(obs_direct, per_scan)
@@ -720,11 +776,11 @@ class TestScanAvg:
 
 
 class TestMerge:
+    """merge multiplies two tables over the union of their time grids."""
 
     def test_two_constant_caltables_multiply(self, obs_direct,
                                              constant_gain_caltable_factory):
-        # Caltable.merge interpolates each input over the union of times and
-        # multiplies pointwise. Two flat caltables a, b ⇒ merged gain = a*b.
+        """Two flat tables a and b merge to the pointwise product a*b."""
         ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
         ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
         out = ct_a.merge([ct_b])
@@ -736,8 +792,7 @@ class TestMerge:
 
     def test_disjoint_sites_are_unioned(self, obs_direct,
                                         constant_gain_caltable_factory):
-        # Drop site x from ct_a and site y from ct_b ⇒ the merged caltable's
-        # data dict must contain every site that appeared in either input.
+        """A site present in only one input still appears in the merged table."""
         ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
         ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
         sites = list(ct_a.data.keys())
@@ -805,11 +860,15 @@ class TestDataAliasesGains:
     """``data`` is the legacy name for the live gain table, not a snapshot."""
 
     def test_data_is_live_alias_of_gains(self, unity_caltable):
+        """ct.data is the gains dict itself, not a copy of it."""
         assert unity_caltable.data is unity_caltable.gains
 
     def test_data_mutation_persists(self, constant_gain_caltable_factory):
-        # The modeling_utils gain-assembly pattern: take .data, np.append into
-        # it per site, and expect the table itself to grow.
+        """Reassigning through ct.data reaches the table.
+
+        This is the modeling_utils gain-assembly pattern: take .data, np.append
+        into it per site, and expect the table itself to grow.
+        """
         ct = constant_gain_caltable_factory(CONST_REAL_GAIN)
         site = next(iter(ct.data))
         n_before = len(ct.gains[site])
@@ -818,6 +877,7 @@ class TestDataAliasesGains:
         assert len(ct.gains[site]) == 2 * n_before
 
     def test_data_setter_replaces_gains(self, unity_caltable, obs_direct):
+        """Assigning to ct.data swaps in a new gain table."""
         ct = unity_caltable.copy()
         replacement = _clean_caldict(_first_sites(obs_direct, 1),
                                      _span_times(obs_direct))
@@ -825,6 +885,7 @@ class TestDataAliasesGains:
         assert ct.gains is replacement
 
     def test_dterms_defaults_empty(self, unity_caltable):
+        """A table built without leakage has an empty dterms dict."""
         assert unity_caltable.dterms == {}
 
 
@@ -832,6 +893,11 @@ class TestConstructorSplit:
     """``__init__`` splits welded input and honours an explicit ``dterms=``."""
 
     def test_constructor_welded_datadict_autosplits(self, obs_direct):
+        """A pre-split datadict is separated into the two tables on construction.
+
+        The extracted D-terms keep the time column they were welded to, which is
+        the faithful migration of an old table.
+        """
         times = _span_times(obs_direct)
         sites = _first_sites(obs_direct)
         ct = eh.caltable.Caltable(
@@ -849,6 +915,7 @@ class TestConstructorSplit:
             np.testing.assert_array_equal(ct.dterms[site]['time'], times)
 
     def test_constructor_dterms_kwarg(self, obs_direct, dterm_dict_factory):
+        """Gains and D-terms passed separately keep their own independent time grids."""
         times = _span_times(obs_direct)
         sites = _first_sites(obs_direct)
         ct = eh.caltable.Caltable(
@@ -867,6 +934,7 @@ class TestConstructorSplit:
 
     def test_constructor_explicit_dterms_overrides_autosplit(self, obs_direct,
                                                              dterm_dict_factory):
+        """An explicit dterms= wins over whatever a welded datadict would have contributed."""
         times = _span_times(obs_direct)
         sites = _first_sites(obs_direct, 1)
         site = sites[0]
@@ -883,8 +951,11 @@ class TestConstructorSplit:
         np.testing.assert_array_equal(ct.gains[site]['rscale'], SPLIT_GAIN_R)
 
     def test_constructor_single_record_list_site(self, obs_direct):
-        # network_cal / polgains_cal leave a bare list of records for a site
-        # seen in exactly one non-first scan; it must normalise, not crash.
+        """A site handed over as a bare list of records is normalised, not rejected.
+
+        network_cal and polgains_cal leave this shape behind for a site seen in
+        exactly one non-first scan.
+        """
         times = _span_times(obs_direct)
         site = _first_sites(obs_direct, 1)[0]
         row = _clean_caldict([site], times)[site][0]
@@ -897,6 +968,7 @@ class TestConstructorSplit:
         assert ct.gains[site]['rscale'][0] == SPLIT_GAIN_R
 
     def test_constructor_non_dict_datadict_stored_verbatim(self, obs_direct):
+        """A non-dict datadict is stored as-is, the way it always was."""
         site = _first_sites(obs_direct, 1)[0]
         arr = _clean_caldict([site], _span_times(obs_direct))[site]
         ct = eh.caltable.Caltable(
@@ -918,6 +990,7 @@ class TestSplitStateRoundTrips:
         )
 
     def test_copy_preserves_dterms_independently(self, obs_direct):
+        """copy() deep-copies the leakage table as well as the gains."""
         ct = self._welded_caltable(obs_direct)
         site = _first_sites(obs_direct, 1)[0]
         cp = ct.copy()
@@ -926,6 +999,7 @@ class TestSplitStateRoundTrips:
         np.testing.assert_array_equal(ct.dterms[site]['dr'], SPLIT_DR)
 
     def test_pickle_roundtrip_with_dterms(self, obs_direct):
+        """Both tables survive a pickle round trip, and data comes back as an alias."""
         ct = self._welded_caltable(obs_direct)
         revived = pickle.loads(pickle.dumps(ct))
         assert set(revived.dterms) == set(ct.dterms)
@@ -936,8 +1010,7 @@ class TestSplitStateRoundTrips:
         assert revived.data is revived.gains
 
     def test_setstate_non_dict_data_stored_verbatim(self, obs_direct):
-        # A pre-split pickle whose 'data' was never a dict: pass it through
-        # rather than trying to split it.
+        """A pre-split pickle whose 'data' was never a dict is passed through untouched."""
         site = _first_sites(obs_direct, 1)[0]
         arr = _clean_caldict([site], _span_times(obs_direct))[site]
         ct = self._welded_caltable(obs_direct)
@@ -952,8 +1025,11 @@ class TestSplitStateRoundTrips:
         assert revived.dterms == {}
 
     def test_setstate_drops_legacy_data_key(self, obs_direct):
-        # 'data' is a property now, so a leftover instance-dict entry of that
-        # name would be shadowed and its gains lost.
+        """A legacy pickle's 'data' key is consumed, not left in the instance dict.
+
+        data is a property now, and a property shadows an instance-dict entry of
+        the same name, so leaving one behind would make those gains unreachable.
+        """
         ct = self._welded_caltable(obs_direct)
         site = _first_sites(obs_direct, 1)[0]
         state = dict(ct.__dict__)
@@ -971,6 +1047,11 @@ class TestSplitLeavesApplycalUnchanged:
     """Splitting the input must not perturb gain application."""
 
     def test_applycal_welded_equals_clean_gains(self, obs_direct):
+        """Splitting the input does not perturb gain application.
+
+        A welded table carrying leakage calibrates identically to the equivalent
+        gains-only table, since applycal has never applied D-terms.
+        """
         times = _span_times(obs_direct)
         sites = obs_direct.tarr['site']
         kwargs = dict(source=obs_direct.source, mjd=obs_direct.mjd,
@@ -1005,6 +1086,7 @@ class TestDtermPersistence:
     def test_save_load_roundtrip_with_dterms(self, obs_direct,
                                              injected_gain_caltable_factory,
                                              dterm_dict_factory, tmp_path):
+        """D-terms written on their own time grid come back on that same grid."""
         ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
         ct.dterms = dterm_dict_factory(list(ct.data), times=DTERM_TIMES)
         eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
@@ -1022,7 +1104,7 @@ class TestDtermPersistence:
     def test_single_row_dterm_file_roundtrip(self, obs_direct,
                                              injected_gain_caltable_factory,
                                              dterm_dict_factory, tmp_path):
-        # one row is the canonical shape for a track-constant D-term
+        """A one-row file, the storage form of a track-constant leakage, round-trips."""
         ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
         ct.dterms = dterm_dict_factory(list(ct.data))
         eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
@@ -1036,6 +1118,7 @@ class TestDtermPersistence:
     def test_dterm_file_has_version_header(self, obs_direct,
                                            injected_gain_caltable_factory,
                                            dterm_dict_factory, tmp_path):
+        """The D-term file leads with its version line."""
         ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
         site = _first_sites(obs_direct, 1)[0]
         ct.dterms = dterm_dict_factory([site])
@@ -1048,7 +1131,7 @@ class TestDtermPersistence:
     def test_gains_only_dir_has_no_dterm_files(self, obs_direct,
                                                injected_gain_caltable_factory,
                                                tmp_path):
-        # a table with no leakage writes exactly what it always did
+        """A table with no leakage writes exactly what it always did, and loads back empty."""
         ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
         assert ct.dterms == {}
         eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
@@ -1060,7 +1143,7 @@ class TestDtermPersistence:
     def test_sqrt_gains_does_not_touch_dterms(self, obs_direct,
                                               injected_gain_caltable_factory,
                                               dterm_dict_factory, tmp_path):
-        # sqrt_gains is a gain-side convention; leakage is written as-is
+        """sqrt_gains is a gain-side convention; leakage is written and read unchanged."""
         ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
         site = _first_sites(obs_direct, 1)[0]
         ct.dterms = dterm_dict_factory([site])
@@ -1075,8 +1158,7 @@ class TestDtermPersistence:
     def test_dterm_files_without_gains_returns_false(self, obs_direct,
                                                      injected_gain_caltable_factory,
                                                      dterm_dict_factory, tmp_path):
-        # the directory gate is unchanged: no gain files means no caltable,
-        # even if leakage files are sitting there
+        """The directory gate is unchanged: no gain files still means no table."""
         ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
         ct.dterms = dterm_dict_factory(list(ct.data))
         eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
@@ -1092,6 +1174,11 @@ class TestLoadSingleRowAndLegacyGainFiles:
     "format unknown" because a 1-D loadtxt result iterates as characters."""
 
     def test_single_row_gain_file_loads(self, obs_direct, tmp_path):
+        """A one-row gain file loads.
+
+        It used to fail with "format unknown": a 1-D loadtxt result iterates as
+        characters, so len(row) measured a string length instead of a column count.
+        """
         site = _first_sites(obs_direct, 1)[0]
         time_mjd = obs_direct.mjd + SINGLE_ROW_TIME_HR / 24.0
         path = tmp_path / f"{obs_direct.source}_{site}.txt"
@@ -1105,7 +1192,7 @@ class TestLoadSingleRowAndLegacyGainFiles:
                                    SINGLE_ROW_TIME_HR, atol=TIME_ATOL)
 
     def test_load_legacy_three_column_real_gains(self, obs_direct, tmp_path):
-        # the oldest on-disk vintage: real-valued gains, three columns
+        """The oldest on-disk vintage, three columns of real-valued gains, still loads."""
         site = _first_sites(obs_direct, 1)[0]
         t0 = obs_direct.mjd + SINGLE_ROW_TIME_HR / 24.0
         t1 = obs_direct.mjd + (SINGLE_ROW_TIME_HR + 1.0) / 24.0
@@ -1124,6 +1211,7 @@ class TestApplycalWarnsOnDterms:
     def test_applycal_warns_on_unapplied_dterms(self, obs_direct,
                                                 constant_gain_caltable_factory,
                                                 dterm_dict_factory):
+        """A table carrying leakage says so, naming the sites it did not correct."""
         ct = constant_gain_caltable_factory(APPLYCAL_WARN_GAIN)
         site = _first_sites(obs_direct, 1)[0]
         ct.dterms = dterm_dict_factory([site])
@@ -1133,6 +1221,7 @@ class TestApplycalWarnsOnDterms:
 
     def test_applycal_silent_without_dterms(self, obs_direct,
                                             constant_gain_caltable_factory):
+        """A gains-only table calibrates without complaint."""
         ct = constant_gain_caltable_factory(APPLYCAL_WARN_GAIN)
         assert ct.dterms == {}
 
@@ -1143,8 +1232,7 @@ class TestApplycalWarnsOnDterms:
     def test_warning_does_not_change_the_output(self, obs_direct,
                                                 constant_gain_caltable_factory,
                                                 dterm_dict_factory):
-        # the warning is advisory: the returned data is the gains-only result,
-        # identical to the same table with no leakage attached
+        """The warning is advisory: the data returned is the same gains-only result."""
         ct_plain = constant_gain_caltable_factory(APPLYCAL_WARN_GAIN)
         ct_leaky = constant_gain_caltable_factory(APPLYCAL_WARN_GAIN)
         ct_leaky.dterms = dterm_dict_factory(list(ct_leaky.data))
@@ -1163,6 +1251,7 @@ class TestTransformsCarryDterms:
     along on its own time grid instead of being silently dropped."""
 
     def test_pad_scans_forwards_dterms_deepcopy(self, obs_direct, dterm_dict_factory):
+        """Padding the gain grid carries the leakage through without resampling it."""
         site = _first_sites(obs_direct, 1)[0]
         dterms = dterm_dict_factory([site], dr=SPLIT_DR, dl=SPLIT_DL)
         ct = _multi_scan_caltable(obs_direct, n_scans=len(PAD_SCAN_MEDIAN_GAINS),
@@ -1179,6 +1268,7 @@ class TestTransformsCarryDterms:
         np.testing.assert_array_equal(ct.dterms[site]['dr'], SPLIT_DR)
 
     def test_scan_avg_forwards_dterms(self, obs_direct, dterm_dict_factory):
+        """Averaging gains per scan leaves the leakage table intact."""
         site = _first_sites(obs_direct, 1)[0]
         dterms = dterm_dict_factory([site], dr=SPLIT_DR, dl=SPLIT_DL)
         ct = _scan_aligned_caltable(obs_direct, np.array(SCAN_COH_GAINS),
@@ -1192,8 +1282,7 @@ class TestTransformsCarryDterms:
 
     def test_merge_forwards_one_sided_dterms_no_aliasing(
             self, obs_direct, constant_gain_caltable_factory, dterm_dict_factory):
-        # Only the merged-in table carries leakage ⇒ it passes through, deep
-        # copied so the merged table does not share the input's array.
+        """Leakage from one side is copied into the merged table, not aliased to it."""
         ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
         ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
         site = _first_sites(obs_direct, 1)[0]
@@ -1208,7 +1297,7 @@ class TestTransformsCarryDterms:
 
     def test_merge_one_sided_dterms_leave_gains_alone(
             self, obs_direct, constant_gain_caltable_factory, dterm_dict_factory):
-        # Carrying leakage through must not perturb the gain product.
+        """Carrying leakage across a merge does not disturb the gain multiplication."""
         ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
         ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
         ct_b.dterms = dterm_dict_factory(_first_sites(obs_direct, 1),
@@ -1222,8 +1311,11 @@ class TestTransformsCarryDterms:
 
     def test_merge_both_sides_dterms_raises(
             self, obs_direct, constant_gain_caltable_factory, dterm_dict_factory):
-        # Composing two leakage solutions is Part C; failing loudly beats
-        # returning a table that looks calibrated and is not.
+        """Two leakage solutions for one site refuse to merge.
+
+        They do compose, since J = G(I+D) is closed under multiplication, but not
+        the way gains do and not commutatively. Raising beats a quietly wrong table.
+        """
         ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
         ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
         sites = _first_sites(obs_direct, 1)
@@ -1235,7 +1327,7 @@ class TestTransformsCarryDterms:
 
     def test_merge_disjoint_dterm_sites_both_kept(
             self, obs_direct, constant_gain_caltable_factory, dterm_dict_factory):
-        # Different sites on each side is not a conflict; both survive.
+        """Leakage for different sites on either side is unioned."""
         ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
         ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
         site_a, site_b = _first_sites(obs_direct, 2)
@@ -1250,9 +1342,7 @@ class TestTransformsCarryDterms:
 
     def test_merge_disjoint_site_gains_not_aliased(
             self, obs_direct, constant_gain_caltable_factory):
-        # For a site only the other table has, merge adopts its gain array.
-        # That must be a copy, or mutating the merged table reaches back into
-        # the input caltable.
+        """A gain array adopted from the other table is copied, so it cannot be mutated back."""
         ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
         ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
         site = _first_sites(obs_direct, 1)[0]

--- a/tests/test_caltable.py
+++ b/tests/test_caltable.py
@@ -884,6 +884,21 @@ class TestDataAliasesGains:
         ct.data = replacement
         assert ct.gains is replacement
 
+    def test_data_setter_rejects_welded_tables(self, obs_direct, unity_caltable):
+        """A welded table assigned to .data is refused where the mistake is made.
+
+        Stored verbatim it would survive the assignment and then fail inside
+        pad_scans with a numpy cast error, far from the cause. Splitting it here
+        instead would be worse: leakage would move into .dterms silently.
+        """
+        ct = unity_caltable.copy()
+        welded = _welded_caldict(_first_sites(obs_direct, 1),
+                                 _span_times(obs_direct))
+        with pytest.raises(TypeError, match="carries D-term columns"):
+            ct.data = welded
+        # the failed assignment left the table alone
+        assert ct.gains is not welded
+
     def test_dterms_defaults_empty(self, unity_caltable):
         """A table built without leakage has an empty dterms dict."""
         assert unity_caltable.dterms == {}

--- a/tests/test_caltable.py
+++ b/tests/test_caltable.py
@@ -1,10 +1,12 @@
 """Tests for ehtim.caltable.Caltable."""
 
+import pickle
+
 import numpy as np
 import pytest
 
 import ehtim as eh
-from ehtim.const_def import DTCAL
+from ehtim.const_def import DTCAL, DTDTERM
 
 # ---------------------------------------------------------------------------
 # Constants used across the module
@@ -730,3 +732,259 @@ class TestMerge:
         out = ct_a.merge([ct_b])
         assert x in out.data
         assert y in out.data
+
+
+# ---------------------------------------------------------------------------
+# Section 11: Gain / D-term storage split
+# ---------------------------------------------------------------------------
+
+# The row dtype from the era when D-terms shared the gain rows (PR #254),
+# reproduced here so the migration paths can be driven from a caller's side.
+_WELDED_DTCAL = [('time', 'f8'),
+                 (('p1scale', 'rscale'), 'c16'), (('p2scale', 'lscale'), 'c16'),
+                 (('d_p1', 'dr'), 'c16'), (('d_p2', 'dl'), 'c16')]
+
+# Gains and leakage used across the split tests. The gain is complex and not
+# unity so an applycal comparison has teeth; the D-terms are nonzero so the
+# split actually extracts a table instead of dropping an all-zero one.
+SPLIT_GAIN_R = 1.4 - 0.2j
+SPLIT_GAIN_L = 0.8 + 0.5j
+SPLIT_DR = 0.03 + 0.01j
+SPLIT_DL = -0.02 + 0.04j
+# A one-row D-term table is the storage form of a track-constant leakage.
+SPLIT_DTERM_TIME = 0.0
+
+
+def _welded_caldict(sites, times):
+    """A pre-split datadict: gains and D-terms welded into one row dtype."""
+    times = np.asarray(times, dtype=float)
+    template = np.zeros(len(times), dtype=_WELDED_DTCAL)
+    template['time'] = times
+    template['rscale'] = SPLIT_GAIN_R
+    template['lscale'] = SPLIT_GAIN_L
+    template['dr'] = SPLIT_DR
+    template['dl'] = SPLIT_DL
+    return {site: template.copy() for site in sites}
+
+
+def _clean_caldict(sites, times):
+    """The gains-only equivalent of :func:`_welded_caldict`."""
+    times = np.asarray(times, dtype=float)
+    template = np.zeros(len(times), dtype=DTCAL)
+    template['time'] = times
+    template['rscale'] = SPLIT_GAIN_R
+    template['lscale'] = SPLIT_GAIN_L
+    return {site: template.copy() for site in sites}
+
+
+def _dterm_dict(sites, times=(SPLIT_DTERM_TIME,), dr=SPLIT_DR, dl=SPLIT_DL):
+    """A D-term table dict on its own (by default single-row) time grid."""
+    times = np.asarray(times, dtype=float)
+    template = np.zeros(len(times), dtype=DTDTERM)
+    template['time'] = times
+    template['dr'] = dr
+    template['dl'] = dl
+    return {site: template.copy() for site in sites}
+
+
+def _span_times(obs):
+    return [obs.data['time'].min() - 1.0, obs.data['time'].max() + 1.0]
+
+
+def _first_sites(obs, n=2):
+    """The first n site names of the observation's array."""
+    return list(obs.tarr['site'])[:n]
+
+
+class TestDataAliasesGains:
+    """``data`` is the legacy name for the live gain table, not a snapshot."""
+
+    def test_data_is_live_alias_of_gains(self, unity_caltable):
+        assert unity_caltable.data is unity_caltable.gains
+
+    def test_data_mutation_persists(self, constant_gain_caltable_factory):
+        # The modeling_utils gain-assembly pattern: take .data, np.append into
+        # it per site, and expect the table itself to grow.
+        ct = constant_gain_caltable_factory(CONST_REAL_GAIN)
+        site = next(iter(ct.data))
+        n_before = len(ct.gains[site])
+        caldict = ct.data
+        caldict[site] = np.append(caldict[site], caldict[site])
+        assert len(ct.gains[site]) == 2 * n_before
+
+    def test_data_setter_replaces_gains(self, unity_caltable, obs_direct):
+        ct = unity_caltable.copy()
+        replacement = _clean_caldict(_first_sites(obs_direct, 1),
+                                     _span_times(obs_direct))
+        ct.data = replacement
+        assert ct.gains is replacement
+
+    def test_dterms_defaults_empty(self, unity_caltable):
+        assert unity_caltable.dterms == {}
+
+
+class TestConstructorSplit:
+    """``__init__`` splits welded input and honours an explicit ``dterms=``."""
+
+    def test_constructor_welded_datadict_autosplits(self, obs_direct):
+        times = _span_times(obs_direct)
+        sites = _first_sites(obs_direct)
+        ct = eh.caltable.Caltable(
+            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+            _welded_caldict(sites, times), obs_direct.tarr,
+            source=obs_direct.source, mjd=obs_direct.mjd,
+        )
+        for site in sites:
+            assert ct.gains[site].dtype.names == ('time', 'rscale', 'lscale')
+            np.testing.assert_array_equal(ct.gains[site]['rscale'], SPLIT_GAIN_R)
+            np.testing.assert_array_equal(ct.gains[site]['lscale'], SPLIT_GAIN_L)
+            np.testing.assert_array_equal(ct.dterms[site]['dr'], SPLIT_DR)
+            np.testing.assert_array_equal(ct.dterms[site]['dl'], SPLIT_DL)
+            # the extracted D-terms keep the time column they were welded to
+            np.testing.assert_array_equal(ct.dterms[site]['time'], times)
+
+    def test_constructor_dterms_kwarg(self, obs_direct):
+        times = _span_times(obs_direct)
+        sites = _first_sites(obs_direct)
+        ct = eh.caltable.Caltable(
+            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+            _clean_caldict(sites, times), obs_direct.tarr,
+            source=obs_direct.source, mjd=obs_direct.mjd,
+            dterms=_dterm_dict(sites),
+        )
+        for site in sites:
+            # gains keep their own (two-point) grid, D-terms their one-row grid
+            assert len(ct.gains[site]) == len(times)
+            assert len(ct.dterms[site]) == 1
+            assert ct.dterms[site]['time'][0] == SPLIT_DTERM_TIME
+            np.testing.assert_array_equal(ct.gains[site]['rscale'], SPLIT_GAIN_R)
+
+    def test_constructor_explicit_dterms_overrides_autosplit(self, obs_direct):
+        times = _span_times(obs_direct)
+        sites = _first_sites(obs_direct, 1)
+        site = sites[0]
+        override = 0.5 + 0.5j
+        ct = eh.caltable.Caltable(
+            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+            _welded_caldict(sites, times), obs_direct.tarr,
+            source=obs_direct.source, mjd=obs_direct.mjd,
+            dterms=_dterm_dict(sites, dr=override, dl=override),
+        )
+        # the explicit table replaces what the weld would have contributed
+        assert len(ct.dterms[site]) == 1
+        assert ct.dterms[site]['dr'][0] == override
+        np.testing.assert_array_equal(ct.gains[site]['rscale'], SPLIT_GAIN_R)
+
+    def test_constructor_single_record_list_site(self, obs_direct):
+        # network_cal / polgains_cal leave a bare list of records for a site
+        # seen in exactly one non-first scan; it must normalise, not crash.
+        times = _span_times(obs_direct)
+        site = _first_sites(obs_direct, 1)[0]
+        row = _clean_caldict([site], times)[site][0]
+        ct = eh.caltable.Caltable(
+            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+            {site: [row]}, obs_direct.tarr,
+            source=obs_direct.source, mjd=obs_direct.mjd,
+        )
+        assert len(ct.gains[site]) == 1
+        assert ct.gains[site]['rscale'][0] == SPLIT_GAIN_R
+
+    def test_constructor_non_dict_datadict_stored_verbatim(self, obs_direct):
+        site = _first_sites(obs_direct, 1)[0]
+        arr = _clean_caldict([site], _span_times(obs_direct))[site]
+        ct = eh.caltable.Caltable(
+            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+            arr, obs_direct.tarr, source=obs_direct.source, mjd=obs_direct.mjd,
+        )
+        assert ct.gains is arr
+        assert ct.data is arr
+
+
+class TestSplitStateRoundTrips:
+    """copy / pickle carry both tables, and legacy states still migrate."""
+
+    def _welded_caltable(self, obs):
+        return eh.caltable.Caltable(
+            obs.ra, obs.dec, obs.rf, obs.bw,
+            _welded_caldict(_first_sites(obs), _span_times(obs)), obs.tarr,
+            source=obs.source, mjd=obs.mjd,
+        )
+
+    def test_copy_preserves_dterms_independently(self, obs_direct):
+        ct = self._welded_caltable(obs_direct)
+        site = _first_sites(obs_direct, 1)[0]
+        cp = ct.copy()
+        np.testing.assert_array_equal(cp.dterms[site]['dr'], SPLIT_DR)
+        cp.dterms[site]['dr'] *= 10
+        np.testing.assert_array_equal(ct.dterms[site]['dr'], SPLIT_DR)
+
+    def test_pickle_roundtrip_with_dterms(self, obs_direct):
+        ct = self._welded_caltable(obs_direct)
+        revived = pickle.loads(pickle.dumps(ct))
+        assert set(revived.dterms) == set(ct.dterms)
+        for site in ct.gains:
+            np.testing.assert_array_equal(revived.gains[site], ct.gains[site])
+            np.testing.assert_array_equal(revived.dterms[site], ct.dterms[site])
+        # the alias survives the round trip as an alias, not a copy
+        assert revived.data is revived.gains
+
+    def test_setstate_non_dict_data_stored_verbatim(self, obs_direct):
+        # A pre-split pickle whose 'data' was never a dict: pass it through
+        # rather than trying to split it.
+        site = _first_sites(obs_direct, 1)[0]
+        arr = _clean_caldict([site], _span_times(obs_direct))[site]
+        ct = self._welded_caltable(obs_direct)
+        state = dict(ct.__dict__)
+        state.pop('gains')
+        state.pop('dterms')
+        state['data'] = arr
+
+        revived = eh.caltable.Caltable.__new__(eh.caltable.Caltable)
+        revived.__setstate__(state)
+        assert revived.gains is arr
+        assert revived.dterms == {}
+
+    def test_setstate_drops_legacy_data_key(self, obs_direct):
+        # 'data' is a property now, so a leftover instance-dict entry of that
+        # name would be shadowed and its gains lost.
+        ct = self._welded_caltable(obs_direct)
+        site = _first_sites(obs_direct, 1)[0]
+        state = dict(ct.__dict__)
+        state.pop('gains')
+        state.pop('dterms')
+        state['data'] = _clean_caldict([site], _span_times(obs_direct))
+
+        revived = eh.caltable.Caltable.__new__(eh.caltable.Caltable)
+        revived.__setstate__(state)
+        assert 'data' not in revived.__dict__
+        np.testing.assert_array_equal(revived.gains[site]['rscale'], SPLIT_GAIN_R)
+
+
+class TestSplitLeavesApplycalUnchanged:
+    """Splitting the input must not perturb gain application."""
+
+    def test_applycal_welded_equals_clean_gains(self, obs_direct):
+        times = _span_times(obs_direct)
+        sites = obs_direct.tarr['site']
+        kwargs = dict(source=obs_direct.source, mjd=obs_direct.mjd,
+                      timetype=obs_direct.timetype)
+        ct_welded = eh.caltable.Caltable(
+            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+            _welded_caldict(sites, times), obs_direct.tarr, **kwargs)
+        ct_clean = eh.caltable.Caltable(
+            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+            _clean_caldict(sites, times), obs_direct.tarr, **kwargs)
+
+        # the welded input carries leakage, the clean one does not
+        assert ct_welded.dterms
+        assert ct_clean.dterms == {}
+
+        out_welded = ct_welded.applycal(obs_direct, interp='nearest')
+        out_clean = ct_clean.applycal(obs_direct, interp='nearest')
+
+        circ_w = out_welded.switch_polrep('circ')
+        circ_c = out_clean.switch_polrep('circ')
+        for field in ('rrvis', 'llvis', 'rlvis', 'lrvis'):
+            np.testing.assert_array_equal(circ_w.data[field], circ_c.data[field])
+        for field in ('rrsigma', 'llsigma', 'rlsigma', 'lrsigma'):
+            np.testing.assert_array_equal(circ_w.data[field], circ_c.data[field])

--- a/tests/test_caltable.py
+++ b/tests/test_caltable.py
@@ -83,7 +83,7 @@ def _unity_caltable(obs):
     caldict = {}
     for site in obs.tarr['site']:
         caldict[site] = np.array(
-            [(t, 1.0 + 0j, 1.0 + 0j, 0j, 0j) for t in times], dtype=DTCAL
+            [(t, 1.0 + 0j, 1.0 + 0j) for t in times], dtype=DTCAL
         ).view(np.recarray)
     return eh.caltable.Caltable(
         obs.ra, obs.dec, obs.rf, obs.bw, caldict, obs.tarr,

--- a/tests/test_caltable.py
+++ b/tests/test_caltable.py
@@ -3,10 +3,12 @@
 import pickle
 import warnings
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
 import ehtim as eh
+import ehtim.const_def as ehc
 from ehtim.const_def import DTARR, DTCAL
 from ehtim.warnings import MixedPolConventionWarning
 
@@ -1133,6 +1135,156 @@ class TestSplitLeavesApplycalUnchanged:
             np.testing.assert_array_equal(circ_w.data[field], circ_c.data[field])
 
 
+class TestSplitFixups:
+    """Regressions for defects found reviewing the split."""
+
+    def test_merge_self_side_gains_not_aliased(self, obs_direct,
+                                               constant_gain_caltable_factory):
+        """A site only the calling table has is copied into the merged result.
+
+        Sharing it would let the merged table's invert_gains rewrite the input's
+        gains, so a later applycal on the input divides where it should multiply.
+        """
+        ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
+        ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
+        site = _first_sites(obs_direct, 1)[0]
+        ct_b.data.pop(site)
+
+        out = ct_a.merge([ct_b])
+
+        assert out.data[site] is not ct_a.data[site]
+        out.data[site]['rscale'] *= 10
+        np.testing.assert_allclose(ct_a.data[site]['rscale'], MERGE_GAIN_A)
+
+    def test_merge_tolerates_none_gain_table(self, obs_direct,
+                                             constant_gain_caltable_factory):
+        """A site whose gain table is None merges instead of raising.
+
+        pad_scans already skips None entries, so they must not be assumed
+        copyable on the way through merge.
+        """
+        ct_a = constant_gain_caltable_factory(MERGE_GAIN_A)
+        ct_b = constant_gain_caltable_factory(MERGE_GAIN_B)
+        site = _first_sites(obs_direct, 1)[0]
+        ct_a.data.pop(site)
+        ct_b.gains[site] = None
+
+        out = ct_a.merge([ct_b])
+        assert out.data[site] is None
+
+    def test_data_setter_normalizes_list_entries(self, unity_caltable, obs_direct):
+        """A caldict holding a bare list of records is reshaped on assignment.
+
+        The solvers leave that shape behind, and the constructor already fixes
+        it, so assigning the same dict should not store something unindexable.
+        """
+        ct = unity_caltable.copy()
+        site = _first_sites(obs_direct, 1)[0]
+        row = _clean_caldict([site], _span_times(obs_direct))[site][0]
+
+        ct.data = {site: [row]}
+
+        assert isinstance(ct.gains[site], np.ndarray)
+        assert ct.gains[site]['rscale'][0] == SPLIT_GAIN_R
+
+    def test_data_setter_rejects_welded_table(self, unity_caltable, obs_direct):
+        """Assigning leakage-bearing rows to the gain alias raises."""
+        ct = unity_caltable.copy()
+        sites = _first_sites(obs_direct, 1)
+        with pytest.raises(TypeError, match="D-term"):
+            ct.data = _welded_caldict(sites, _span_times(obs_direct))
+
+    def test_constructor_normalizes_zero_d_dterm_record(self, obs_direct):
+        """A 0-d D-term record becomes a one-row table.
+
+        Solvers build a single time the same way they build gain rows, and
+        save_caltable calls len() on whatever is stored.
+        """
+        site = _first_sites(obs_direct, 1)[0]
+        rec = np.zeros((), dtype=ehc.DTDTERM)
+        rec['dr'] = SPLIT_DR
+        ct = eh.caltable.Caltable(
+            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+            _clean_caldict([site], _span_times(obs_direct)), obs_direct.tarr,
+            source=obs_direct.source, mjd=obs_direct.mjd, dterms={site: rec},
+        )
+        assert len(ct.dterms[site]) == 1
+        assert ct.dterms[site]['dr'][0] == SPLIT_DR
+
+    def test_empty_dterm_table_is_not_stored(self, obs_direct):
+        """An empty D-term table is dropped rather than kept as leakage.
+
+        A sidecar file holding only its version line reads back this way, and
+        `if self.dterms:` would then warn about leakage that is not there.
+        """
+        site = _first_sites(obs_direct, 1)[0]
+        ct = eh.caltable.Caltable(
+            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+            _clean_caldict([site], _span_times(obs_direct)), obs_direct.tarr,
+            source=obs_direct.source, mjd=obs_direct.mjd,
+            dterms={site: np.array([])},
+        )
+        assert ct.dterms == {}
+
+    def test_stale_dterm_file_removed_on_resave(self, obs_direct,
+                                                injected_gain_caltable_factory,
+                                                dterm_dict_factory, tmp_path):
+        """Re-saving without leakage clears the sidecar from a reused directory.
+
+        Otherwise the next load re-attaches D-terms the user believes they
+        dropped.
+        """
+        ct = injected_gain_caltable_factory(seed=SEED_DTERM_ROUNDTRIP)
+        ct.dterms = dterm_dict_factory(list(ct.data))
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
+        assert list(tmp_path.glob("*" + eh.caltable.DTERM_FILE_SUFFIX))
+
+        ct.dterms = {}
+        eh.caltable.save_caltable(ct, obs_direct, datadir=str(tmp_path))
+
+        assert not list(tmp_path.glob("*" + eh.caltable.DTERM_FILE_SUFFIX))
+        assert eh.caltable.load_caltable(obs_direct, str(tmp_path)).dterms == {}
+
+    def test_pad_scans_keeps_linear_gain_dtype(self, obs_direct):
+        """A linear-feed gain table pads as itself instead of being recast.
+
+        The rows were being rebuilt with the circular dtype, which casts by
+        position, so the X gains came back labelled rscale.
+        """
+        site = _first_sites(obs_direct, 1)[0]
+        times = np.array([0.0, 0.1])
+        lin = np.zeros(len(times), dtype=ehc.DTCAL_LIN)
+        lin['time'] = times
+        lin['xscale'] = [3 + 0j, 4 + 0j]
+        lin['yscale'] = [5 + 0j, 6 + 0j]
+        ct = eh.caltable.Caltable(
+            obs_direct.ra, obs_direct.dec, obs_direct.rf, obs_direct.bw,
+            {site: lin}, obs_direct.tarr,
+            source=obs_direct.source, mjd=obs_direct.mjd,
+        )
+
+        out = ct.pad_scans(maxdiff=PAD_SCAN_MAXDIFF_SEC, padtype='endval')
+
+        assert out.data[site].dtype.names == ('time', 'xscale', 'yscale')
+        np.testing.assert_array_equal(out.data[site]['xscale'][:2], [3 + 0j, 3 + 0j])
+
+    def test_plot_dterms_warns_when_table_has_leakage(self, obs_direct,
+                                                     constant_gain_caltable_factory,
+                                                     dterm_dict_factory):
+        """plot_dterms draws the array table, so say so when the cal table has its own.
+
+        After load_caltable the array table's leakage is zero while self.dterms
+        holds the solution, and the plot would silently read as "no leakage".
+        """
+        ct = constant_gain_caltable_factory(APPLYCAL_WARN_GAIN)
+        site = _first_sites(obs_direct, 1)[0]
+        ct.dterms = dterm_dict_factory([site])
+
+        with pytest.warns(MixedPolConventionWarning, match="self.dterms"):
+            ct.plot_dterms(sites=[site], show=False)
+        plt.close('all')
+
+
 class TestDtermPersistence:
     """D-terms round-trip through their own per-site files. The gain files keep
     their long-standing format, so directories written before the split still
@@ -1307,9 +1459,14 @@ class TestApplycalWarnsOnDterms:
         ct = constant_gain_caltable_factory(APPLYCAL_WARN_GAIN)
         assert ct.dterms == {}
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", MixedPolConventionWarning)
+        # Match the D-term warning itself: applycal's polrep conversion emits a
+        # once-per-session warning of the same class, so escalating the whole
+        # category would make this depend on test order.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
             ct.applycal(obs_direct)
+
+        assert not [w for w in caught if "carries D-terms" in str(w.message)]
 
     def test_warning_does_not_change_the_output(self, obs_direct,
                                                 constant_gain_caltable_factory,

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -170,6 +170,26 @@ def test_dtcal_legacy_alias_is_dtcal_circ():
     assert ehc.DTCAL is ehc.DTCAL_CIRC
 
 
+# ----- DTDTERM -------------------------------------------------------------
+
+def test_dtdterm_circ_alias_equivalence():
+    d = np.zeros(2, dtype=ehc.DTDTERM_CIRC)
+    d['dr'] = [0.01 + 0.02j, 0.03 - 0.01j]
+    assert np.array_equal(d['d_p1'], d['dr'])
+    d['dl'] = [0.04 + 0.0j, -0.02 + 0.01j]
+    assert np.array_equal(d['d_p2'], d['dl'])
+
+
+def test_dtdterm_lin_names():
+    # linear leakage carries only the generic names (no physical dr/dl aliases)
+    d = np.zeros(2, dtype=ehc.DTDTERM_LIN)
+    assert d.dtype.names == ('time', 'd_p1', 'd_p2')
+
+
+def test_dtdterm_legacy_alias_is_circ():
+    assert ehc.DTDTERM is ehc.DTDTERM_CIRC
+
+
 # ----- Polrep / feed dispatch helpers --------------------------------------
 
 def test_feed_dtype_for_polrep():

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -181,10 +181,13 @@ def test_dtdterm_circ_alias_equivalence():
     assert np.array_equal(d['d_p2'], d['dl'])
 
 
-def test_dtdterm_lin_names():
-    """Linear leakage carries only the generic names; there are no established physical ones."""
+def test_dtdterm_lin_alias_equivalence():
+    """The generic names d_p1/d_p2 and the physical dx/dy address the same columns."""
     d = np.zeros(2, dtype=ehc.DTDTERM_LIN)
-    assert d.dtype.names == ('time', 'd_p1', 'd_p2')
+    d['dx'] = [0.01 + 0.02j, 0.03 - 0.01j]
+    assert np.array_equal(d['d_p1'], d['dx'])
+    d['dy'] = [0.04 + 0.0j, -0.02 + 0.01j]
+    assert np.array_equal(d['d_p2'], d['dy'])
 
 
 def test_dtdterm_legacy_alias_is_circ():
@@ -367,7 +370,7 @@ def test_split_dtcal_welded_lin_basis():
     w['d_p1'] = 0.05 + 0j
     gains, dterms = ehc.split_dtcal(w)
     assert gains.dtype.names == ('time', 'xscale', 'yscale')
-    assert dterms.dtype.names == ('time', 'd_p1', 'd_p2')
+    assert dterms.dtype.names == ('time', 'dx', 'dy')
     assert np.array_equal(gains['xscale'], w['xscale'])
     assert np.array_equal(dterms['d_p1'], w['d_p1'])
 

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -293,19 +293,36 @@ def _welded(n=2, dr=0j, dl=0j):
     return w
 
 
-def test_split_dtcal_legacy_is_zero_copy_view():
-    """A legacy gains-only table is re-viewed, not copied.
+def test_split_dtcal_legacy_is_copied_not_shared():
+    """A legacy gains-only table is copied, so the caller's array is insulated.
 
-    The bytes already match the target layout, so only the dtype object
-    changes and the result shares its buffer with the input.
+    Re-viewing the buffer would be cheaper, but then invert_gains and
+    enforce_positive on the Caltable would write through to whatever dict the
+    caller handed in.
     """
     oc = np.zeros(2, dtype=_LEGACY_DTCAL)
     oc['rscale'] = [1 + 0j, 2 + 0j]
     gains, dterms = ehc.split_dtcal(oc)
-    assert gains.base is oc          # view, not a copy
     assert dterms is None
     assert gains.dtype.names == ('time', 'rscale', 'lscale')
     assert np.array_equal(gains['p1scale'], oc['rscale'])
+    gains['rscale'] *= 10
+    assert np.array_equal(oc['rscale'], [1 + 0j, 2 + 0j])
+
+
+def test_split_dtcal_byte_swapped_legacy_converts():
+    """A big-endian table is converted, not reinterpreted.
+
+    Its field names and itemsize match the target exactly, so a view would
+    silently turn the values into denormal garbage.
+    """
+    be = np.dtype([('time', '>f8'), ('rscale', '>c16'), ('lscale', '>c16')])
+    oc = np.zeros(2, dtype=be)
+    oc['time'] = [1.0, 2.0]
+    oc['rscale'] = [2 + 0j, 4 + 0j]
+    gains, _ = ehc.split_dtcal(oc)
+    np.testing.assert_array_equal(gains['time'], [1.0, 2.0])
+    np.testing.assert_array_equal(gains['rscale'], [2 + 0j, 4 + 0j])
 
 
 def test_split_dtcal_identity_on_target_dtype():

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -156,8 +156,8 @@ def test_dtcal_circ_alias_equivalence():
     c = np.zeros(2, dtype=ehc.DTCAL_CIRC)
     c['rscale'] = [1 + 0j, 2 + 0j]
     assert np.array_equal(c['p1scale'], c['rscale'])
-    c['dr'] = [0.01 + 0.02j, 0.03 - 0.01j]
-    assert np.array_equal(c['d_p1'], c['dr'])
+    c['lscale'] = [3 + 0j, 4 + 0j]
+    assert np.array_equal(c['p2scale'], c['lscale'])
 
 
 def test_dtcal_lin_alias_equivalence():
@@ -272,15 +272,118 @@ def test_upgrade_dtpol_circ_idempotent():
     assert out.dtype == d.dtype
 
 
-def test_upgrade_dtcal_circ_from_legacy_adds_dterm_fields():
+_WELDED_DTCAL = [('time', 'f8'),
+                 (('p1scale', 'rscale'), 'c16'), (('p2scale', 'lscale'), 'c16'),
+                 (('d_p1', 'dr'), 'c16'), (('d_p2', 'dl'), 'c16')]
+
+_WELDED_DTCAL_LIN = [('time', 'f8'),
+                     (('p1scale', 'xscale'), 'c16'), (('p2scale', 'yscale'), 'c16'),
+                     ('d_p1', 'c16'), ('d_p2', 'c16')]
+
+
+def _welded(n=2, dr=0j, dl=0j):
+    w = np.zeros(n, dtype=_WELDED_DTCAL)
+    w['time'] = np.arange(n)
+    w['rscale'] = np.arange(1, n + 1) + 0j
+    w['lscale'] = np.arange(1, n + 1) * 2 + 0j
+    w['dr'] = dr
+    w['dl'] = dl
+    return w
+
+
+def test_split_dtcal_legacy_is_zero_copy_view():
     oc = np.zeros(2, dtype=_LEGACY_DTCAL)
     oc['rscale'] = [1 + 0j, 2 + 0j]
-    nc = ehc.upgrade_dtcal_circ(oc)
-    assert nc.dtype.names == ('time', 'rscale', 'lscale', 'dr', 'dl')
-    assert np.array_equal(nc['rscale'], oc['rscale'])
-    # dr/dl default to 0
-    assert np.all(nc['dr'] == 0)
-    assert np.all(nc['dl'] == 0)
+    gains, dterms = ehc.split_dtcal(oc)
+    assert gains.base is oc          # view, not a copy
+    assert dterms is None
+    assert gains.dtype.names == ('time', 'rscale', 'lscale')
+    assert np.array_equal(gains['p1scale'], oc['rscale'])
+
+
+def test_split_dtcal_identity_on_target_dtype():
+    g = np.zeros(2, dtype=ehc.DTCAL_CIRC)
+    gains, dterms = ehc.split_dtcal(g)
+    assert gains is g
+    assert dterms is None
+
+
+def test_split_dtcal_welded_zero_dterms_narrows_to_gains_only():
+    w = _welded()
+    gains, dterms = ehc.split_dtcal(w)
+    assert gains.dtype.names == ('time', 'rscale', 'lscale')
+    assert dterms is None
+    assert np.array_equal(gains['rscale'], w['rscale'])
+    assert np.array_equal(gains['lscale'], w['lscale'])
+    assert np.array_equal(gains['time'], w['time'])
+
+
+def test_split_dtcal_welded_nonzero_dterms_extracts_table():
+    w = _welded(dr=0.01 + 0.02j, dl=-0.03j)
+    gains, dterms = ehc.split_dtcal(w)
+    assert 'dr' not in gains.dtype.fields
+    assert dterms.dtype.names == ('time', 'dr', 'dl')
+    # the D-terms keep their own copy of the time column
+    assert np.array_equal(dterms['time'], w['time'])
+    assert np.array_equal(dterms['dr'], w['dr'])
+    assert np.array_equal(dterms['d_p2'], w['dl'])
+
+
+def test_split_dtcal_welded_lin_basis():
+    w = np.zeros(2, dtype=_WELDED_DTCAL_LIN)
+    w['xscale'] = [1 + 0j, 2 + 0j]
+    w['d_p1'] = 0.05 + 0j
+    gains, dterms = ehc.split_dtcal(w)
+    assert gains.dtype.names == ('time', 'xscale', 'yscale')
+    assert dterms.dtype.names == ('time', 'd_p1', 'd_p2')
+    assert np.array_equal(gains['xscale'], w['xscale'])
+    assert np.array_equal(dterms['d_p1'], w['d_p1'])
+
+
+def test_split_dtcal_idempotent():
+    w = _welded(dr=0.01 + 0j)
+    gains, dterms = ehc.split_dtcal(w)
+    again, again_dterms = ehc.split_dtcal(gains)
+    assert again is gains
+    assert again_dterms is None
+
+
+def test_split_dtcal_zero_d_record_normalized_to_one_row():
+    # solvers can hand over a bare record for a site seen in a single scan
+    rec = np.zeros((), dtype=_LEGACY_DTCAL)
+    gains, dterms = ehc.split_dtcal(rec)
+    assert gains.shape == (1,)
+    assert dterms is None
+
+
+def test_split_dtcal_list_of_records():
+    # a site appearing in exactly one non-first scan arrives as [record]
+    rec = np.zeros((), dtype=ehc.DTCAL_CIRC)
+    gains, dterms = ehc.split_dtcal([rec])
+    assert gains.shape == (1,)
+    assert gains.dtype.names == ('time', 'rscale', 'lscale')
+    assert dterms is None
+
+
+def test_split_dtcal_untitled_welded_passthrough():
+    # plain-named 5-field arrays predate the titles; leave them alone
+    untitled = np.zeros(2, dtype=[('time', 'f8'), ('rscale', 'c16'), ('lscale', 'c16'),
+                                  ('dr', 'c16'), ('dl', 'c16')])
+    gains, dterms = ehc.split_dtcal(untitled)
+    assert gains is untitled
+    assert dterms is None
+
+
+def test_split_dtcal_none_passthrough():
+    gains, dterms = ehc.split_dtcal(None)
+    assert gains is None
+    assert dterms is None
+
+
+def test_split_dtcal_empty_array():
+    gains, dterms = ehc.split_dtcal(np.zeros(0, dtype=_LEGACY_DTCAL))
+    assert len(gains) == 0
+    assert dterms is None
 
 
 # ----- End-to-end: Array / Obsdata / Caltable upgrade through __init__ ----
@@ -335,9 +438,9 @@ def test_caltable_upgrades_legacy_dtcal():
                          datadict={'A': oc.copy(), 'B': oc.copy()},
                          tarr=_legacy_tarr())
     for site in ('A', 'B'):
-        assert 'dr' in caltab.data[site].dtype.names
-        assert 'd_p1' in caltab.data[site].dtype.fields  # title alias
-        assert np.all(caltab.data[site]['dr'] == 0)
+        assert caltab.data[site].dtype.names == ('time', 'rscale', 'lscale')
+        assert 'p1scale' in caltab.data[site].dtype.fields  # title alias
+    assert caltab.dterms == {}
 
 
 def test_caltable_pickle_roundtrip_legacy_dtcal():
@@ -346,9 +449,29 @@ def test_caltable_pickle_roundtrip_legacy_dtcal():
     caltab = ec.Caltable(ra=0., dec=0., rf=230e9, bw=1e9,
                          datadict={'A': oc.copy()}, tarr=_legacy_tarr())
     caltab2 = pickle.loads(pickle.dumps(caltab))
-    assert 'dr' in caltab2.data['A'].dtype.names
+    assert caltab2.data['A'].dtype.names == ('time', 'rscale', 'lscale')
+    assert caltab2.dterms == {}
     assert np.array_equal(caltab2.data['A']['rscale'],
                           caltab.data['A']['rscale'])
+
+
+def test_caltable_pickle_welded_nonzero_dterms_migrates():
+    # a pickle from when the D-terms still lived in the gain rows
+    w = np.zeros(2, dtype=_WELDED_DTCAL)
+    w['rscale'] = [1 + 0j, 1.1 + 0j]
+    w['dr'] = 0.04 + 0.01j
+    caltab = ec.Caltable(ra=0., dec=0., rf=230e9, bw=1e9,
+                         datadict={'A': np.zeros(2, dtype=ehc.DTCAL)},
+                         tarr=_legacy_tarr())
+    state = dict(caltab.__dict__)
+    state['data'] = {'A': w}
+    state.pop('dterms')
+    revived = ec.Caltable.__new__(ec.Caltable)
+    revived.__setstate__(state)
+    assert revived.data['A'].dtype.names == ('time', 'rscale', 'lscale')
+    assert np.array_equal(revived.data['A']['rscale'], w['rscale'])
+    assert np.array_equal(revived.dterms['A']['dr'], w['dr'])
+    assert np.array_equal(revived.dterms['A']['time'], w['time'])
 
 
 # ============================================================================

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -463,9 +463,11 @@ def test_caltable_pickle_welded_nonzero_dterms_migrates():
     caltab = ec.Caltable(ra=0., dec=0., rf=230e9, bw=1e9,
                          datadict={'A': np.zeros(2, dtype=ehc.DTCAL)},
                          tarr=_legacy_tarr())
+    # a pre-split pickle carries 'data' and neither 'gains' nor 'dterms'
     state = dict(caltab.__dict__)
-    state['data'] = {'A': w}
+    state.pop('gains')
     state.pop('dterms')
+    state['data'] = {'A': w}
     revived = ec.Caltable.__new__(ec.Caltable)
     revived.__setstate__(state)
     assert revived.data['A'].dtype.names == ('time', 'rscale', 'lscale')

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -296,7 +296,7 @@ def _welded(n=2, dr=0j, dl=0j):
     return w
 
 
-def test_split_dtcal_legacy_is_copied_not_shared():
+def test_upgrade_caltable_legacy_is_copied_not_shared():
     """A legacy gains-only table is copied, so the caller's array is insulated.
 
     Re-viewing the buffer would be cheaper, but then invert_gains and
@@ -305,7 +305,7 @@ def test_split_dtcal_legacy_is_copied_not_shared():
     """
     oc = np.zeros(2, dtype=_LEGACY_DTCAL)
     oc['rscale'] = [1 + 0j, 2 + 0j]
-    gains, dterms = ehc.split_dtcal(oc)
+    gains, dterms = ehc.upgrade_caltable(oc)
     assert dterms is None
     assert gains.dtype.names == ('time', 'rscale', 'lscale')
     assert np.array_equal(gains['p1scale'], oc['rscale'])
@@ -313,7 +313,7 @@ def test_split_dtcal_legacy_is_copied_not_shared():
     assert np.array_equal(oc['rscale'], [1 + 0j, 2 + 0j])
 
 
-def test_split_dtcal_byte_swapped_legacy_converts():
+def test_upgrade_caltable_byte_swapped_legacy_converts():
     """A big-endian table is converted, not reinterpreted.
 
     Its field names and itemsize match the target exactly, so a view would
@@ -323,27 +323,27 @@ def test_split_dtcal_byte_swapped_legacy_converts():
     oc = np.zeros(2, dtype=be)
     oc['time'] = [1.0, 2.0]
     oc['rscale'] = [2 + 0j, 4 + 0j]
-    gains, _ = ehc.split_dtcal(oc)
+    gains, _ = ehc.upgrade_caltable(oc)
     np.testing.assert_array_equal(gains['time'], [1.0, 2.0])
     np.testing.assert_array_equal(gains['rscale'], [2 + 0j, 4 + 0j])
 
 
-def test_split_dtcal_identity_on_target_dtype():
+def test_upgrade_caltable_identity_on_target_dtype():
     """A table already in the target dtype is handed straight back."""
     g = np.zeros(2, dtype=ehc.DTCAL_CIRC)
-    gains, dterms = ehc.split_dtcal(g)
+    gains, dterms = ehc.upgrade_caltable(g)
     assert gains is g
     assert dterms is None
 
 
-def test_split_dtcal_welded_zero_dterms_narrows_to_gains_only():
+def test_upgrade_caltable_welded_zero_dterms_narrows_to_gains_only():
     """A welded table whose D-terms are all zero yields no D-term table.
 
     Every writer between PR #254 and the split padded these columns with 0j,
     so this is the common case and it should migrate to a clean gain table.
     """
     w = _welded()
-    gains, dterms = ehc.split_dtcal(w)
+    gains, dterms = ehc.upgrade_caltable(w)
     assert gains.dtype.names == ('time', 'rscale', 'lscale')
     assert dterms is None
     assert np.array_equal(gains['rscale'], w['rscale'])
@@ -351,10 +351,10 @@ def test_split_dtcal_welded_zero_dterms_narrows_to_gains_only():
     assert np.array_equal(gains['time'], w['time'])
 
 
-def test_split_dtcal_welded_nonzero_dterms_extracts_table():
+def test_upgrade_caltable_welded_nonzero_dterms_extracts_table():
     """Real D-terms are lifted out onto their own time column, with the gains left clean."""
     w = _welded(dr=0.01 + 0.02j, dl=-0.03j)
-    gains, dterms = ehc.split_dtcal(w)
+    gains, dterms = ehc.upgrade_caltable(w)
     assert 'dr' not in gains.dtype.fields
     assert dterms.dtype.names == ('time', 'dr', 'dl')
     # the D-terms keep their own copy of the time column
@@ -363,70 +363,99 @@ def test_split_dtcal_welded_nonzero_dterms_extracts_table():
     assert np.array_equal(dterms['d_p2'], w['dl'])
 
 
-def test_split_dtcal_welded_lin_basis():
+def test_upgrade_caltable_welded_lin_basis():
     """The same split works on a linear-feed table, whose columns are named differently."""
     w = np.zeros(2, dtype=_WELDED_DTCAL_LIN)
     w['xscale'] = [1 + 0j, 2 + 0j]
     w['d_p1'] = 0.05 + 0j
-    gains, dterms = ehc.split_dtcal(w)
+    gains, dterms = ehc.upgrade_caltable(w)
     assert gains.dtype.names == ('time', 'xscale', 'yscale')
     assert dterms.dtype.names == ('time', 'dx', 'dy')
     assert np.array_equal(gains['xscale'], w['xscale'])
     assert np.array_equal(dterms['d_p1'], w['d_p1'])
 
 
-def test_split_dtcal_idempotent():
+def test_upgrade_caltable_idempotent():
     """Splitting an already-split table changes nothing."""
     w = _welded(dr=0.01 + 0j)
-    gains, dterms = ehc.split_dtcal(w)
-    again, again_dterms = ehc.split_dtcal(gains)
+    gains, dterms = ehc.upgrade_caltable(w)
+    again, again_dterms = ehc.upgrade_caltable(gains)
     assert again is gains
     assert again_dterms is None
 
 
-def test_split_dtcal_zero_d_record_normalized_to_one_row():
+def test_upgrade_caltable_zero_d_record_normalized_to_one_row():
     """A bare record is promoted to a one-row table.
 
     self_cal leaves this shape behind for a site seen in a single scan.
     """
     rec = np.zeros((), dtype=_LEGACY_DTCAL)
-    gains, dterms = ehc.split_dtcal(rec)
+    gains, dterms = ehc.upgrade_caltable(rec)
     assert gains.shape == (1,)
     assert dterms is None
 
 
-def test_split_dtcal_list_of_records():
+def test_upgrade_caltable_list_of_records():
     """A site handed over as a list of records is normalised rather than crashing.
 
     network_cal and polgains_cal produce this for a site that turns up in
     exactly one non-first scan; it used to raise on the missing .dtype.
     """
     rec = np.zeros((), dtype=ehc.DTCAL_CIRC)
-    gains, dterms = ehc.split_dtcal([rec])
+    gains, dterms = ehc.upgrade_caltable([rec])
     assert gains.shape == (1,)
     assert gains.dtype.names == ('time', 'rscale', 'lscale')
     assert dterms is None
 
 
-def test_split_dtcal_untitled_welded_passthrough():
-    """A plain-named five-field table predates the title aliases, so it is left alone."""
+def test_upgrade_caltable_untitled_welded_splits():
+    """A plain-named five-field table is upgraded the same way as a titled one."""
     untitled = np.zeros(2, dtype=[('time', 'f8'), ('rscale', 'c16'), ('lscale', 'c16'),
                                   ('dr', 'c16'), ('dl', 'c16')])
-    gains, dterms = ehc.split_dtcal(untitled)
-    assert gains is untitled
+    untitled['rscale'] = [1 + 0j, 2 + 0j]
+    untitled['dr'] = 0.05j
+    gains, dterms = ehc.upgrade_caltable(untitled)
+    assert gains.dtype.names == ('time', 'rscale', 'lscale')
+    assert np.array_equal(gains['rscale'], untitled['rscale'])
+    assert np.array_equal(dterms['dr'], untitled['dr'])
+
+
+def test_upgrade_caltable_generic_names_assume_circular():
+    """Generic-only field names cannot reveal the basis; circular is assumed, with a warning."""
+    generic = np.zeros(2, dtype=[('time', 'f8'), ('p1scale', 'c16'), ('p2scale', 'c16')])
+    generic['p1scale'] = [1 + 0j, 2 + 0j]
+    with pytest.warns(ehw.MixedPolConventionWarning, match="assuming circular"):
+        gains, dterms = ehc.upgrade_caltable(generic)
+    assert gains.dtype == np.dtype(ehc.DTCAL_CIRC)
+    assert np.array_equal(gains['rscale'], generic['p1scale'])
     assert dterms is None
 
 
-def test_split_dtcal_none_passthrough():
+def test_upgrade_caltable_unknown_fields_raise():
+    """Field names that are not caltable fields raise instead of being relabelled."""
+    bad = np.zeros(2, dtype=[('time', 'f8'), ('foo', 'c16'), ('bar', 'c16')])
+    with pytest.raises(Exception, match="cannot interpret"):
+        ehc.upgrade_caltable(bad)
+
+
+def test_upgrade_caltable_dterm_table_raises():
+    """A D-term table passed as gain data raises instead of being stored as gains."""
+    d = np.zeros(2, dtype=ehc.DTDTERM_CIRC)
+    d['dr'] = 0.05j
+    with pytest.raises(Exception, match="cannot interpret"):
+        ehc.upgrade_caltable(d)
+
+
+def test_upgrade_caltable_none_passthrough():
     """None is passed straight through, as pad_scans expects."""
-    gains, dterms = ehc.split_dtcal(None)
+    gains, dterms = ehc.upgrade_caltable(None)
     assert gains is None
     assert dterms is None
 
 
-def test_split_dtcal_empty_array():
+def test_upgrade_caltable_empty_array():
     """An empty table splits into an empty table and no D-terms."""
-    gains, dterms = ehc.split_dtcal(np.zeros(0, dtype=_LEGACY_DTCAL))
+    gains, dterms = ehc.upgrade_caltable(np.zeros(0, dtype=_LEGACY_DTCAL))
     assert len(gains) == 0
     assert dterms is None
 

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -173,6 +173,7 @@ def test_dtcal_legacy_alias_is_dtcal_circ():
 # ----- DTDTERM -------------------------------------------------------------
 
 def test_dtdterm_circ_alias_equivalence():
+    """The generic names d_p1/d_p2 and the physical dr/dl address the same columns."""
     d = np.zeros(2, dtype=ehc.DTDTERM_CIRC)
     d['dr'] = [0.01 + 0.02j, 0.03 - 0.01j]
     assert np.array_equal(d['d_p1'], d['dr'])
@@ -181,12 +182,13 @@ def test_dtdterm_circ_alias_equivalence():
 
 
 def test_dtdterm_lin_names():
-    # linear leakage carries only the generic names (no physical dr/dl aliases)
+    """Linear leakage carries only the generic names; there are no established physical ones."""
     d = np.zeros(2, dtype=ehc.DTDTERM_LIN)
     assert d.dtype.names == ('time', 'd_p1', 'd_p2')
 
 
 def test_dtdterm_legacy_alias_is_circ():
+    """The bare DTDTERM name still means the circular dtype."""
     assert ehc.DTDTERM is ehc.DTDTERM_CIRC
 
 
@@ -292,6 +294,11 @@ def _welded(n=2, dr=0j, dl=0j):
 
 
 def test_split_dtcal_legacy_is_zero_copy_view():
+    """A legacy gains-only table is re-viewed, not copied.
+
+    The bytes already match the target layout, so only the dtype object
+    changes and the result shares its buffer with the input.
+    """
     oc = np.zeros(2, dtype=_LEGACY_DTCAL)
     oc['rscale'] = [1 + 0j, 2 + 0j]
     gains, dterms = ehc.split_dtcal(oc)
@@ -302,6 +309,7 @@ def test_split_dtcal_legacy_is_zero_copy_view():
 
 
 def test_split_dtcal_identity_on_target_dtype():
+    """A table already in the target dtype is handed straight back."""
     g = np.zeros(2, dtype=ehc.DTCAL_CIRC)
     gains, dterms = ehc.split_dtcal(g)
     assert gains is g
@@ -309,6 +317,11 @@ def test_split_dtcal_identity_on_target_dtype():
 
 
 def test_split_dtcal_welded_zero_dterms_narrows_to_gains_only():
+    """A welded table whose D-terms are all zero yields no D-term table.
+
+    Every writer between PR #254 and the split padded these columns with 0j,
+    so this is the common case and it should migrate to a clean gain table.
+    """
     w = _welded()
     gains, dterms = ehc.split_dtcal(w)
     assert gains.dtype.names == ('time', 'rscale', 'lscale')
@@ -319,6 +332,7 @@ def test_split_dtcal_welded_zero_dterms_narrows_to_gains_only():
 
 
 def test_split_dtcal_welded_nonzero_dterms_extracts_table():
+    """Real D-terms are lifted out onto their own time column, with the gains left clean."""
     w = _welded(dr=0.01 + 0.02j, dl=-0.03j)
     gains, dterms = ehc.split_dtcal(w)
     assert 'dr' not in gains.dtype.fields
@@ -330,6 +344,7 @@ def test_split_dtcal_welded_nonzero_dterms_extracts_table():
 
 
 def test_split_dtcal_welded_lin_basis():
+    """The same split works on a linear-feed table, whose columns are named differently."""
     w = np.zeros(2, dtype=_WELDED_DTCAL_LIN)
     w['xscale'] = [1 + 0j, 2 + 0j]
     w['d_p1'] = 0.05 + 0j
@@ -341,6 +356,7 @@ def test_split_dtcal_welded_lin_basis():
 
 
 def test_split_dtcal_idempotent():
+    """Splitting an already-split table changes nothing."""
     w = _welded(dr=0.01 + 0j)
     gains, dterms = ehc.split_dtcal(w)
     again, again_dterms = ehc.split_dtcal(gains)
@@ -349,7 +365,10 @@ def test_split_dtcal_idempotent():
 
 
 def test_split_dtcal_zero_d_record_normalized_to_one_row():
-    # solvers can hand over a bare record for a site seen in a single scan
+    """A bare record is promoted to a one-row table.
+
+    self_cal leaves this shape behind for a site seen in a single scan.
+    """
     rec = np.zeros((), dtype=_LEGACY_DTCAL)
     gains, dterms = ehc.split_dtcal(rec)
     assert gains.shape == (1,)
@@ -357,7 +376,11 @@ def test_split_dtcal_zero_d_record_normalized_to_one_row():
 
 
 def test_split_dtcal_list_of_records():
-    # a site appearing in exactly one non-first scan arrives as [record]
+    """A site handed over as a list of records is normalised rather than crashing.
+
+    network_cal and polgains_cal produce this for a site that turns up in
+    exactly one non-first scan; it used to raise on the missing .dtype.
+    """
     rec = np.zeros((), dtype=ehc.DTCAL_CIRC)
     gains, dterms = ehc.split_dtcal([rec])
     assert gains.shape == (1,)
@@ -366,7 +389,7 @@ def test_split_dtcal_list_of_records():
 
 
 def test_split_dtcal_untitled_welded_passthrough():
-    # plain-named 5-field arrays predate the titles; leave them alone
+    """A plain-named five-field table predates the title aliases, so it is left alone."""
     untitled = np.zeros(2, dtype=[('time', 'f8'), ('rscale', 'c16'), ('lscale', 'c16'),
                                   ('dr', 'c16'), ('dl', 'c16')])
     gains, dterms = ehc.split_dtcal(untitled)
@@ -375,12 +398,14 @@ def test_split_dtcal_untitled_welded_passthrough():
 
 
 def test_split_dtcal_none_passthrough():
+    """None is passed straight through, as pad_scans expects."""
     gains, dterms = ehc.split_dtcal(None)
     assert gains is None
     assert dterms is None
 
 
 def test_split_dtcal_empty_array():
+    """An empty table splits into an empty table and no D-terms."""
     gains, dterms = ehc.split_dtcal(np.zeros(0, dtype=_LEGACY_DTCAL))
     assert len(gains) == 0
     assert dterms is None
@@ -456,7 +481,11 @@ def test_caltable_pickle_roundtrip_legacy_dtcal():
 
 
 def test_caltable_pickle_welded_nonzero_dterms_migrates():
-    # a pickle from when the D-terms still lived in the gain rows
+    """A pickle from when D-terms lived in the gain rows loads into both tables.
+
+    The state is hand-built in the old schema rather than taken from a live
+    instance, or the new-state guard would skip the migration entirely.
+    """
     w = np.zeros(2, dtype=_WELDED_DTCAL)
     w['rscale'] = [1 + 0j, 1.1 + 0j]
     w['dr'] = 0.04 + 0.01j

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -277,27 +277,8 @@ def test_upgrade_dtpol_circ_idempotent():
     assert out.dtype == d.dtype
 
 
-_WELDED_DTCAL = [('time', 'f8'),
-                 (('p1scale', 'rscale'), 'c16'), (('p2scale', 'lscale'), 'c16'),
-                 (('d_p1', 'dr'), 'c16'), (('d_p2', 'dl'), 'c16')]
-
-_WELDED_DTCAL_LIN = [('time', 'f8'),
-                     (('p1scale', 'xscale'), 'c16'), (('p2scale', 'yscale'), 'c16'),
-                     ('d_p1', 'c16'), ('d_p2', 'c16')]
-
-
-def _welded(n=2, dr=0j, dl=0j):
-    w = np.zeros(n, dtype=_WELDED_DTCAL)
-    w['time'] = np.arange(n)
-    w['rscale'] = np.arange(1, n + 1) + 0j
-    w['lscale'] = np.arange(1, n + 1) * 2 + 0j
-    w['dr'] = dr
-    w['dl'] = dl
-    return w
-
-
 def test_upgrade_caltable_legacy_is_copied_not_shared():
-    """A legacy gains-only table is copied, so the caller's array is insulated.
+    """A legacy gains table is copied, so the caller's array is insulated.
 
     Re-viewing the buffer would be cheaper, but then invert_gains and
     enforce_positive on the Caltable would write through to whatever dict the
@@ -305,8 +286,7 @@ def test_upgrade_caltable_legacy_is_copied_not_shared():
     """
     oc = np.zeros(2, dtype=_LEGACY_DTCAL)
     oc['rscale'] = [1 + 0j, 2 + 0j]
-    gains, dterms = ehc.upgrade_caltable(oc)
-    assert dterms is None
+    gains = ehc.upgrade_caltable(oc)
     assert gains.dtype.names == ('time', 'rscale', 'lscale')
     assert np.array_equal(gains['p1scale'], oc['rscale'])
     gains['rscale'] *= 10
@@ -323,7 +303,7 @@ def test_upgrade_caltable_byte_swapped_legacy_converts():
     oc = np.zeros(2, dtype=be)
     oc['time'] = [1.0, 2.0]
     oc['rscale'] = [2 + 0j, 4 + 0j]
-    gains, _ = ehc.upgrade_caltable(oc)
+    gains = ehc.upgrade_caltable(oc)
     np.testing.assert_array_equal(gains['time'], [1.0, 2.0])
     np.testing.assert_array_equal(gains['rscale'], [2 + 0j, 4 + 0j])
 
@@ -331,57 +311,23 @@ def test_upgrade_caltable_byte_swapped_legacy_converts():
 def test_upgrade_caltable_identity_on_target_dtype():
     """A table already in the target dtype is handed straight back."""
     g = np.zeros(2, dtype=ehc.DTCAL_CIRC)
-    gains, dterms = ehc.upgrade_caltable(g)
-    assert gains is g
-    assert dterms is None
+    assert ehc.upgrade_caltable(g) is g
 
 
-def test_upgrade_caltable_welded_zero_dterms_narrows_to_gains_only():
-    """A welded table whose D-terms are all zero yields no D-term table.
-
-    Every writer between PR #254 and the split padded these columns with 0j,
-    so this is the common case and it should migrate to a clean gain table.
-    """
-    w = _welded()
-    gains, dterms = ehc.upgrade_caltable(w)
-    assert gains.dtype.names == ('time', 'rscale', 'lscale')
-    assert dterms is None
-    assert np.array_equal(gains['rscale'], w['rscale'])
-    assert np.array_equal(gains['lscale'], w['lscale'])
-    assert np.array_equal(gains['time'], w['time'])
-
-
-def test_upgrade_caltable_welded_nonzero_dterms_extracts_table():
-    """Real D-terms are lifted out onto their own time column, with the gains left clean."""
-    w = _welded(dr=0.01 + 0.02j, dl=-0.03j)
-    gains, dterms = ehc.upgrade_caltable(w)
-    assert 'dr' not in gains.dtype.fields
-    assert dterms.dtype.names == ('time', 'dr', 'dl')
-    # the D-terms keep their own copy of the time column
-    assert np.array_equal(dterms['time'], w['time'])
-    assert np.array_equal(dterms['dr'], w['dr'])
-    assert np.array_equal(dterms['d_p2'], w['dl'])
-
-
-def test_upgrade_caltable_welded_lin_basis():
-    """The same split works on a linear-feed table, whose columns are named differently."""
-    w = np.zeros(2, dtype=_WELDED_DTCAL_LIN)
-    w['xscale'] = [1 + 0j, 2 + 0j]
-    w['d_p1'] = 0.05 + 0j
-    gains, dterms = ehc.upgrade_caltable(w)
+def test_upgrade_caltable_linear_basis():
+    """A linear-feed table keeps its own dtype rather than being recast."""
+    lin = np.zeros(2, dtype=[('time', 'f8'), ('xscale', 'c16'), ('yscale', 'c16')])
+    lin['xscale'] = [1 + 0j, 2 + 0j]
+    gains = ehc.upgrade_caltable(lin)
     assert gains.dtype.names == ('time', 'xscale', 'yscale')
-    assert dterms.dtype.names == ('time', 'dx', 'dy')
-    assert np.array_equal(gains['xscale'], w['xscale'])
-    assert np.array_equal(dterms['d_p1'], w['d_p1'])
+    assert np.array_equal(gains['p1scale'], lin['xscale'])
 
 
 def test_upgrade_caltable_idempotent():
-    """Splitting an already-split table changes nothing."""
-    w = _welded(dr=0.01 + 0j)
-    gains, dterms = ehc.upgrade_caltable(w)
-    again, again_dterms = ehc.upgrade_caltable(gains)
-    assert again is gains
-    assert again_dterms is None
+    """Upgrading an already-upgraded table changes nothing."""
+    oc = np.zeros(2, dtype=_LEGACY_DTCAL)
+    gains = ehc.upgrade_caltable(oc)
+    assert ehc.upgrade_caltable(gains) is gains
 
 
 def test_upgrade_caltable_zero_d_record_normalized_to_one_row():
@@ -390,9 +336,7 @@ def test_upgrade_caltable_zero_d_record_normalized_to_one_row():
     self_cal leaves this shape behind for a site seen in a single scan.
     """
     rec = np.zeros((), dtype=_LEGACY_DTCAL)
-    gains, dterms = ehc.upgrade_caltable(rec)
-    assert gains.shape == (1,)
-    assert dterms is None
+    assert ehc.upgrade_caltable(rec).shape == (1,)
 
 
 def test_upgrade_caltable_list_of_records():
@@ -402,22 +346,9 @@ def test_upgrade_caltable_list_of_records():
     exactly one non-first scan; it used to raise on the missing .dtype.
     """
     rec = np.zeros((), dtype=ehc.DTCAL_CIRC)
-    gains, dterms = ehc.upgrade_caltable([rec])
+    gains = ehc.upgrade_caltable([rec])
     assert gains.shape == (1,)
     assert gains.dtype.names == ('time', 'rscale', 'lscale')
-    assert dterms is None
-
-
-def test_upgrade_caltable_untitled_welded_splits():
-    """A plain-named five-field table is upgraded the same way as a titled one."""
-    untitled = np.zeros(2, dtype=[('time', 'f8'), ('rscale', 'c16'), ('lscale', 'c16'),
-                                  ('dr', 'c16'), ('dl', 'c16')])
-    untitled['rscale'] = [1 + 0j, 2 + 0j]
-    untitled['dr'] = 0.05j
-    gains, dterms = ehc.upgrade_caltable(untitled)
-    assert gains.dtype.names == ('time', 'rscale', 'lscale')
-    assert np.array_equal(gains['rscale'], untitled['rscale'])
-    assert np.array_equal(dterms['dr'], untitled['dr'])
 
 
 def test_upgrade_caltable_generic_names_assume_circular():
@@ -425,10 +356,9 @@ def test_upgrade_caltable_generic_names_assume_circular():
     generic = np.zeros(2, dtype=[('time', 'f8'), ('p1scale', 'c16'), ('p2scale', 'c16')])
     generic['p1scale'] = [1 + 0j, 2 + 0j]
     with pytest.warns(ehw.MixedPolConventionWarning, match="assuming circular"):
-        gains, dterms = ehc.upgrade_caltable(generic)
+        gains = ehc.upgrade_caltable(generic)
     assert gains.dtype == np.dtype(ehc.DTCAL_CIRC)
     assert np.array_equal(gains['rscale'], generic['p1scale'])
-    assert dterms is None
 
 
 def test_upgrade_caltable_unknown_fields_raise():
@@ -446,63 +376,26 @@ def test_upgrade_caltable_dterm_table_raises():
         ehc.upgrade_caltable(d)
 
 
+def test_upgrade_caltable_combined_gain_dterm_table_raises():
+    """The short-lived combined gain+D-term format is no longer read.
+
+    It was only ever a development format and never used for real data, so it
+    raises rather than being silently reinterpreted.
+    """
+    combined = np.zeros(2, dtype=[('time', 'f8'), ('rscale', 'c16'), ('lscale', 'c16'),
+                                  ('dr', 'c16'), ('dl', 'c16')])
+    with pytest.raises(Exception, match="cannot interpret"):
+        ehc.upgrade_caltable(combined)
+
+
 def test_upgrade_caltable_none_passthrough():
     """None is passed straight through, as pad_scans expects."""
-    gains, dterms = ehc.upgrade_caltable(None)
-    assert gains is None
-    assert dterms is None
+    assert ehc.upgrade_caltable(None) is None
 
 
 def test_upgrade_caltable_empty_array():
-    """An empty table splits into an empty table and no D-terms."""
-    gains, dterms = ehc.upgrade_caltable(np.zeros(0, dtype=_LEGACY_DTCAL))
-    assert len(gains) == 0
-    assert dterms is None
-
-
-# ----- End-to-end: Array / Obsdata / Caltable upgrade through __init__ ----
-
-def test_array_upgrades_legacy_tarr():
-    arr = ea.Array(_legacy_tarr())
-    assert 'feed_type' in arr.tarr.dtype.names
-    assert np.all(arr.tarr['feed_type'] == 'rl')
-
-
-def test_array_pickle_roundtrip_from_new():
-    arr = ea.Array(_legacy_tarr())
-    arr2 = pickle.loads(pickle.dumps(arr))
-    assert np.all(arr2.tarr['feed_type'] == 'rl')
-    assert np.array_equal(arr2.tarr['sefd_p1'], arr.tarr['sefd_p1'])
-
-
-def test_array_setstate_upgrades_legacy_pickle():
-    # Simulate a pickle made before the schema migration:
-    legacy_state = {'_tarr': _legacy_tarr(), 'ephem': {},
-                    'tkey': {'A': 0, 'B': 1}}
-    arr = ea.Array.__new__(ea.Array)
-    arr.__setstate__(legacy_state)
-    assert 'feed_type' in arr.tarr.dtype.names
-    assert np.all(arr.tarr['feed_type'] == 'rl')
-
-
-def test_obsdata_upgrades_legacy_datatable_and_tarr():
-    obs = eo.Obsdata(ra=0., dec=0., rf=230e9, bw=1e9,
-                     datatable=_legacy_circ_datatable(),
-                     tarr=_legacy_tarr(), polrep='circ')
-    assert obs.polrep == 'circ'
-    assert 'feed_type' in obs.tarr.dtype.names
-    assert np.all(obs.tarr['feed_type'] == 'rl')
-    # Generic accessor works on upgraded data
-    assert np.array_equal(obs.data['p1p1vis'], obs.data['rrvis'])
-
-
-def test_obsdata_pickle_roundtrip_legacy_recarrays():
-    obs = eo.Obsdata(ra=0., dec=0., rf=230e9, bw=1e9,
-                     datatable=_legacy_circ_datatable(),
-                     tarr=_legacy_tarr(), polrep='circ')
-    obs2 = pickle.loads(pickle.dumps(obs))
-    assert np.all(obs2.tarr['feed_type'] == 'rl')
-    assert np.array_equal(obs2.data['p1p1vis'], obs.data['rrvis'])
+    """An empty table upgrades to an empty table."""
+    assert len(ehc.upgrade_caltable(np.zeros(0, dtype=_LEGACY_DTCAL))) == 0
 
 
 def test_caltable_upgrades_legacy_dtcal():
@@ -529,29 +422,20 @@ def test_caltable_pickle_roundtrip_legacy_dtcal():
                           caltab.data['A']['rscale'])
 
 
-def test_caltable_pickle_welded_nonzero_dterms_migrates():
-    """A pickle from when D-terms lived in the gain rows loads into both tables.
-
-    The state is hand-built in the old schema rather than taken from a live
-    instance, or the new-state guard would skip the migration entirely.
-    """
-    w = np.zeros(2, dtype=_WELDED_DTCAL)
-    w['rscale'] = [1 + 0j, 1.1 + 0j]
-    w['dr'] = 0.04 + 0.01j
+def test_caltable_pickle_combined_format_raises():
+    """A pickle in the short-lived combined format is refused, not misread."""
+    combined = np.zeros(2, dtype=[('time', 'f8'), ('rscale', 'c16'), ('lscale', 'c16'),
+                                  ('dr', 'c16'), ('dl', 'c16')])
     caltab = ec.Caltable(ra=0., dec=0., rf=230e9, bw=1e9,
                          datadict={'A': np.zeros(2, dtype=ehc.DTCAL)},
                          tarr=_legacy_tarr())
-    # a pre-split pickle carries 'data' and neither 'gains' nor 'dterms'
     state = dict(caltab.__dict__)
     state.pop('gains')
     state.pop('dterms')
-    state['data'] = {'A': w}
+    state['data'] = {'A': combined}
     revived = ec.Caltable.__new__(ec.Caltable)
-    revived.__setstate__(state)
-    assert revived.data['A'].dtype.names == ('time', 'rscale', 'lscale')
-    assert np.array_equal(revived.data['A']['rscale'], w['rscale'])
-    assert np.array_equal(revived.dterms['A']['dr'], w['dr'])
-    assert np.array_equal(revived.dterms['A']['time'], w['time'])
+    with pytest.raises(Exception, match="cannot interpret"):
+        revived.__setstate__(state)
 
 
 # ============================================================================

--- a/tests/test_mixedpol.py
+++ b/tests/test_mixedpol.py
@@ -388,6 +388,16 @@ def test_upgrade_caltable_combined_gain_dterm_table_raises():
         ehc.upgrade_caltable(combined)
 
 
+def test_upgrade_caltable_unnamed_array_raises():
+    """An array with no fields at all raises rather than being read as gains.
+
+    The shared normalizer returns None for it, which must not be confused with
+    the None that means there is no table.
+    """
+    with pytest.raises(Exception, match="no named fields"):
+        ehc.upgrade_caltable(np.zeros(3))
+
+
 def test_upgrade_caltable_none_passthrough():
     """None is passed straight through, as pad_scans expects."""
     assert ehc.upgrade_caltable(None) is None

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -21,10 +21,13 @@ def model_obs(gauss_model, eht_array):
 
 
 def test_modeler_func_fit_gains_caltable(gauss_model, model_obs):
-    """fit_gains=True must build a valid 5-field DTCAL caltable.
+    """fit_gains=True must build a caltable whose rows match the DTCAL dtype.
 
-    Regression for the DTCAL write-site that appended a 3-tuple gain row,
-    which fails to cast against the widened (5-field) DTCAL dtype.
+    Regression for the modeling gain write-site, which builds its rows as
+    tuple literals: the literal's width and the dtype's field count have to
+    agree, so the write-site breaks whenever DTCAL gains or loses a column.
+    The assertion compares against np.dtype(ehc.DTCAL).names rather than a
+    fixed field count, so it holds on either side of such a change.
     """
     res = eh.modeler_func(model_obs, gauss_model, gauss_model.default_prior(),
                           d1='amp', fit_model=False, fit_gains=True, quiet=True)
@@ -32,7 +35,7 @@ def test_modeler_func_fit_gains_caltable(gauss_model, model_obs):
     ct = res['caltable']
     assert isinstance(ct, eh.caltable.Caltable)
 
-    # every per-site gain table must carry the full 5-field dtype
+    # every per-site gain table must carry the current DTCAL fields
     assert len(ct.data) > 0
     for site, rows in ct.data.items():
         assert rows.dtype.names == np.dtype(ehc.DTCAL).names


### PR DESCRIPTION
## What and why

D-terms used to be welded into the gain table, sharing one time column, so a static leakage value had to be duplicated across every gain row. `Caltable` now holds two tables per site on independent time grids:

```python
ct.gains[site]    # DTCAL:   (time, rscale, lscale)
ct.dterms[site]   # DTDTERM: (time, dr, dl)   -- {} if there is no leakage
ct.data           # alias for gains, kept for backward compatibility
```

A one-row table is how a time-constant D-term is stored.

## Since the last review

- `split_dtcal` -> `upgrade_caltable`: detects feed basis from field names, upgrades legacy/solver shapes, raises on anything it can't interpret. The short-lived combined gain+D-term format is no longer read at all, per the 08-20 call.
- `dterms` kwarg renamed `dtermdict`, moved next to `tarr`.
- `save_caltable`/`save_txt` take `overwrite=False`; refuse to clobber existing files unless asked, clean up stale gain and D-term files on save.
- `DTDTERM_LIN` gained `dx`/`dy` aliases to match `DTCAL_LIN`.
- Non-dict `datadict` raises instead of being stored silently.
- Comments trimmed; the 1-2 line rule is now in CLAUDE.md.
- NOTE + TODO at the top of caltable.py: no D-term table means fall back to tarr D-terms; resolving both-defined is a follow-up PR.

## Bugs found along the way

- Single-row gain files failed to load (`ndmin=2`)
- List/0-d construction crashes in the solver caldict path, since #254
- `merge` aliased one side's gain arrays, so mutating the result wrote back into the input
- Byte-swapped legacy tables were reinterpreted instead of converted
- A leakage-only site lost its D-terms on save (`array.txt` came from the wrong tarr)
- `pad_scans` recast linear-feed gains as circular
- `scripts/imaging.py`, broken by #254, works again

## Deferred (unreachable via the current API)

- `applycal` doesn't apply D-terms yet (Part A)
- `DTDTERM_LIN` doesn't survive save/load (needs the basis dispatch Part A adds anyway)
- `plot_dterms` still plots tarr; warns when `self.dterms` disagrees with it
- Two-sided D-term merge raises: leakage composes as a Jones product, not a gain-style multiply, and needs an order convention first

399 tests pass. Sections 1-10 of `test_caltable.py` are unmodified except `_unity_caltable`, which is the no-regression contract for applycal, save/load, and the transforms.
