### PR TITLE
Add example: Cramer-Rao forecasts for the photon-ring Lyapunov exponent

### DIFF
--- a/examples/example_subring_crb.py
+++ b/examples/example_subring_crb.py
@@ -1,0 +1,110 @@
+# example_subring_crb.py
+#
+# Cramer-Rao forecasts for the photon-ring Lyapunov exponent from
+# interferometric visibilities.
+#
+# The photon ring is a stack of subrings converging geometrically to the
+# critical curve, with demagnification set by the Lyapunov exponent gamma
+# (Johnson et al. 2020, arXiv:1907.04329). This example asks a simple
+# question with a Fisher matrix: given a visibility coverage and thermal
+# noise, how well can gamma itself be estimated, treating the subring
+# amplitudes as free parameters?
+#
+# Two results:
+#   1. With the real EHT 2017 M87 coverage shipped with eht-imaging, gamma
+#      is unconstrained (relative errors above 100 percent): measuring the
+#      Lyapunov exponent needs longer baselines, quantified here.
+#   2. A mission-design curve sigma(gamma)/gamma versus maximum baseline,
+#      at the 2017 thermal noise level. Kerr-like gamma ~ 1.1 becomes a
+#      10 percent measurement near u_max ~ 60 Glambda. Schwarzschild-like
+#      gamma = pi is much harder at every baseline: large gamma collapses
+#      the subring stack onto the critical curve, and the estimation cost
+#      explodes as the tower degenerates. Conditioning analyses of this
+#      near-degenerate regime are developed in
+#      https://github.com/maiconburn/recoverability-criticality
+#      (DOI 10.5281/zenodo.22156019).
+#
+# Model: NRING thin rings, diameters d_n = d_inf (1 + c exp(-gamma n)),
+# ring visibility J0(pi d |u|), amplitudes free, gamma the parameter of
+# interest. Systematic-floor studies for low-order rings are in
+# Salehi et al. (arXiv:2512.16983); Fisher forecasts for spin with BHEX
+# are in Farah et al. (arXiv:2608.23672).
+
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+from scipy.special import j0, j1
+
+import ehtim as eh
+
+RADPERUAS = eh.RADPERUAS
+
+D_INF = 40.0      # uas
+C_OFF = 0.3
+N_RING = 4
+A_TOT = 0.5       # Jy in the ring stack
+
+
+def ring_diameter(gamma, n):
+    return D_INF * (1 + C_OFF * np.exp(-gamma * n)) * RADPERUAS
+
+
+def crb_gamma(gamma, bl, sigma):
+    """Cramer-Rao bound on gamma with free subring amplitudes.
+
+    Args:
+        gamma: Lyapunov exponent
+        bl: array of baseline lengths |u| in lambda
+        sigma: per-visibility thermal noise (Jy), scalar or array
+
+    Returns:
+        sigma_gamma: the 1-sigma bound on gamma
+    """
+    w = np.exp(-gamma)
+    comps = []
+    dgam = 0.0
+    for n in range(1, N_RING + 1):
+        d = ring_diameter(gamma, n)
+        comps.append(j0(np.pi * d * bl))
+        dd = -D_INF * C_OFF * n * np.exp(-gamma * n) * RADPERUAS
+        dgam = dgam + A_TOT * w**n * (-j1(np.pi * d * bl)) * np.pi * bl * dd
+    cols = [dgam] + comps
+    X = np.vstack(cols).T / np.atleast_1d(sigma)[:, None] \
+        if np.ndim(sigma) else np.vstack(cols).T / sigma
+    F = X.T @ X
+    return np.sqrt(np.linalg.pinv(F)[0, 0])
+
+
+# 1. real EHT 2017 coverage
+obs = eh.obsdata.load_uvfits("../data/hops_lo_3601_M87+zbl-dtcal_selfcal.uvfits")
+u = obs.data['u']
+v = obs.data['v']
+sig = obs.data['sigma']
+bl = np.sqrt(u**2 + v**2)
+print("EHT 2017 M87 (lo band): %d visibilities, median sigma %.1f mJy"
+      % (len(bl), 1000 * np.median(sig)))
+for gamma in (1.1, np.pi):
+    s = crb_gamma(gamma, bl, sig)
+    print("  gamma = %.3f: sigma(gamma)/gamma = %.0f%%" % (gamma, 100 * s / gamma))
+print("  -> the 2017 coverage does not constrain the Lyapunov exponent.")
+
+# 2. mission-design curve at the 2017 noise level
+print("\nsigma(gamma)/gamma vs maximum baseline (dense coverage, %d points,"
+      % len(bl))
+print("thermal noise fixed at the 2017 median):")
+print("u_max (Glambda)   gamma=1.1    gamma=pi")
+sig0 = np.median(sig)
+for umax in (16, 25, 40, 60, 80, 120):
+    b = np.geomspace(1e9, umax * 1e9, len(bl))
+    r1 = crb_gamma(1.1, b, sig0) / 1.1
+    r2 = crb_gamma(np.pi, b, sig0) / np.pi
+    print("   %5d          %7.1f%%    %8.0f%%" % (umax, 100 * r1, 100 * r2))
+print("\nKerr-like gamma reaches the 10 percent level near u_max ~ 60 Glambda;")
+print("Schwarzschild-like gamma = pi stays far harder at every baseline,")
+print("because large gamma collapses the subring tower onto the critical")
+print("curve and the free-amplitude estimation cost explodes.")
+print("\nCaveats: thin rings with free amplitudes and fixed d_inf; dense")
+print("synthetic coverage (optimistic vs real tracks); thermal noise only,")
+print("no gain or systematic errors. Treat the numbers as best-case bounds")
+print("useful for comparing configurations, not as mission predictions.")


### PR DESCRIPTION
## What this adds

A new example, `examples/example_subring_crb.py`, that asks a simple question with a Fisher matrix: given a visibility coverage and thermal noise, how well can the photon-ring Lyapunov exponent gamma be estimated, treating the subring amplitudes as free parameters?

The subring model is the standard geometric stack (Johnson et al. 2020, arXiv:1907.04329): thin rings with diameters d_n = d_inf (1 + c exp(-gamma n)) and ring visibilities J0(pi d |u|).

## Results the example prints

1. With the real EHT 2017 M87 coverage already shipped in `data/` (hops lo band, 5877 visibilities), gamma is unconstrained: relative errors above 100 percent for both Kerr-like and Schwarzschild-like values. This quantifies, with the real coverage, why Lyapunov measurements need longer baselines.

2. A mission-design curve of sigma(gamma)/gamma versus maximum baseline at the 2017 thermal noise level:

```
u_max (Glambda)   gamma=1.1    gamma=pi
      25            141%         15612%
      40              28%         5297%
      60             7.4%         2067%
     120             1.1%          398%
```

Kerr-like gamma reaches the 10 percent level near u_max of about 60 Glambda. Schwarzschild-like gamma = pi is far harder at every baseline, because large gamma collapses the subring stack onto the critical curve and the free-amplitude estimation cost grows steeply as the tower degenerates. The conditioning analysis behind that last statement is developed in https://github.com/maiconburn/recoverability-criticality (DOI 10.5281/zenodo.22156019).

## Relation to existing work

Fisher forecasts for spin with BHEX exist (arXiv:2608.23672), and systematic floors for low-order rings are studied in arXiv:2512.16983. As far as I could find, an explicit Cramer-Rao bound for gamma itself from visibility data, and its scaling as the subrings degenerate, had not been written down, so a small runnable example seemed useful.

## Caveats

Thin rings, free amplitudes, fixed d_inf, dense synthetic coverage for the design curve, thermal noise only. The script prints these caveats and frames the numbers as best-case bounds for comparing configurations, not mission predictions.

Happy to adjust style, move the file, or trim the printout.
